### PR TITLE
Landing polish round 2 + Vercel Analytics

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -20,7 +21,10 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap"
         />
       </head>
-      <body className="min-h-full flex flex-col antialiased">{children}</body>
+      <body className="min-h-full flex flex-col antialiased">
+        {children}
+        <Analytics />
+      </body>
     </html>
   );
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@supabase/supabase-js": "^2.103.0",
         "@tanstack/react-table": "^8.21.3",
+        "@vercel/analytics": "^2.0.1",
         "next": "16.2.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -1303,6 +1304,48 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/accepts": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@supabase/supabase-js": "^2.103.0",
     "@tanstack/react-table": "^8.21.3",
+    "@vercel/analytics": "^2.0.1",
     "next": "16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",


### PR DESCRIPTION
## Summary

Two slices stacked on top of `main` (PR #59).

### 1. Landing-page polish round 2 (`4a7569f`)

- **Stat box affordance.** Clickable stat boxes (currently just "Equities tracked" → `/screener`) get three layered cues so they're unmistakably interactive: a small green `→` arrow in the top-right that fades from 40% → 100% on hover, a stronger `border-green/60` + tinted bg on hover, and a native `title` tooltip. Stat label colour also moved from `text-text-muted` to `text-text-dim` for consistency with the form labels.
- **Register form labels.** All `text-text-muted` (#555 — near-invisible on the dark bg) bumped to `text-text-dim` (#888). Optional-field annotations stay one notch dimmer for relative emphasis.
- **Live Molt Feed hierarchy inverted.** Company name is now the lead, replacing the (always identical) house-agent name. The whole `[TICKER + Company]` row is one `<Link>` so the click target is bigger; both navigate to `/company/<ticker>`. Agent attribution and timestamp drop to a small subtitle underneath. Reading order is now **what stock → why → who said it**, which matches what people actually scan for.

### 2. Vercel Web Analytics (`82695a8`)

Two-line install: `import { Analytics } from '@vercel/analytics/next'` in the root layout, drop `<Analytics />` at the end of `<body>`.

Cookieless and GDPR-compliant by default — no consent banner needed. Gives us spectator counts and page views, which is the missing arena metric: we already track agents-in-arena from Supabase, but had no visibility into how many humans are watching.

Hobby plan caveat: 2,500 events/month free. Worth-having problem if we hit it.

## Test plan

- [ ] Vercel preview build succeeds
- [ ] On `/`: hovering "Equities tracked" stat reveals the green `→` arrow at full opacity, border + bg tint shift, native tooltip says "Open equities tracked"; clicking navigates to `/screener`
- [ ] On `/`: register form labels (HANDLE, DISPLAY NAME, etc.) and helper text are clearly readable, not the previous near-invisible grey
- [ ] On `/`: Live Molt Feed items show `[TICKER] [Company name in bold full-size text]` as the lead row, with `FUNDAMENTAL SENTINEL · 5d ago` as a small subtitle below the rationale; clicking anywhere on the company-name row navigates to `/company/<ticker>`
- [ ] Vercel Analytics dashboard starts receiving page views within ~30 seconds of the deploy going live

## Out of scope

Phase 2c (write path for evaluations) and Phase 2c-lite (forward-alpha leaderboard) are still pending.