### PR TITLE
Expose portfolio trading via MCP and REST

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,13 @@
     "supabase": {
       "type": "http",
       "url": "https://mcp.supabase.com/mcp?project_ref=nojoooddiadyrduikgsk"
+    },
+    "alphamolt": {
+      "type": "http",
+      "url": "https://alphamolt.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer ${ALPHAMOLT_API_KEY}"
+      }
     }
   }
 }

--- a/web/app/api/v1/portfolio/buy/route.ts
+++ b/web/app/api/v1/portfolio/buy/route.ts
@@ -1,0 +1,71 @@
+/**
+ * POST /api/v1/portfolio/buy
+ *
+ * Body: { ticker: string, quantity: number, note?: string }
+ * Requires Authorization: Bearer <api_key>
+ *
+ * Fills at the latest companies.price, cash-settled, weighted-average cost
+ * basis. Rejects on unknown ticker, null price, or insufficient cash.
+ */
+
+import {
+  errorResponse,
+  jsonResponse,
+  optionsResponse,
+} from "@/lib/api-utils";
+import { requireAgent } from "@/lib/auth";
+import { buy, PortfolioError } from "@/lib/portfolio";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+export async function POST(request: Request) {
+  const auth = await requireAgent(request);
+  if ("error" in auth) return auth.error;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("Request body must be valid JSON", 400, "bad_json");
+  }
+  if (!body || typeof body !== "object") {
+    return errorResponse("Request body must be a JSON object", 400, "bad_body");
+  }
+  const { ticker, quantity, note } = body as {
+    ticker?: unknown;
+    quantity?: unknown;
+    note?: unknown;
+  };
+  if (typeof ticker !== "string" || ticker.trim().length === 0) {
+    return errorResponse("'ticker' is required", 400, "missing_ticker");
+  }
+  if (typeof quantity !== "number" || !Number.isFinite(quantity) || quantity <= 0) {
+    return errorResponse(
+      "'quantity' must be a positive number",
+      400,
+      "invalid_quantity",
+    );
+  }
+  const noteStr = typeof note === "string" ? note : "";
+
+  try {
+    const trade = await buy(auth.agent.id, ticker.trim().toUpperCase(), quantity, noteStr);
+    return jsonResponse({ trade }, { status: 201 });
+  } catch (err) {
+    if (err instanceof PortfolioError) {
+      const status = err.code === "insufficient_cash" || err.code === "no_price"
+        ? 400
+        : err.code === "unknown_ticker"
+          ? 404
+          : 400;
+      return errorResponse(err.message, status, err.code);
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 500);
+  }
+}

--- a/web/app/api/v1/portfolio/leaderboard/route.ts
+++ b/web/app/api/v1/portfolio/leaderboard/route.ts
@@ -1,0 +1,33 @@
+/**
+ * GET /api/v1/portfolio/leaderboard
+ *
+ * Public (no auth) — latest mark-to-market snapshot per agent, ranked by
+ * total return. Reads the `agent_leaderboard` Supabase view.
+ */
+
+import {
+  errorResponse,
+  jsonResponse,
+  optionsResponse,
+} from "@/lib/api-utils";
+import { getLeaderboard, PortfolioError } from "@/lib/portfolio";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+export async function GET() {
+  try {
+    const rows = await getLeaderboard();
+    return jsonResponse({ count: rows.length, agents: rows });
+  } catch (err) {
+    if (err instanceof PortfolioError) {
+      return errorResponse(err.message, 500, err.code);
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 500);
+  }
+}

--- a/web/app/api/v1/portfolio/route.ts
+++ b/web/app/api/v1/portfolio/route.ts
@@ -1,0 +1,42 @@
+/**
+ * GET /api/v1/portfolio
+ *
+ * Returns the authenticated agent's portfolio with current mark-to-market
+ * valuation. Lazily opens a $1M account on first call.
+ *
+ * Requires Authorization: Bearer <api_key>
+ */
+
+import {
+  errorResponse,
+  jsonResponse,
+  optionsResponse,
+} from "@/lib/api-utils";
+import { requireAgent } from "@/lib/auth";
+import { getPortfolio, PortfolioError } from "@/lib/portfolio";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+export async function GET(request: Request) {
+  const auth = await requireAgent(request);
+  if ("error" in auth) return auth.error;
+
+  try {
+    const portfolio = await getPortfolio(auth.agent.id);
+    return jsonResponse({
+      agent: { handle: auth.agent.handle, display_name: auth.agent.display_name },
+      ...portfolio,
+    });
+  } catch (err) {
+    if (err instanceof PortfolioError) {
+      return errorResponse(err.message, 400, err.code);
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 500);
+  }
+}

--- a/web/app/api/v1/portfolio/sell/route.ts
+++ b/web/app/api/v1/portfolio/sell/route.ts
@@ -1,0 +1,70 @@
+/**
+ * POST /api/v1/portfolio/sell
+ *
+ * Body: { ticker: string, quantity: number, note?: string }
+ * Requires Authorization: Bearer <api_key>
+ *
+ * Cash-settled at the latest companies.price. Rejects when the agent has
+ * no position or is trying to sell more than held.
+ */
+
+import {
+  errorResponse,
+  jsonResponse,
+  optionsResponse,
+} from "@/lib/api-utils";
+import { requireAgent } from "@/lib/auth";
+import { sell, PortfolioError } from "@/lib/portfolio";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+export async function POST(request: Request) {
+  const auth = await requireAgent(request);
+  if ("error" in auth) return auth.error;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("Request body must be valid JSON", 400, "bad_json");
+  }
+  if (!body || typeof body !== "object") {
+    return errorResponse("Request body must be a JSON object", 400, "bad_body");
+  }
+  const { ticker, quantity, note } = body as {
+    ticker?: unknown;
+    quantity?: unknown;
+    note?: unknown;
+  };
+  if (typeof ticker !== "string" || ticker.trim().length === 0) {
+    return errorResponse("'ticker' is required", 400, "missing_ticker");
+  }
+  if (typeof quantity !== "number" || !Number.isFinite(quantity) || quantity <= 0) {
+    return errorResponse(
+      "'quantity' must be a positive number",
+      400,
+      "invalid_quantity",
+    );
+  }
+  const noteStr = typeof note === "string" ? note : "";
+
+  try {
+    const trade = await sell(auth.agent.id, ticker.trim().toUpperCase(), quantity, noteStr);
+    return jsonResponse({ trade }, { status: 201 });
+  } catch (err) {
+    if (err instanceof PortfolioError) {
+      const status =
+        err.code === "no_position" || err.code === "unknown_ticker"
+          ? 404
+          : 400;
+      return errorResponse(err.message, status, err.code);
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 500);
+  }
+}

--- a/web/app/mcp/route.ts
+++ b/web/app/mcp/route.ts
@@ -14,18 +14,66 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { z } from "zod";
 
-import { corsHeaders } from "@/lib/api-utils";
+import { resolveAgentByApiKey, type Agent } from "@/lib/agents-query";
+import { corsHeaders, extractBearerToken } from "@/lib/api-utils";
 import {
   getEquity,
   listEquities,
   searchEquities,
 } from "@/lib/equities-query";
+import {
+  buy,
+  getLeaderboard,
+  getPortfolio,
+  openAccount,
+  PortfolioError,
+  sell,
+} from "@/lib/portfolio";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 export const maxDuration = 60;
 
-function buildServer(): McpServer {
+/**
+ * Wrap a portfolio tool handler so unauthenticated clients get a clear MCP
+ * error instead of a cryptic PortfolioError. The three read-only screener
+ * tools remain public; every portfolio tool needs a resolved agent.
+ */
+function requireAuth(
+  agent: Agent | null,
+): { ok: true; agent: Agent } | { ok: false; error: { isError: true; content: [{ type: "text"; text: string }] } } {
+  if (!agent) {
+    return {
+      ok: false,
+      error: {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text:
+              "This tool requires authentication. Register at https://alphamolt.ai/ to get an API key, then add it as an Authorization: Bearer header when configuring this MCP server.",
+          },
+        ],
+      },
+    };
+  }
+  return { ok: true, agent };
+}
+
+function formatPortfolioError(err: unknown): {
+  isError: true;
+  content: [{ type: "text"; text: string }];
+} {
+  const msg =
+    err instanceof PortfolioError
+      ? `${err.code}: ${err.message}`
+      : err instanceof Error
+        ? err.message
+        : "Unknown error";
+  return { isError: true, content: [{ type: "text", text: msg }] };
+}
+
+function buildServer(agent: Agent | null): McpServer {
   const server = new McpServer({
     name: "alphamolt",
     version: "1.0.0",
@@ -154,14 +202,209 @@ function buildServer(): McpServer {
     },
   );
 
+  // --------------------------------------------------------------------
+  // Portfolio tools (require Authorization: Bearer <api_key>)
+  // --------------------------------------------------------------------
+
+  server.registerTool(
+    "open_account",
+    {
+      title: "Open portfolio account",
+      description:
+        "Idempotently open a $1M virtual trading account for the authenticated agent. Safe to call at any time — if an account already exists it is returned unchanged. Note that buy() also auto-opens an account on first call, so this is rarely needed.",
+      inputSchema: {},
+    },
+    async () => {
+      const auth = requireAuth(agent);
+      if (!auth.ok) return auth.error;
+      try {
+        const account = await openAccount(auth.agent.id);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  agent: {
+                    handle: auth.agent.handle,
+                    display_name: auth.agent.display_name,
+                  },
+                  account,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return formatPortfolioError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "buy",
+    {
+      title: "Buy equity",
+      description:
+        "Buy shares of a ticker at the latest companies.price. Cash-settled. Uses weighted-average cost basis. Rejects if the agent lacks the cash, the ticker is unknown, or the ticker has no usable price. Prices are treated as USD (v1 simplification — agents should prefer US-listed tickers).",
+      inputSchema: {
+        ticker: z
+          .string()
+          .min(1)
+          .describe("Ticker symbol to buy (e.g. 'NVDA', 'BCRX')."),
+        quantity: z
+          .number()
+          .positive()
+          .describe(
+            "Number of shares to buy. Fractional shares allowed (v1 has no share-size constraints).",
+          ),
+        note: z
+          .string()
+          .optional()
+          .describe("Optional note attached to the trade journal entry."),
+      },
+    },
+    async ({ ticker, quantity, note }) => {
+      const auth = requireAuth(agent);
+      if (!auth.ok) return auth.error;
+      try {
+        const trade = await buy(
+          auth.agent.id,
+          ticker.trim().toUpperCase(),
+          quantity,
+          note ?? "",
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify({ trade }, null, 2) }],
+        };
+      } catch (err) {
+        return formatPortfolioError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "sell",
+    {
+      title: "Sell equity",
+      description:
+        "Sell shares of a ticker at the latest companies.price. Cash-settled. Rejects if the agent doesn't hold the ticker or is trying to sell more than the current position. Deletes the holding row when quantity reaches 0.",
+      inputSchema: {
+        ticker: z
+          .string()
+          .min(1)
+          .describe("Ticker symbol to sell."),
+        quantity: z
+          .number()
+          .positive()
+          .describe("Number of shares to sell."),
+        note: z
+          .string()
+          .optional()
+          .describe("Optional note attached to the trade journal entry."),
+      },
+    },
+    async ({ ticker, quantity, note }) => {
+      const auth = requireAuth(agent);
+      if (!auth.ok) return auth.error;
+      try {
+        const trade = await sell(
+          auth.agent.id,
+          ticker.trim().toUpperCase(),
+          quantity,
+          note ?? "",
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify({ trade }, null, 2) }],
+        };
+      } catch (err) {
+        return formatPortfolioError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_portfolio",
+    {
+      title: "Get portfolio",
+      description:
+        "Return the authenticated agent's current portfolio: cash, holdings, mark-to-market valuation, and PnL since inception. Lazily opens an account on first call so new agents always see a fresh $1M.",
+      inputSchema: {},
+    },
+    async () => {
+      const auth = requireAuth(agent);
+      if (!auth.ok) return auth.error;
+      try {
+        const portfolio = await getPortfolio(auth.agent.id);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  agent: {
+                    handle: auth.agent.handle,
+                    display_name: auth.agent.display_name,
+                  },
+                  ...portfolio,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return formatPortfolioError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_leaderboard",
+    {
+      title: "Get leaderboard",
+      description:
+        "Return the public agent leaderboard — latest daily mark-to-market snapshot per agent, ranked by total return (pnl_pct). No authentication required.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const rows = await getLeaderboard();
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                { count: rows.length, agents: rows },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return formatPortfolioError(err);
+      }
+    },
+  );
+
   return server;
 }
 
 async function handle(request: Request): Promise<Response> {
+  // Resolve the caller's agent from Authorization: Bearer <api_key>. Missing
+  // or invalid keys still get a working server — read-only screener tools
+  // stay public — but any portfolio tool call returns a clear auth error.
+  const token = extractBearerToken(request);
+  const agent = token ? await resolveAgentByApiKey(token) : null;
+
   // Stateless transport: a fresh server + transport per request keeps Vercel
   // serverless invocations independent. There's no in-memory session state
   // to lose between cold starts.
-  const server = buildServer();
+  const server = buildServer(agent);
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -6,7 +6,7 @@
  */
 
 import { getSupabase } from "@/lib/supabase";
-import { generateApiKey, type GeneratedKey } from "@/lib/api-keys";
+import { generateApiKey, hashApiKey, type GeneratedKey } from "@/lib/api-keys";
 
 export interface Agent {
   id: string;
@@ -157,4 +157,30 @@ export async function createAgent(
   }
 
   return { agent: data as PublicAgent, api_key: key.plaintext };
+}
+
+/**
+ * Resolve a plaintext API key back to the owning agent row.
+ *
+ * Returns `null` when the key doesn't match any registered agent. Never
+ * throws on a not-found result — callers wrap this in a 401 response.
+ */
+export async function resolveAgentByApiKey(
+  plaintext: string,
+): Promise<Agent | null> {
+  if (!plaintext || !plaintext.startsWith("ak_live_")) return null;
+  const hash = hashApiKey(plaintext);
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agents")
+    .select(
+      "id, handle, display_name, description, contact_email, api_key_prefix, is_house_agent, created_at, updated_at",
+    )
+    .eq("api_key_hash", hash)
+    .maybeSingle();
+  if (error) {
+    console.error("resolveAgentByApiKey query failed:", error);
+    return null;
+  }
+  return (data as Agent | null) ?? null;
 }

--- a/web/lib/api-utils.ts
+++ b/web/lib/api-utils.ts
@@ -53,8 +53,25 @@ export function optionsResponse(): Response {
 
 function httpStatusToCode(status: number): string {
   if (status === 400) return "bad_request";
+  if (status === 401) return "unauthorized";
+  if (status === 403) return "forbidden";
   if (status === 404) return "not_found";
   if (status === 429) return "rate_limited";
   if (status >= 500) return "internal_error";
   return "error";
+}
+
+/**
+ * Extract a Bearer token from a Request's Authorization header.
+ *
+ * Returns the plaintext token string, or `null` when the header is missing
+ * or malformed. Callers should respond with 401 on null.
+ */
+export function extractBearerToken(request: Request): string | null {
+  const header = request.headers.get("authorization");
+  if (!header) return null;
+  const match = /^bearer\s+(.+)$/i.exec(header.trim());
+  if (!match) return null;
+  const token = match[1].trim();
+  return token.length > 0 ? token : null;
 }

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared auth helper for any route that needs an authenticated agent.
+ *
+ * Usage:
+ *
+ *     const auth = await requireAgent(request);
+ *     if ("error" in auth) return auth.error;
+ *     const agent = auth.agent;
+ *
+ * Kept deliberately tiny and route-handler-agnostic so both REST routes and
+ * the MCP server can share the exact same resolution path.
+ */
+
+import type { Agent } from "@/lib/agents-query";
+import { resolveAgentByApiKey } from "@/lib/agents-query";
+import { errorResponse, extractBearerToken } from "@/lib/api-utils";
+
+export type RequireAgentResult =
+  | { agent: Agent }
+  | { error: Response };
+
+export async function requireAgent(
+  request: Request,
+): Promise<RequireAgentResult> {
+  const token = extractBearerToken(request);
+  if (!token) {
+    return {
+      error: errorResponse(
+        "Missing Authorization header. Send 'Authorization: Bearer ak_live_...'",
+        401,
+        "missing_auth",
+      ),
+    };
+  }
+  const agent = await resolveAgentByApiKey(token);
+  if (!agent) {
+    return {
+      error: errorResponse(
+        "API key did not match any registered agent.",
+        401,
+        "invalid_api_key",
+      ),
+    };
+  }
+  return { agent };
+}
+
+/**
+ * Same as requireAgent but for in-process callers (e.g. the MCP route
+ * handler) that already have the plaintext key. Throws on failure with a
+ * message suitable for surfacing through the MCP error channel.
+ */
+export async function requireAgentFromToken(token: string | null): Promise<Agent> {
+  if (!token) {
+    throw new Error(
+      "Missing Authorization header. Send 'Authorization: Bearer ak_live_...'",
+    );
+  }
+  const agent = await resolveAgentByApiKey(token);
+  if (!agent) {
+    throw new Error("API key did not match any registered agent.");
+  }
+  return agent;
+}

--- a/web/lib/portfolio.ts
+++ b/web/lib/portfolio.ts
@@ -1,0 +1,525 @@
+/**
+ * TypeScript port of PortfolioManager — used by the REST API and MCP server.
+ *
+ * Mirrors the Python `portfolio.py` module so interactive agent trades and
+ * the nightly valuation job follow identical rules. Both flows converge on
+ * the same Supabase tables (agent_accounts, agent_holdings, agent_trades,
+ * agent_portfolio_history).
+ *
+ * v1 simplifications (matches the Python side):
+ *   - All prices treated as USD even for non-US listings
+ *   - No fees, slippage, shorting, margin, splits, or dividends
+ *   - Single-writer per agent; no row-level locks (a future RPC should wrap
+ *     cash debit + holding upsert in a single transaction)
+ */
+
+import { getSupabase } from "@/lib/supabase";
+
+export const DEFAULT_STARTING_CASH = 1_000_000;
+
+export class PortfolioError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+// ----- Types --------------------------------------------------------------
+
+export interface AgentAccount {
+  agent_id: string;
+  starting_cash: number;
+  cash_usd: number;
+  inception_date: string;
+}
+
+export interface AgentHolding {
+  agent_id: string;
+  ticker: string;
+  quantity: number;
+  avg_cost_usd: number;
+  first_bought_at: string;
+}
+
+export interface TradeResult {
+  agent_id: string;
+  ticker: string;
+  side: "buy" | "sell";
+  quantity: number;
+  price_usd: number;
+  gross_usd: number;
+  cash_after_usd: number;
+  executed_at: string;
+  note: string;
+}
+
+export interface HoldingWithMtm {
+  ticker: string;
+  quantity: number;
+  avg_cost_usd: number;
+  price_usd: number;
+  market_value_usd: number;
+  unrealized_pnl_usd: number;
+}
+
+export interface PortfolioSnapshot {
+  agent_id: string;
+  cash_usd: number;
+  starting_cash: number;
+  holdings: HoldingWithMtm[];
+  holdings_value_usd: number;
+  total_value_usd: number;
+  pnl_usd: number;
+  pnl_pct: number;
+}
+
+export interface LeaderboardRow {
+  handle: string;
+  display_name: string;
+  is_house_agent: boolean;
+  snapshot_date: string;
+  cash_usd: number;
+  holdings_value_usd: number;
+  total_value_usd: number;
+  pnl_usd: number;
+  pnl_pct: number;
+  num_positions: number;
+}
+
+// ----- Internals ----------------------------------------------------------
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10000) / 10000;
+}
+
+async function getPrice(ticker: string): Promise<number> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("companies")
+    .select("ticker, price")
+    .eq("ticker", ticker)
+    .maybeSingle();
+  if (error) {
+    throw new PortfolioError(
+      "price_lookup_failed",
+      `Price lookup failed for ${ticker}: ${error.message}`,
+    );
+  }
+  if (!data) {
+    throw new PortfolioError("unknown_ticker", `Unknown ticker: ${ticker}`);
+  }
+  const price = Number((data as { price: number | null }).price);
+  if (!Number.isFinite(price) || price <= 0) {
+    throw new PortfolioError(
+      "no_price",
+      `No usable price for ${ticker} (companies.price is null or <=0)`,
+    );
+  }
+  return price;
+}
+
+async function getAccountRow(agentId: string): Promise<AgentAccount | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agent_accounts")
+    .select("*")
+    .eq("agent_id", agentId)
+    .maybeSingle();
+  if (error) {
+    throw new PortfolioError(
+      "db_error",
+      `agent_accounts lookup failed: ${error.message}`,
+    );
+  }
+  if (!data) return null;
+  const row = data as {
+    agent_id: string;
+    starting_cash: string | number;
+    cash_usd: string | number;
+    inception_date: string;
+  };
+  return {
+    agent_id: row.agent_id,
+    starting_cash: Number(row.starting_cash),
+    cash_usd: Number(row.cash_usd),
+    inception_date: row.inception_date,
+  };
+}
+
+async function requireAccount(agentId: string): Promise<AgentAccount> {
+  const account = await getAccountRow(agentId);
+  if (!account) {
+    throw new PortfolioError(
+      "no_account",
+      `No agent_accounts row for ${agentId} — call openAccount() first`,
+    );
+  }
+  return account;
+}
+
+async function getHoldingRow(
+  agentId: string,
+  ticker: string,
+): Promise<AgentHolding | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agent_holdings")
+    .select("*")
+    .eq("agent_id", agentId)
+    .eq("ticker", ticker)
+    .maybeSingle();
+  if (error) {
+    throw new PortfolioError(
+      "db_error",
+      `agent_holdings lookup failed: ${error.message}`,
+    );
+  }
+  if (!data) return null;
+  const row = data as {
+    agent_id: string;
+    ticker: string;
+    quantity: string | number;
+    avg_cost_usd: string | number;
+    first_bought_at: string;
+  };
+  return {
+    agent_id: row.agent_id,
+    ticker: row.ticker,
+    quantity: Number(row.quantity),
+    avg_cost_usd: Number(row.avg_cost_usd),
+    first_bought_at: row.first_bought_at,
+  };
+}
+
+async function getAllHoldings(agentId: string): Promise<AgentHolding[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agent_holdings")
+    .select("*")
+    .eq("agent_id", agentId);
+  if (error) {
+    throw new PortfolioError(
+      "db_error",
+      `agent_holdings lookup failed: ${error.message}`,
+    );
+  }
+  return (data ?? []).map((row) => {
+    const r = row as {
+      agent_id: string;
+      ticker: string;
+      quantity: string | number;
+      avg_cost_usd: string | number;
+      first_bought_at: string;
+    };
+    return {
+      agent_id: r.agent_id,
+      ticker: r.ticker,
+      quantity: Number(r.quantity),
+      avg_cost_usd: Number(r.avg_cost_usd),
+      first_bought_at: r.first_bought_at,
+    };
+  });
+}
+
+// ----- Public API ---------------------------------------------------------
+
+/**
+ * Idempotently create an agent_accounts row. If one already exists it is
+ * returned unchanged — safe to call on every request (first-trade lazy init).
+ */
+export async function openAccount(
+  agentId: string,
+  startingCash: number = DEFAULT_STARTING_CASH,
+): Promise<AgentAccount> {
+  const existing = await getAccountRow(agentId);
+  if (existing) return existing;
+
+  const supabase = getSupabase();
+  const { error } = await supabase.from("agent_accounts").upsert({
+    agent_id: agentId,
+    starting_cash: startingCash,
+    cash_usd: startingCash,
+    inception_date: new Date().toISOString().slice(0, 10),
+  });
+  if (error) {
+    throw new PortfolioError(
+      "db_error",
+      `openAccount insert failed: ${error.message}`,
+    );
+  }
+  const row = await getAccountRow(agentId);
+  if (!row) {
+    throw new PortfolioError(
+      "db_error",
+      "openAccount insert succeeded but row not found on readback",
+    );
+  }
+  return row;
+}
+
+export async function buy(
+  agentId: string,
+  ticker: string,
+  quantity: number,
+  note = "",
+): Promise<TradeResult> {
+  if (!(quantity > 0)) {
+    throw new PortfolioError(
+      "invalid_quantity",
+      `buy quantity must be > 0, got ${quantity}`,
+    );
+  }
+
+  const account = await openAccount(agentId); // lazy bootstrap
+  const price = await getPrice(ticker);
+  const gross = round2(quantity * price);
+  const cash = account.cash_usd;
+
+  if (gross > cash + 1e-9) {
+    throw new PortfolioError(
+      "insufficient_cash",
+      `Insufficient cash: need $${gross.toFixed(2)}, have $${cash.toFixed(2)}`,
+    );
+  }
+
+  const newCash = round2(cash - gross);
+  const supabase = getSupabase();
+
+  const existing = await getHoldingRow(agentId, ticker);
+  if (existing) {
+    const newQty = existing.quantity + quantity;
+    const newAvgCost = round4(
+      (existing.quantity * existing.avg_cost_usd + quantity * price) / newQty,
+    );
+    const { error: hErr } = await supabase.from("agent_holdings").upsert({
+      agent_id: agentId,
+      ticker,
+      quantity: newQty,
+      avg_cost_usd: newAvgCost,
+      first_bought_at: existing.first_bought_at,
+    });
+    if (hErr) {
+      throw new PortfolioError(
+        "db_error",
+        `agent_holdings upsert failed: ${hErr.message}`,
+      );
+    }
+  } else {
+    const { error: hErr } = await supabase.from("agent_holdings").upsert({
+      agent_id: agentId,
+      ticker,
+      quantity,
+      avg_cost_usd: round4(price),
+    });
+    if (hErr) {
+      throw new PortfolioError(
+        "db_error",
+        `agent_holdings insert failed: ${hErr.message}`,
+      );
+    }
+  }
+
+  const { error: aErr } = await supabase
+    .from("agent_accounts")
+    .update({ cash_usd: newCash })
+    .eq("agent_id", agentId);
+  if (aErr) {
+    throw new PortfolioError(
+      "db_error",
+      `agent_accounts update failed: ${aErr.message}`,
+    );
+  }
+
+  const executed_at = new Date().toISOString();
+  const trade = {
+    agent_id: agentId,
+    ticker,
+    side: "buy" as const,
+    quantity,
+    price_usd: round4(price),
+    gross_usd: gross,
+    cash_after_usd: newCash,
+    executed_at,
+    note,
+  };
+  const { error: tErr } = await supabase.from("agent_trades").insert(trade);
+  if (tErr) {
+    throw new PortfolioError(
+      "db_error",
+      `agent_trades insert failed: ${tErr.message}`,
+    );
+  }
+  return trade;
+}
+
+export async function sell(
+  agentId: string,
+  ticker: string,
+  quantity: number,
+  note = "",
+): Promise<TradeResult> {
+  if (!(quantity > 0)) {
+    throw new PortfolioError(
+      "invalid_quantity",
+      `sell quantity must be > 0, got ${quantity}`,
+    );
+  }
+
+  const account = await requireAccount(agentId);
+  const holding = await getHoldingRow(agentId, ticker);
+  if (!holding) {
+    throw new PortfolioError(
+      "no_position",
+      `No position in ${ticker} for agent ${agentId}`,
+    );
+  }
+  if (quantity > holding.quantity + 1e-9) {
+    throw new PortfolioError(
+      "oversell",
+      `Cannot sell ${quantity} of ${ticker}: holding only ${holding.quantity}`,
+    );
+  }
+
+  const price = await getPrice(ticker);
+  const gross = round2(quantity * price);
+  const newCash = round2(account.cash_usd + gross);
+  const remaining = Math.round((holding.quantity - quantity) * 1e6) / 1e6;
+  const supabase = getSupabase();
+
+  if (remaining <= 1e-9) {
+    const { error: dErr } = await supabase
+      .from("agent_holdings")
+      .delete()
+      .eq("agent_id", agentId)
+      .eq("ticker", ticker);
+    if (dErr) {
+      throw new PortfolioError(
+        "db_error",
+        `agent_holdings delete failed: ${dErr.message}`,
+      );
+    }
+  } else {
+    // avg_cost_usd unchanged on sells (weighted-avg convention)
+    const { error: uErr } = await supabase.from("agent_holdings").upsert({
+      agent_id: agentId,
+      ticker,
+      quantity: remaining,
+      avg_cost_usd: holding.avg_cost_usd,
+      first_bought_at: holding.first_bought_at,
+    });
+    if (uErr) {
+      throw new PortfolioError(
+        "db_error",
+        `agent_holdings upsert failed: ${uErr.message}`,
+      );
+    }
+  }
+
+  const { error: aErr } = await supabase
+    .from("agent_accounts")
+    .update({ cash_usd: newCash })
+    .eq("agent_id", agentId);
+  if (aErr) {
+    throw new PortfolioError(
+      "db_error",
+      `agent_accounts update failed: ${aErr.message}`,
+    );
+  }
+
+  const executed_at = new Date().toISOString();
+  const trade = {
+    agent_id: agentId,
+    ticker,
+    side: "sell" as const,
+    quantity,
+    price_usd: round4(price),
+    gross_usd: gross,
+    cash_after_usd: newCash,
+    executed_at,
+    note,
+  };
+  const { error: tErr } = await supabase.from("agent_trades").insert(trade);
+  if (tErr) {
+    throw new PortfolioError(
+      "db_error",
+      `agent_trades insert failed: ${tErr.message}`,
+    );
+  }
+  return trade;
+}
+
+/**
+ * Mark-to-market valuation for a single agent. Lazily opens an account on
+ * first call so new agents always see a fresh $1M portfolio.
+ */
+export async function getPortfolio(
+  agentId: string,
+): Promise<PortfolioSnapshot> {
+  const account = await openAccount(agentId);
+  const holdings = await getAllHoldings(agentId);
+
+  const enriched: HoldingWithMtm[] = [];
+  let holdingsValue = 0;
+
+  for (const h of holdings) {
+    let price: number;
+    try {
+      price = await getPrice(h.ticker);
+    } catch {
+      // Fall back to avg cost when price unavailable so the row still shows
+      price = h.avg_cost_usd;
+    }
+    const mv = round2(h.quantity * price);
+    holdingsValue += mv;
+    enriched.push({
+      ticker: h.ticker,
+      quantity: h.quantity,
+      avg_cost_usd: h.avg_cost_usd,
+      price_usd: round4(price),
+      market_value_usd: mv,
+      unrealized_pnl_usd: round2((price - h.avg_cost_usd) * h.quantity),
+    });
+  }
+
+  holdingsValue = round2(holdingsValue);
+  const total = round2(account.cash_usd + holdingsValue);
+  const pnl = round2(total - account.starting_cash);
+  const pnlPct =
+    account.starting_cash > 0
+      ? Math.round((pnl / account.starting_cash) * 1_000_000) / 10_000
+      : 0;
+
+  return {
+    agent_id: agentId,
+    cash_usd: account.cash_usd,
+    starting_cash: account.starting_cash,
+    holdings: enriched,
+    holdings_value_usd: holdingsValue,
+    total_value_usd: total,
+    pnl_usd: pnl,
+    pnl_pct: pnlPct,
+  };
+}
+
+export async function getLeaderboard(): Promise<LeaderboardRow[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agent_leaderboard")
+    .select(
+      "handle, display_name, is_house_agent, snapshot_date, cash_usd, holdings_value_usd, total_value_usd, pnl_usd, pnl_pct, num_positions",
+    )
+    .order("pnl_pct", { ascending: false, nullsFirst: false });
+  if (error) {
+    throw new PortfolioError(
+      "db_error",
+      `agent_leaderboard query failed: ${error.message}`,
+    );
+  }
+  return (data ?? []) as unknown as LeaderboardRow[];
+}


### PR DESCRIPTION
## Summary

Lets any registered agent trade the AlphaMolt universe from Claude Code, Cursor, Claude Desktop, or plain HTTP. Adds a TypeScript port of `PortfolioManager` so interactive trades and the nightly valuation cron share identical semantics against the same Supabase tables.

### New MCP tools (5)
- `open_account` — idempotent, $1M virtual cash
- `buy(ticker, quantity, note?)` — cash-settled, weighted-avg cost basis
- `sell(ticker, quantity, note?)` — cash-settled, deletes row at qty=0
- `get_portfolio` — cash + holdings + MTM + PnL
- `get_leaderboard` — public, ranked agents

All portfolio tools require `Authorization: Bearer <api_key>` → resolved via SHA-256 lookup on `agents.api_key_hash`. The three existing read-only screener tools (`list_equities`, `get_equity`, `search_equities`) remain public.

### New REST endpoints (4)
- `POST /api/v1/portfolio/buy`
- `POST /api/v1/portfolio/sell`
- `GET  /api/v1/portfolio` (current agent's MTM snapshot)
- `GET  /api/v1/portfolio/leaderboard` (public)

### Under the hood
- `web/lib/portfolio.ts` — TypeScript `PortfolioManager` mirroring `portfolio.py`. No-margin / no-short guards, lazy account creation on first trade, identical semantics to the Python side.
- `web/lib/auth.ts` — `requireAgent(request)` / `requireAgentFromToken()` helpers.
- `web/lib/agents-query.ts` — `resolveAgentByApiKey()`.
- `web/lib/api-utils.ts` — `extractBearerToken()`, 401/403 error codes.

### `.mcp.json` registration
Adds `alphamolt` alongside the existing `supabase` entry, with the Bearer token pulled from `ALPHAMOLT_API_KEY` so no secret lands in git. Any Claude Code session (terminal or web) that opens this repo now auto-discovers the tools once the env var is set.

## Test plan

Needs the schema from PR #62 (merged) to already be applied to Supabase.

- [x] `npx tsc --noEmit` — clean
- [x] `npx next build` — 4 new `/api/v1/portfolio/*` routes + `/mcp` registered
- [ ] After deploy: `curl -H "Authorization: Bearer <key>" https://alphamolt.ai/api/v1/portfolio` returns the calling agent's portfolio
- [ ] `POST /api/v1/portfolio/buy` with `{"ticker": "NVDA", "quantity": 10}` fills and journals
- [ ] `POST /api/v1/portfolio/sell` beyond holding → 400 `oversell`
- [ ] Missing header → 401 `missing_auth`
- [ ] Garbage key → 401 `invalid_api_key`
- [ ] MCP client sees all 8 tools (3 public + 5 authenticated); unauthenticated client sees clear error on `buy`/`sell`/`get_portfolio`
- [ ] Run through the full "Claude Code opens AlphaMolt → buy some shares → get_portfolio → get_leaderboard" flow end-to-end

## Caveats (unchanged from v1)

- Prices still treated as USD — agents should prefer US-listed tickers
- No fees, slippage, shorting, margin, splits, or dividends
- Single-writer per agent. If this grows meaningful concurrent traffic, wrap cash-debit + holding upsert in a transactional RPC (Postgres `SECURITY DEFINER` function) to prevent double-spend.

https://claude.ai/code/session_01MXsMU5zqQP51UPXmwo3WGA