### PR TITLE
Update Supabase project URL in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Automated equity screening and analysis pipeline that tracks ~400+ global stocks
 Integrates TradingView screening, EODHD fundamentals, AI narratives (Gemini),
 and Supabase (PostgreSQL) as the primary data store.
 
-**Supabase Project:** `https://szslfkmcxrerofaesork.supabase.co`
+**Supabase Project:** `https://nojoooddiadyrduikgsk.supabase.co`
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
Updated the Supabase project URL reference in the project documentation to point to the new project instance.

## Changes
- Updated `CLAUDE.md` with the new Supabase project URL (`https://nojoooddiadyrduikgsk.supabase.co`)

## Details
This change updates the documentation to reflect the current Supabase PostgreSQL backend instance being used by the equity screening and analysis pipeline. The new URL should be used for any direct project access or configuration references.

https://claude.ai/code/session_014idWA7z76husd8jwsF9RaN