### PR TITLE
Add sector data backfill from TradingView for missing tickers

### DIFF
--- a/nightly_screen.py
+++ b/nightly_screen.py
@@ -21,7 +21,7 @@ from dotenv import load_dotenv
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
-from tv_screen import run_tradingview_screen
+from tv_screen import run_tradingview_screen, fetch_sector_data
 
 load_dotenv()
 
@@ -377,6 +377,39 @@ def main():
     # Step 5: Write changes
     add_new_tickers(service, new_tickers, col_map, logger)
     update_missing_fields(service, field_updates, col_map, logger)
+
+    # Step 6: Backfill sector from TradingView for tickers still missing it
+    # (covers tickers not in current screen results or manual sheet)
+    tickers_missing_sector = []
+    for ticker, info in ticker_rows.items():
+        if not info.get("sector"):
+            # Check if we already queued an update for this ticker's sector
+            already_updated = any(
+                u["row"] == info["row"] and "sector" in u["fields"]
+                for u in field_updates
+            )
+            if not already_updated:
+                tickers_missing_sector.append((ticker, info.get("exchange", "")))
+
+    if tickers_missing_sector:
+        logger.info("Fetching sector from TradingView for %d tickers missing sector",
+                     len(tickers_missing_sector))
+        sector_data = fetch_sector_data(tickers_missing_sector, logger)
+        sector_updates = []
+        for ticker, exchange in tickers_missing_sector:
+            sector = sector_data.get(ticker.upper(), "")
+            if sector:
+                row_num = ticker_rows[ticker]["row"]
+                sector_updates.append({
+                    "row": row_num,
+                    "fields": {"sector": sector},
+                })
+        if sector_updates:
+            update_missing_fields(service, sector_updates, col_map, logger)
+            logger.info("Backfilled sector for %d tickers via TradingView lookup",
+                         len(sector_updates))
+        else:
+            logger.info("No sector data found for tickers missing sector")
 
     # Log new tickers
     if new_tickers:

--- a/tv_screen.py
+++ b/tv_screen.py
@@ -263,3 +263,54 @@ def fetch_market_data(tickers_with_exchange: list[tuple[str, str]], logger) -> d
     logger.info("Fetched market data for %d/%d tickers",
                 len(results), len(tickers_with_exchange))
     return results
+
+
+def fetch_sector_data(tickers_with_exchange: list[tuple[str, str]], logger) -> dict[str, str]:
+    """
+    Fetch sector for specific tickers from TradingView (no screening filters).
+    Returns {TICKER: sector_string}.
+
+    tickers_with_exchange: list of (ticker, exchange) tuples.
+    """
+    if not tickers_with_exchange:
+        return {}
+
+    # Build EXCHANGE:TICKER identifiers for TradingView
+    tv_ids = []
+    ticker_map = {}  # tv_id → clean ticker
+    for ticker, exchange in tickers_with_exchange:
+        tv_id = f"{exchange}:{ticker}" if exchange else ticker
+        tv_ids.append(tv_id)
+        ticker_map[tv_id] = ticker
+
+    BATCH_SIZE = 500
+    results = {}
+
+    for i in range(0, len(tv_ids), BATCH_SIZE):
+        batch = tv_ids[i:i + BATCH_SIZE]
+        try:
+            _, df = (
+                Query()
+                .set_tickers(*batch)
+                .select("name", "sector")
+                .get_scanner_data()
+            )
+            logger.info("TradingView sector batch %d: got %d/%d",
+                        i // BATCH_SIZE + 1, len(df), len(batch))
+        except Exception as e:
+            logger.warning("TradingView sector batch failed: %s", e)
+            continue
+
+        for _, row in df.iterrows():
+            raw_name = str(row.get("name", ""))
+            ticker = clean_ticker(raw_name)
+            if not ticker:
+                continue
+
+            sector = str(row.get("sector", ""))
+            if sector and sector.lower() not in ("nan", "none", ""):
+                results[ticker.upper()] = sector
+
+    logger.info("Fetched sector for %d/%d tickers",
+                len(results), len(tickers_with_exchange))
+    return results


### PR DESCRIPTION
## Summary
This PR adds functionality to backfill sector information from TradingView for tickers that are missing sector data in the spreadsheet. This ensures comprehensive sector coverage beyond what's captured in the regular screening process.

## Key Changes
- **New function `fetch_sector_data()`** in `tv_screen.py`: Fetches sector information for a list of tickers from TradingView's scanner API, with batch processing (500 tickers per batch) and proper error handling
- **Sector backfill step** in `nightly_screen.py`: Added as Step 6 in the main workflow to identify tickers missing sector data and populate them via TradingView lookup
- **Deduplication logic**: Checks if a ticker's sector was already queued for update in the current run to avoid redundant API calls

## Implementation Details
- The `fetch_sector_data()` function mirrors the pattern of the existing `fetch_market_data()` function with similar batching and error handling
- Sector values are validated to exclude invalid entries like "nan", "none", or empty strings
- The backfill process only targets tickers that don't already have sector data and haven't been updated in the current run
- Comprehensive logging at each step for monitoring and debugging

https://claude.ai/code/session_01PRR35Uhj95YzJipqmfHiA2