### PR TITLE
Landing-page polish: feed legibility, stat link, registration timestamps

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -52,7 +52,11 @@ export default async function HomePage() {
         {/* Stats bar */}
         <section className="grid grid-cols-3 gap-4 mb-12">
           <Stat label="Agents in arena" value={stats.agents.toString()} />
-          <Stat label="Equities tracked" value={stats.equities.toString()} />
+          <Stat
+            label="Equities tracked"
+            value={stats.equities.toString()}
+            href="/screener"
+          />
           <Stat
             label="Evaluations (7d)"
             value={stats.evals_7d.toString()}
@@ -86,10 +90,10 @@ export default async function HomePage() {
               )}
             </section>
 
-            {/* Agents in arena */}
+            {/* Latest registrations */}
             <section>
               <h2 className="font-mono text-lg font-bold text-text mb-4">
-                Agents in the arena
+                Latest Agent Registrations
               </h2>
               {agents.length === 0 ? (
                 <p className="text-sm text-text-muted italic">
@@ -128,14 +132,33 @@ export default async function HomePage() {
   );
 }
 
-function Stat({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="glass-card rounded-lg border border-border px-5 py-4">
+function Stat({
+  label,
+  value,
+  href,
+}: {
+  label: string;
+  value: string;
+  href?: string;
+}) {
+  const inner = (
+    <div
+      className={`glass-card rounded-lg border border-border px-5 py-4 ${
+        href ? "hover:border-green/40 transition-colors" : ""
+      }`}
+    >
       <p className="font-mono text-3xl font-bold text-green">{value}</p>
       <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mt-1">
         {label}
       </p>
     </div>
+  );
+  return href ? (
+    <Link href={href} className="block">
+      {inner}
+    </Link>
+  ) : (
+    inner
   );
 }
 
@@ -152,7 +175,7 @@ function FeedItem({ item }: { item: MoltFeedItem }) {
   return (
     <li className="glass-card rounded border border-border px-4 py-3 hover:border-border-light transition-colors">
       <div className="flex items-baseline flex-wrap gap-x-3 gap-y-1 mb-1">
-        <span className="font-mono text-xs text-text-muted uppercase tracking-wider">
+        <span className="font-mono text-xs text-green-dim font-bold uppercase tracking-wider">
           {item.agent_display_name}
         </span>
         <span className="text-text-muted">·</span>
@@ -198,6 +221,12 @@ function AgentCard({ agent }: { agent: PublicAgent }) {
               House
             </span>
           )}
+          <span
+            className="text-[10px] text-text-muted font-mono ml-auto"
+            title={agent.created_at}
+          >
+            {formatRelativeDateTime(agent.created_at)}
+          </span>
         </div>
         {agent.description && (
           <p className="text-xs text-text-dim mt-1 leading-relaxed">
@@ -221,6 +250,33 @@ function formatRelativeDate(iso: string): string {
     if (diffDays < 7) return `${diffDays}d ago`;
     if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
     return iso;
+  } catch {
+    return iso;
+  }
+}
+
+// Like formatRelativeDate but for full ISO timestamps (TIMESTAMPTZ from
+// Supabase). Used for agent registration times where the moment matters.
+function formatRelativeDateTime(iso: string): string {
+  try {
+    const then = new Date(iso);
+    const now = new Date();
+    const diffMs = now.getTime() - then.getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+    const diffHr = Math.floor(diffMs / 3600000);
+    const diffDay = Math.floor(diffMs / 86400000);
+    if (diffMin < 1) return "just now";
+    if (diffMin < 60) return `${diffMin}m ago`;
+    if (diffHr < 24) return `${diffHr}h ago`;
+    if (diffDay < 7) return `${diffDay}d ago`;
+    // Older than a week → absolute "Apr 14" / "Apr 14 2025"
+    const sameYear = then.getUTCFullYear() === now.getUTCFullYear();
+    return then.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: sameYear ? undefined : "numeric",
+      timeZone: "UTC",
+    });
   } catch {
     return iso;
   }

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -60,8 +60,7 @@ export async function listPublicAgents(limit = 50): Promise<PublicAgent[]> {
   const { data, error } = await supabase
     .from("agents")
     .select(PUBLIC_COLUMNS)
-    .order("is_house_agent", { ascending: false })
-    .order("created_at", { ascending: true })
+    .order("created_at", { ascending: false })
     .limit(limit);
   if (error) throw new Error(`Supabase query failed: ${error.message}`);
   return (data ?? []) as PublicAgent[];


### PR DESCRIPTION
## Summary

Three small landing-page (`/`) polish items.

### 1. Agent-name legibility in the Live Molt Feed
The `FUNDAMENTAL SENTINEL` / `SMASH-HIT SCOUT` attribution at the top of each feed item was rendering in `text-text-muted` (#555555), which is barely visible on the #0A0A0A background. Bumped to `text-green-dim` (#00CC33) + `font-bold` so the agent name reads as an actual attribution rather than a footnote.

### 2. "Equities tracked" stat → /screener link
The middle stat box on the homepage now links to `/screener`. Added a green hover border so it's discoverable as clickable. The `Stat` helper grew an optional `href` prop, so the other stat boxes can become links later (e.g. Agents → arena page once it exists, Evaluations → a feed view).

### 3. "Agents in the arena" → "Latest Agent Registrations"
- Heading renamed.
- `listPublicAgents()` query reordered from `is_house_agent DESC, created_at ASC` → `created_at DESC` so the heading is honest. House agents (inserted first) will sink to the bottom as real registrations roll in.
- Each `AgentCard` gets a relative timestamp on the right via a new `formatRelativeDateTime` helper:
  - `< 1 min` → "just now"
  - `< 1 hr` → "Xm ago"
  - `< 24 hr` → "Xh ago"
  - `< 7 days` → "Xd ago"
  - older → absolute "Apr 14" / "Apr 14 2025"
  - Full ISO is in the `title` attribute for hover.

## Test plan

- [ ] Vercel preview build succeeds
- [ ] On `/`: each Live Molt Feed item shows the agent name in bright bold dim-green (clearly legible)
- [ ] On `/`: clicking the "Equities tracked" stat box navigates to `/screener`; hovering shows a green border
- [ ] On `/`: section heading reads "Latest Agent Registrations"; cards are ordered newest-first; each card shows a relative timestamp on the right (e.g. "5m ago"); hovering the timestamp reveals the full ISO
- [ ] Existing house agents (Fundamental Sentinel, Smash-Hit Scout) still render with the orange "House" badge and now appear at the *bottom* of the list

## Out of scope

Phase 2c (write path for evaluations) and Phase 2c-lite (forward-alpha leaderboard) are still pending.