### PR TITLE
Refactor composite_score: r40 × collar multipliers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,12 +87,11 @@ LAST ANALYSIS: ai, data
 ```
 
 **Status (auto-assigned):**
-- 🟢 Eligible — has dates in both `ai` and `data` columns, no 🔴 flags
+- 🟢 Eligible — has dates in both `ai` and `data` columns
 - 🏷️ Discount — P/S >20% below 12-month median
-- 📌 Manual — manual-only ticker (not in TradingView screen), no flags
-- 📌❌ Manual Excluded — manual ticker with 🔴 flags
+- 📌 Manual — manual-only ticker (not in TradingView screen)
 - 🆕 New — missing `ai` or `data` date
-- ❌ Excluded — 🔴 marker on any column; sorted to bottom with note of flagged columns
+- ❌ Unprofitable Health Tech — Health Technology sector with negative net margin (only hard exclusion)
 
 **Composite score:** `r40 × collar_multipliers`
 **Collars (multipliers on r40):**

--- a/score_ai_analysis.py
+++ b/score_ai_analysis.py
@@ -235,20 +235,6 @@ def load_ai_analysis(service, logger) -> tuple[list[dict], dict[str, int]]:
         for key, idx in col_map.items():
             entry[key] = padded[idx].strip() if idx < len(padded) else ""
 
-        # Detect red/yellow flags (🔴/🟡 markers on any column)
-        red_flags = []
-        yellow_flags = []
-        for col_name, col_idx in col_map.items():
-            if col_name in ("ticker", "status", "composite_score"):
-                continue
-            cell_val = padded[col_idx].strip() if col_idx < len(padded) else ""
-            if "🔴" in cell_val:
-                red_flags.append(col_name)
-            if "🟡" in cell_val:
-                yellow_flags.append(col_name)
-        entry["_red_flags"] = red_flags
-        entry["_yellow_flags"] = yellow_flags
-
         data.append(entry)
 
     logger.info("Loaded %d tickers from AI Analysis", len(data))
@@ -391,19 +377,13 @@ def _status_base(status_str):
 def compute_status(entry, ps_data, screened_tickers, manual_tickers):
     """Determine status for a single ticker."""
     ticker = entry["_ticker"]
-    red_flags = entry.get("_red_flags", [])
     has_ai = bool(entry.get("ai", "").strip())
     has_eodhd = bool(entry.get("data", "").strip())
     is_manual = ticker in manual_tickers
     is_screened = ticker in screened_tickers
     is_manual_only = is_manual and not is_screened
 
-    if red_flags:
-        flag_names = ", ".join(red_flags[:3])
-        if is_manual_only:
-            return f"📌❌ {flag_names}"
-        return f"❌ {flag_names}"
-
+    # Only hard exclusion: unprofitable Health Technology
     sector = entry.get("sector", "")
     net_margin = _safe_float(entry.get("net_margin%", ""))
     if sector == "Health Technology" and net_margin is not None and net_margin < 0:


### PR DESCRIPTION
## Summary

- **composite_score** is now `r40 × collar_multipliers` instead of a percentile-weighted sum
- **r40_score column** stores plain numeric value (e.g. `167`) instead of formatted string
- **Rating collar**: 1.0–1.2 → ×1.0, 1.21–1.6 → linear taper to ×0.01, >1.6 → ×0.01
- **Momentum collar** (perf_52w_vs_spy): < -0.5 → ×0 (falling knife), -0.5–0.4 → linear ×0→×1.0, > 0.4 → ×1.0
- **🔴 disqualifiers**: short_outlook, key_risks, event_impact, rev_consistency_score → ×0
- **❌ status** now only for unprofitable Health Tech (all other exclusions via composite_score)
- Preserves existing sheet values when TradingView doesn't return data
- Removes `scipy` dependency

## Test plan

- [ ] Run `python eodhd_updater.py --force` to backfill numeric r40_score values
- [ ] Run `python score_ai_analysis.py` and verify composite scores reflect r40 × collars
- [ ] Verify falling knives (perf < -0.5) get score 0
- [ ] Verify 🔴 flagged tickers get score 0
- [ ] Verify rating > 1.6 tickers get near-zero scores

https://claude.ai/code/session_01TbsGjHmjJvfzBCc8RvcCBJ