### PR TITLE
Use Google Finance search for exchanges with non-standard tickers

### DIFF
--- a/nightly_screen.py
+++ b/nightly_screen.py
@@ -60,8 +60,6 @@ TV_TO_GF_EXCHANGE = {
     "TSXV": "CVE",
     "LSE": "LON",
     "LON": "LON",
-    "LSX": "LON",
-    "LSIN": "LON",
     "ASX": "ASX",
     "NSE": "NSE",
     "BSE": "BOM",
@@ -85,14 +83,11 @@ TV_TO_GF_EXCHANGE = {
     "OMXVSE": "VSE",
     "OMXRSE": "RSE",
     "XETR": "ETR",
-    "GETTEX": "ETR",
-    "DUS": "ETR",
     "FWB": "FRA",
     "SWX": "SWX",
     "SIX": "SWX",
     "VIE": "VIE",
     "EURONEXT": "EPA",
-    "EUROTLX": "BIT",
     "MIL": "BIT",
     "BME": "BME",
     "ATHEX": "ATH",
@@ -109,11 +104,25 @@ TV_TO_GF_EXCHANGE = {
     "PSE": "PSE",
 }
 
+# Exchanges where ticker symbols differ from the main exchange listing.
+# These use a Google Finance search URL instead of a direct quote link.
+SEARCH_FALLBACK_EXCHANGES = {
+    "GETTEX", "DUS", "LSX", "LSIN", "EUROTLX",
+}
 
-def ticker_hyperlink(ticker: str, exchange: str) -> str:
-    """Build a Google Sheets HYPERLINK formula pointing to Google Finance."""
-    gf_exchange = TV_TO_GF_EXCHANGE.get(exchange, exchange)
-    url = f"https://www.google.com/finance/quote/{ticker}:{gf_exchange}"
+
+def ticker_hyperlink(ticker: str, exchange: str, company_name: str = "") -> str:
+    """Build a Google Sheets HYPERLINK formula pointing to Google Finance.
+
+    For exchanges with non-standard ticker symbols (GETTEX, LSX, LSIN, etc.),
+    falls back to a Google Finance search using the company name.
+    """
+    if exchange in SEARCH_FALLBACK_EXCHANGES:
+        query = company_name or ticker
+        url = f"https://www.google.com/finance?q={query}"
+    else:
+        gf_exchange = TV_TO_GF_EXCHANGE.get(exchange, exchange)
+        url = f"https://www.google.com/finance/quote/{ticker}:{gf_exchange}"
     return f'=HYPERLINK("{url}", "{ticker}")'
 
 
@@ -331,7 +340,8 @@ def add_new_tickers(service, new_tickers: list[dict], col_map: dict, logger):
         row = [""] * max_col
         if "ticker" in col_map:
             row[col_map["ticker"]] = ticker_hyperlink(
-                eq["ticker"], eq.get("exchange", "")
+                eq["ticker"], eq.get("exchange", ""),
+                eq.get("company_name", ""),
             )
         if "exchange" in col_map:
             row[col_map["exchange"]] = eq.get("exchange", "")

--- a/score_ai_analysis.py
+++ b/score_ai_analysis.py
@@ -507,13 +507,14 @@ def write_sorted_sheet(service, entries: list[dict], col_map: dict, raw_rows: li
         else:
             row_data = [""] * max_col
 
-        # Repair ticker cell: ensure it has a HYPERLINK formula
+        # Repair/regenerate ticker HYPERLINK formula
         ticker_idx = col_map.get("ticker")
         if ticker_idx is not None:
-            ticker_val = row_data[ticker_idx] if ticker_idx < len(row_data) else ""
-            if not str(ticker_val).startswith("=HYPERLINK"):
-                exchange = entry.get("exchange", "")
-                row_data[ticker_idx] = ticker_hyperlink(entry["_ticker"], exchange)
+            row_data[ticker_idx] = ticker_hyperlink(
+                entry["_ticker"],
+                entry.get("exchange", ""),
+                entry.get("company_name", ""),
+            )
 
         # Update screening columns
         for col_name in SCREENING_COLS:


### PR DESCRIPTION
GETTEX, DUS, LSX, LSIN, EUROTLX use different ticker symbols than the main exchanges, so direct quote URLs 404. These now fall back to a Google Finance search URL using the company name.

Also always regenerate hyperlinks on sort (not just for plain text) to fix existing bad links.

https://claude.ai/code/session_01TbsGjHmjJvfzBCc8RvcCBJ