### PR TITLE
Add automated company sync from CURRENT to AI Analysis sheet

### DIFF
--- a/.github/workflows/sync-companies.yml
+++ b/.github/workflows/sync-companies.yml
@@ -1,0 +1,38 @@
+name: Sync Companies to AI Analysis
+
+on:
+  schedule:
+    # Runs at 4:30 AM UTC daily (before EODHD at 5:00 AM and narratives at 6:00 AM)
+    - cron: "30 4 * * *"
+  workflow_dispatch: # Allow manual trigger from GitHub UI
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Sync new companies from CURRENT to AI Analysis
+        env:
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+        run: python sync_companies.py
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 30

--- a/sync_companies.py
+++ b/sync_companies.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Sync new companies from the 'CURRENT' sheet to the 'AI Analysis' sheet.
+
+Reads tickers from both sheets, identifies companies present in CURRENT
+but missing from AI Analysis, and appends them to AI Analysis.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+from dotenv import load_dotenv
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SPREADSHEET_ID = "1js3dUTJtKhY1dUcwzYUGBOdKDZXBurLtRGgcIV8msYk"
+SOURCE_SHEET = "CURRENT"
+TARGET_SHEET = "AI Analysis"
+
+SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+def setup_logging() -> logging.Logger:
+    today_str = date.today().isoformat()
+    log_dir = Path(__file__).parent / "logs"
+    log_dir.mkdir(exist_ok=True)
+    log_file = log_dir / f"sync_companies_{today_str}.txt"
+
+    logger = logging.getLogger("sync_companies")
+    logger.setLevel(logging.INFO)
+
+    fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s",
+                            datefmt="%Y-%m-%d %H:%M:%S")
+
+    fh = logging.FileHandler(log_file, encoding="utf-8")
+    fh.setFormatter(fmt)
+    logger.addHandler(fh)
+
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(fmt)
+    logger.addHandler(sh)
+
+    return logger
+
+
+# ---------------------------------------------------------------------------
+# Google Sheets helpers
+# ---------------------------------------------------------------------------
+
+
+def get_sheets_service():
+    sa_value = os.environ.get("GOOGLE_SERVICE_ACCOUNT_JSON", "")
+    if not sa_value:
+        raise RuntimeError("GOOGLE_SERVICE_ACCOUNT_JSON env var is not set")
+
+    if sa_value.strip().startswith("{"):
+        info = json.loads(sa_value)
+        creds = service_account.Credentials.from_service_account_info(
+            info, scopes=SCOPES
+        )
+    else:
+        creds = service_account.Credentials.from_service_account_file(
+            sa_value, scopes=SCOPES
+        )
+    return build("sheets", "v4", credentials=creds)
+
+
+def read_sheet_rows(service, sheet_name: str) -> list[list[str]]:
+    """Return all rows from a sheet."""
+    result = (
+        service.spreadsheets()
+        .values()
+        .get(
+            spreadsheetId=SPREADSHEET_ID,
+            range=f"'{sheet_name}'!A1:ZZ",
+            valueRenderOption="FORMATTED_VALUE",
+        )
+        .execute()
+    )
+    return result.get("values", [])
+
+
+def _col_letter(idx: int) -> str:
+    """Convert 0-based column index to Excel-style letter(s)."""
+    result = ""
+    while True:
+        result = chr(65 + idx % 26) + result
+        idx = idx // 26 - 1
+        if idx < 0:
+            break
+    return result
+
+
+def find_column(headers: list[str], *names: str) -> int | None:
+    """Find a column index by trying multiple header names (case-insensitive)."""
+    for idx, header in enumerate(headers):
+        normalized = header.strip().lower()
+        for name in names:
+            if normalized == name.lower():
+                return idx
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    load_dotenv()
+
+    parser = argparse.ArgumentParser(description="Sync companies from CURRENT to AI Analysis")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would be added without writing")
+    args = parser.parse_args()
+
+    logger = setup_logging()
+    logger.info("=== Sync Companies started (dry_run=%s) ===", args.dry_run)
+
+    service = get_sheets_service()
+
+    # --- Read SOURCE (CURRENT) sheet ---
+    source_rows = read_sheet_rows(service, SOURCE_SHEET)
+    if len(source_rows) < 2:
+        logger.error("Source sheet '%s' has fewer than 2 rows", SOURCE_SHEET)
+        sys.exit(1)
+
+    # Headers are in row 2 (index 1)
+    source_headers = source_rows[1] if len(source_rows) >= 2 else source_rows[0]
+    src_ticker_col = find_column(source_headers, "ticker")
+    src_company_col = find_column(source_headers, "company_name")
+
+    if src_ticker_col is None:
+        logger.error("Could not find 'ticker' column in %s headers: %s",
+                      SOURCE_SHEET, source_headers)
+        sys.exit(1)
+    if src_company_col is None:
+        logger.error("Could not find 'company_name' column in %s headers: %s",
+                      SOURCE_SHEET, source_headers)
+        sys.exit(1)
+
+    logger.info("Source '%s': ticker=col %d, company_name=col %d",
+                SOURCE_SHEET, src_ticker_col, src_company_col)
+
+    # Extract source companies (data starts at row 3, index 2)
+    source_companies = {}  # ticker → company_name
+    for row in source_rows[2:]:
+        max_col = max(src_ticker_col, src_company_col)
+        padded = row + [""] * (max_col + 1 - len(row))
+        ticker = padded[src_ticker_col].strip().upper()
+        company = padded[src_company_col].strip()
+        if ticker:
+            source_companies[ticker] = company
+
+    logger.info("Found %d companies in '%s'", len(source_companies), SOURCE_SHEET)
+
+    # --- Read TARGET (AI Analysis) sheet ---
+    target_rows = read_sheet_rows(service, TARGET_SHEET)
+    if len(target_rows) < 2:
+        logger.error("Target sheet '%s' has fewer than 2 rows", TARGET_SHEET)
+        sys.exit(1)
+
+    # Headers in row 2 (index 1)
+    target_headers = target_rows[1] if len(target_rows) >= 2 else target_rows[0]
+    tgt_ticker_col = find_column(target_headers, "ticker")
+    tgt_company_col = find_column(target_headers, "company", "company name")
+
+    if tgt_ticker_col is None:
+        logger.error("Could not find 'Ticker' column in %s headers: %s",
+                      TARGET_SHEET, target_headers)
+        sys.exit(1)
+    if tgt_company_col is None:
+        logger.error("Could not find 'Company' / 'Company Name' column in %s headers: %s",
+                      TARGET_SHEET, target_headers)
+        sys.exit(1)
+
+    logger.info("Target '%s': Ticker=col %d, Company=col %d",
+                TARGET_SHEET, tgt_ticker_col, tgt_company_col)
+
+    # Extract existing tickers in AI Analysis
+    existing_tickers = set()
+    for row in target_rows[2:]:
+        padded = row + [""] * (tgt_ticker_col + 1 - len(row))
+        ticker = padded[tgt_ticker_col].strip().upper()
+        if ticker:
+            existing_tickers.add(ticker)
+
+    logger.info("Found %d existing companies in '%s'", len(existing_tickers), TARGET_SHEET)
+
+    # --- Find new companies ---
+    new_companies = {
+        ticker: name
+        for ticker, name in source_companies.items()
+        if ticker not in existing_tickers
+    }
+
+    if not new_companies:
+        logger.info("No new companies to add — all CURRENT tickers already exist in AI Analysis.")
+        return
+
+    logger.info("Found %d new companies to add:", len(new_companies))
+    for ticker, name in sorted(new_companies.items()):
+        logger.info("  %s — %s", ticker, name)
+
+    if args.dry_run:
+        logger.info("=== DRY RUN complete — no changes made ===")
+        return
+
+    # --- Append new rows to AI Analysis ---
+    # Build rows with ticker and company in the correct columns
+    num_cols = len(target_headers)
+    append_rows = []
+    for ticker, name in sorted(new_companies.items()):
+        new_row = [""] * num_cols
+        new_row[tgt_ticker_col] = ticker
+        new_row[tgt_company_col] = name
+        append_rows.append(new_row)
+
+    # Append after the last row
+    service.spreadsheets().values().append(
+        spreadsheetId=SPREADSHEET_ID,
+        range=f"'{TARGET_SHEET}'!A1",
+        valueInputOption="USER_ENTERED",
+        insertDataOption="INSERT_ROWS",
+        body={"values": append_rows},
+    ).execute()
+
+    logger.info("Appended %d new companies to '%s'", len(append_rows), TARGET_SHEET)
+    logger.info("=== Sync complete ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/sync_companies.py
+++ b/sync_companies.py
@@ -135,12 +135,12 @@ def main():
 
     # --- Read SOURCE (CURRENT) sheet ---
     source_rows = read_sheet_rows(service, SOURCE_SHEET)
-    if len(source_rows) < 2:
-        logger.error("Source sheet '%s' has fewer than 2 rows", SOURCE_SHEET)
+    if len(source_rows) < 1:
+        logger.error("Source sheet '%s' is empty", SOURCE_SHEET)
         sys.exit(1)
 
-    # Headers are in row 2 (index 1)
-    source_headers = source_rows[1] if len(source_rows) >= 2 else source_rows[0]
+    # Headers are in row 1 (index 0)
+    source_headers = source_rows[0]
     src_ticker_col = find_column(source_headers, "ticker")
     src_company_col = find_column(source_headers, "company_name")
 
@@ -156,9 +156,9 @@ def main():
     logger.info("Source '%s': ticker=col %d, company_name=col %d",
                 SOURCE_SHEET, src_ticker_col, src_company_col)
 
-    # Extract source companies (data starts at row 3, index 2)
+    # Extract source companies (data starts at row 2, index 1)
     source_companies = {}  # ticker → company_name
-    for row in source_rows[2:]:
+    for row in source_rows[1:]:
         max_col = max(src_ticker_col, src_company_col)
         padded = row + [""] * (max_col + 1 - len(row))
         ticker = padded[src_ticker_col].strip().upper()


### PR DESCRIPTION
## Summary
This PR adds a new automated workflow to synchronize company data from the 'CURRENT' sheet to the 'AI Analysis' sheet in Google Sheets. The system identifies companies present in CURRENT but missing from AI Analysis and appends them automatically.

## Key Changes
- **New script `sync_companies.py`**: Main synchronization logic that:
  - Reads tickers and company names from both source (CURRENT) and target (AI Analysis) sheets
  - Identifies new companies in CURRENT that don't exist in AI Analysis
  - Appends new companies to the target sheet with proper column mapping
  - Includes comprehensive logging to file and stdout with daily log rotation
  - Supports `--dry-run` mode for safe testing

- **New GitHub Actions workflow `.github/workflows/sync-companies.yml`**:
  - Scheduled to run daily at 4:30 AM UTC (before downstream processes)
  - Supports manual triggering via workflow_dispatch
  - Automatically uploads logs as artifacts for audit trail
  - 10-minute timeout with Python 3.12

## Notable Implementation Details
- **Flexible column detection**: Uses case-insensitive header matching to find ticker and company name columns, supporting multiple column name variations
- **Robust row handling**: Pads rows to handle variable column counts and safely accesses columns
- **Google Sheets authentication**: Supports both inline JSON and file-based service account credentials via environment variable
- **Idempotent design**: Only adds companies that don't already exist, preventing duplicates
- **Comprehensive logging**: Logs to both file and console with timestamps, making it easy to audit sync operations
- **Safe defaults**: Requires explicit `--dry-run` flag to preview changes without modifying sheets

https://claude.ai/code/session_01FWwN5pZ2CUUoQPad11Qtwd