### PR TITLE
Screener UX polish + OpenClaw on /docs

### DIFF
--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -15,6 +15,8 @@ const MCP_CONFIG = `{
   }
 }`;
 
+const OPENCLAW_CMD = `openclaw mcp set alphamolt '{"url":"https://alphamolt.ai/mcp"}'`;
+
 const CURL_LIST = `curl https://alphamolt.ai/api/v1/equities?limit=5`;
 const CURL_DETAIL = `curl https://alphamolt.ai/api/v1/equities/BCRX`;
 const CURL_FILTER = `curl "https://alphamolt.ai/api/v1/equities?status=Eligible&limit=20"`;
@@ -67,15 +69,52 @@ export default function DocsPage() {
             </span>
           </div>
           <p className="text-sm text-text-dim mb-4 max-w-2xl">
-            Drop this into your Claude Code, Claude Desktop, Cursor, or Cline
-            config. Restart the client and the <code className="text-green">alphamolt</code> tools
+            Drop this into any MCP client that uses the standard{" "}
+            <code className="text-green">mcpServers</code> format — Claude
+            Code, Claude Desktop, Cursor, Cline, Zed, and others. Restart the
+            client and the <code className="text-green">alphamolt</code> tools
             appear automatically.
           </p>
           <CopyBlock code={MCP_CONFIG} language="json" />
-          <div className="mt-4 p-3 border border-border rounded text-xs font-mono text-text-muted">
-            Claude Code: <code className="text-text-dim">~/.claude.json</code>
-            {" · "}
-            Claude Desktop: <code className="text-text-dim">Settings → Developer → Edit Config</code>
+          <div className="mt-4 p-3 border border-border rounded text-xs font-mono text-text-muted leading-relaxed">
+            <p>
+              Claude Code:{" "}
+              <code className="text-text-dim">~/.claude.json</code>
+            </p>
+            <p>
+              Claude Desktop:{" "}
+              <code className="text-text-dim">
+                Settings → Developer → Edit Config
+              </code>
+            </p>
+            <p>
+              Cursor:{" "}
+              <code className="text-text-dim">
+                Settings → MCP → Add new MCP server
+              </code>
+            </p>
+            <p>
+              Cline:{" "}
+              <code className="text-text-dim">
+                MCP Servers panel → Configure MCP Servers
+              </code>
+            </p>
+            <p>
+              Zed:{" "}
+              <code className="text-text-dim">
+                ~/.config/zed/settings.json
+              </code>
+            </p>
+          </div>
+
+          {/* OpenClaw uses a different config key (mcp.servers, not
+              mcpServers) and the practical install path is a CLI command,
+              so it gets its own snippet. */}
+          <div className="mt-6">
+            <p className="text-xs font-mono text-text-muted mb-2 uppercase tracking-wider">
+              OpenClaw
+            </p>
+            <CopyBlock code={OPENCLAW_CMD} language="bash" />
           </div>
         </section>
 

--- a/web/components/data-table.tsx
+++ b/web/components/data-table.tsx
@@ -136,6 +136,7 @@ export default function DataTable({ companies }: { companies: Company[] }) {
               const st = parseStatus(c.status);
               const bear = parseEval(c.bear_eval);
               const bull = parseEval(c.bull_eval);
+              const bearRationale = extractEvalRationale(c.bear_eval);
               const bullRationale = extractEvalRationale(c.bull_eval);
 
               return (
@@ -220,8 +221,16 @@ export default function DataTable({ companies }: { companies: Company[] }) {
                   <td className="px-3 py-2 text-right text-text-dim whitespace-nowrap">
                     {formatNumber(c.rating, { decimals: 1 })}
                   </td>
-                  <td className="px-3 py-2 text-center whitespace-nowrap">
-                    <span style={{ color: bear.color }}>{bear.label}</span>
+                  <td
+                    className="px-3 py-2 text-center whitespace-nowrap"
+                    title={bearRationale ?? undefined}
+                  >
+                    <span
+                      style={{ color: bear.color }}
+                      className={bearRationale ? "cursor-help" : undefined}
+                    >
+                      {bear.label}
+                    </span>
                   </td>
                   <td
                     className="px-3 py-2 text-center whitespace-nowrap"

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -15,7 +15,7 @@ export default function Nav() {
   return (
     <header className="border-b border-border bg-bg/80 backdrop-blur-md sticky top-0 z-50">
       <div className="max-w-[1600px] mx-auto px-4 h-14 flex items-center justify-between">
-        <Link href="/screener" className="flex items-center gap-3">
+        <Link href="/" className="flex items-center gap-3">
           <span className="font-mono text-lg font-bold tracking-tight text-green">
             ALPHAMOLT
           </span>


### PR DESCRIPTION
## Summary

Five small UX fixes on top of `main` (PR #56). All shippable independently — none touch shared logic.

### Screener tweaks (`70c83c4`)
- **Link moved from Ticker → Company column.** People scan the table by company name; the link should follow the eye.
- **Bull rationale tooltip.** Hovering a PASS/FAIL in the Bull column now reveals the bull-case rationale via a `title` attribute, with `cursor-help` when text exists. Read from the existing `bull_eval` column via `extractEvalRationale`.

### Nav logo (`0129e74`)
- **`ALPHAMOLT` wordmark** in the top-left now routes to `/` instead of `/screener`. Standard convention now that the landing page exists.

### Bear rationale tooltip (`adb104b`)
- Mirror of the bull tooltip. Confirmed from `bear_evaluation.py` lines 94–97 that bear FAIL verdicts always carry rationale text in parentheses (`❌ (reason)`), same shape as bull. PASS verdicts have no text and the tooltip is simply absent.

### Docs: OpenClaw + broader MCP client list (`efcf1a0`)
- Intro on `/docs` broadened from "Claude Code, Claude Desktop, Cursor, or Cline" → "any MCP client that uses the standard `mcpServers` format" with Zed added.
- File-location footer expanded from 2 → 5 clients (Claude Code, Claude Desktop, Cursor, Cline, Zed).
- **OpenClaw** added with its own bash snippet because it uses a different config shape (`mcp.servers` not `mcpServers`) and the practical install is a CLI command:
  ```bash
  openclaw mcp set alphamolt '{"url":"https://alphamolt.ai/mcp"}'
  ```
- Inline comment in the JSX documents *why* OpenClaw is treated separately.

## Test plan

- [ ] Vercel preview build succeeds
- [ ] On `/screener`: clicking a row's **company name** navigates to `/company/<ticker>` (clicking the bare ticker does not)
- [ ] On `/screener`: hover a PASS or FAIL in the **Bull** column on a row with a rationale → tooltip shows the rationale text; cursor turns to help
- [ ] On `/screener`: same behavior for the **Bear** column
- [ ] On `/screener`: rows where the bull or bear is plain `✅` (no rationale) get no tooltip and no help cursor
- [ ] Click `ALPHAMOLT` wordmark anywhere in the app → lands on `/` not `/screener`
- [ ] On `/docs`: see Zed in the file-location footer; see the OpenClaw bash snippet under the JSON snippet, with working copy button

## Out of scope

Phase 2c (write path for evaluations) and Phase 2c-lite (forward-alpha leaderboard) are still pending. This PR is purely UX polish on the existing surfaces.