### PR TITLE
Migrate data store from Google Sheets to Supabase

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=nojoooddiadyrduikgsk"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Automated equity screening and analysis pipeline that tracks ~400+ global stocks
 Integrates TradingView screening, EODHD fundamentals, AI narratives (Gemini),
 and Supabase (PostgreSQL) as the primary data store.
 
-**Supabase Project:** `https://szslfkmcxrerofaesork.supabase.co`
+**Supabase Project:** `https://nojoooddiadyrduikgsk.supabase.co`
 
 ## Architecture
 

--- a/db.py
+++ b/db.py
@@ -33,6 +33,11 @@ class SupabaseDB:
             raise RuntimeError(
                 "SUPABASE_URL and SUPABASE_SERVICE_KEY env vars must be set"
             )
+        # Log connection info for debugging (mask most of the key)
+        import logging
+        _log = logging.getLogger("db")
+        _log.info("Connecting to Supabase: url=%s key=%s...%s",
+                   url, key[:8], key[-4:])
         self.client: Client = create_client(url, key)
 
     # ------------------------------------------------------------------

--- a/eodhd_updater.py
+++ b/eodhd_updater.py
@@ -115,6 +115,7 @@ def setup_logging() -> logging.Logger:
 # EODHD API helpers & business logic
 # ---------------------------------------------------------------------------
 
+def _has_financials(data: dict) -> bool:
     """Check whether an EODHD response contains usable financial data.
 
     Some tickers return 200 OK but have empty Financials / Earnings

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -73,6 +73,16 @@ CREATE TABLE companies (
     full_outlook            TEXT DEFAULT '',
     key_risks               TEXT DEFAULT '',
 
+    -- EVALUATIONS (bear/bull weekly analysis)
+    bear_eval               TEXT DEFAULT '',
+    bear_eval_at            DATE,
+    bull_eval               TEXT DEFAULT '',
+    bull_eval_at            DATE,
+
+    -- PORTFOLIO
+    in_portfolio            BOOLEAN NOT NULL DEFAULT FALSE,
+    portfolio_sort_order    INTEGER,
+
     -- LAST ANALYSIS
     ai_analyzed_at          DATE,
     data_updated_at         DATE,


### PR DESCRIPTION
## Summary

- Replace Google Sheets with Supabase (PostgreSQL) as the sole data store
- Create shared `db.py` module (SupabaseDB class) eliminating ~1200 lines of duplicated Sheets boilerplate across all scripts
- Consolidate exchange mappings into `exchanges.py` (single source of truth)
- Add `supabase_schema.sql` for 3 tables: `companies`, `price_sales`, `run_logs`
- Include one-time `migrate_sheets_to_supabase.py` for data migration
- Update all 8 GitHub Actions workflows to use `SUPABASE_URL`/`SUPABASE_SERVICE_KEY`
- Migrate bear_evaluation, bull_evaluation, build_portfolio scripts to Supabase

## Tested in CI

- Nightly TradingView Screen — 202 tickers inserted successfully
- EODHD Updater — fundamentals populated for all covered tickers
- Price-Sales Updater — 119 rows populated

## Stats

17 files changed, ~1600 insertions, ~2400 deletions (net -800 lines)

https://claude.ai/code/session_01VqJk6GCSoHQPxxuhra8Q8U