### PR TITLE
Refactor composite_score: r40 × collar multipliers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,9 +94,10 @@ LAST ANALYSIS: ai, data
 - 🆕 New — missing `ai` or `data` date
 - ❌ Excluded — 🔴 marker on any column; sorted to bottom with note of flagged columns
 
-**Composite score base weights:** R40 47%, P/S 29% (inverted), 52w vs SPY 24%
-**Momentum collar (perf_52w_vs_spy):** < -0.5 → score=0 (falling knife), > 0.4 → capped at 0.4 (blow-off top)
-**Rating multiplier:** 1.0–1.2 → ×1.0, 1.21–1.6 → linear taper ×1.0→×0.01, >1.6 → ×0.01 (disqualify)
+**Composite score:** `r40 × collar_multipliers`
+**Collars (multipliers on r40):**
+- **Rating:** 1.0–1.2 → ×1.0, 1.21–1.6 → linear taper ×1.0→×0.01, >1.6 → ×0.01 (disqualify)
+- **Momentum (perf_52w_vs_spy):** < -0.5 → ×0 (falling knife), -0.5–0.4 → linear ×0→×1.0, > 0.4 → ×1.0 (capped)
 **Penalties:** 🔴 outlook ×0.25, 🟡 outlook ×0.50, 🟡 flags on any column ×0.50
 
 ## Key Constants

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ LAST ANALYSIS: ai, data
 **Collars (multipliers on r40):**
 - **Rating:** 1.0–1.2 → ×1.0, 1.21–1.6 → linear taper ×1.0→×0.01, >1.6 → ×0.01 (disqualify)
 - **Momentum (perf_52w_vs_spy):** < -0.5 → ×0 (falling knife), -0.5–0.4 → linear ×0→×1.0, > 0.4 → ×1.0 (capped)
-**Penalties:** 🔴 outlook ×0.25, 🟡 outlook ×0.50, 🟡 flags on any column ×0.50
+**Penalties:** 🔴 on short_outlook/key_risks/event_impact/rev_consistency_score → ×0, 🟡 outlook ×0.50, 🟡 flags on any column ×0.50
 
 ## Key Constants
 

--- a/eodhd_updater.py
+++ b/eodhd_updater.py
@@ -1436,43 +1436,10 @@ def fetch_eodhd_data(ticker: str, api_key: str, logger: logging.Logger,
         result["one_time_events"] = None
 
     # ── R40 Score ─────────────────────────────────────────────────────
-    # Format: 💎💎 R40: 54 | FCF +27% | ⏳ ~12 qtrs GAAP
-    #
-    # Gem scale calibrated to screened universe (GM>45%, RevGr>20%):
-    #   no gems  = R40 < 20  (weakest in this universe)
-    #   💎       = R40 20–39
-    #   💎💎     = R40 40–59
-    #   💎💎💎   = R40 60+
+    # Plain numeric value (rule_of_40 rounded to nearest integer).
     r40 = result.get("rule_of_40")
     if r40 is not None:
-        if r40 >= 60:
-            gem_str = "\U0001f48e\U0001f48e\U0001f48e"   # 💎💎💎
-        elif r40 >= 40:
-            gem_str = "\U0001f48e\U0001f48e"              # 💎💎
-        elif r40 >= 20:
-            gem_str = "\U0001f48e"                        # 💎
-        else:
-            gem_str = ""                                  # no gems
-
-        # FCF segment
-        fcf = result.get("fcf_margin")
-        fcf_str = f"FCF {'+' if fcf >= 0 else ''}{fcf:.0f}%" if fcf is not None else None
-
-        # Profitability status segment
-        nm = result.get("net_margin")
-        qtrs = qtrs_to_prof
-        if nm is not None and nm >= 0:
-            profit_str = "\u2705"                          # ✅
-        elif qtrs is not None:
-            profit_str = f"\u23f3 ~{qtrs:.0f} qtrs GAAP"  # ⏳
-        else:
-            profit_str = "\u2753 path unclear"             # ❓
-
-        r40_parts = [f"{gem_str} R40: {r40:.0f}".strip()]
-        if fcf_str:
-            r40_parts.append(fcf_str)
-        r40_parts.append(profit_str)
-        result["r40_score"] = " | ".join(r40_parts)
+        result["r40_score"] = round(r40)
 
     # ── Fundamentals Snapshot ─────────────────────────────────────────
     # Format: Rev +27% YoY | 3Y CAGR +44% | GM 88% ↑ | Net -5% ⚡ FCF +27% | ⏳ ~12 qtrs GAAP

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ requests>=2.31.0
 python-dateutil
 python-dotenv
 tradingview-screener>=3.0.0
-scipy>=1.11.0

--- a/score_ai_analysis.py
+++ b/score_ai_analysis.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from dotenv import load_dotenv
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
-from scipy.stats import percentileofscore
 
 from tv_screen import run_tradingview_screen, fetch_market_data
 
@@ -347,12 +346,19 @@ def load_manual_tickers(service, logger) -> set[str]:
 
 
 def parse_r40_score(r40_str):
-    """Parse r40_score like '💎💎💎 R40: 90' → 90."""
+    """Parse r40_score — handles both plain numeric and legacy '💎💎💎 R40: 90' format."""
     if not r40_str:
         return None
-    match = re.search(r"R40:\s*(\d+)", str(r40_str))
+    s = str(r40_str).strip()
+    # Try plain numeric first (new format)
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    # Legacy formatted string
+    match = re.search(r"R40:\s*(-?\d+)", s)
     if match:
-        return int(match.group(1))
+        return float(match.group(1))
     return None
 
 
@@ -431,52 +437,40 @@ def _rating_multiplier(rating):
     return 0.01
 
 
-def _collar_perf(perf):
-    """Apply strict momentum collar to perf_52w_vs_spy.
+def _perf_multiplier(perf):
+    """Return a multiplier based on 52-week performance vs SPY.
 
-    < -0.5  → None  (disqualified — falling knife)
-    > 0.4   → 0.4   (capped — avoid hype blow-off tops)
-    else    → perf   (pass through for linear scaling)
+    < -0.5  → 0.0   (falling knife — disqualify)
+    -0.5–0.4 → linear 0.0 → 1.0
+    > 0.4   → 1.0   (capped — no extra credit for blow-off tops)
+    None    → 1.0   (no data, no penalty)
     """
     if perf is None:
-        return perf
+        return 1.0
     if perf < -0.5:
-        return None  # sentinel: hard disqualify
-    return min(perf, 0.4)
+        return 0.0
+    if perf > 0.4:
+        return 1.0
+    return (perf + 0.5) / 0.9
 
 
-def compute_composite_score(row_data, all_rows):
-    """Calculate composite score using percentile-based weighting.
+def compute_composite_score(row_data):
+    """Calculate composite score: r40 × collar multipliers.
 
-    Base score (0–100) from three factors, then multiplied by a rating gate.
-    Performance is collared: < -0.5 disqualifies, > 0.4 capped.
-    Percentile ranking uses the collared values so scaling is linear
-    within the -0.5 to 0.4 band.
+    Base is the raw R40 score (rule_of_40 = rev_growth_ttm + net_margin).
+    Collars gate/scale the score:
+      - Rating:  1.0–1.2 ×1.0, 1.21–1.6 taper to ×0.01, >1.6 ×0.01
+      - Perf:    <-0.5 ×0, -0.5–0.4 linear 0→1, >0.4 ×1.0
     """
-    def pct(values, v, invert=False):
-        if v is None or not values:
-            return 0.5
-        p = percentileofscore(values, v, kind="mean") / 100
-        return (1 - p) if invert else p
-
-    # Hard disqualify: perf < -0.5
-    collared_perf = _collar_perf(row_data.get("_perf_f"))
-    if row_data.get("_perf_f") is not None and collared_perf is None:
+    r40 = row_data.get("_r40_f")
+    if r40 is None:
         return 0
 
-    all_ps = [r["_ps_now_f"] for r in all_rows if r.get("_ps_now_f") is not None]
-    all_r40 = [r["_r40_f"] for r in all_rows if r.get("_r40_f") is not None]
-    # Collar all perf values so percentile ranking scales within the band
-    all_perf = [_collar_perf(r["_perf_f"]) for r in all_rows
-                if r.get("_perf_f") is not None and _collar_perf(r["_perf_f"]) is not None]
-
-    base = (
-        pct(all_r40, row_data.get("_r40_f")) * 47
-        + pct(all_ps, row_data.get("_ps_now_f"), invert=True) * 29
-        + pct(all_perf, collared_perf) * 24
+    return (
+        r40
+        * _rating_multiplier(row_data.get("_rating_f"))
+        * _perf_multiplier(row_data.get("_perf_f"))
     )
-
-    return base * _rating_multiplier(row_data.get("_rating_f"))
 
 
 # ---------------------------------------------------------------------------
@@ -646,7 +640,6 @@ def main():
         entry["status"] = compute_status(entry, ps_data, screened_tickers, manual_tickers)
 
         # Scoring inputs
-        entry["_ps_now_f"] = ps_now
         perf_raw = entry.get("perf_52w_vs_spy")
         entry["_perf_f"] = _safe_float(perf_raw)
         entry["_r40_f"] = parse_r40_score(entry.get("r40_score", ""))
@@ -659,7 +652,7 @@ def main():
     # Step 4: Compute composite scores with penalties
     collar_disqualified = []
     for entry in ai_entries:
-        raw = compute_composite_score(entry, ai_entries)
+        raw = compute_composite_score(entry)
 
         if raw == 0 and entry.get("_perf_f") is not None:
             collar_disqualified.append(

--- a/score_ai_analysis.py
+++ b/score_ai_analysis.py
@@ -63,6 +63,12 @@ HEADER_ALIASES = {
     "Rating": "rating",
     "Short Outlook": "short_outlook",
     "R40 Score": "r40_score",
+    "Key Risks": "key_risks",
+    "key_risks": "key_risks",
+    "Event Impact": "event_impact",
+    "event_impact": "event_impact",
+    "Rev Consistency Score": "rev_consistency_score",
+    "rev_consistency_score": "rev_consistency_score",
     "AI": "ai",
     "Analyzed": "ai",
     "AI Analyzed": "ai",
@@ -649,8 +655,10 @@ def main():
             logger.info("DEBUG %s: perf_raw=%r  _perf_f=%s  rating=%s  _rating_f=%s",
                         ticker, perf_raw, entry["_perf_f"], entry.get("rating"), entry["_rating_f"])
 
-    # Step 4: Compute composite scores with penalties
+    # Step 4: Compute composite scores with collar multipliers and penalties
     collar_disqualified = []
+    # Columns where a 🔴 marker zeroes the composite score
+    RED_ZERO_COLS = ("short_outlook", "key_risks", "event_impact", "rev_consistency_score")
     for entry in ai_entries:
         raw = compute_composite_score(entry)
 
@@ -659,14 +667,19 @@ def main():
                 (entry["_ticker"], entry.get("_perf_f"))
             )
 
-        # Penalty from short_outlook emoji
+        # 🔴 on any of these columns → multiply by 0
+        for col in RED_ZERO_COLS:
+            val = str(entry.get(col, "")).strip()
+            if "🔴" in val:
+                raw *= 0
+                break
+
+        # 🟡 on short_outlook → ×0.50
         outlook = str(entry.get("short_outlook", "")).strip()
-        if outlook.startswith("🔴"):
-            raw *= 0.25
-        elif outlook.startswith("🟡"):
+        if outlook.startswith("🟡"):
             raw *= 0.50
 
-        # Penalty from 🟡 flags
+        # Penalty from 🟡 flags on any column
         if entry.get("_yellow_flags"):
             raw *= 0.50
 


### PR DESCRIPTION
## Summary

- **composite_score** is now `r40 × collar_multipliers` instead of a percentile-weighted sum of 4 factors
- **r40_score column** stores plain numeric value (e.g. `167`) instead of formatted string (`💎💎💎 R40: 167 | FCF -3% | ✅`)
- **Rating collar**: 1.0–1.2 → ×1.0, 1.21–1.6 → linear taper to ×0.01, >1.6 → ×0.01 (disqualify)
- **Momentum collar** (perf_52w_vs_spy): < -0.5 → ×0 (falling knife), -0.5–0.4 → linear ×0→×1.0, > 0.4 → ×1.0 (capped)
- **🔴 disqualifiers**: short_outlook, key_risks, event_impact, rev_consistency_score → ×0
- Preserves existing sheet values for price/perf/rating when TradingView doesn't return data
- Removes `scipy` dependency (no longer using percentileofscore)

## Test plan

- [ ] Merge and run `python eodhd_updater.py --force` to backfill numeric r40_score values
- [ ] Run `python score_ai_analysis.py` and verify composite scores reflect r40 × collars
- [ ] Verify falling knives (perf < -0.5) get score 0 (e.g. TLPPF)
- [ ] Verify 🔴 flagged tickers get score 0
- [ ] Verify rating > 1.6 tickers get near-zero scores

https://claude.ai/code/session_01TbsGjHmjJvfzBCc8RvcCBJ