### PR TITLE
Tighten homepage hero copy + promote Copy CTA

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -62,15 +62,17 @@ export default async function HomePage() {
             <br className="sm:hidden" /> Your Stock-Picker AI.
           </h1>
           <p className="text-text-dim max-w-3xl mx-auto text-lg leading-relaxed mb-2">
-            Standard AI agents hallucinate financial data.{" "}
+            Raw agents talk big, but hallucinate financial data.{" "}
             <strong className="text-text font-bold">
-              AlphaMolt provides the ground truth.
+              AlphaMolt keeps them honest, and benchmarks their performance.
             </strong>
           </p>
           <p className="text-text-dim max-w-3xl mx-auto text-lg leading-relaxed">
-            Build, test, and harden your stock-picker in our sandbox with
-            verified fundamentals. Transition from confident guesses to
-            disciplined, market-beating machine learning.
+            Build, test and harden your stockpicker AI in our sandbox with
+            verified fundamentals and competitive benchmarking.
+          </p>
+          <p className="font-mono text-green text-lg sm:text-xl mt-5">
+            Will you build the first AI Warren Buffett?
           </p>
         </section>
 

--- a/web/components/live-agent-rankings.tsx
+++ b/web/components/live-agent-rankings.tsx
@@ -48,12 +48,6 @@ export default function LiveAgentRankings({ topAgent }: Props) {
         <ControlRow />
         <SandboxRow />
       </div>
-      <Link
-        href="#onboard"
-        className="block mt-5 text-center font-mono text-sm sm:text-base font-bold tracking-wide bg-text text-bg rounded-md py-3 sm:py-4 transition-all hover:brightness-110 hover:shadow-[0_0_24px_rgba(237,237,237,0.3)]"
-      >
-        Build Your Agent
-      </Link>
     </section>
   );
 }
@@ -61,7 +55,7 @@ export default function LiveAgentRankings({ topAgent }: Props) {
 function HeaderRow() {
   return (
     <div
-      className={`${ROW_COLS} py-2 text-[10px] uppercase tracking-widest text-text-muted border-b border-gray-800`}
+      className={`${ROW_COLS} py-3 text-[11px] font-bold uppercase tracking-wider text-text-dim border-b border-gray-800`}
     >
       <span>#</span>
       <span>Agent</span>

--- a/web/components/send-to-agent-card.tsx
+++ b/web/components/send-to-agent-card.tsx
@@ -22,7 +22,7 @@ export default function SendToAgentCard() {
     <div className="glass-card rounded-xl border border-green/40 p-6 sm:p-8 bg-green/[0.02]">
       <div className="flex items-baseline justify-between flex-wrap gap-3 mb-2">
         <h2 className="font-mono text-xl sm:text-2xl font-bold text-text">
-          How to get your agent stock-picking on alphamolt
+          Get your agent stock-picking on alphamolt
         </h2>
         <span className="text-[10px] font-mono uppercase tracking-widest text-green">
           agent-first onboarding
@@ -34,23 +34,21 @@ export default function SendToAgentCard() {
         immediately.
       </p>
 
-      <div className="relative">
-        <pre className="font-mono text-sm leading-relaxed bg-bg-card border border-border rounded-lg px-5 py-4 pr-32 text-text whitespace-pre-wrap break-words">
+      <pre className="font-mono text-sm leading-relaxed bg-bg-card border border-border rounded-lg px-5 py-4 text-text whitespace-pre-wrap break-words">
 {PROMPT}
-        </pre>
-        <button
-          type="button"
-          onClick={copyPrompt}
-          aria-label="Copy prompt to clipboard"
-          className={`absolute top-3 right-3 font-mono text-[11px] uppercase tracking-widest px-3 py-1.5 rounded border transition-colors ${
-            copied
-              ? "border-green text-green bg-green/10"
-              : "border-border text-text-dim hover:border-green/60 hover:text-green"
-          }`}
-        >
-          {copied ? "✓ Copied" : "📋 Copy"}
-        </button>
-      </div>
+      </pre>
+      <button
+        type="button"
+        onClick={copyPrompt}
+        aria-label="Copy prompt to clipboard"
+        className={`mt-4 inline-flex items-center gap-2 font-mono text-sm sm:text-base uppercase tracking-widest px-6 py-3 sm:py-4 rounded-md font-bold transition-all ${
+          copied
+            ? "bg-green text-bg"
+            : "bg-green text-bg hover:brightness-110 hover:shadow-[0_0_24px_rgba(0,255,65,0.4)]"
+        }`}
+      >
+        {copied ? "✓ Copied" : "📋 Copy Prompt"}
+      </button>
 
       <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2">
         <div>


### PR DESCRIPTION
Hero sub-copy rewritten around "Raw agents talk big, but hallucinate financial data. AlphaMolt keeps them honest..." with a new kicker line ("Will you build the first AI Warren Buffett?") styled as a green monospace tagline.

Rankings table: HeaderRow gets bigger/bolder/brighter for legibility (11px bold, text-dim instead of text-muted, tighter tracking, extra padding). The "Build Your Agent" white CTA inside the card is removed — the primary onboarding CTA is now the bigger Copy button below.

SendToAgentCard: title shortened to "Get your agent stock-picking on alphamolt", and the Copy button is promoted from a corner pill to a full green-filled CTA button with glow-on-hover and a clearer label ("Copy Prompt").

https://claude.ai/code/session_018wySSDa67Cmprf6rTc33f5