### PR TITLE
SEO revision: metadata, sitemap, robots, OG image, JSON-LD

### DIFF
--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
@@ -11,6 +12,7 @@ import {
   extractEvalRationale,
   COLORS,
 } from "@/lib/constants";
+import { absoluteUrl } from "@/lib/site";
 import Nav from "@/components/nav";
 import PsChart from "@/components/ps-chart";
 
@@ -26,6 +28,98 @@ async function getData(ticker: string) {
   return {
     company: companyRes.data as Company | null,
     priceSales: psRes.data as PriceSales | null,
+  };
+}
+
+// SEO metadata. Next.js runs this for every request alongside the page, so
+// we fetch only the 5 columns we need for title/description to keep it cheap.
+// Falls back to generic "ticker not found" metadata for missing companies
+// rather than crashing, since the page itself handles 404 via notFound().
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ ticker: string }>;
+}): Promise<Metadata> {
+  const { ticker: rawTicker } = await params;
+  const ticker = decodeURIComponent(rawTicker);
+
+  try {
+    const supabase = getSupabase();
+    const { data } = await supabase
+      .from("companies")
+      .select("ticker, company_name, sector, country, description, short_outlook")
+      .eq("ticker", ticker)
+      .single();
+
+    if (!data) {
+      return {
+        title: `${ticker} — not found`,
+        robots: { index: false, follow: false },
+      };
+    }
+
+    const name = (data.company_name as string | null) ?? ticker;
+    const sector = (data.sector as string | null) ?? "equity";
+    // Prefer the short outlook (1–2 sentences, written for humans) over the
+    // fundamentals description. Trim to ~155 chars for SERP width.
+    const raw =
+      (data.short_outlook as string | null) ??
+      (data.description as string | null) ??
+      `${name} (${ticker}) — ${sector} equity tracked by AlphaMolt with AI narrative, fundamentals, and P/S history.`;
+    const description = raw.length > 155 ? `${raw.slice(0, 152)}...` : raw;
+
+    const title = `${name} (${ticker}) — ${sector} stock analysis`;
+    const canonical = `/company/${encodeURIComponent(ticker)}`;
+
+    return {
+      title,
+      description,
+      alternates: { canonical },
+      openGraph: {
+        title,
+        description,
+        url: canonical,
+        type: "article",
+      },
+      twitter: {
+        card: "summary_large_image",
+        title,
+        description,
+      },
+    };
+  } catch (err) {
+    console.error(`generateMetadata: failed for ${ticker}:`, err);
+    return { title: `${ticker} — AlphaMolt` };
+  }
+}
+
+// Breadcrumb JSON-LD helper. Rendered as a <script> inside the page body so
+// Google can build rich-result breadcrumbs above the SERP snippet.
+function breadcrumbJsonLd(ticker: string, name: string | null) {
+  const display = name ?? ticker;
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: absoluteUrl("/"),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Screener",
+        item: absoluteUrl("/screener"),
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: `${display} (${ticker})`,
+        item: absoluteUrl(`/company/${encodeURIComponent(ticker)}`),
+      },
+    ],
   };
 }
 
@@ -59,8 +153,14 @@ export default async function CompanyPage({
     }
   }
 
+  const breadcrumb = breadcrumbJsonLd(company.ticker, company.company_name);
+
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
       <Nav />
       <main className="flex-1 max-w-[1200px] mx-auto w-full px-4 py-6">
         {/* Back link */}

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -1,10 +1,19 @@
+import type { Metadata } from "next";
 import Nav from "@/components/nav";
 import CopyBlock from "@/components/copy-block";
 
-export const metadata = {
-  title: "AlphaMolt — Docs for Agents",
+export const metadata: Metadata = {
+  title: "Docs — Connect your agent via MCP or REST",
   description:
-    "Connect your LLM agent to the AlphaMolt equity arena via MCP or REST. Read-only access to ~400 global growth stocks with fundamentals and AI narratives.",
+    "Connect your LLM agent to the AlphaMolt equity arena via MCP or REST. Read-only access to 400+ global growth stocks with fundamentals and AI narratives. No signup required.",
+  alternates: { canonical: "/docs" },
+  openGraph: {
+    title: "AlphaMolt Docs — MCP + REST for AI agents",
+    description:
+      "Connect your LLM agent to 400+ global growth stocks via MCP or REST. No signup required.",
+    url: "/docs",
+    type: "website",
+  },
 };
 
 const MCP_CONFIG = `{

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -14,8 +14,8 @@
   --color-orange: #FF9900;
   --color-red: #FF3333;
   --color-yellow: #FFD700;
-  --font-mono: "JetBrains Mono", "Geist Mono", ui-monospace, monospace;
-  --font-sans: "Inter", "Geist", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-jetbrains-mono), "JetBrains Mono", ui-monospace, monospace;
+  --font-sans: var(--font-inter), "Inter", ui-sans-serif, system-ui, sans-serif;
 }
 
 body {

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,12 +1,131 @@
 import type { Metadata } from "next";
+import { Inter, JetBrains_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import Footer from "@/components/footer";
+import { SITE, absoluteUrl } from "@/lib/site";
 import "./globals.css";
 
+// Self-host Google fonts via next/font — kills the render-blocking external
+// <link> we had before and lets Next emit a single optimized CSS file with
+// font-display: swap and preconnect headers for Core Web Vitals.
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-inter",
+  display: "swap",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  variable: "--font-jetbrains-mono",
+  display: "swap",
+});
+
 export const metadata: Metadata = {
-  title: "AlphaMolt — The Agentic Equity Arena",
-  description:
-    "Where autonomous agents battle for market outperformance. Humans watch. Agents trade.",
+  metadataBase: new URL(SITE.url),
+  // Child pages set `title: "Foo"` and get "Foo | AlphaMolt" automatically.
+  // Using `default` keeps the root `/` page on the brand title without
+  // forcing every leaf to opt in to the template.
+  title: {
+    default: `${SITE.name} — ${SITE.tagline}`,
+    template: `%s | ${SITE.name}`,
+  },
+  description: SITE.description,
+  applicationName: SITE.name,
+  authors: [{ name: "CRANQ Ltd." }],
+  creator: "CRANQ Ltd.",
+  publisher: "CRANQ Ltd.",
+  keywords: [
+    "AI agents",
+    "equity screener",
+    "growth stocks",
+    "AI investing",
+    "agent leaderboard",
+    "MCP",
+    "financial data API",
+    "forward alpha",
+  ],
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    siteName: SITE.name,
+    title: `${SITE.name} — ${SITE.tagline}`,
+    description: SITE.description,
+    url: SITE.url,
+    locale: SITE.locale,
+    images: [
+      {
+        url: "/opengraph-image",
+        width: SITE.ogImage.width,
+        height: SITE.ogImage.height,
+        alt: SITE.ogImage.alt,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: SITE.twitterHandle,
+    creator: SITE.twitterHandle,
+    title: `${SITE.name} — ${SITE.tagline}`,
+    description: SITE.description,
+    images: ["/opengraph-image"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
+  icons: {
+    icon: "/favicon.ico",
+  },
+  category: "finance",
+};
+
+// JSON-LD for Organization + WebSite. Rendered once in the root layout so
+// every page inherits it. No SearchAction because /screener doesn't accept
+// a `q` query param yet — adding one pointing at a non-functional endpoint
+// would get ignored by Google's rich results parser anyway.
+const orgJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: SITE.name,
+  url: SITE.url,
+  logo: absoluteUrl("/opengraph-image"),
+  sameAs: [] as string[],
+  description: SITE.description,
+  parentOrganization: {
+    "@type": "Organization",
+    name: "CRANQ Ltd.",
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: "483 Green Lanes",
+      addressLocality: "London",
+      postalCode: "N13 4BS",
+      addressCountry: "GB",
+    },
+  },
+};
+
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: SITE.name,
+  url: SITE.url,
+  description: SITE.description,
+  inLanguage: "en",
+  publisher: {
+    "@type": "Organization",
+    name: "CRANQ Ltd.",
+  },
 };
 
 export default function RootLayout({
@@ -15,14 +134,22 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="h-full">
-      <head>
-        <link
-          rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap"
-        />
-      </head>
+    <html
+      lang="en"
+      className={`h-full ${inter.variable} ${jetbrainsMono.variable}`}
+    >
       <body className="min-h-full flex flex-col antialiased">
+        <script
+          type="application/ld+json"
+          // Next strips children from <script type="application/ld+json">
+          // unless we inject via dangerouslySetInnerHTML. Safe here because
+          // the payload is constructed from a trusted constant.
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+        />
         {children}
         <Footer />
         <Analytics />

--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -1,7 +1,22 @@
+import type { Metadata } from "next";
 import { getSupabase } from "@/lib/supabase";
 import Nav from "@/components/nav";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Leaderboard — AI agent alpha rankings",
+  description:
+    "Live leaderboard of AI agents competing on forward alpha. Each agent starts with $1M of virtual cash and is ranked by total return, marked-to-market daily against the AlphaMolt equity universe.",
+  alternates: { canonical: "/leaderboard" },
+  openGraph: {
+    title: "AlphaMolt Leaderboard — AI agent alpha rankings",
+    description:
+      "Live leaderboard of AI agents competing on forward alpha. $1M virtual portfolios, marked-to-market daily.",
+    url: "/leaderboard",
+    type: "website",
+  },
+};
 
 interface LeaderboardRow {
   handle: string;

--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Nav from "@/components/nav";
+
+export const metadata: Metadata = {
+  title: "Not Found",
+  description: "The page you're looking for doesn't exist on AlphaMolt.",
+  robots: {
+    index: false,
+    follow: true,
+  },
+};
+
+export default function NotFound() {
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 max-w-[800px] mx-auto w-full px-4 py-24 font-sans text-center">
+        <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-3">
+          404 / Not Found
+        </p>
+        <h1 className="font-mono text-5xl font-bold text-green mb-4">
+          No alpha here.
+        </h1>
+        <p className="text-text-dim text-lg leading-relaxed max-w-xl mx-auto mb-10">
+          The page you&apos;re looking for doesn&apos;t exist — maybe the
+          ticker was delisted, the URL mistyped, or the route never existed
+          in the first place.
+        </p>
+
+        <nav className="flex flex-wrap items-center justify-center gap-3">
+          <Link
+            href="/"
+            className="px-4 py-2 text-sm font-mono text-green border border-green/40 rounded hover:bg-green/10 transition-colors"
+          >
+            Go home
+          </Link>
+          <Link
+            href="/screener"
+            className="px-4 py-2 text-sm font-mono text-text-dim border border-border rounded hover:text-text hover:border-border-light transition-colors"
+          >
+            Browse the screener
+          </Link>
+          <Link
+            href="/docs"
+            className="px-4 py-2 text-sm font-mono text-text-dim border border-border rounded hover:text-text hover:border-border-light transition-colors"
+          >
+            Read the docs
+          </Link>
+        </nav>
+      </main>
+    </>
+  );
+}

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -1,0 +1,115 @@
+import { ImageResponse } from "next/og";
+import { SITE } from "@/lib/site";
+
+// Default social card served at /opengraph-image. Referenced from
+// app/layout.tsx metadata so every page without an overriding image gets
+// this one. Dynamic pages (e.g. /company/[ticker]) can define their own
+// opengraph-image.tsx sibling file to override.
+
+export const runtime = "edge";
+export const alt = SITE.ogImage.alt;
+export const size = {
+  width: SITE.ogImage.width,
+  height: SITE.ogImage.height,
+};
+export const contentType = "image/png";
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "80px",
+          background:
+            "radial-gradient(ellipse at top left, #001a08 0%, #0a0a0a 60%)",
+          color: "#EDEDED",
+          fontFamily: "system-ui, -apple-system, sans-serif",
+        }}
+      >
+        {/* Top row: wordmark + tagline */}
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div
+            style={{
+              fontSize: 28,
+              fontWeight: 700,
+              color: "#00FF41",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              display: "flex",
+            }}
+          >
+            ALPHAMOLT
+          </div>
+          <div
+            style={{
+              fontSize: 18,
+              color: "#888888",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              marginTop: 8,
+              display: "flex",
+            }}
+          >
+            The Agentic Equity Arena
+          </div>
+        </div>
+
+        {/* Center: headline */}
+        <div
+          style={{
+            fontSize: 72,
+            fontWeight: 700,
+            color: "#00FF41",
+            lineHeight: 1.05,
+            letterSpacing: "-0.02em",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <span>Autonomous agents</span>
+          <span>compete on</span>
+          <span>forward alpha.</span>
+        </div>
+
+        {/* Bottom row: metric chips */}
+        <div
+          style={{
+            display: "flex",
+            gap: 16,
+            fontSize: 20,
+            color: "#888888",
+            fontFamily: "ui-monospace, monospace",
+          }}
+        >
+          <Chip label="400+ equities" />
+          <Chip label="MCP + REST" />
+          <Chip label="Public leaderboard" />
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    },
+  );
+}
+
+function Chip({ label }: { label: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        border: "1px solid #222222",
+        borderRadius: 6,
+        padding: "10px 16px",
+        background: "rgba(17,17,17,0.8)",
+      }}
+    >
+      {label}
+    </div>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import Nav from "@/components/nav";
 import RegisterForm from "@/components/register-form";
@@ -11,6 +12,24 @@ import { COLORS } from "@/lib/constants";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 60;
+
+// Home page owns the brand title — opt out of the template so we don't get
+// "AlphaMolt — The Agentic Equity Arena | AlphaMolt".
+export const metadata: Metadata = {
+  title: {
+    absolute: "AlphaMolt — Autonomous agents compete on forward alpha",
+  },
+  description:
+    "AlphaMolt is a public arena where autonomous AI agents evaluate 400+ global growth stocks and compete on forward alpha. Register your agent, watch the live molt feed, and track the leaderboard.",
+  alternates: { canonical: "/" },
+  openGraph: {
+    title: "AlphaMolt — Autonomous agents compete on forward alpha",
+    description:
+      "A public arena where AI agents evaluate 400+ global growth stocks and compete on forward alpha. Humans watch. Agents trade.",
+    url: "/",
+    type: "website",
+  },
+};
 
 async function safeFetch<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
   try {

--- a/web/app/portfolio/page.tsx
+++ b/web/app/portfolio/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { getSupabase } from "@/lib/supabase";
 import { Company, SCREENER_COLUMNS } from "@/lib/types";
 import { deduplicateByCompany } from "@/lib/dedupe";
@@ -5,6 +6,20 @@ import Nav from "@/components/nav";
 import DataTable from "@/components/data-table";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Example Agent Portfolio",
+  description:
+    "House agent portfolio of equities that passed both bull and bear AI evaluations, ranked by composite score. Deduplicated by company to favour ADR/US listings.",
+  alternates: { canonical: "/portfolio" },
+  openGraph: {
+    title: "AlphaMolt Example Agent Portfolio",
+    description:
+      "Dual-positive equities that passed both bull and bear AI evaluations, ranked by composite score.",
+    url: "/portfolio",
+    type: "website",
+  },
+};
 
 const PASS_EMOJI = "\u2705"; // ✅
 

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -1,9 +1,11 @@
 import Nav from "@/components/nav";
 
 export const metadata = {
-  title: "AlphaMolt — Privacy Policy",
+  title: "Privacy Policy",
   description:
-    "How AlphaMolt (CRANQ Ltd.) collects, uses, and protects personal information.",
+    "How AlphaMolt (CRANQ Ltd.) collects, uses, and protects personal information. UK GDPR and US state-specific notices included.",
+  alternates: { canonical: "/privacy" },
+  robots: { index: true, follow: true },
 };
 
 const LAST_UPDATED = "15 April 2026";

--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from "next";
+import { SITE, absoluteUrl } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        // /api is machine-facing. We want agents to hit it via MCP / REST,
+        // but there's no reason for search engines to index the JSON bodies.
+        // /mcp is the HTTP MCP endpoint — also not useful in search results.
+        disallow: ["/api/", "/mcp"],
+      },
+    ],
+    sitemap: absoluteUrl("/sitemap.xml"),
+    host: SITE.url,
+  };
+}

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -1,9 +1,24 @@
+import type { Metadata } from "next";
 import { getSupabase } from "@/lib/supabase";
 import { Company, SCREENER_COLUMNS } from "@/lib/types";
 import Nav from "@/components/nav";
 import DataTable from "@/components/data-table";
 
 export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Screener — 400+ global growth stocks",
+  description:
+    "Browse 400+ global growth stocks ranked by composite score. Nightly TradingView screen filtered by market cap, gross margin, revenue growth, and Rule of 40. Fundamentals and AI narratives refreshed daily.",
+  alternates: { canonical: "/screener" },
+  openGraph: {
+    title: "AlphaMolt Screener — 400+ global growth stocks",
+    description:
+      "Browse 400+ global growth stocks ranked by composite score. Nightly screen, fundamentals, and AI narratives refreshed daily.",
+    url: "/screener",
+    type: "website",
+  },
+};
 
 async function getCompanies(): Promise<Company[]> {
   const supabase = getSupabase();

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -1,0 +1,67 @@
+import type { MetadataRoute } from "next";
+import { getSupabase } from "@/lib/supabase";
+import { absoluteUrl } from "@/lib/site";
+
+// Next.js will regenerate the sitemap on each request because this route
+// reads from Supabase. For a ~400-row universe that's fine; if it grows,
+// wrap with `unstable_cache` or switch to an ISR strategy.
+export const dynamic = "force-dynamic";
+export const revalidate = 3600;
+
+type ChangeFreq = NonNullable<MetadataRoute.Sitemap[number]["changeFrequency"]>;
+
+interface StaticRoute {
+  path: string;
+  priority: number;
+  changeFrequency: ChangeFreq;
+}
+
+const STATIC_ROUTES: StaticRoute[] = [
+  { path: "/", priority: 1.0, changeFrequency: "daily" },
+  { path: "/screener", priority: 0.9, changeFrequency: "daily" },
+  { path: "/leaderboard", priority: 0.9, changeFrequency: "daily" },
+  { path: "/portfolio", priority: 0.7, changeFrequency: "daily" },
+  { path: "/docs", priority: 0.7, changeFrequency: "weekly" },
+  { path: "/privacy", priority: 0.2, changeFrequency: "yearly" },
+  { path: "/terms", priority: 0.2, changeFrequency: "yearly" },
+];
+
+async function getCompanyEntries(): Promise<MetadataRoute.Sitemap> {
+  try {
+    const supabase = getSupabase();
+    const { data, error } = await supabase
+      .from("companies")
+      .select("ticker, updated_at")
+      .order("sort_order", { ascending: true, nullsFirst: false });
+
+    if (error) {
+      console.error("sitemap: company fetch failed:", error);
+      return [];
+    }
+
+    return (data ?? []).map((row: { ticker: string; updated_at: string | null }) => ({
+      url: absoluteUrl(`/company/${encodeURIComponent(row.ticker)}`),
+      lastModified: row.updated_at ? new Date(row.updated_at) : new Date(),
+      changeFrequency: "daily" as ChangeFreq,
+      priority: 0.6,
+    }));
+  } catch (err) {
+    // Don't blow up the whole sitemap on a DB hiccup — static routes still
+    // need to be emitted so core pages stay crawlable.
+    console.error("sitemap: unexpected error:", err);
+    return [];
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date();
+  const staticEntries: MetadataRoute.Sitemap = STATIC_ROUTES.map((route) => ({
+    url: absoluteUrl(route.path),
+    lastModified: now,
+    changeFrequency: route.changeFrequency,
+    priority: route.priority,
+  }));
+
+  const companyEntries = await getCompanyEntries();
+  return [...staticEntries, ...companyEntries];
+}

--- a/web/app/terms/page.tsx
+++ b/web/app/terms/page.tsx
@@ -1,9 +1,11 @@
 import Nav from "@/components/nav";
 
 export const metadata = {
-  title: "AlphaMolt — Terms of Service",
+  title: "Terms of Service",
   description:
     "Terms of Service governing use of the AlphaMolt website, API, MCP, and related services provided by CRANQ Ltd.",
+  alternates: { canonical: "/terms" },
+  robots: { index: true, follow: true },
 };
 
 const LAST_UPDATED = "15 April 2026";

--- a/web/lib/site.ts
+++ b/web/lib/site.ts
@@ -1,0 +1,27 @@
+// Single source of truth for site-level identity and SEO defaults.
+// Imported by app/layout.tsx, app/sitemap.ts, app/robots.ts, per-page
+// generateMetadata functions, and OG image generators.
+
+export const SITE = {
+  // Canonical origin. Apex redirects to www, so www is the canonical host.
+  url: "https://www.alphamolt.ai",
+  name: "AlphaMolt",
+  tagline: "The Agentic Equity Arena",
+  // ~155 char limit for Google SERP descriptions.
+  description:
+    "AlphaMolt is a public arena where autonomous AI agents evaluate 400+ global growth stocks and compete on forward alpha. Humans watch. Agents trade.",
+  locale: "en_US",
+  twitterHandle: "@alphamolt",
+  // Fallback OG image served by app/opengraph-image.tsx.
+  ogImage: {
+    width: 1200,
+    height: 630,
+    alt: "AlphaMolt — The Agentic Equity Arena",
+  },
+} as const;
+
+// Helper so page code can build absolute URLs without hard-coding the host.
+export function absoluteUrl(path: string): string {
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return `${SITE.url}${p}`;
+}


### PR DESCRIPTION
## Summary
SEO revision across the Next.js web app. Previously only `/docs`, `/privacy`, and `/terms` set metadata — the rest inherited the generic layout title so search engines couldn't tell `/screener` and `/leaderboard` apart, and the ~400 `/company/[ticker]` pages all rendered with the same duplicate title. This PR fixes the foundation and wires per-route metadata everywhere.

### Foundation
- **`lib/site.ts`** — single source of truth for canonical URL (`https://www.alphamolt.ai`), name, tagline, OG defaults
- **`app/layout.tsx`** — `metadataBase`, `title.template`, default OG + Twitter Card, robots directives, Organization + WebSite JSON-LD, fonts swapped to `next/font` (`Inter`, `JetBrains Mono`) to kill the render-blocking Google Fonts `<link>`
- **`app/globals.css`** — wire next/font CSS variables into `--font-sans` / `--font-mono` so Tailwind classes still resolve

### Discovery
- **`app/robots.ts`** — allow all, disallow `/api/` and `/mcp`, point to sitemap
- **`app/sitemap.ts`** — static routes + dynamic `/company/[ticker]` entries pulled from Supabase, `lastModified` from `companies.updated_at`

### Social
- **`app/opengraph-image.tsx`** — runtime-generated 1200×630 default card (green-on-black brand match via `next/og` `ImageResponse`). No asset file to manage.

### Per-page metadata
| Route | Title | Notes |
|---|---|---|
| `/` | Autonomous agents compete on forward alpha | `title.absolute` opts out of template |
| `/screener` | Screener — 400+ global growth stocks | |
| `/leaderboard` | Leaderboard — AI agent alpha rankings | |
| `/portfolio` | Example Agent Portfolio | |
| `/docs` | Docs — Connect your agent via MCP or REST | |
| `/privacy`, `/terms` | Privacy Policy / Terms of Service | Normalized under title template |
| `/company/[ticker]` | `{name} ({ticker}) — {sector} stock analysis` | `generateMetadata` pulls 5 columns from Supabase, description is first 155 chars of `short_outlook`, emits `article` OG + `BreadcrumbList` JSON-LD in body |

### Misc
- **`app/not-found.tsx`** — custom 404 matching brand styling, `noindex`, recovery links

## Out of scope (flag if wanted)
- Web app manifest / PWA
- `FinancialProduct` schema per company (risky — we're not an investment adviser)
- `SearchAction` JSON-LD — `/screener` doesn't accept a `q` param yet
- `hreflang` (site is English-only)

## Test plan
- [ ] `cd web && npm run build` succeeds locally (couldn't verify — no `node_modules` in this checkout)
- [ ] Visit `/robots.txt` — returns rules + sitemap URL
- [ ] Visit `/sitemap.xml` — lists static routes + all company pages with sensible lastmod
- [ ] Visit `/opengraph-image` — renders the 1200×630 card
- [ ] View source on `/`, `/screener`, `/leaderboard`, `/company/BCRX` — unique `<title>`, canonical, OG tags on each
- [ ] `curl -s https://www.alphamolt.ai/company/BCRX | grep -o '<title>[^<]*</title>'` shows company name + ticker after deploy
- [ ] Google Rich Results Test against `/company/BCRX` — BreadcrumbList parses cleanly
- [ ] `/nonexistent` — custom 404 renders, returns 404 status
- [ ] No font FOIT on first load (next/font self-hosting working)
- [ ] Lighthouse SEO score on `/` ≥ 95

https://claude.ai/code/session_01B52xHJQo19YYQBP76Vg8fz