### PR TITLE
Fetch per-submolt feeds instead of general feed for engagement

### DIFF
--- a/moltbook_heartbeat.py
+++ b/moltbook_heartbeat.py
@@ -357,8 +357,19 @@ def _engage_feed(
     """Browse the feed, follow + upvote finance-relevant agents, comment."""
     stats: dict[str, int] = {"followed": 0, "upvoted": 0, "commented": 0}
 
-    posts = client.feed(sort="new", limit=15)
-    log.info("feed fetched: %d posts", len(posts))
+    # Fetch per-submolt feeds to guarantee finance-relevant content.
+    # The general feed is dominated by high-traffic submolts (general, agents)
+    # and rarely surfaces posts from smaller finance communities.
+    seen_ids: set[str] = set()
+    posts: list[dict] = []
+    for submolt_name in FINANCE_SUBMOLTS:
+        for p in client.feed(sort="new", limit=5, submolt=submolt_name):
+            pid = p.get("id", "")
+            if pid and pid not in seen_ids:
+                seen_ids.add(pid)
+                posts.append(p)
+    log.info("feed fetched: %d unique posts from %d submolts",
+             len(posts), len(FINANCE_SUBMOLTS))
 
     already_followed: set[str] = set(ledger.get("followed", []))
     already_upvoted: set[str] = set(ledger.get("upvoted_posts", []))

--- a/moltbook_lib.py
+++ b/moltbook_lib.py
@@ -159,8 +159,13 @@ class MoltbookClient:
         )
 
     # Engagement endpoints (proactive growth)
-    def feed(self, sort: str = "new", limit: int = 15) -> list[dict]:
-        data = self._get(f"/feed?sort={sort}&limit={limit}") or {}
+    def feed(
+        self, sort: str = "new", limit: int = 15, submolt: str | None = None
+    ) -> list[dict]:
+        path = f"/feed?sort={sort}&limit={limit}"
+        if submolt:
+            path += f"&submolt={submolt}"
+        data = self._get(path) or {}
         return data.get("posts") or data.get("items") or []
 
     def follow_agent(self, agent_name: str) -> bool:


### PR DESCRIPTION
The first live run fetched 15 posts but zero were from finance submolts — the general feed is dominated by general (1.5M posts), agents (58K), and philosophy (28K). Finance submolts (7–259 subscribers) never appear in the top 15.

Fix: iterate through each FINANCE_SUBMOLTS entry and fetch 5 posts per submolt via the ?submolt= query parameter, deduping by post ID. This guarantees up to 40 finance-relevant posts per run. If the submolt filter isn't supported by the API, the FINANCE_SUBMOLTS membership check in the loop still runs as a safety net.