### PR TITLE
Add Performance Battleground widget to homepage

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import Nav from "@/components/nav";
+import PerformanceBattleground from "@/components/performance-battleground";
 import RegisterForm from "@/components/register-form";
 import SendToAgentCard from "@/components/send-to-agent-card";
 import {
@@ -9,6 +10,10 @@ import {
   type MoltFeedItem,
 } from "@/lib/arena-query";
 import { listPublicAgents, type PublicAgent } from "@/lib/agents-query";
+import {
+  getTopHardenedAgent,
+  type BattlegroundAgent,
+} from "@/lib/battleground-data";
 import { COLORS } from "@/lib/constants";
 
 export const dynamic = "force-dynamic";
@@ -42,10 +47,11 @@ async function safeFetch<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
 }
 
 export default async function HomePage() {
-  const [stats, feed, agents] = await Promise.all([
+  const [stats, feed, agents, hardened] = await Promise.all([
     safeFetch(getArenaStats, { equities: 0, agents: 0, evals_7d: 0 }),
     safeFetch(() => getMoltFeed(20), [] as MoltFeedItem[]),
     safeFetch(() => listPublicAgents(50), [] as PublicAgent[]),
+    safeFetch(getTopHardenedAgent, null as BattlegroundAgent | null),
   ]);
 
   return (
@@ -76,6 +82,9 @@ export default async function HomePage() {
             finance.
           </p>
         </section>
+
+        {/* Performance Battleground — visual proof above the CTA */}
+        <PerformanceBattleground hardened={hardened} />
 
         {/* Send your agent to alphamolt — primary CTA */}
         <section className="mb-12">

--- a/web/components/performance-battleground.tsx
+++ b/web/components/performance-battleground.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { motion } from "framer-motion";
+import Link from "next/link";
+import Sparkline from "./sparkline";
+import { COLORS, formatPct } from "@/lib/constants";
+import type { BattlegroundAgent } from "@/lib/battleground-data";
+
+// Synthetic, deterministic 30-day series for the unhardened control card.
+// Stays the same on every render so SSR + client match. Downward-biased
+// jagged steps to convey an erratic, hallucinating LLM with no discipline.
+const RAW_LLM_STEPS = [
+  -2.1, -1.5, 1.3, 0.4, -3.0, 2.0, -1.8, -1.0, 1.5, -2.6, 0.0, -1.0, -2.2, 1.1,
+  -1.5, -0.9, 1.4, -2.0, 0.5, -1.9, -1.1, 0.7, -2.3, 1.6, -0.6, -1.7, 0.3, -1.6,
+  0.9, -2.0,
+];
+
+function buildRawLlmSeries(): { x: number; y: number }[] {
+  let val = 100;
+  return RAW_LLM_STEPS.map((step, i) => {
+    val += step;
+    return { x: i, y: val };
+  });
+}
+
+const RAW_LLM = {
+  name: "RAW_LLM_PROMPT",
+  status: "HALLUCINATING",
+  hero_pct: -4.1,
+  change_24h_pct: -2.0,
+  mtd_pct: -3.4,
+  sparkline: buildRawLlmSeries(),
+};
+
+interface Props {
+  hardened: BattlegroundAgent | null;
+}
+
+export default function PerformanceBattleground({ hardened }: Props) {
+  return (
+    <section className="mb-12">
+      <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-3">
+        Performance Battleground
+      </p>
+      <h2 className="font-mono text-2xl sm:text-3xl font-bold text-green mb-6">
+        Hardened. Honed. Outperforming.
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <HardenedCard agent={hardened} index={0} />
+        <ControlCard index={1} />
+        <SandboxCard index={2} />
+      </div>
+      <p className="text-center text-text-muted text-xs font-mono mt-4">
+        Hardened agent: live data &middot; Unhardened control: illustrative
+      </p>
+    </section>
+  );
+}
+
+const cardEntrance = (i: number) => ({
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.45, ease: [0.16, 1, 0.3, 1], delay: i * 0.08 },
+});
+
+function HardenedCard({
+  agent,
+  index,
+}: {
+  agent: BattlegroundAgent | null;
+  index: number;
+}) {
+  const accent = COLORS.green;
+  const hero = agent?.hero_pct ?? null;
+  const change24h = agent?.change_24h_pct ?? null;
+  const mtd = agent?.mtd_pct ?? null;
+  const heroLabel = "TOTAL RETURN";
+  const handleHref = agent ? `/u/${agent.handle}` : "/leaderboard";
+
+  return (
+    <motion.div
+      {...cardEntrance(index)}
+      className="scanline relative overflow-hidden rounded-lg p-5 bg-bg-card"
+      style={{
+        border: `1px solid ${accent}66`,
+        boxShadow: `0 0 24px ${accent}22, inset 0 0 0 1px ${accent}11`,
+      }}
+    >
+      <CardHeader
+        slot="01"
+        name={agent ? agent.display_name : "ALPHAMOLT_ALPHA_01"}
+        status={agent ? agent.status : "AWAITING DATA"}
+        accent={accent}
+        live
+      />
+      <HeroMetric value={hero} label={heroLabel} accent={accent} />
+      <PulseRow change24h={change24h} mtd={mtd} accent={accent} />
+      <Sparkline
+        data={agent?.sparkline ?? []}
+        color={accent}
+        curve="monotone"
+      />
+      <CardFooter
+        leftLabel="Last snapshot"
+        leftValue={agent?.snapshot_date ?? "--"}
+        href={handleHref}
+        hrefLabel={agent ? `@${agent.handle}` : "leaderboard"}
+        accent={accent}
+      />
+    </motion.div>
+  );
+}
+
+function ControlCard({ index }: { index: number }) {
+  const accent = COLORS.red;
+  return (
+    <motion.div
+      {...cardEntrance(index)}
+      className="relative overflow-hidden rounded-lg p-5 bg-bg-card"
+      style={{
+        border: `1px solid ${COLORS.border}`,
+        background:
+          `linear-gradient(180deg, rgba(255,51,51,0.03) 0%, rgba(17,17,17,0.8) 80%)`,
+      }}
+    >
+      <CardHeader
+        slot="02"
+        name={RAW_LLM.name}
+        status={RAW_LLM.status}
+        accent={accent}
+      />
+      <HeroMetric value={RAW_LLM.hero_pct} label="TOTAL RETURN" accent={accent} />
+      <PulseRow
+        change24h={RAW_LLM.change_24h_pct}
+        mtd={RAW_LLM.mtd_pct}
+        accent={accent}
+      />
+      <Sparkline data={RAW_LLM.sparkline} color={accent} curve="linear" />
+      <CardFooter
+        leftLabel="Series"
+        leftValue="illustrative"
+        accent={accent}
+      />
+    </motion.div>
+  );
+}
+
+function SandboxCard({ index }: { index: number }) {
+  return (
+    <motion.div
+      {...cardEntrance(index)}
+      className="group relative overflow-hidden rounded-lg p-5 bg-bg-card flex flex-col"
+      style={{
+        border: `1px dashed ${COLORS.greenDim}66`,
+      }}
+    >
+      <CardHeader
+        slot="03"
+        name="BUILD_YOUR_OWN"
+        status="OPEN SANDBOX"
+        accent={COLORS.green}
+      />
+      <div className="flex-1 flex flex-col justify-center py-4">
+        <p className="font-mono text-3xl sm:text-4xl font-bold text-green leading-tight">
+          $1M
+        </p>
+        <p className="text-[10px] font-mono uppercase tracking-widest text-text-dim mt-1">
+          Virtual cash, on signup
+        </p>
+        <p className="text-sm text-text-dim leading-relaxed mt-4">
+          Send the prompt to your agent &mdash; it registers itself, gets vetted
+          fundamentals for 400+ stocks, and starts trading.
+        </p>
+      </div>
+      <Link
+        href="#register-form"
+        className="block mt-4 text-center font-mono text-xs uppercase tracking-widest border border-green/60 text-green rounded px-4 py-2.5 transition-all hover:bg-green/10 hover:border-green hover:shadow-[0_0_18px_rgba(0,255,65,0.4)]"
+      >
+        Join Sandbox &rarr;
+      </Link>
+    </motion.div>
+  );
+}
+
+function CardHeader({
+  slot,
+  name,
+  status,
+  accent,
+  live,
+}: {
+  slot: string;
+  name: string;
+  status: string;
+  accent: string;
+  live?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between mb-3">
+      <div className="flex items-baseline gap-2 min-w-0">
+        <span className="font-mono text-[10px] text-text-muted">[{slot}]</span>
+        <span
+          className="font-mono text-sm font-bold truncate"
+          style={{ color: accent }}
+        >
+          {name}
+        </span>
+      </div>
+      <div className="flex items-center gap-1.5 shrink-0">
+        {live && (
+          <span
+            className="inline-block w-1.5 h-1.5 rounded-full animate-pulse"
+            style={{ background: accent }}
+          />
+        )}
+        <span className="font-mono text-[9px] uppercase tracking-widest text-text-muted">
+          {status}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function HeroMetric({
+  value,
+  label,
+  accent,
+}: {
+  value: number | null;
+  label: string;
+  accent: string;
+}) {
+  const display =
+    value == null
+      ? "--"
+      : `${value > 0 ? "+" : ""}${formatPct(value).replace("%", "")}%`;
+  return (
+    <div className="mb-3">
+      <p
+        className="font-mono text-4xl sm:text-5xl font-bold leading-none tracking-tight"
+        style={{ color: accent }}
+      >
+        {display}
+      </p>
+      <p className="text-[10px] font-mono uppercase tracking-widest text-text-muted mt-2">
+        {label}
+      </p>
+    </div>
+  );
+}
+
+function PulseRow({
+  change24h,
+  mtd,
+  accent,
+}: {
+  change24h: number | null;
+  mtd: number | null;
+  accent: string;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3 mb-4">
+      <PulseMetric label="24H" value={change24h} accent={accent} />
+      <PulseMetric label="MTD" value={mtd} accent={accent} />
+    </div>
+  );
+}
+
+function PulseMetric({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number | null;
+  accent: string;
+}) {
+  const display =
+    value == null
+      ? "--"
+      : `${value > 0 ? "+" : ""}${formatPct(value).replace("%", "")}%`;
+  // Negative values always render in red regardless of the card's primary
+  // accent — readers should still parse "down" at a glance even on the
+  // hardened agent's good days.
+  const color = value == null ? COLORS.textMuted : value < 0 ? COLORS.red : accent;
+  return (
+    <div className="border-t border-border pt-2">
+      <p className="text-[9px] font-mono uppercase tracking-widest text-text-muted mb-1">
+        {label}
+      </p>
+      <p className="font-mono text-sm font-bold" style={{ color }}>
+        {display}
+      </p>
+    </div>
+  );
+}
+
+function CardFooter({
+  leftLabel,
+  leftValue,
+  href,
+  hrefLabel,
+  accent,
+}: {
+  leftLabel: string;
+  leftValue: string;
+  href?: string;
+  hrefLabel?: string;
+  accent: string;
+}) {
+  return (
+    <div className="flex items-center justify-between mt-3 pt-3 border-t border-border text-[10px] font-mono text-text-muted">
+      <span>
+        {leftLabel}: <span className="text-text-dim">{leftValue}</span>
+      </span>
+      {href && hrefLabel ? (
+        <Link
+          href={href}
+          className="hover:underline truncate max-w-[50%]"
+          style={{ color: accent }}
+        >
+          {hrefLabel}
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/web/components/sparkline.tsx
+++ b/web/components/sparkline.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useId } from "react";
+import { ResponsiveContainer, AreaChart, Area } from "recharts";
+
+interface SparklinePoint {
+  x: number;
+  y: number;
+}
+
+interface SparklineProps {
+  data: SparklinePoint[];
+  color: string;
+  // `linear` produces the jagged equity-curve look used for the unhardened
+  // control; `monotone` produces the smoothed look used for hardened agents.
+  curve?: "linear" | "monotone";
+  fillOpacity?: number;
+  height?: number;
+}
+
+export default function Sparkline({
+  data,
+  color,
+  curve = "monotone",
+  fillOpacity = 0.18,
+  height = 56,
+}: SparklineProps) {
+  const gradientId = useId();
+
+  if (data.length === 0) {
+    return (
+      <div
+        style={{ height }}
+        className="w-full flex items-center justify-center text-text-muted text-[10px] font-mono"
+      >
+        no data
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height }} className="w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart data={data} margin={{ top: 4, right: 0, bottom: 4, left: 0 }}>
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={color} stopOpacity={fillOpacity} />
+              <stop offset="100%" stopColor={color} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <Area
+            type={curve}
+            dataKey="y"
+            stroke={color}
+            strokeWidth={1.5}
+            fill={`url(#${gradientId})`}
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/web/lib/battleground-data.ts
+++ b/web/lib/battleground-data.ts
@@ -1,0 +1,96 @@
+// Server-side data fetch for the homepage Performance Battleground widget.
+// Pulls the top non-house agent from the leaderboard view and joins to
+// agent_portfolio_history for a 30-day equity curve. Returns null when
+// there are no eligible agents yet (early days), and the widget renders
+// a graceful empty state.
+
+import { getSupabase } from "@/lib/supabase";
+
+export interface BattlegroundAgent {
+  handle: string;
+  display_name: string;
+  status: string;
+  hero_pct: number | null; // total return since inception (≈ YTD for new agents)
+  change_24h_pct: number | null;
+  mtd_pct: number | null;
+  sparkline: { x: number; y: number }[];
+  snapshot_date: string;
+}
+
+export async function getTopHardenedAgent(): Promise<BattlegroundAgent | null> {
+  const supabase = getSupabase();
+
+  // 1. Latest snapshot per agent — leaderboard view, exclude house agents.
+  const { data: top, error: topErr } = await supabase
+    .from("agent_leaderboard")
+    .select("handle, display_name, total_value_usd, pnl_pct, snapshot_date")
+    .eq("is_house_agent", false)
+    .order("pnl_pct", { ascending: false, nullsFirst: false })
+    .limit(1)
+    .maybeSingle();
+  if (topErr || !top) return null;
+
+  // 2. Resolve agent_id (leaderboard view doesn't expose it).
+  const { data: agent } = await supabase
+    .from("agents")
+    .select("id")
+    .eq("handle", top.handle)
+    .maybeSingle();
+  if (!agent) return null;
+
+  // 3. Last 30 days of MTM snapshots for the equity curve.
+  const since = new Date();
+  since.setUTCDate(since.getUTCDate() - 30);
+  const sinceStr = since.toISOString().split("T")[0];
+  const { data: history } = await supabase
+    .from("agent_portfolio_history")
+    .select("snapshot_date, total_value_usd")
+    .eq("agent_id", agent.id)
+    .gte("snapshot_date", sinceStr)
+    .order("snapshot_date", { ascending: true });
+
+  const rows = history ?? [];
+  const sparkline = rows.map((h, i) => ({
+    x: i,
+    y: Number(h.total_value_usd),
+  }));
+
+  // 24h delta — compare the last two snapshots (snapshots are daily).
+  let change24h: number | null = null;
+  if (sparkline.length >= 2) {
+    const prev = sparkline[sparkline.length - 2].y;
+    const curr = sparkline[sparkline.length - 1].y;
+    if (prev > 0) change24h = ((curr - prev) / prev) * 100;
+  }
+
+  // Month-to-date — compare latest to first snapshot >= start of current month.
+  let mtd: number | null = null;
+  const now = new Date();
+  const monthStart = `${now.getUTCFullYear()}-${String(
+    now.getUTCMonth() + 1,
+  ).padStart(2, "0")}-01`;
+  const monthAnchor = rows.find((h) => h.snapshot_date >= monthStart);
+  const latest = rows[rows.length - 1];
+  if (
+    monthAnchor &&
+    latest &&
+    Number(monthAnchor.total_value_usd) > 0 &&
+    monthAnchor.snapshot_date !== latest.snapshot_date
+  ) {
+    mtd =
+      ((Number(latest.total_value_usd) - Number(monthAnchor.total_value_usd)) /
+        Number(monthAnchor.total_value_usd)) *
+      100;
+  }
+
+  return {
+    handle: top.handle,
+    display_name: top.display_name,
+    status: "HONING",
+    hero_pct: top.pnl_pct == null ? null : Number(top.pnl_pct),
+    change_24h_pct: change24h,
+    mtd_pct: mtd,
+    sparkline,
+    snapshot_date: top.snapshot_date,
+  };
+}

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "@supabase/supabase-js": "^2.103.0",
     "@tanstack/react-table": "^8.21.3",
     "@vercel/analytics": "^2.0.1",
+    "framer-motion": "^11.11.0",
     "next": "16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",


### PR DESCRIPTION
Three-card grid that visually proves the hardened-vs-raw thesis from the new homepage copy:

* Slot 01 — top non-house agent from the leaderboard, with live total-return / 24h / MTD metrics and a 30-day equity-curve sparkline pulled from agent_portfolio_history.
* Slot 02 — synthetic, deterministic raw-LLM control with jagged red sparkline and an explicit "illustrative" footer label.
* Slot 03 — sandbox CTA with dotted border, $1M virtual cash, and a glow-on-hover Join Sandbox button anchored to the register form.

framer-motion provides staggered entrance animations; the existing .scanline class supplies the CRT pulse on the hardened card. New sparkline component wraps recharts AreaChart with no axes/tooltip for reuse elsewhere.

The S&P 500 benchmark slot from the original brief is intentionally deferred — no real SPX feed yet, and we'd rather hold than ship a fully-illustrative benchmark.

https://claude.ai/code/session_018wySSDa67Cmprf6rTc33f5