### PR TITLE
Phase 2a: Agent data layer (REST + MCP) and Status column fix

### DIFF
--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -80,6 +80,7 @@ export default async function CompanyPage({
               </h1>
               <span
                 className="text-xs px-2 py-0.5 rounded font-mono"
+                title={status.detail ?? status.label}
                 style={{
                   color: status.color,
                   backgroundColor: status.color + "15",
@@ -88,6 +89,11 @@ export default async function CompanyPage({
                 {status.label}
               </span>
             </div>
+            {status.detail && (
+              <p className="text-xs font-mono mt-1" style={{ color: status.color }}>
+                {status.detail}
+              </p>
+            )}
             <p className="text-text-dim text-sm">
               {company.company_name} &middot; {company.exchange} &middot;{" "}
               {company.country}

--- a/web/components/data-table.tsx
+++ b/web/components/data-table.tsx
@@ -144,7 +144,10 @@ export default function DataTable({ companies }: { companies: Company[] }) {
                   <td className="px-3 py-2 text-text-muted text-right whitespace-nowrap">
                     {c.sort_order ?? "--"}
                   </td>
-                  <td className="px-3 py-2 whitespace-nowrap">
+                  <td
+                    className="px-3 py-2 whitespace-nowrap overflow-hidden"
+                    title={st.detail ?? st.label}
+                  >
                     <span
                       className="text-xs px-1.5 py-0.5 rounded"
                       style={{

--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -35,15 +35,29 @@ export function formatPrice(val: number | null | undefined): string {
 export function parseStatus(status: string): {
   label: string;
   color: string;
+  detail: string | null;
 } {
-  if (status.includes("Eligible"))
-    return { label: "Eligible", color: COLORS.green };
-  if (status.includes("Discount"))
-    return { label: "Discount", color: COLORS.orange };
-  if (status.includes("New")) return { label: "New", color: COLORS.yellow };
-  if (status.includes("Excluded"))
-    return { label: "Excluded", color: COLORS.red };
-  return { label: status || "--", color: COLORS.textDim };
+  // Statuses are written by score_ai_analysis.py as emoji-prefixed strings:
+  //   "🟢 Eligible"
+  //   "🆕 New"
+  //   "🏷️ -25% vs. 52w p/s"           (Discount)
+  //   "❌ net_margin, fcf_margin"     (Excluded — joined red-flag names)
+  //   "❌ Unprofitable Health Tech"   (Excluded — sector rule)
+  // Match on the emoji prefix first, since the English words don't always appear.
+  const s = status ?? "";
+  // Strip any leading emoji(s) — including variation selectors like 🏷️ — to
+  // surface the human-readable detail (e.g. "net_margin, fcf_margin").
+  const trimmed = s.replace(/^(?:\p{Extended_Pictographic}\uFE0F?\s*)+/u, "").trim();
+
+  if (s.startsWith("❌"))
+    return { label: "Excluded", color: COLORS.red, detail: trimmed || null };
+  if (s.startsWith("🏷️") || s.includes("Discount"))
+    return { label: "Discount", color: COLORS.orange, detail: trimmed || null };
+  if (s.startsWith("🆕") || s.includes("New"))
+    return { label: "New", color: COLORS.yellow, detail: null };
+  if (s.startsWith("🟢") || s.includes("Eligible"))
+    return { label: "Eligible", color: COLORS.green, detail: null };
+  return { label: s || "--", color: COLORS.textDim, detail: null };
 }
 
 export function parseEval(val: string | null): {


### PR DESCRIPTION
## Summary

First slice of the public agent arena: read-only data layer that any MCP-compatible agent (Claude Code, Claude Desktop, Cursor, Cline, OpenAI Agents SDK) can plug into without signup. Plus a Status-column rendering fix spotted in the wild.

### Agent data layer (`b59e04d`)

- **REST API** at `/api/v1/equities` (list with `status`/`sector`/`country`/`limit`/`offset` filters) and `/api/v1/equities/{ticker}` (full detail + P/S history)
- **OpenAPI 3.1 spec** at `/api/v1/openapi.json` for machine discovery
- **MCP Streamable HTTP server** at `/mcp` exposing `list_equities`, `get_equity`, `search_equities` tools — uses `WebStandardStreamableHTTPServerTransport` from `@modelcontextprotocol/sdk` v1.29, runs stateless so each Vercel invocation is independent
- **`/docs` page** with copy-paste MCP install snippet, curl examples, and tool reference
- **`proxy.ts`** lets `/api/v1`, `/mcp`, `/docs` bypass the site password — these surfaces are intentionally public

Tool handlers and REST routes share `web/lib/equities-query.ts` so both surfaces return identical shapes and respect the same limits. Smoke-tested locally: MCP `initialize` and `tools/list` return correct JSON-RPC, REST routes serve the OpenAPI spec and proper JSON error shapes.

### Status badge fix (`fcdf716`)

`parseStatus` only matched the literal English words `Eligible`/`Discount`/`New`/`Excluded`, but `score_ai_analysis.py` writes statuses with emoji prefixes (`🏷️ -25% vs. 52w p/s`, `❌ net_margin, fcf_margin`, `❌ Unprofitable Health Tech`). The Discount and Excluded forms fell through to the default branch and rendered the entire raw string as the badge, which then visually overflowed the 90px Status column into the Ticker column.

- Match on emoji prefix (❌, 🏷️, 🆕, 🟢) instead of English keywords
- Return a separate `detail` field carrying the rich text for tooltips
- Added `overflow-hidden` + `title` on the Status `<td>` defensively
- Surface the detail line on the company detail page in the status colour

Verified the `\p{Extended_Pictographic}\uFE0F?` regex against all 5 real status forms in Node before committing — handles both variation selectors (`🏷` + `U+FE0F`) and supplementary-plane emoji (`🆕` = `U+1F195`).

## Test plan

- [ ] Vercel preview build succeeds
- [ ] `curl https://<preview>/api/v1/equities?limit=5` returns 5 rows
- [ ] `curl https://<preview>/api/v1/equities/BCRX` returns full detail + P/S history
- [ ] `curl https://<preview>/api/v1/openapi.json` validates at editor.swagger.io
- [ ] `/docs` renders without auth, MCP install snippet has working copy button
- [ ] Add `{"alphamolt": {"url": "https://<preview>/mcp"}}` to local `~/.claude.json`, restart Claude Code, verify the three tools appear and `list_equities` returns real data
- [ ] Screener row 142+ (Madrigal, AnaptysBio etc.) now shows a clean "Excluded" badge with hover tooltip — no overflow into Ticker column
- [ ] Discount rows now show "Discount" badge instead of raw "🏷️ -X% vs. 52w p/s"
- [ ] Company detail page shows the detail line under the badge for excluded/discount rows

## Out of scope (future slices)

Phase 2b adds agent registration + evaluation submission. Phase 2c adds forward-return tracking + leaderboard. Phase 2d seeds 4-5 house agents. Phase 2e adds the Live Molt Feed + landing page rework. Read-only data ships first so agents can build against a stable surface.