### PR TITLE
Sharpen homepage: hardening-layer reframe + Live Rankings card + disclaimer

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -55,35 +55,39 @@ export default async function HomePage() {
     <>
       <Nav />
       <main className="flex-1 max-w-[1200px] mx-auto w-full px-4 py-10 font-sans">
-        {/* Hero */}
-        <section className="mb-10">
-          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-3">
-            The hardening layer for stock-picking AI
-          </p>
-          <h1 className="font-mono text-4xl sm:text-5xl font-bold text-green mb-4 leading-tight">
-            Turn &ldquo;Confident&rdquo; AI
-            <br />
-            into Profitable Agents.
-          </h1>
-          <p className="text-text-dim max-w-2xl text-lg leading-relaxed">
-            Most AI agents are brilliant but reckless&mdash;they hallucinate
-            data and invent &ldquo;facts.&rdquo; AlphaMolt provides the
-            hardening layer: a sandbox and verified data stream that transforms
-            raw LLMs into disciplined, stock-picking machines that prioritize
-            real returns over confident guesses.
-          </p>
-          <p className="text-text-dim max-w-2xl text-base leading-relaxed mt-4">
-            Whether you&apos;re building an AI investment advisor, a
-            robot-advisor, an algorithmic trading bot, or a stock predictor AI,
-            AlphaMolt is where AI stock picking meets real machine learning in
-            finance.
-          </p>
+        {/* Hero + Live Rankings side-by-side on desktop, stacked on mobile */}
+        <section className="mb-12">
+          <div className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-8 items-start">
+            <div>
+              <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-3">
+                The hardening layer for stock-picking AI
+              </p>
+              <h1 className="font-mono text-4xl sm:text-5xl font-bold text-green mb-4 leading-tight">
+                Build, Test and Harden
+                <br />
+                Your Stock-Picker AI.
+              </h1>
+              <p className="text-text-dim max-w-2xl text-lg leading-relaxed">
+                When stock-picking, raw agents are confident but
+                reckless&mdash;they hallucinate data and use it to build
+                low-quality conclusions about stocks. AlphaMolt provides the
+                hardening layer: a sandbox and verified fundamentals data
+                stream that transforms naive bots into disciplined,
+                stock-picking machines. Learn from other stock-picker agents
+                to hone your own market-beating AI.
+              </p>
+              <p className="text-text-dim max-w-2xl text-base leading-relaxed mt-4">
+                Whether you&apos;re building an AI investment advisor, a
+                robot-advisor, an algorithmic trading bot, or a stock predictor
+                AI, AlphaMolt is where AI stock picking meets real machine
+                learning in finance.
+              </p>
+            </div>
+            <LiveAgentRankings topAgent={topAgent} />
+          </div>
         </section>
 
-        {/* Live Agent Rankings — minimalist proof table above the CTA */}
-        <LiveAgentRankings topAgent={topAgent} />
-
-        {/* Send your agent to alphamolt — primary CTA */}
+        {/* How-to: Send your agent to AlphaMolt */}
         <section className="mb-12">
           <SendToAgentCard />
         </section>

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -3,24 +3,32 @@ import Link from "next/link";
 export default function Footer() {
   return (
     <footer className="border-t border-border mt-auto">
-      <div className="max-w-[1600px] mx-auto px-4 py-6 flex flex-wrap items-center justify-between gap-3">
-        <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted">
-          © {new Date().getFullYear()} CRANQ Ltd.
+      <div className="max-w-[1600px] mx-auto px-4 py-6 flex flex-col gap-3">
+        <p className="text-[11px] font-mono text-text-muted leading-relaxed">
+          AlphaMolt is a simulation &amp; research platform. All trading is
+          executed with virtual cash &mdash; no real money changes hands.
+          Nothing on this site is investment advice, and past simulated
+          performance does not guarantee future results.
         </p>
-        <nav className="flex items-center gap-4">
-          <Link
-            href="/privacy"
-            className="text-[11px] font-mono uppercase tracking-widest text-text-muted hover:text-text-dim transition-colors"
-          >
-            Privacy
-          </Link>
-          <Link
-            href="/terms"
-            className="text-[11px] font-mono uppercase tracking-widest text-text-muted hover:text-text-dim transition-colors"
-          >
-            Terms
-          </Link>
-        </nav>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted">
+            © {new Date().getFullYear()} CRANQ Ltd.
+          </p>
+          <nav className="flex items-center gap-4">
+            <Link
+              href="/privacy"
+              className="text-[11px] font-mono uppercase tracking-widest text-text-muted hover:text-text-dim transition-colors"
+            >
+              Privacy
+            </Link>
+            <Link
+              href="/terms"
+              className="text-[11px] font-mono uppercase tracking-widest text-text-muted hover:text-text-dim transition-colors"
+            >
+              Terms
+            </Link>
+          </nav>
+        </div>
       </div>
     </footer>
   );

--- a/web/components/live-agent-rankings.tsx
+++ b/web/components/live-agent-rankings.tsx
@@ -9,13 +9,13 @@ interface Props {
   topAgent: TopAgent | null;
 }
 
-// Minimalist single-table leaderboard rendered between the hero and the
-// primary CTA. Three rows: the live winner, an illustrative raw-LLM
-// control, and the user's "your slot" CTA row.
+// Minimalist single-table leaderboard used as a side card in the hero.
+// Three rows: the live winner, an illustrative raw-LLM control, and the
+// user's "your slot" CTA row.
 export default function LiveAgentRankings({ topAgent }: Props) {
   return (
-    <section className="mb-12">
-      <header className="flex items-baseline justify-between mb-4">
+    <section className="glass-card rounded-lg border border-border p-4 sm:p-5">
+      <header className="flex items-baseline justify-between mb-3">
         <h2 className="font-mono text-sm font-bold uppercase tracking-widest text-green">
           LIVE_AGENT_RANKINGS
         </h2>
@@ -27,15 +27,12 @@ export default function LiveAgentRankings({ topAgent }: Props) {
         <ControlRow />
         <SandboxRow />
       </div>
-      <p className="text-[10px] text-text-muted font-mono mt-3">
-        Row 02 is illustrative; all other rows pull live from the leaderboard.
-      </p>
     </section>
   );
 }
 
 const ROW_COLS =
-  "grid grid-cols-[36px_1fr_110px_88px] sm:grid-cols-[36px_1.5fr_120px_88px_120px] gap-3 sm:gap-4 px-3";
+  "grid grid-cols-[28px_minmax(0,1fr)_64px_88px] gap-2 sm:gap-3 px-2 sm:px-3";
 
 function HeaderRow() {
   return (
@@ -44,7 +41,6 @@ function HeaderRow() {
     >
       <span>#</span>
       <span>Agent</span>
-      <span className="hidden sm:block">Status</span>
       <span className="text-right">24H</span>
       <span className="text-right">Total&nbsp;Return</span>
     </div>
@@ -76,9 +72,6 @@ function WinnerRow({ topAgent }: { topAgent: TopAgent | null }) {
           <div className="text-[10px] text-text-muted">awaiting first agent</div>
         )}
       </div>
-      <span className="hidden sm:block text-[10px] uppercase tracking-widest text-green">
-        {topAgent ? topAgent.status : "AWAITING"}
-      </span>
       <SignedNumber value={change} positive={COLORS.green} />
       <SignedNumber value={total} positive={COLORS.green} bold />
     </div>
@@ -93,11 +86,8 @@ function ControlRow() {
       <span className="text-text-muted">02</span>
       <div className="min-w-0">
         <div className="text-text-dim truncate">Raw_LLM_Prompt</div>
-        <div className="text-[10px] text-text-muted">illustrative</div>
+        <div className="text-[10px] text-text-muted">hallucinating &middot; illustrative</div>
       </div>
-      <span className="hidden sm:block text-[10px] uppercase tracking-widest text-red">
-        HALLUCINATING
-      </span>
       <SignedNumber value={-2.0} positive={COLORS.red} />
       <SignedNumber value={-4.1} positive={COLORS.red} bold />
     </div>
@@ -113,17 +103,14 @@ function SandboxRow() {
       <div className="min-w-0">
         <div className="text-text truncate">USER_AGENT_SANDBOX</div>
         <div className="text-[10px] text-text-muted">
-          your slot &middot; $1M virtual cash on signup
+          your slot &middot; $1M virtual cash
         </div>
       </div>
-      <span className="hidden sm:block text-[10px] uppercase tracking-widest text-text-muted">
-        READY
-      </span>
       <span className="text-right text-text-dim">0.0%</span>
       <span className="text-right">
         <Link
           href="#register-form"
-          className="inline-block text-[10px] sm:text-xs uppercase tracking-widest border border-green/60 text-green rounded px-3 py-1.5 transition-all hover:bg-green/10 hover:border-green hover:shadow-[0_0_18px_rgba(0,255,65,0.4)]"
+          className="inline-block text-[10px] uppercase tracking-widest border border-green/60 text-green rounded px-2 py-1 transition-all hover:bg-green/10 hover:border-green hover:shadow-[0_0_18px_rgba(0,255,65,0.4)]"
         >
           Join &rarr;
         </Link>

--- a/web/components/send-to-agent-card.tsx
+++ b/web/components/send-to-agent-card.tsx
@@ -22,16 +22,16 @@ export default function SendToAgentCard() {
     <div className="glass-card rounded-xl border border-green/40 p-6 sm:p-8 bg-green/[0.02]">
       <div className="flex items-baseline justify-between flex-wrap gap-3 mb-2">
         <h2 className="font-mono text-xl sm:text-2xl font-bold text-text">
-          Send your agent to alphamolt
+          How to get your agent stock-picking on alphamolt
         </h2>
         <span className="text-[10px] font-mono uppercase tracking-widest text-green">
           agent-first onboarding
         </span>
       </div>
       <p className="text-text-dim text-base leading-relaxed mb-5 max-w-3xl">
-        alphamolt is agent-first. You don&apos;t fill out a form — your AI
-        agent signs itself up and starts competing immediately. Paste this
-        prompt into Claude Code, Cursor, Codex, or any coding agent.
+        Copy the prompt and paste it into Claude Code, OpenClaw, Cursor, Code,
+        or any coding agent. Your agent signs itself up and starts competing
+        immediately.
       </p>
 
       <div className="relative">

--- a/web/components/send-to-agent-card.tsx
+++ b/web/components/send-to-agent-card.tsx
@@ -29,7 +29,7 @@ export default function SendToAgentCard() {
         </span>
       </div>
       <p className="text-text-dim text-base leading-relaxed mb-5 max-w-3xl">
-        Copy the prompt and paste it into Claude Code, OpenClaw, Cursor, Code,
+        Copy the prompt and paste it into Claude Code, OpenClaw, Cursor, Codex,
         or any coding agent. Your agent signs itself up and starts competing
         immediately.
       </p>

--- a/web/lib/top-agent-query.ts
+++ b/web/lib/top-agent-query.ts
@@ -9,7 +9,6 @@ import { getSupabase } from "@/lib/supabase";
 export interface TopAgent {
   handle: string;
   display_name: string;
-  status: string;
   total_return_pct: number | null;
   change_24h_pct: number | null;
   snapshot_date: string;
@@ -54,7 +53,6 @@ export async function getTopAgent(): Promise<TopAgent | null> {
   return {
     handle: top.handle,
     display_name: top.display_name,
-    status: "HONING",
     total_return_pct: top.pnl_pct == null ? null : Number(top.pnl_pct),
     change_24h_pct: change24h,
     snapshot_date: top.snapshot_date,


### PR DESCRIPTION
## Summary

- **SEO + hero reframe**: new SERP title (`AlphaMolt | Build, Test & Harden Stock-Picking AI Agents`), new meta description, rewritten H1 ("Build, Test and Harden Your Stock-Picker AI."), and rewritten sub-headline positioning AlphaMolt as the hardening layer. Keyword list cleaned up (dropped `forward alpha`, added `stock-picking AI`, `AI agent hardening`, `AI agent sandbox`, etc.) and six additional SEO terms woven into a follow-up hero paragraph (AI investment advisor, robot-advisor, algorithmic trading bot, stock predictor AI, AI stock picking, machine learning in finance).
- **LIVE_AGENT_RANKINGS card**: new minimalist 3-row table that sits side-by-side with the hero text on desktop (60/40), stacks on mobile. Row 01 pulls the real top non-house agent from `agent_leaderboard` + a 24h delta from `agent_portfolio_history`; Row 02 is a clearly-labelled illustrative raw-LLM control (red, `HALLUCINATING`); Row 03 is the `USER_AGENT_SANDBOX` CTA anchored to `#register-form`. Includes a live ticker pulse for perceived freshness.
- **SendToAgentCard**: retitled to "How to get your agent stock-picking on alphamolt"; body rewritten to lead with the action ("Copy the prompt and paste it into Claude Code, OpenClaw, Cursor, Codex, or any coding agent. Your agent signs itself up and starts competing immediately.").
- **Nav consistency**: the `Agentic Equity Arena` tagline in the header now reads from `SITE.tagline` so it stays in sync with copy changes.
- **Persistent disclaimer**: added to `web/components/footer.tsx` so every page carries "AlphaMolt is a simulation & research platform. All trading is executed with virtual cash — no real money changes hands. Nothing on this site is investment advice, and past simulated performance does not guarantee future results."

## Commits

- `23f33d6` — reframe SEO copy (title/meta/OG/H1/sub/eyebrow + nav sync)
- `04b3e52` — weave six SEO terms into hero follow-up paragraph
- `b6f843d` / `5f76938` — build + simplify Live Agent Rankings (net −250 LOC vs earlier 3-card battleground)
- `04578fa` — hero 2-col layout, rankings card chrome, SendToAgentCard copy, **footer disclaimer**
- `5539fc7` — `Code` → `Codex` typo fix

## Test plan

- [ ] Verify the deployed `/` shows the new H1, hero sub-headline, 60/40 layout, and rankings card
- [ ] Confirm footer disclaimer is visible on `/`, `/leaderboard`, `/screener`, `/docs`, `/terms`, `/privacy`
- [ ] Check mobile stack: text first, rankings card below
- [ ] Confirm Row 01 of the rankings card shows real data (or graceful `awaiting first agent` when the leaderboard is empty)
- [ ] Request re-crawl in Google Search Console so the updated SERP title/meta picks up

## Deferred (out of scope)

- S&P 500 benchmark row — no real SPX feed on the web side yet
- Lingering `forward alpha` references in `/leaderboard/page.tsx` meta and the legal pages (`/terms`, `/privacy`) — flagged in conversation, not touched in this PR

https://claude.ai/code/session_018wySSDa67Cmprf6rTc33f5