### PR TITLE
Remove yellow flag penalties from composite_score

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ LAST ANALYSIS: ai, data
 **Collars (multipliers on r40):**
 - **Rating:** 1.0–1.2 → ×1.0, 1.21–1.6 → linear taper ×1.0→×0.01, >1.6 → ×0.01 (disqualify)
 - **Momentum (perf_52w_vs_spy):** < -0.5 → ×0 (falling knife), -0.5–0.4 → linear ×0→×1.0, > 0.4 → ×1.0 (capped)
-**Penalties:** 🔴 on short_outlook/key_risks/event_impact/rev_consistency_score → ×0, 🟡 outlook ×0.50, 🟡 flags on any column ×0.50
+**Penalties:** 🔴 on short_outlook/key_risks/event_impact/rev_consistency_score → ×0
 
 ## Key Constants
 

--- a/score_ai_analysis.py
+++ b/score_ai_analysis.py
@@ -674,15 +674,6 @@ def main():
                 raw *= 0
                 break
 
-        # 🟡 on short_outlook → ×0.50
-        outlook = str(entry.get("short_outlook", "")).strip()
-        if outlook.startswith("🟡"):
-            raw *= 0.50
-
-        # Penalty from 🟡 flags on any column
-        if entry.get("_yellow_flags"):
-            raw *= 0.50
-
         entry["_composite_score"] = raw
         entry["composite_score"] = raw
         entry["scoring"] = date.today().isoformat()


### PR DESCRIPTION
Drop 🟡 outlook ×0.50 and 🟡 any-column ×0.50 penalties. Only 🔴 disqualifiers remain as post-collar multipliers.

https://claude.ai/code/session_01TbsGjHmjJvfzBCc8RvcCBJ