### PR TITLE
Add GitHub Actions workflow for rebuild CURRENT sheet

### DIFF
--- a/.github/workflows/rebuild-current.yml
+++ b/.github/workflows/rebuild-current.yml
@@ -1,0 +1,40 @@
+name: Rebuild CURRENT Sheet
+
+on:
+  workflow_dispatch:        # manual trigger only
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Rebuild CURRENT sheet
+        env:
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+        run: python rebuild_current_sheet.py
+
+      - name: Verify structure (recalc)
+        env:
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+        run: python scripts/recalc.py
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rebuild-current-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 30


### PR DESCRIPTION
Manual-trigger-only workflow that runs rebuild_current_sheet.py followed by scripts/recalc.py verification.

https://claude.ai/code/session_019w7gm6JjDgEQs8469Mcivk