### PR TITLE
Refine homepage to institutional North Star copy

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -55,33 +55,37 @@ export default async function HomePage() {
     <>
       <Nav />
       <main className="flex-1 max-w-[1200px] mx-auto w-full px-4 py-10 font-sans">
-        {/* Hero — centered, tight copy */}
-        <section className="mb-10 text-center">
-          <h1 className="font-mono text-4xl sm:text-6xl font-bold text-green mb-6 leading-tight">
-            Build, Test and Harden
-            <br className="sm:hidden" /> Your Stock-Picker AI.
+        {/* Hero — institutional copy hierarchy */}
+        <section className="mb-8 text-center">
+          <h1 className="font-mono text-4xl sm:text-6xl lg:text-7xl font-bold text-green leading-[1.05] mb-4">
+            Build the First
+            <br className="sm:hidden" /> AI Warren Buffett.
           </h1>
-          <p className="text-text-dim max-w-3xl mx-auto text-lg leading-relaxed mb-2">
-            Raw agents talk big, but hallucinate financial data.{" "}
-            <strong className="text-text font-bold">
-              AlphaMolt keeps them honest, and benchmarks their performance.
-            </strong>
+          <p className="font-mono text-xl sm:text-3xl font-bold text-text leading-tight mb-5">
+            Stop Hallucinating. Start Compounding.
           </p>
-          <p className="text-text-dim max-w-3xl mx-auto text-lg leading-relaxed">
-            Build, test and harden your stockpicker AI in our sandbox with
-            verified fundamentals and competitive benchmarking.
-          </p>
-          <p className="font-mono text-green text-lg sm:text-xl mt-5">
-            Will you build the first AI Warren Buffett?
+          <p className="text-text-dim max-w-3xl mx-auto text-base sm:text-lg leading-relaxed">
+            Raw LLMs invent data. AlphaMolt provides the ground
+            truth&mdash;vetted fundamentals and a high-stakes sandbox to harden
+            your agent&apos;s edge.
           </p>
         </section>
 
-        {/* Live Agent Rankings — full-width proof table under the hero */}
+        {/* Three-pillar feature bar — the "how" in 6 words */}
+        <section className="mb-8 border-y border-border py-4">
+          <div className="flex flex-wrap justify-around items-center gap-y-3 gap-x-6 text-center">
+            <Pillar num="01" label="Vetted Fundamentals" />
+            <Pillar num="02" label="Competitive Benchmarking" />
+            <Pillar num="03" label="Zero-Hallucination Sandbox" />
+          </div>
+        </section>
+
+        {/* Live Agent Rankings — full-width proof table */}
         <section className="mb-12">
           <LiveAgentRankings topAgent={topAgent} />
         </section>
 
-        {/* How-to: Send your agent to AlphaMolt */}
+        {/* Get your agent stock-picking */}
         <section id="onboard" className="mb-12 scroll-mt-20">
           <SendToAgentCard />
         </section>
@@ -242,6 +246,19 @@ export default async function HomePage() {
         </div>
       </main>
     </>
+  );
+}
+
+function Pillar({ num, label }: { num: string; label: string }) {
+  return (
+    <div className="flex items-baseline gap-2 font-mono">
+      <span className="text-green text-sm sm:text-base font-bold tabular-nums">
+        {num}
+      </span>
+      <span className="text-text text-[11px] sm:text-sm uppercase tracking-wider">
+        {label}
+      </span>
+    </div>
   );
 }
 

--- a/web/components/live-agent-rankings.tsx
+++ b/web/components/live-agent-rankings.tsx
@@ -27,13 +27,24 @@ const RAW_LLM_SPARKLINE = (() => {
   });
 })();
 
+const RAW_LLM_YTD = -5.2;
+// Illustrative delta shown when no hardened agent has YTD data yet — keeps
+// the "institutional" aesthetic from feeling half-built on empty leaderboards.
+const FALLBACK_DELTA_PCT = 14.1;
+
 // Column grid: 4 cols on mobile, 7 cols on desktop.
 // Mobile order: #, Agent, 24H, YTD  (Trades, MTD, sparkline hidden)
 // Desktop order: #, Agent, Trades (30d), 24H, MTD, YTD, sparkline
 const ROW_COLS =
-  "grid grid-cols-[28px_minmax(0,1fr)_72px_88px] sm:grid-cols-[36px_minmax(200px,1fr)_100px_80px_80px_92px_minmax(120px,1.2fr)] gap-2 sm:gap-3 px-3 sm:px-4";
+  "grid grid-cols-[28px_minmax(0,1fr)_72px_88px] sm:grid-cols-[36px_minmax(220px,1fr)_100px_80px_80px_92px_minmax(120px,1.2fr)] gap-2 sm:gap-3 px-3 sm:px-4";
 
 export default function LiveAgentRankings({ topAgent }: Props) {
+  const delta =
+    topAgent?.ytd_pct != null
+      ? topAgent.ytd_pct - RAW_LLM_YTD
+      : FALLBACK_DELTA_PCT;
+  const isFallback = topAgent?.ytd_pct == null;
+
   return (
     <section className="glass-card rounded-lg border border-border p-4 sm:p-6">
       <header className="flex items-baseline justify-between mb-4">
@@ -48,6 +59,13 @@ export default function LiveAgentRankings({ topAgent }: Props) {
         <ControlRow />
         <SandboxRow />
       </div>
+      <p className="mt-3 text-[10px] sm:text-[11px] font-mono italic text-text-muted text-center">
+        System Note: Hardening layer currently providing{" "}
+        <span className="text-green not-italic font-semibold">
+          +{delta.toFixed(1)}%
+        </span>{" "}
+        performance delta{isFallback ? " (illustrative until first snapshot)" : ""}.
+      </p>
     </section>
   );
 }
@@ -55,7 +73,7 @@ export default function LiveAgentRankings({ topAgent }: Props) {
 function HeaderRow() {
   return (
     <div
-      className={`${ROW_COLS} py-3 text-[11px] font-bold uppercase tracking-wider text-text-dim border-b border-gray-800`}
+      className={`${ROW_COLS} py-3 text-[11px] font-semibold uppercase tracking-wider text-text-dim border-b border-gray-800`}
     >
       <span>#</span>
       <span>Agent</span>
@@ -79,7 +97,10 @@ function WinnerRow({ topAgent }: { topAgent: TopAgent | null }) {
     >
       <span className="text-green font-bold">01</span>
       <div className="min-w-0">
-        <div className="font-bold text-green truncate">AGENT_ZERO</div>
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="font-bold text-green truncate">AGENT_ZERO</span>
+          <StatusChip variant="hardened" label="HARDENED / MOLT_LVL_4" />
+        </div>
         {topAgent ? (
           <Link
             href={`/u/${topAgent.handle}`}
@@ -91,8 +112,11 @@ function WinnerRow({ topAgent }: { topAgent: TopAgent | null }) {
           <div className="text-[10px] text-text-muted">awaiting first agent</div>
         )}
       </div>
-      <NumberCell value={topAgent?.trades_30d ?? null} suffix="" hideOnMobile />
-      <SignedNumber value={topAgent?.change_24h_pct ?? null} positive={COLORS.green} />
+      <NumberCell value={topAgent?.trades_30d ?? null} hideOnMobile />
+      <SignedNumber
+        value={topAgent?.change_24h_pct ?? null}
+        positive={COLORS.green}
+      />
       <SignedNumber
         value={topAgent?.mtd_pct ?? null}
         positive={COLORS.green}
@@ -101,7 +125,7 @@ function WinnerRow({ topAgent }: { topAgent: TopAgent | null }) {
       <SignedNumber
         value={topAgent?.ytd_pct ?? null}
         positive={COLORS.green}
-        bold
+        hero
       />
       <div className="hidden sm:block">
         <Sparkline data={topAgent?.sparkline ?? []} color={COLORS.green} />
@@ -113,19 +137,22 @@ function WinnerRow({ topAgent }: { topAgent: TopAgent | null }) {
 function ControlRow() {
   return (
     <div
-      className={`${ROW_COLS} py-3 border-b border-gray-800 items-center opacity-75`}
+      className={`${ROW_COLS} py-3 border-b border-gray-800 items-center opacity-55`}
     >
       <span className="text-text-muted">02</span>
       <div className="min-w-0">
-        <div className="text-text-dim truncate">Raw_LLM_Prompt</div>
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-text-dim truncate">Raw_LLM_Prompt</span>
+          <StatusChip variant="naive" label="NAIVE / UNGROUNDED" />
+        </div>
         <div className="text-[10px] text-text-muted">
-          hallucinating &middot; illustrative
+          illustrative
         </div>
       </div>
-      <NumberCell value={0} suffix="" hideOnMobile muted />
+      <NumberCell value={0} hideOnMobile muted />
       <SignedNumber value={-2.1} positive={COLORS.red} />
       <SignedNumber value={-3.4} positive={COLORS.red} hideOnMobile />
-      <SignedNumber value={-5.2} positive={COLORS.red} bold />
+      <SignedNumber value={RAW_LLM_YTD} positive={COLORS.red} hero />
       <div className="hidden sm:block">
         <Sparkline data={RAW_LLM_SPARKLINE} color={COLORS.red} curve="linear" />
       </div>
@@ -140,24 +167,53 @@ function SandboxRow() {
     >
       <span className="text-text-muted">03</span>
       <div className="min-w-0">
-        <div className="text-text truncate">USER_AGENT_SANDBOX</div>
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-text truncate">USER_AGENT_SANDBOX</span>
+          <StatusChip variant="ready" label="READY / AWAITING" />
+        </div>
         <div className="text-[10px] text-text-muted">
           your slot &middot; $1M virtual cash
         </div>
       </div>
       <span className="hidden sm:block text-right text-text-muted">--</span>
       <span className="text-right text-text-muted">--</span>
-      <span className="hidden sm:block text-right text-text-dim">0.0%</span>
-      <span className="text-right text-text-dim font-bold">0.0%</span>
-      <div className="hidden sm:block text-right">
+      <span className="hidden sm:block text-right text-text-dim font-semibold">
+        0.0%
+      </span>
+      <span className="text-right text-text-dim font-bold text-base">
+        0.0%
+      </span>
+      <div className="hidden sm:flex justify-end">
         <Link
           href="#onboard"
-          className="inline-block text-[10px] uppercase tracking-widest border border-green/60 text-green rounded px-3 py-1.5 transition-all hover:bg-green/10 hover:border-green hover:shadow-[0_0_18px_rgba(0,255,65,0.4)]"
+          className="inline-block text-[10px] font-bold uppercase tracking-widest border border-green/70 text-green rounded px-3 py-1.5 bg-green/[0.04] shadow-[0_0_10px_rgba(0,255,65,0.25)] transition-all hover:bg-green/10 hover:border-green hover:shadow-[0_0_18px_rgba(0,255,65,0.6)]"
         >
-          Join &rarr;
+          Join Sandbox &rarr;
         </Link>
       </div>
     </div>
+  );
+}
+
+function StatusChip({
+  variant,
+  label,
+}: {
+  variant: "hardened" | "naive" | "ready";
+  label: string;
+}) {
+  const styles =
+    variant === "hardened"
+      ? "border-green/50 text-green bg-green/5"
+      : variant === "naive"
+        ? "border-red/30 text-red/80"
+        : "border-border-light text-text-muted";
+  return (
+    <span
+      className={`hidden md:inline-flex items-center text-[9px] font-mono font-semibold uppercase tracking-widest px-1.5 py-0.5 rounded-sm border shrink-0 ${styles}`}
+    >
+      [&nbsp;{label}&nbsp;]
+    </span>
   );
 }
 
@@ -175,7 +231,7 @@ function NumberCell({
   const display = value == null ? "--" : `${value}${suffix}`;
   return (
     <span
-      className={`text-right tabular-nums ${hideOnMobile ? "hidden sm:block" : ""} ${muted ? "text-text-muted" : "text-text-dim"}`}
+      className={`text-right tabular-nums font-semibold ${hideOnMobile ? "hidden sm:block" : ""} ${muted ? "text-text-muted" : "text-text"}`}
     >
       {display}
     </span>
@@ -185,23 +241,21 @@ function NumberCell({
 function SignedNumber({
   value,
   positive,
-  bold,
+  hero,
   hideOnMobile,
 }: {
   value: number | null;
   positive: string;
-  bold?: boolean;
+  hero?: boolean;
   hideOnMobile?: boolean;
 }) {
   const display =
-    value == null
-      ? "--"
-      : `${value > 0 ? "+" : ""}${value.toFixed(1)}%`;
+    value == null ? "--" : `${value > 0 ? "+" : ""}${value.toFixed(1)}%`;
   const color =
     value == null ? COLORS.textMuted : value < 0 ? COLORS.red : positive;
   return (
     <span
-      className={`text-right tabular-nums ${bold ? "text-base font-bold" : ""} ${hideOnMobile ? "hidden sm:block" : ""}`}
+      className={`text-right tabular-nums ${hero ? "text-base font-bold" : "font-semibold"} ${hideOnMobile ? "hidden sm:block" : ""}`}
       style={{ color }}
     >
       {display}


### PR DESCRIPTION
Hero copy hierarchy rebuilt around the aspiration → reality-check → evidence shape:

  H1 (green mono, huge)  "Build the First AI Warren Buffett."
  H2 (muted white, bold) "Stop Hallucinating. Start Compounding."
  Body                   "Raw LLMs invent data. AlphaMolt provides
                          the ground truth — vetted fundamentals and
                          a high-stakes sandbox to harden your
                          agent's edge."

New three-pillar feature bar (01 VETTED FUNDAMENTALS / 02 COMPETITIVE BENCHMARKING / 03 ZERO-HALLUCINATION SANDBOX) sits between the hero and the rankings table in a Bloomberg-ticker strip bounded by top/ bottom borders.

LIVE_AGENT_RANKINGS:
* Row 01 gains a [ HARDENED / MOLT_LVL_4 ] chip inline with AGENT_ZERO (green border, tinted bg).
* Row 02 gains a [ NAIVE / UNGROUNDED ] chip (muted red, no bg) and is dimmed further (opacity 75 → 55) so the "lesser" feel lands.
* Row 03 gains a neutral [ READY / AWAITING ] chip for consistency; Join Sandbox button now carries a compact always-on green shadow that intensifies on hover — the glow sits on the button, not the row.
* Weight hierarchy: column headers drop to font-semibold; all number cells step up to font-semibold, YTD stays font-bold text-base. Numbers now visibly out-weight labels, Bloomberg-style.
* System Note caption below the table reads "Hardening layer currently providing +N.N% performance delta", computed dynamically from AGENT_ZERO YTD minus the illustrative RAW_LLM YTD; falls back to +14.1% until the first snapshot lands.

Status chips hide on screens narrower than md so the table stays readable on tablets; handle + illustrative sublines remain.

https://claude.ai/code/session_018wySSDa67Cmprf6rTc33f5