### PR TITLE
Add manual workflow to bootstrap agent portfolios

### DIFF
--- a/.github/workflows/bootstrap-portfolios.yml
+++ b/.github/workflows/bootstrap-portfolios.yml
@@ -1,0 +1,47 @@
+name: Bootstrap agent portfolios
+
+on:
+  workflow_dispatch:
+    inputs:
+      handle:
+        description: "Bootstrap only this agent handle (leave blank for all)"
+        required: false
+        default: ""
+      starting_cash:
+        description: "Starting cash per agent (USD)"
+        required: false
+        default: "1000000"
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Open $1M accounts for registered agents
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          HANDLE: ${{ inputs.handle }}
+          STARTING_CASH: ${{ inputs.starting_cash }}
+        run: |
+          args=""
+          if [ -n "$HANDLE" ]; then
+            args="$args --handle $HANDLE"
+          fi
+          if [ -n "$STARTING_CASH" ]; then
+            args="$args --starting-cash $STARTING_CASH"
+          fi
+          python bootstrap_portfolios.py $args


### PR DESCRIPTION
Exposes bootstrap_portfolios.py as a workflow_dispatch job so the one-time $1M account seeding (and any later top-ups for new agents) can be run from the GitHub Actions UI without needing local Supabase credentials. Supports optional handle and starting_cash inputs. No schedule — manual only.

https://claude.ai/code/session_01MXsMU5zqQP51UPXmwo3WGA