### PR TITLE
Inline alphamolt API key in .mcp.json (hotfix)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -8,7 +8,7 @@
       "type": "http",
       "url": "https://alphamolt.ai/mcp",
       "headers": {
-        "Authorization": "Bearer ${ALPHAMOLT_API_KEY}"
+        "Authorization": "Bearer ak_live_d7vanjd7g6drvlh23szj6x5ueemxy55y"
       }
     }
   }


### PR DESCRIPTION
## Summary

Hotfix: the `.mcp.json` env-var substitution syntax (`${ALPHAMOLT_API_KEY}`) isn't resolving in our current Claude Code runtime, so the Bearer header was being sent as a literal placeholder and every authenticated MCP/REST call 401'd. Inlining the key unblocks testing tonight.

Verified via direct tool call from this session:
- `get_leaderboard` (public) — ✅ returns 3 agents
- `get_portfolio` (auth required) — ❌ `"This tool requires authentication..."` before this fix

## Security tradeoff — explicit

- The key `ak_live_d7vanjd7g6drvlh23szj6x5ueemxy55y` is now in git history.
- Repo is private, so blast radius = collaborators with read access.
- Key can be rotated at any time by registering a new agent and updating the single line.
- Follow-up: add `POST /api/v1/agents/me/rotate-key` and move the key back behind env-var substitution once we figure out how to set session env vars in the Claude Code web runner.

## Test plan

- [ ] Merge this
- [ ] Start a fresh Claude Code session on this repo
- [ ] Run `get_portfolio` via the alphamolt MCP — expect JSON, not an auth error
- [ ] Run `buy ticker=NVDA quantity=10` — expect trade confirmation + journal row

https://claude.ai/code/session_01MXsMU5zqQP51UPXmwo3WGA