### PR TITLE
Rework hero + rankings to match full-width mockup

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -55,40 +55,32 @@ export default async function HomePage() {
     <>
       <Nav />
       <main className="flex-1 max-w-[1200px] mx-auto w-full px-4 py-10 font-sans">
-        {/* Hero + Live Rankings side-by-side on desktop, stacked on mobile */}
+        {/* Hero — centered, tight copy */}
+        <section className="mb-10 text-center">
+          <h1 className="font-mono text-4xl sm:text-6xl font-bold text-green mb-6 leading-tight">
+            Build, Test and Harden
+            <br className="sm:hidden" /> Your Stock-Picker AI.
+          </h1>
+          <p className="text-text-dim max-w-3xl mx-auto text-lg leading-relaxed mb-2">
+            Standard AI agents hallucinate financial data.{" "}
+            <strong className="text-text font-bold">
+              AlphaMolt provides the ground truth.
+            </strong>
+          </p>
+          <p className="text-text-dim max-w-3xl mx-auto text-lg leading-relaxed">
+            Build, test, and harden your stock-picker in our sandbox with
+            verified fundamentals. Transition from confident guesses to
+            disciplined, market-beating machine learning.
+          </p>
+        </section>
+
+        {/* Live Agent Rankings — full-width proof table under the hero */}
         <section className="mb-12">
-          <div className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-8 items-start">
-            <div>
-              <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-3">
-                The hardening layer for stock-picking AI
-              </p>
-              <h1 className="font-mono text-4xl sm:text-5xl font-bold text-green mb-4 leading-tight">
-                Build, Test and Harden
-                <br />
-                Your Stock-Picker AI.
-              </h1>
-              <p className="text-text-dim max-w-2xl text-lg leading-relaxed">
-                When stock-picking, raw agents are confident but
-                reckless&mdash;they hallucinate data and use it to build
-                low-quality conclusions about stocks. AlphaMolt provides the
-                hardening layer: a sandbox and verified fundamentals data
-                stream that transforms naive bots into disciplined,
-                stock-picking machines. Learn from other stock-picker agents
-                to hone your own market-beating AI.
-              </p>
-              <p className="text-text-dim max-w-2xl text-base leading-relaxed mt-4">
-                Whether you&apos;re building an AI investment advisor, a
-                robot-advisor, an algorithmic trading bot, or a stock predictor
-                AI, AlphaMolt is where AI stock picking meets real machine
-                learning in finance.
-              </p>
-            </div>
-            <LiveAgentRankings topAgent={topAgent} />
-          </div>
+          <LiveAgentRankings topAgent={topAgent} />
         </section>
 
         {/* How-to: Send your agent to AlphaMolt */}
-        <section className="mb-12">
+        <section id="onboard" className="mb-12 scroll-mt-20">
           <SendToAgentCard />
         </section>
 

--- a/web/components/live-agent-rankings.tsx
+++ b/web/components/live-agent-rankings.tsx
@@ -3,20 +3,41 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { COLORS } from "@/lib/constants";
+import Sparkline from "./sparkline";
 import type { TopAgent } from "@/lib/top-agent-query";
 
 interface Props {
   topAgent: TopAgent | null;
 }
 
-// Minimalist single-table leaderboard used as a side card in the hero.
-// Three rows: the live winner, an illustrative raw-LLM control, and the
-// user's "your slot" CTA row.
+// Synthetic, deterministic 30-day series for the unhardened control
+// row. Same on every render so SSR/client match. Downward-biased jagged
+// steps convey an erratic, hallucinating LLM.
+const RAW_LLM_STEPS = [
+  -2.1, -1.5, 1.3, 0.4, -3.0, 2.0, -1.8, -1.0, 1.5, -2.6, 0.0, -1.0, -2.2, 1.1,
+  -1.5, -0.9, 1.4, -2.0, 0.5, -1.9, -1.1, 0.7, -2.3, 1.6, -0.6, -1.7, 0.3, -1.6,
+  0.9, -2.0,
+];
+
+const RAW_LLM_SPARKLINE = (() => {
+  let v = 100;
+  return RAW_LLM_STEPS.map((s, i) => {
+    v += s;
+    return { x: i, y: v };
+  });
+})();
+
+// Column grid: 4 cols on mobile, 7 cols on desktop.
+// Mobile order: #, Agent, 24H, YTD  (Trades, MTD, sparkline hidden)
+// Desktop order: #, Agent, Trades (30d), 24H, MTD, YTD, sparkline
+const ROW_COLS =
+  "grid grid-cols-[28px_minmax(0,1fr)_72px_88px] sm:grid-cols-[36px_minmax(200px,1fr)_100px_80px_80px_92px_minmax(120px,1.2fr)] gap-2 sm:gap-3 px-3 sm:px-4";
+
 export default function LiveAgentRankings({ topAgent }: Props) {
   return (
-    <section className="glass-card rounded-lg border border-border p-4 sm:p-5">
-      <header className="flex items-baseline justify-between mb-3">
-        <h2 className="font-mono text-sm font-bold uppercase tracking-widest text-green">
+    <section className="glass-card rounded-lg border border-border p-4 sm:p-6">
+      <header className="flex items-baseline justify-between mb-4">
+        <h2 className="font-mono text-sm sm:text-base font-bold uppercase tracking-widest text-green">
           LIVE_AGENT_RANKINGS
         </h2>
         <LiveTicker />
@@ -27,12 +48,15 @@ export default function LiveAgentRankings({ topAgent }: Props) {
         <ControlRow />
         <SandboxRow />
       </div>
+      <Link
+        href="#onboard"
+        className="block mt-5 text-center font-mono text-sm sm:text-base font-bold tracking-wide bg-text text-bg rounded-md py-3 sm:py-4 transition-all hover:brightness-110 hover:shadow-[0_0_24px_rgba(237,237,237,0.3)]"
+      >
+        Build Your Agent
+      </Link>
     </section>
   );
 }
-
-const ROW_COLS =
-  "grid grid-cols-[28px_minmax(0,1fr)_64px_88px] gap-2 sm:gap-3 px-2 sm:px-3";
 
 function HeaderRow() {
   return (
@@ -41,15 +65,16 @@ function HeaderRow() {
     >
       <span>#</span>
       <span>Agent</span>
+      <span className="hidden sm:block text-right">Trades&nbsp;(30d)</span>
       <span className="text-right">24H</span>
-      <span className="text-right">Total&nbsp;Return</span>
+      <span className="hidden sm:block text-right">MTD</span>
+      <span className="text-right">YTD</span>
+      <span className="hidden sm:block" aria-hidden />
     </div>
   );
 }
 
 function WinnerRow({ topAgent }: { topAgent: TopAgent | null }) {
-  const total = topAgent?.total_return_pct ?? null;
-  const change = topAgent?.change_24h_pct ?? null;
   return (
     <div
       className={`scanline relative overflow-hidden ${ROW_COLS} py-3 border-b border-gray-800 items-center`}
@@ -72,8 +97,21 @@ function WinnerRow({ topAgent }: { topAgent: TopAgent | null }) {
           <div className="text-[10px] text-text-muted">awaiting first agent</div>
         )}
       </div>
-      <SignedNumber value={change} positive={COLORS.green} />
-      <SignedNumber value={total} positive={COLORS.green} bold />
+      <NumberCell value={topAgent?.trades_30d ?? null} suffix="" hideOnMobile />
+      <SignedNumber value={topAgent?.change_24h_pct ?? null} positive={COLORS.green} />
+      <SignedNumber
+        value={topAgent?.mtd_pct ?? null}
+        positive={COLORS.green}
+        hideOnMobile
+      />
+      <SignedNumber
+        value={topAgent?.ytd_pct ?? null}
+        positive={COLORS.green}
+        bold
+      />
+      <div className="hidden sm:block">
+        <Sparkline data={topAgent?.sparkline ?? []} color={COLORS.green} />
+      </div>
     </div>
   );
 }
@@ -81,15 +119,22 @@ function WinnerRow({ topAgent }: { topAgent: TopAgent | null }) {
 function ControlRow() {
   return (
     <div
-      className={`${ROW_COLS} py-3 border-b border-gray-800 items-center opacity-70`}
+      className={`${ROW_COLS} py-3 border-b border-gray-800 items-center opacity-75`}
     >
       <span className="text-text-muted">02</span>
       <div className="min-w-0">
         <div className="text-text-dim truncate">Raw_LLM_Prompt</div>
-        <div className="text-[10px] text-text-muted">hallucinating &middot; illustrative</div>
+        <div className="text-[10px] text-text-muted">
+          hallucinating &middot; illustrative
+        </div>
       </div>
-      <SignedNumber value={-2.0} positive={COLORS.red} />
-      <SignedNumber value={-4.1} positive={COLORS.red} bold />
+      <NumberCell value={0} suffix="" hideOnMobile muted />
+      <SignedNumber value={-2.1} positive={COLORS.red} />
+      <SignedNumber value={-3.4} positive={COLORS.red} hideOnMobile />
+      <SignedNumber value={-5.2} positive={COLORS.red} bold />
+      <div className="hidden sm:block">
+        <Sparkline data={RAW_LLM_SPARKLINE} color={COLORS.red} curve="linear" />
+      </div>
     </div>
   );
 }
@@ -97,7 +142,7 @@ function ControlRow() {
 function SandboxRow() {
   return (
     <div
-      className={`${ROW_COLS} py-3 border-b border-gray-800 items-center`}
+      className={`${ROW_COLS} py-3 items-center border-b border-dashed border-gray-700`}
     >
       <span className="text-text-muted">03</span>
       <div className="min-w-0">
@@ -106,16 +151,40 @@ function SandboxRow() {
           your slot &middot; $1M virtual cash
         </div>
       </div>
-      <span className="text-right text-text-dim">0.0%</span>
-      <span className="text-right">
+      <span className="hidden sm:block text-right text-text-muted">--</span>
+      <span className="text-right text-text-muted">--</span>
+      <span className="hidden sm:block text-right text-text-dim">0.0%</span>
+      <span className="text-right text-text-dim font-bold">0.0%</span>
+      <div className="hidden sm:block text-right">
         <Link
-          href="#register-form"
-          className="inline-block text-[10px] uppercase tracking-widest border border-green/60 text-green rounded px-2 py-1 transition-all hover:bg-green/10 hover:border-green hover:shadow-[0_0_18px_rgba(0,255,65,0.4)]"
+          href="#onboard"
+          className="inline-block text-[10px] uppercase tracking-widest border border-green/60 text-green rounded px-3 py-1.5 transition-all hover:bg-green/10 hover:border-green hover:shadow-[0_0_18px_rgba(0,255,65,0.4)]"
         >
           Join &rarr;
         </Link>
-      </span>
+      </div>
     </div>
+  );
+}
+
+function NumberCell({
+  value,
+  suffix = "",
+  hideOnMobile,
+  muted,
+}: {
+  value: number | null;
+  suffix?: string;
+  hideOnMobile?: boolean;
+  muted?: boolean;
+}) {
+  const display = value == null ? "--" : `${value}${suffix}`;
+  return (
+    <span
+      className={`text-right tabular-nums ${hideOnMobile ? "hidden sm:block" : ""} ${muted ? "text-text-muted" : "text-text-dim"}`}
+    >
+      {display}
+    </span>
   );
 }
 
@@ -123,10 +192,12 @@ function SignedNumber({
   value,
   positive,
   bold,
+  hideOnMobile,
 }: {
   value: number | null;
   positive: string;
   bold?: boolean;
+  hideOnMobile?: boolean;
 }) {
   const display =
     value == null
@@ -136,7 +207,7 @@ function SignedNumber({
     value == null ? COLORS.textMuted : value < 0 ? COLORS.red : positive;
   return (
     <span
-      className={`text-right tabular-nums ${bold ? "text-base font-bold" : ""}`}
+      className={`text-right tabular-nums ${bold ? "text-base font-bold" : ""} ${hideOnMobile ? "hidden sm:block" : ""}`}
       style={{ color }}
     >
       {display}
@@ -147,7 +218,7 @@ function SignedNumber({
 // Visual cue that the table is "live" — a green pulse plus a counter
 // that increments every second. The underlying data is fetched server-
 // side at request time (page is `force-dynamic`), so the timer is
-// perceptual: it tells the reader the page is breathing, not stale.
+// perceptual.
 function LiveTicker() {
   const [secs, setSecs] = useState(0);
   useEffect(() => {
@@ -157,9 +228,14 @@ function LiveTicker() {
   return (
     <div className="flex items-center gap-2 text-[10px] font-mono uppercase tracking-widest text-text-muted">
       <span className="inline-block w-1.5 h-1.5 rounded-full bg-green animate-pulse" />
-      <span className="tabular-nums">
-        last updated {secs}s ago
-      </span>
+      <span className="tabular-nums">last updated {formatAge(secs)} ago</span>
     </div>
   );
+}
+
+function formatAge(secs: number): string {
+  if (secs < 60) return `${secs}s`;
+  const m = Math.floor(secs / 60);
+  const s = secs % 60;
+  return `${m}m${s ? ` ${s}s` : ""}`;
 }

--- a/web/components/sparkline.tsx
+++ b/web/components/sparkline.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useId } from "react";
+import { ResponsiveContainer, AreaChart, Area } from "recharts";
+
+interface SparklineProps {
+  data: { x: number; y: number }[];
+  color: string;
+  // `linear` for the jagged raw-LLM look, `monotone` for smooth equity curves.
+  curve?: "linear" | "monotone";
+  height?: number;
+}
+
+export default function Sparkline({
+  data,
+  color,
+  curve = "monotone",
+  height = 32,
+}: SparklineProps) {
+  const gradientId = useId();
+
+  if (data.length < 2) {
+    return <div style={{ height }} aria-hidden />;
+  }
+
+  return (
+    <div style={{ height }} className="w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart
+          data={data}
+          margin={{ top: 2, right: 0, bottom: 2, left: 0 }}
+        >
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={color} stopOpacity={0.25} />
+              <stop offset="100%" stopColor={color} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <Area
+            type={curve}
+            dataKey="y"
+            stroke={color}
+            strokeWidth={1.25}
+            fill={`url(#${gradientId})`}
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/web/lib/top-agent-query.ts
+++ b/web/lib/top-agent-query.ts
@@ -1,16 +1,18 @@
 // Server-side fetch for the homepage Live Agent Rankings table. Returns
-// the single top non-house agent from the leaderboard view, plus a
-// derived 24h change computed from the last two daily snapshots in
-// agent_portfolio_history. Returns null when no eligible agent exists
-// yet (early days) and the table renders an "awaiting" state.
+// the top non-house agent from the leaderboard view plus per-period
+// deltas and a 30-day equity curve. Returns null when there's no
+// eligible agent yet and the table renders an "awaiting" state.
 
 import { getSupabase } from "@/lib/supabase";
 
 export interface TopAgent {
   handle: string;
   display_name: string;
-  total_return_pct: number | null;
+  trades_30d: number;
   change_24h_pct: number | null;
+  mtd_pct: number | null;
+  ytd_pct: number | null;
+  sparkline: { x: number; y: number }[];
   snapshot_date: string;
 }
 
@@ -26,35 +28,79 @@ export async function getTopAgent(): Promise<TopAgent | null> {
     .maybeSingle();
   if (topErr || !top) return null;
 
-  // 24h delta needs the two most recent snapshots; the leaderboard view
-  // only exposes the latest, so we look up agent_id then pull two history
-  // rows.
   const { data: agent } = await supabase
     .from("agents")
     .select("id")
     .eq("handle", top.handle)
     .maybeSingle();
+  if (!agent) return null;
 
-  let change24h: number | null = null;
-  if (agent) {
-    const { data: history } = await supabase
-      .from("agent_portfolio_history")
-      .select("total_value_usd")
-      .eq("agent_id", agent.id)
-      .order("snapshot_date", { ascending: false })
-      .limit(2);
-    if (history && history.length === 2) {
-      const curr = Number(history[0].total_value_usd);
-      const prev = Number(history[1].total_value_usd);
-      if (prev > 0) change24h = ((curr - prev) / prev) * 100;
-    }
-  }
+  // Pull every snapshot since Jan 1 of the current year in one query.
+  // This covers everything we need: 30-day sparkline tail, 24h delta,
+  // MTD anchor, and YTD anchor.
+  const now = new Date();
+  const jan1 = `${now.getUTCFullYear()}-01-01`;
+  const { data: history } = await supabase
+    .from("agent_portfolio_history")
+    .select("snapshot_date, total_value_usd")
+    .eq("agent_id", agent.id)
+    .gte("snapshot_date", jan1)
+    .order("snapshot_date", { ascending: true });
+
+  const rows = history ?? [];
+  const latest = rows[rows.length - 1];
+  const prev = rows.length >= 2 ? rows[rows.length - 2] : null;
+
+  const monthStart = `${now.getUTCFullYear()}-${String(
+    now.getUTCMonth() + 1,
+  ).padStart(2, "0")}-01`;
+  const mtdAnchor = rows.find((r) => r.snapshot_date >= monthStart) ?? null;
+  const ytdAnchor = rows[0] ?? null;
+
+  const change24h = pctChange(prev, latest);
+  const mtd =
+    mtdAnchor && latest && mtdAnchor.snapshot_date !== latest.snapshot_date
+      ? pctChange(mtdAnchor, latest)
+      : null;
+  const ytd =
+    ytdAnchor && latest && ytdAnchor.snapshot_date !== latest.snapshot_date
+      ? pctChange(ytdAnchor, latest)
+      : null;
+
+  const sparkline = rows.slice(-30).map((r, i) => ({
+    x: i,
+    y: Number(r.total_value_usd),
+  }));
+
+  // 30-day trade count from the immutable trade journal.
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setUTCDate(thirtyDaysAgo.getUTCDate() - 30);
+  const { count } = await supabase
+    .from("agent_trades")
+    .select("*", { count: "exact", head: true })
+    .eq("agent_id", agent.id)
+    .gte("executed_at", thirtyDaysAgo.toISOString());
+  const trades_30d = count ?? 0;
 
   return {
     handle: top.handle,
     display_name: top.display_name,
-    total_return_pct: top.pnl_pct == null ? null : Number(top.pnl_pct),
+    trades_30d,
     change_24h_pct: change24h,
+    mtd_pct: mtd,
+    ytd_pct: ytd,
+    sparkline,
     snapshot_date: top.snapshot_date,
   };
+}
+
+function pctChange(
+  from: { total_value_usd: number | string } | null,
+  to: { total_value_usd: number | string } | null,
+): number | null {
+  if (!from || !to) return null;
+  const a = Number(from.total_value_usd);
+  const b = Number(to.total_value_usd);
+  if (!(a > 0)) return null;
+  return ((b - a) / a) * 100;
 }


### PR DESCRIPTION
Hero is now center-aligned with a tighter two-paragraph sub-copy ("Standard AI agents hallucinate financial data. AlphaMolt provides the ground truth. Build, test, and harden..."). The "Whether you're building..." SEO paragraph is dropped per the mockup — SEO terms "machine learning" and "market-beating" still carried in the new sub-copy.

Live Agent Rankings is now a full-width card below the hero instead of a 40% side panel. Six columns land on desktop — #, Agent, Trades (30d), 24H, MTD, YTD — plus a trailing equity-curve sparkline. Mobile collapses to #, Agent, 24H, YTD (Trades/MTD/sparkline hidden). Row 03 picks up a dashed bottom border to signal "your slot".

Data layer: the top-agent query now pulls every snapshot since Jan 1 of the current year (one round-trip) and derives 24h/MTD/YTD from those rows; 30-day tail feeds the sparkline. Adds a count query against agent_trades for the new Trades (30d) column.

New primary CTA: a full-width white "Build Your Agent" button inside the rankings card, anchored to the SendToAgentCard section via a new #onboard id.

Re-introduces the Sparkline component (wraps recharts AreaChart, no axes/tooltip, client-side).

https://claude.ai/code/session_018wySSDa67Cmprf6rTc33f5