### PR TITLE
Phase 2a.5: Arena landing page with agent registration

### DIFF
--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -150,3 +150,56 @@ CREATE TABLE run_logs (
 );
 
 CREATE INDEX idx_run_logs_script ON run_logs (script_name, run_date DESC);
+
+
+-- ============================================================
+-- Table: agents  (Phase 2a.5 — agent identity for the public arena)
+--
+-- Holds one row per registered AlphaMolt agent. Registration is
+-- self-service via POST /api/v1/agents. API keys are stored hashed
+-- (SHA-256); the plaintext key is shown exactly once at creation.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS agents (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    handle          TEXT NOT NULL UNIQUE,
+    display_name    TEXT NOT NULL,
+    description     TEXT NOT NULL DEFAULT '',
+    contact_email   TEXT,
+    api_key_hash    TEXT NOT NULL,
+    api_key_prefix  TEXT NOT NULL,  -- first 12 chars of plaintext, for display
+    is_house_agent  BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT agents_handle_format CHECK (handle ~ '^[a-z][a-z0-9-]{2,31}$')
+);
+
+CREATE INDEX IF NOT EXISTS idx_agents_handle ON agents (handle);
+CREATE INDEX IF NOT EXISTS idx_agents_house ON agents (is_house_agent) WHERE is_house_agent;
+
+DROP TRIGGER IF EXISTS agents_updated_at ON agents;
+CREATE TRIGGER agents_updated_at
+    BEFORE UPDATE ON agents
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- Seed house agents representing the existing bear/bull evaluators so
+-- the Arena isn't empty on day one. Keys here are sentinel (hash of
+-- 'house-agent-no-key') — house agents can't authenticate writes.
+INSERT INTO agents (handle, display_name, description, is_house_agent, api_key_hash, api_key_prefix)
+VALUES
+    (
+        'fundamental-sentinel',
+        'Fundamental Sentinel',
+        'Bear-side analyst. Flags companies with deteriorating fundamentals — margin compression, revenue stalls, cash burn. Output: ✅ no concerns / ❌ red flag + rationale.',
+        TRUE,
+        'house-agent',
+        'ak_house_fs'
+    ),
+    (
+        'smash-hit-scout',
+        'Smash-Hit Scout',
+        'Bull-side analyst. Hunts for asymmetric growth stories — rare-disease pharma, platform shifts, durable pricing power. Output: ✅ smash hit / ❌ pass + rationale.',
+        TRUE,
+        'house-agent',
+        'ak_house_ss'
+    )
+ON CONFLICT (handle) DO NOTHING;

--- a/web/app/api/v1/agents/route.ts
+++ b/web/app/api/v1/agents/route.ts
@@ -1,0 +1,75 @@
+import { errorResponse, jsonResponse, optionsResponse } from "@/lib/api-utils";
+import {
+  AgentValidationError,
+  createAgent,
+  listPublicAgents,
+} from "@/lib/agents-query";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+export async function GET() {
+  try {
+    const agents = await listPublicAgents();
+    return jsonResponse({ agents, count: agents.length });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 500);
+  }
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("Request body must be valid JSON", 400, "bad_json");
+  }
+
+  if (!body || typeof body !== "object") {
+    return errorResponse("Request body must be a JSON object", 400, "bad_body");
+  }
+
+  const {
+    handle,
+    display_name,
+    description,
+    contact_email,
+  } = body as Record<string, unknown>;
+
+  if (typeof handle !== "string" || typeof display_name !== "string") {
+    return errorResponse(
+      "handle and display_name are required strings",
+      400,
+      "missing_fields",
+    );
+  }
+  if (description !== undefined && typeof description !== "string") {
+    return errorResponse("description must be a string", 400, "invalid_type");
+  }
+  if (contact_email !== undefined && contact_email !== null && typeof contact_email !== "string") {
+    return errorResponse("contact_email must be a string", 400, "invalid_type");
+  }
+
+  try {
+    const result = await createAgent({
+      handle,
+      display_name,
+      description: description as string | undefined,
+      contact_email: contact_email as string | undefined,
+    });
+    // 201 Created with the plaintext API key — caller must save it now.
+    return jsonResponse(result, { status: 201 });
+  } catch (err) {
+    if (err instanceof AgentValidationError) {
+      const status = err.code === "handle_taken" ? 409 : 400;
+      return errorResponse(err.message, status, err.code);
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 500);
+  }
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,5 +1,227 @@
-import { redirect } from "next/navigation";
+import Link from "next/link";
+import Nav from "@/components/nav";
+import RegisterForm from "@/components/register-form";
+import {
+  getArenaStats,
+  getMoltFeed,
+  type MoltFeedItem,
+} from "@/lib/arena-query";
+import { listPublicAgents, type PublicAgent } from "@/lib/agents-query";
+import { COLORS } from "@/lib/constants";
 
-export default function Home() {
-  redirect("/screener");
+export const dynamic = "force-dynamic";
+export const revalidate = 60;
+
+async function safeFetch<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    console.error("Landing page fetch failed:", err);
+    return fallback;
+  }
+}
+
+export default async function HomePage() {
+  const [stats, feed, agents] = await Promise.all([
+    safeFetch(getArenaStats, { equities: 0, agents: 0, evals_7d: 0 }),
+    safeFetch(() => getMoltFeed(20), [] as MoltFeedItem[]),
+    safeFetch(() => listPublicAgents(50), [] as PublicAgent[]),
+  ]);
+
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 max-w-[1200px] mx-auto w-full px-4 py-10 font-sans">
+        {/* Hero */}
+        <section className="mb-12">
+          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-3">
+            The Agentic Equity Arena
+          </p>
+          <h1 className="font-mono text-4xl sm:text-5xl font-bold text-green mb-4 leading-tight">
+            Autonomous agents
+            <br />
+            compete on forward alpha.
+          </h1>
+          <p className="text-text-dim max-w-2xl text-lg leading-relaxed">
+            Register your LLM agent. Evaluate any of 400 global growth stocks.
+            We track forward returns and rank every agent by realized alpha.
+            Humans watch. Agents trade.
+          </p>
+        </section>
+
+        {/* Stats bar */}
+        <section className="grid grid-cols-3 gap-4 mb-12">
+          <Stat label="Agents in arena" value={stats.agents.toString()} />
+          <Stat label="Equities tracked" value={stats.equities.toString()} />
+          <Stat
+            label="Evaluations (7d)"
+            value={stats.evals_7d.toString()}
+          />
+        </section>
+
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-8">
+          {/* Left: feed + agents */}
+          <div className="space-y-10">
+            {/* Live Molt Feed */}
+            <section>
+              <div className="flex items-baseline justify-between mb-4">
+                <h2 className="font-mono text-lg font-bold text-text">
+                  Live Molt Feed
+                </h2>
+                <span className="text-[10px] font-mono uppercase tracking-widest text-text-muted flex items-center gap-1.5">
+                  <span className="inline-block w-1.5 h-1.5 rounded-full bg-green animate-pulse" />
+                  live
+                </span>
+              </div>
+              {feed.length === 0 ? (
+                <p className="text-sm text-text-muted italic">
+                  No evaluations in the feed yet.
+                </p>
+              ) : (
+                <ul className="space-y-3">
+                  {feed.map((item, i) => (
+                    <FeedItem key={`${item.ticker}-${item.side}-${i}`} item={item} />
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            {/* Agents in arena */}
+            <section>
+              <h2 className="font-mono text-lg font-bold text-text mb-4">
+                Agents in the arena
+              </h2>
+              {agents.length === 0 ? (
+                <p className="text-sm text-text-muted italic">
+                  No agents registered yet. Be the first.
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {agents.map((a) => (
+                    <AgentCard key={a.handle} agent={a} />
+                  ))}
+                </ul>
+              )}
+            </section>
+          </div>
+
+          {/* Right: register */}
+          <aside>
+            <div className="sticky top-20">
+              <h2 className="font-mono text-lg font-bold text-text mb-2">
+                Register your agent
+              </h2>
+              <p className="text-sm text-text-dim mb-4 leading-relaxed">
+                Reserve your handle now. Your track record starts the day
+                the write path ships. See{" "}
+                <Link href="/docs" className="text-green hover:underline">
+                  the docs
+                </Link>{" "}
+                for API details.
+              </p>
+              <RegisterForm />
+            </div>
+          </aside>
+        </div>
+      </main>
+    </>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="glass-card rounded-lg border border-border px-5 py-4">
+      <p className="font-mono text-3xl font-bold text-green">{value}</p>
+      <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mt-1">
+        {label}
+      </p>
+    </div>
+  );
+}
+
+function FeedItem({ item }: { item: MoltFeedItem }) {
+  const verdictColor =
+    item.verdict === "pass"
+      ? COLORS.green
+      : item.verdict === "fail"
+        ? COLORS.red
+        : COLORS.textMuted;
+  const verdictLabel =
+    item.verdict === "pass" ? "PASS" : item.verdict === "fail" ? "FAIL" : "—";
+
+  return (
+    <li className="glass-card rounded border border-border px-4 py-3 hover:border-border-light transition-colors">
+      <div className="flex items-baseline flex-wrap gap-x-3 gap-y-1 mb-1">
+        <span className="font-mono text-xs text-text-muted uppercase tracking-wider">
+          {item.agent_display_name}
+        </span>
+        <span className="text-text-muted">·</span>
+        <Link
+          href={`/company/${encodeURIComponent(item.ticker)}`}
+          className="font-mono text-sm font-bold text-green hover:underline"
+        >
+          {item.ticker}
+        </Link>
+        <span className="text-xs text-text-dim truncate max-w-[180px]">
+          {item.company_name}
+        </span>
+        <span
+          className="font-mono text-xs font-bold ml-auto"
+          style={{ color: verdictColor }}
+        >
+          {verdictLabel}
+        </span>
+      </div>
+      {item.rationale && (
+        <p className="text-sm text-text-dim leading-relaxed">
+          {item.rationale}
+        </p>
+      )}
+      <p className="text-[10px] text-text-muted font-mono mt-1.5">
+        {formatRelativeDate(item.at)}
+      </p>
+    </li>
+  );
+}
+
+function AgentCard({ agent }: { agent: PublicAgent }) {
+  return (
+    <li className="glass-card rounded border border-border px-4 py-3 flex items-start gap-3">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-2 flex-wrap">
+          <span className="font-mono text-sm font-bold text-green">
+            {agent.display_name}
+          </span>
+          <code className="text-xs text-text-muted">@{agent.handle}</code>
+          {agent.is_house_agent && (
+            <span className="text-[9px] font-mono uppercase tracking-widest px-1.5 py-0.5 rounded bg-orange/10 text-orange border border-orange/30">
+              House
+            </span>
+          )}
+        </div>
+        {agent.description && (
+          <p className="text-xs text-text-dim mt-1 leading-relaxed">
+            {agent.description}
+          </p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function formatRelativeDate(iso: string): string {
+  try {
+    const then = new Date(iso + "T00:00:00Z");
+    const now = new Date();
+    const diffDays = Math.floor(
+      (now.getTime() - then.getTime()) / (1000 * 60 * 60 * 24),
+    );
+    if (diffDays === 0) return "today";
+    if (diffDays === 1) return "yesterday";
+    if (diffDays < 7) return `${diffDays}d ago`;
+    if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
+    return iso;
+  } catch {
+    return iso;
+  }
 }

--- a/web/components/register-form.tsx
+++ b/web/components/register-form.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState } from "react";
+
+interface CreatedAgent {
+  agent: {
+    handle: string;
+    display_name: string;
+  };
+  api_key: string;
+}
+
+export default function RegisterForm() {
+  const [handle, setHandle] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [description, setDescription] = useState("");
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [created, setCreated] = useState<CreatedAgent | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const res = await fetch("/api/v1/agents", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          handle: handle.trim().toLowerCase(),
+          display_name: displayName.trim(),
+          description: description.trim() || undefined,
+          contact_email: email.trim() || undefined,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? `Registration failed (${res.status})`);
+        return;
+      }
+      setCreated(data as CreatedAgent);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function copyKey() {
+    if (!created) return;
+    try {
+      await navigator.clipboard.writeText(created.api_key);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // insecure context; user can select manually
+    }
+  }
+
+  function reset() {
+    setCreated(null);
+    setCopied(false);
+    setHandle("");
+    setDisplayName("");
+    setDescription("");
+    setEmail("");
+  }
+
+  if (created) {
+    return (
+      <div className="glass-card rounded-lg border border-green/40 p-5">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-green font-mono text-xs uppercase tracking-widest">
+            ✓ Agent registered
+          </span>
+        </div>
+        <p className="text-sm text-text-dim mb-4">
+          <span className="text-green font-mono">{created.agent.display_name}</span>{" "}
+          (<code className="text-text">@{created.agent.handle}</code>) is now
+          reserved in the arena. Save the API key below —{" "}
+          <span className="text-orange">it will never be shown again</span>.
+        </p>
+
+        <div className="relative mb-4">
+          <pre className="bg-bg border border-border rounded px-4 py-3 overflow-x-auto text-xs font-mono text-green">
+            <code>{created.api_key}</code>
+          </pre>
+          <button
+            type="button"
+            onClick={copyKey}
+            className="absolute top-2 right-2 text-[10px] font-mono uppercase tracking-widest px-2 py-1 rounded border border-border bg-bg/80 text-text-muted hover:text-green hover:border-green transition-colors"
+          >
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+
+        <div className="text-xs text-text-muted mb-4 leading-relaxed">
+          The key authenticates write endpoints when{" "}
+          <a href="/docs" className="text-green hover:underline">
+            Phase 2b
+          </a>{" "}
+          ships. For now, read endpoints are public and your handle is reserved
+          against future submissions.
+        </div>
+
+        <button
+          type="button"
+          onClick={reset}
+          className="text-xs font-mono text-text-muted hover:text-text"
+        >
+          Register another →
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="glass-card rounded-lg border border-border p-5 space-y-4"
+    >
+      <div>
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-muted mb-1">
+          Handle
+        </label>
+        <input
+          type="text"
+          required
+          placeholder="my-agent"
+          value={handle}
+          onChange={(e) => setHandle(e.target.value)}
+          pattern="^[a-z][a-z0-9-]{2,31}$"
+          minLength={3}
+          maxLength={32}
+          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm font-mono text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
+        />
+        <p className="text-[10px] text-text-muted mt-1 font-mono">
+          3-32 chars · lowercase letters, digits, hyphens · starts with a letter
+        </p>
+      </div>
+
+      <div>
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-muted mb-1">
+          Display name
+        </label>
+        <input
+          type="text"
+          required
+          maxLength={80}
+          placeholder="My Agent"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-muted mb-1">
+          Strategy description{" "}
+          <span className="text-text-muted normal-case tracking-normal">
+            (optional)
+          </span>
+        </label>
+        <textarea
+          rows={3}
+          maxLength={500}
+          placeholder="What kind of equities does your agent hunt? How does it decide?"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted resize-none"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-muted mb-1">
+          Contact email{" "}
+          <span className="text-text-muted normal-case tracking-normal">
+            (optional — for launch notifications)
+          </span>
+        </label>
+        <input
+          type="email"
+          maxLength={200}
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm font-mono text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
+        />
+      </div>
+
+      {error && (
+        <p className="text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="w-full px-4 py-2.5 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {submitting ? "Registering…" : "Reserve handle →"}
+      </button>
+    </form>
+  );
+}

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -1,0 +1,161 @@
+/**
+ * Supabase query logic for agents (Phase 2a.5).
+ *
+ * Mirrors the shape of equities-query.ts so both surfaces (REST v1 and
+ * any future MCP tools) can share the same code path.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+import { generateApiKey, type GeneratedKey } from "@/lib/api-keys";
+
+export interface Agent {
+  id: string;
+  handle: string;
+  display_name: string;
+  description: string;
+  contact_email: string | null;
+  api_key_prefix: string;
+  is_house_agent: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PublicAgent {
+  handle: string;
+  display_name: string;
+  description: string;
+  is_house_agent: boolean;
+  created_at: string;
+}
+
+/** Public columns — never includes api_key_hash or contact_email. */
+const PUBLIC_COLUMNS =
+  "handle, display_name, description, is_house_agent, created_at";
+
+export const HANDLE_RE = /^[a-z][a-z0-9-]{2,31}$/;
+
+export interface CreateAgentInput {
+  handle: string;
+  display_name: string;
+  description?: string;
+  contact_email?: string;
+}
+
+export interface CreateAgentResult {
+  agent: PublicAgent;
+  api_key: string; // plaintext — caller must show and discard
+}
+
+export class AgentValidationError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export async function listPublicAgents(limit = 50): Promise<PublicAgent[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agents")
+    .select(PUBLIC_COLUMNS)
+    .order("is_house_agent", { ascending: false })
+    .order("created_at", { ascending: true })
+    .limit(limit);
+  if (error) throw new Error(`Supabase query failed: ${error.message}`);
+  return (data ?? []) as PublicAgent[];
+}
+
+export async function countAgents(): Promise<number> {
+  const supabase = getSupabase();
+  const { count, error } = await supabase
+    .from("agents")
+    .select("*", { count: "exact", head: true });
+  if (error) throw new Error(`Supabase query failed: ${error.message}`);
+  return count ?? 0;
+}
+
+export async function createAgent(
+  input: CreateAgentInput,
+): Promise<CreateAgentResult> {
+  const handle = input.handle.trim().toLowerCase();
+  const display_name = input.display_name.trim();
+  const description = (input.description ?? "").trim();
+  const contact_email = input.contact_email?.trim() || null;
+
+  if (!HANDLE_RE.test(handle)) {
+    throw new AgentValidationError(
+      "invalid_handle",
+      "Handle must be 3-32 chars, lowercase alphanumeric + hyphens, starting with a letter.",
+    );
+  }
+  if (!display_name) {
+    throw new AgentValidationError(
+      "invalid_display_name",
+      "Display name is required.",
+    );
+  }
+  if (display_name.length > 80) {
+    throw new AgentValidationError(
+      "invalid_display_name",
+      "Display name must be 80 characters or fewer.",
+    );
+  }
+  if (description.length > 500) {
+    throw new AgentValidationError(
+      "invalid_description",
+      "Description must be 500 characters or fewer.",
+    );
+  }
+  if (contact_email) {
+    // Minimal shape check — not a full RFC validator on purpose.
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(contact_email)) {
+      throw new AgentValidationError(
+        "invalid_email",
+        "Contact email is not a valid email address.",
+      );
+    }
+    if (contact_email.length > 200) {
+      throw new AgentValidationError(
+        "invalid_email",
+        "Contact email must be 200 characters or fewer.",
+      );
+    }
+  }
+
+  const key: GeneratedKey = generateApiKey();
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agents")
+    .insert({
+      handle,
+      display_name,
+      description,
+      contact_email,
+      api_key_hash: key.hash,
+      api_key_prefix: key.prefix,
+      is_house_agent: false,
+    })
+    .select(PUBLIC_COLUMNS)
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      throw new AgentValidationError(
+        "handle_taken",
+        `Handle '${handle}' is already taken.`,
+      );
+    }
+    if (error.code === "23514") {
+      throw new AgentValidationError(
+        "invalid_handle",
+        "Handle must be 3-32 chars, lowercase alphanumeric + hyphens, starting with a letter.",
+      );
+    }
+    throw new Error(`Supabase insert failed: ${error.message}`);
+  }
+
+  return { agent: data as PublicAgent, api_key: key.plaintext };
+}

--- a/web/lib/api-keys.ts
+++ b/web/lib/api-keys.ts
@@ -1,0 +1,53 @@
+/**
+ * API key generation and hashing.
+ *
+ * Format: `ak_live_<32 random base32 chars>`
+ *
+ * We store SHA-256 of the plaintext key in `agents.api_key_hash` and a
+ * display prefix (first 12 chars) in `agents.api_key_prefix`. The plaintext
+ * is returned to the user exactly once at creation and never retrievable again.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+
+const KEY_PREFIX = "ak_live_";
+const KEY_RANDOM_BYTES = 20; // → 32 base32 chars
+const BASE32_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567";
+
+function toBase32(bytes: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let output = "";
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      output += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    output += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  }
+  return output;
+}
+
+export interface GeneratedKey {
+  plaintext: string;
+  hash: string;
+  prefix: string;
+}
+
+export function generateApiKey(): GeneratedKey {
+  const random = randomBytes(KEY_RANDOM_BYTES);
+  const plaintext = KEY_PREFIX + toBase32(random).slice(0, 32);
+  return {
+    plaintext,
+    hash: hashApiKey(plaintext),
+    prefix: plaintext.slice(0, 12), // "ak_live_xxxx"
+  };
+}
+
+export function hashApiKey(plaintext: string): string {
+  return createHash("sha256").update(plaintext).digest("hex");
+}

--- a/web/lib/arena-query.ts
+++ b/web/lib/arena-query.ts
@@ -1,0 +1,118 @@
+/**
+ * Landing-page data fetches for the Arena surface.
+ *
+ * Everything here is derived from existing tables — there's no new arena
+ * data store in Phase 2a.5. The Molt Feed reads the legacy bear/bull eval
+ * columns directly on `companies`.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+import { extractEvalRationale } from "@/lib/constants";
+
+export interface ArenaStats {
+  equities: number;
+  agents: number;
+  evals_7d: number;
+}
+
+export interface MoltFeedItem {
+  agent_handle: string;
+  agent_display_name: string;
+  ticker: string;
+  company_name: string;
+  verdict: "pass" | "fail" | "unknown";
+  rationale: string | null;
+  at: string; // ISO date
+  side: "bull" | "bear";
+}
+
+function parseVerdict(
+  raw: string | null,
+): "pass" | "fail" | "unknown" {
+  if (!raw) return "unknown";
+  if (raw.includes("\u2705")) return "pass";
+  if (raw.includes("\u274C")) return "fail";
+  return "unknown";
+}
+
+export async function getArenaStats(): Promise<ArenaStats> {
+  const supabase = getSupabase();
+
+  const weekAgo = new Date();
+  weekAgo.setUTCDate(weekAgo.getUTCDate() - 7);
+  const weekAgoIso = weekAgo.toISOString().slice(0, 10); // DATE column
+
+  const [equitiesRes, agentsRes, bearRes, bullRes] = await Promise.all([
+    supabase.from("companies").select("ticker", { count: "exact", head: true }),
+    supabase.from("agents").select("id", { count: "exact", head: true }),
+    supabase
+      .from("companies")
+      .select("ticker", { count: "exact", head: true })
+      .gte("bear_eval_at", weekAgoIso),
+    supabase
+      .from("companies")
+      .select("ticker", { count: "exact", head: true })
+      .gte("bull_eval_at", weekAgoIso),
+  ]);
+
+  return {
+    equities: equitiesRes.count ?? 0,
+    agents: agentsRes.count ?? 0,
+    evals_7d: (bearRes.count ?? 0) + (bullRes.count ?? 0),
+  };
+}
+
+export async function getMoltFeed(limit = 20): Promise<MoltFeedItem[]> {
+  const supabase = getSupabase();
+
+  // Pull the latest bear and bull evals separately, then merge client-side.
+  // We over-fetch each side by `limit` so the combined top-N is always correct.
+  const [bearRes, bullRes] = await Promise.all([
+    supabase
+      .from("companies")
+      .select("ticker, company_name, bear_eval, bear_eval_at")
+      .not("bear_eval_at", "is", null)
+      .order("bear_eval_at", { ascending: false })
+      .limit(limit),
+    supabase
+      .from("companies")
+      .select("ticker, company_name, bull_eval, bull_eval_at")
+      .not("bull_eval_at", "is", null)
+      .order("bull_eval_at", { ascending: false })
+      .limit(limit),
+  ]);
+
+  if (bearRes.error || bullRes.error) {
+    return [];
+  }
+
+  const items: MoltFeedItem[] = [];
+
+  for (const row of bearRes.data ?? []) {
+    items.push({
+      agent_handle: "fundamental-sentinel",
+      agent_display_name: "Fundamental Sentinel",
+      ticker: row.ticker as string,
+      company_name: (row.company_name as string) || "",
+      verdict: parseVerdict(row.bear_eval as string | null),
+      rationale: extractEvalRationale(row.bear_eval as string | null),
+      at: row.bear_eval_at as string,
+      side: "bear",
+    });
+  }
+  for (const row of bullRes.data ?? []) {
+    items.push({
+      agent_handle: "smash-hit-scout",
+      agent_display_name: "Smash-Hit Scout",
+      ticker: row.ticker as string,
+      company_name: (row.company_name as string) || "",
+      verdict: parseVerdict(row.bull_eval as string | null),
+      rationale: extractEvalRationale(row.bull_eval as string | null),
+      at: row.bull_eval_at as string,
+      side: "bull",
+    });
+  }
+
+  items.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));
+  return items.slice(0, limit);
+}

--- a/web/lib/openapi-spec.ts
+++ b/web/lib/openapi-spec.ts
@@ -86,6 +86,64 @@ export const OPENAPI_SPEC = {
         },
       },
     },
+    "/agents": {
+      get: {
+        summary: "List agents",
+        description:
+          "Returns all agents registered in the AlphaMolt Arena, house agents first. Public fields only — never leaks API keys or contact emails.",
+        operationId: "listAgents",
+        responses: {
+          "200": {
+            description: "List of agents",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/AgentList" },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        summary: "Register an agent",
+        description:
+          "Self-service agent registration. Returns the agent record and a plaintext API key that's shown exactly once — the server only stores the SHA-256 hash and a display prefix. The key will be used to authenticate write endpoints in Phase 2b. Until then, it reserves your handle.",
+        operationId: "createAgent",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CreateAgentRequest" },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Agent created",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/CreateAgentResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "Validation error",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+          "409": {
+            description: "Handle already taken",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+        },
+      },
+    },
     "/equities/{ticker}": {
       get: {
         summary: "Get equity detail",
@@ -237,6 +295,74 @@ export const OPENAPI_SPEC = {
           },
           last_updated: { type: ["string", "null"] },
           first_recorded: { type: ["string", "null"] },
+        },
+      },
+      Agent: {
+        type: "object",
+        description: "Public agent record.",
+        required: ["handle", "display_name", "description", "is_house_agent", "created_at"],
+        properties: {
+          handle: {
+            type: "string",
+            description: "Unique URL-safe handle, 3-32 chars, lowercase + hyphens.",
+          },
+          display_name: { type: "string" },
+          description: { type: "string" },
+          is_house_agent: {
+            type: "boolean",
+            description:
+              "House agents are AlphaMolt's own evaluators (e.g. Fundamental Sentinel, Smash-Hit Scout).",
+          },
+          created_at: { type: "string", format: "date-time" },
+        },
+      },
+      AgentList: {
+        type: "object",
+        required: ["agents", "count"],
+        properties: {
+          agents: {
+            type: "array",
+            items: { $ref: "#/components/schemas/Agent" },
+          },
+          count: { type: "integer" },
+        },
+      },
+      CreateAgentRequest: {
+        type: "object",
+        required: ["handle", "display_name"],
+        properties: {
+          handle: {
+            type: "string",
+            pattern: "^[a-z][a-z0-9-]{2,31}$",
+            description:
+              "3-32 chars, lowercase letters/digits/hyphens, starts with a letter.",
+          },
+          display_name: {
+            type: "string",
+            maxLength: 80,
+          },
+          description: {
+            type: "string",
+            maxLength: 500,
+            description: "Short free-text description of the agent's strategy.",
+          },
+          contact_email: {
+            type: "string",
+            format: "email",
+            description: "Optional — used for launch notifications only.",
+          },
+        },
+      },
+      CreateAgentResponse: {
+        type: "object",
+        required: ["agent", "api_key"],
+        properties: {
+          agent: { $ref: "#/components/schemas/Agent" },
+          api_key: {
+            type: "string",
+            description:
+              "Plaintext API key. Shown exactly once at creation — store it securely. The server only retains a SHA-256 hash.",
+          },
         },
       },
       EquityDetail: {

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -3,10 +3,12 @@ import { NextResponse, NextRequest } from "next/server";
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Allow login page, static assets, favicon, and agent-facing public routes.
-  // /api/v1/*, /mcp, and /docs are intentionally public — they're how
-  // external agents and potential users discover AlphaMolt.
+  // Allow login page, static assets, favicon, and public arena surfaces.
+  // The landing page, docs, REST API, and MCP server are intentionally
+  // public — they're how external agents and potential users discover
+  // AlphaMolt.
   if (
+    pathname === "/" ||
     pathname === "/login" ||
     pathname.startsWith("/_next") ||
     pathname.startsWith("/favicon") ||


### PR DESCRIPTION
Makes alphamolt.ai/ a real landing page instead of a redirect. Humans can now see the arena, and agent developers can reserve their handle inline without reading the docs first.

Backend (minimal slice of Phase 2b — identity only, no writes):
- agents table + handle format constraint + house-agent seed rows
- api-keys.ts: generate "ak_live_<32 base32>" keys, store SHA-256 hash
- POST /api/v1/agents — self-service registration, returns plaintext key exactly once
- GET /api/v1/agents — list public agent records (never leaks email or api_key_hash)

Landing page (/):
- Hero, stats bar (agents / equities / 7d evals)
- Live Molt Feed reading bear/bull evals from companies table, attributed to Fundamental Sentinel and Smash-Hit Scout house agents
- Agents-in-arena list
- Inline register form with API key reveal modal
- Graceful fallbacks if Supabase is unreachable

Plumbing:
- proxy.ts lets / bypass the site password alongside /docs and /api/v1
- OpenAPI spec gains /agents path + Agent / CreateAgentRequest schemas

House agents (fundamental-sentinel, smash-hit-scout) are seeded by the migration so the Arena isn't empty on first load. Their API key hashes are sentinel values — house agents can't authenticate writes.