### PR TITLE
Fix alphamolt MCP URL to bypass apex→www redirect

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
     },
     "alphamolt": {
       "type": "http",
-      "url": "https://alphamolt.ai/mcp",
+      "url": "https://www.alphamolt.ai/mcp",
       "headers": {
         "Authorization": "Bearer ak_live_d7vanjd7g6drvlh23szj6x5ueemxy55y"
       }


### PR DESCRIPTION
## Root cause

Every auth failure we've been debugging for the last hour traces to **one thing**: Vercel canonicalizes `alphamolt.ai` → `www.alphamolt.ai` with a 307 redirect, and HTTP clients strip the `Authorization` header on cross-host redirects per RFC 7235 security behavior. Every MCP tool call, every REST call, every session restart — all of them were hitting the apex domain, losing the Bearer header, and arriving at the server as unauthenticated requests. The server was returning `missing_auth` correctly every time.

## Proof

Before (apex):
```
$ curl -sSL -H "Authorization: Bearer ak_live_..." https://alphamolt.ai/api/v1/portfolio
{"error":"Missing Authorization header...","code":"missing_auth"}
HTTP 401
```

After (canonical www):
```
$ curl -sS -H "Authorization: Bearer ak_live_..." https://www.alphamolt.ai/api/v1/portfolio
{"agent":{"handle":"agentzero","display_name":"Agent Zero"},"cash_usd":1000000,...}
HTTP 200
```

Same for `POST https://www.alphamolt.ai/mcp` with a full MCP `tools/call` payload — returns the portfolio JSON-RPC response correctly.

## Fix

One-line change: point `.mcp.json` at the canonical URL (`https://www.alphamolt.ai/mcp`). No redirect, no header stripping, auth flows end-to-end.

## Follow-up (not in this PR)

Change the apex-domain canonicalization from a **redirect** to a **rewrite** so naive clients hitting `alphamolt.ai/...` also work transparently. That's a Vercel domain-config change + possibly a `vercel.json` or `next.config.ts` `rewrites` entry. Worth doing for UX but it's a separate surface area.

Also worth doing: update the registration response page to show users the exact MCP config snippet (with `www.alphamolt.ai` URL) so nobody else hits this.

## Test plan

- [x] `curl -H "Authorization: Bearer <key>" https://www.alphamolt.ai/api/v1/portfolio` → 200 with agent JSON ✓
- [x] `curl -X POST https://www.alphamolt.ai/mcp` with `tools/call` → JSON-RPC with portfolio ✓
- [ ] Merge this
- [ ] Start a fresh Claude Code session on `main`
- [ ] Ask: "use alphamolt to show my portfolio and buy 10 shares of NVDA"
- [ ] Verify trade lands in `agent_trades` table

https://claude.ai/code/session_01MXsMU5zqQP51UPXmwo3WGA