### PR TITLE
Rename scoring workflow and update schedules

### DIFF
--- a/.github/workflows/nightly-screen.yml
+++ b/.github/workflows/nightly-screen.yml
@@ -2,8 +2,8 @@ name: Nightly TradingView Screen
 
 on:
   schedule:
-    # Runs at midnight UTC daily (before EODHD at 5:00 AM)
-    - cron: "0 0 * * *"
+    # Runs at 3:00 AM UTC (4:00 AM BST) — before EODHD at 5:00 AM
+    - cron: "0 3 * * *"
   workflow_dispatch: # Allow manual trigger from GitHub UI
 
 jobs:

--- a/.github/workflows/score-ai-analysis.yml
+++ b/.github/workflows/score-ai-analysis.yml
@@ -1,4 +1,4 @@
-name: Update AI Analysis w TradingView
+name: Get TV data and score
 
 on:
   schedule:


### PR DESCRIPTION
- Scoring workflow renamed to 'Get TV data and score'
- Nightly screen moved to 03:00 UTC (4am UK/BST)

Schedule:
  03:00 UTC  Nightly TradingView Screen (add new tickers) 05:00 UTC  EODHD update 06:00 UTC  AI Narratives 06:30 UTC  Get TV data and score

https://claude.ai/code/session_01GtAxBeeUpSEyxyMQjevvJP