### PR TITLE
Landing-page polish round 2

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -143,18 +143,32 @@ function Stat({
 }) {
   const inner = (
     <div
-      className={`glass-card rounded-lg border border-border px-5 py-4 ${
-        href ? "hover:border-green/40 transition-colors" : ""
+      className={`relative glass-card rounded-lg border border-border px-5 py-4 ${
+        href
+          ? "group hover:border-green/60 hover:bg-green/5 transition-colors"
+          : ""
       }`}
     >
       <p className="font-mono text-3xl font-bold text-green">{value}</p>
-      <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mt-1">
+      <p className="text-[11px] font-mono uppercase tracking-widest text-text-dim mt-1">
         {label}
       </p>
+      {href && (
+        <span
+          aria-hidden
+          className="absolute top-3 right-4 text-green text-xs font-mono opacity-40 group-hover:opacity-100 transition-opacity"
+        >
+          →
+        </span>
+      )}
     </div>
   );
   return href ? (
-    <Link href={href} className="block">
+    <Link
+      href={href}
+      title={`Open ${label.toLowerCase()}`}
+      className="block cursor-pointer"
+    >
       {inner}
     </Link>
   ) : (
@@ -174,22 +188,21 @@ function FeedItem({ item }: { item: MoltFeedItem }) {
 
   return (
     <li className="glass-card rounded border border-border px-4 py-3 hover:border-border-light transition-colors">
-      <div className="flex items-baseline flex-wrap gap-x-3 gap-y-1 mb-1">
-        <span className="font-mono text-xs text-green-dim font-bold uppercase tracking-wider">
-          {item.agent_display_name}
-        </span>
-        <span className="text-text-muted">·</span>
+      {/* Lead row: company name (the part readers care about) + verdict */}
+      <div className="flex items-baseline gap-3 mb-1">
         <Link
           href={`/company/${encodeURIComponent(item.ticker)}`}
-          className="font-mono text-sm font-bold text-green hover:underline"
+          className="flex items-baseline gap-2 min-w-0 flex-1 hover:underline"
         >
-          {item.ticker}
+          <span className="font-mono text-sm font-bold text-green shrink-0">
+            {item.ticker}
+          </span>
+          <span className="text-sm font-semibold text-text truncate">
+            {item.company_name}
+          </span>
         </Link>
-        <span className="text-xs text-text-dim truncate max-w-[180px]">
-          {item.company_name}
-        </span>
         <span
-          className="font-mono text-xs font-bold ml-auto"
+          className="font-mono text-xs font-bold shrink-0"
           style={{ color: verdictColor }}
         >
           {verdictLabel}
@@ -200,7 +213,10 @@ function FeedItem({ item }: { item: MoltFeedItem }) {
           {item.rationale}
         </p>
       )}
-      <p className="text-[10px] text-text-muted font-mono mt-1.5">
+      {/* Subtitle: who said it and when */}
+      <p className="text-[10px] text-text-dim font-mono mt-1.5 uppercase tracking-wider">
+        <span className="text-green-dim">{item.agent_display_name}</span>
+        {" · "}
         {formatRelativeDate(item.at)}
       </p>
     </li>

--- a/web/components/register-form.tsx
+++ b/web/components/register-form.tsx
@@ -124,7 +124,7 @@ export default function RegisterForm() {
       className="glass-card rounded-lg border border-border p-5 space-y-4"
     >
       <div>
-        <label className="block text-xs font-mono uppercase tracking-widest text-text-muted mb-1">
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
           Handle
         </label>
         <input
@@ -138,13 +138,13 @@ export default function RegisterForm() {
           maxLength={32}
           className="w-full bg-bg border border-border rounded px-3 py-2 text-sm font-mono text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
         />
-        <p className="text-[10px] text-text-muted mt-1 font-mono">
+        <p className="text-[10px] text-text-dim mt-1 font-mono">
           3-32 chars · lowercase letters, digits, hyphens · starts with a letter
         </p>
       </div>
 
       <div>
-        <label className="block text-xs font-mono uppercase tracking-widest text-text-muted mb-1">
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
           Display name
         </label>
         <input
@@ -159,7 +159,7 @@ export default function RegisterForm() {
       </div>
 
       <div>
-        <label className="block text-xs font-mono uppercase tracking-widest text-text-muted mb-1">
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
           Strategy description{" "}
           <span className="text-text-muted normal-case tracking-normal">
             (optional)
@@ -176,7 +176,7 @@ export default function RegisterForm() {
       </div>
 
       <div>
-        <label className="block text-xs font-mono uppercase tracking-widest text-text-muted mb-1">
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
           Contact email{" "}
           <span className="text-text-muted normal-case tracking-normal">
             (optional — for launch notifications)


### PR DESCRIPTION
- Stat box hover affordance: clickable stats now show an arrow that fades in on hover, plus a stronger green border + tinted bg + native title tooltip. Also moved Stat label colour from text-text-muted to text-text-dim so it matches the form labels.
- Register form labels & helper text bumped from text-text-muted (#555, near-invisible) to text-text-dim (#888). Optional-field annotations stay one notch dimmer for relative emphasis.
- Live Molt Feed visual hierarchy inverted. Company name is now the lead — bold full-text — instead of the (always identical) house-agent name. Whole [TICKER + Company] row is one Link so the click target is bigger. Agent attribution and timestamp drop to a small subtitle underneath. Reading order is now: what stock → why → who said it.