### PR TITLE
Homepage tweaks: equity-framed body, leaderboard link, bigger labels

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -65,9 +65,9 @@ export default async function HomePage() {
             Stop Hallucinating. Start Compounding.
           </p>
           <p className="text-text-dim max-w-3xl mx-auto text-base sm:text-lg leading-relaxed">
-            Raw LLMs invent data. AlphaMolt provides the ground
-            truth&mdash;vetted fundamentals and a high-stakes sandbox to harden
-            your agent&apos;s edge.
+            Raw LLMs invent equity fundamentals data. AlphaMolt keeps them
+            honest, with vetted equity information and a competitive sandbox
+            to harden your agent&apos;s edge.
           </p>
         </section>
 

--- a/web/components/live-agent-rankings.tsx
+++ b/web/components/live-agent-rankings.tsx
@@ -28,9 +28,6 @@ const RAW_LLM_SPARKLINE = (() => {
 })();
 
 const RAW_LLM_YTD = -5.2;
-// Illustrative delta shown when no hardened agent has YTD data yet — keeps
-// the "institutional" aesthetic from feeling half-built on empty leaderboards.
-const FALLBACK_DELTA_PCT = 14.1;
 
 // Column grid: 4 cols on mobile, 7 cols on desktop.
 // Mobile order: #, Agent, 24H, YTD  (Trades, MTD, sparkline hidden)
@@ -39,18 +36,15 @@ const ROW_COLS =
   "grid grid-cols-[28px_minmax(0,1fr)_72px_88px] sm:grid-cols-[36px_minmax(220px,1fr)_100px_80px_80px_92px_minmax(120px,1.2fr)] gap-2 sm:gap-3 px-3 sm:px-4";
 
 export default function LiveAgentRankings({ topAgent }: Props) {
-  const delta =
-    topAgent?.ytd_pct != null
-      ? topAgent.ytd_pct - RAW_LLM_YTD
-      : FALLBACK_DELTA_PCT;
-  const isFallback = topAgent?.ytd_pct == null;
-
   return (
     <section className="glass-card rounded-lg border border-border p-4 sm:p-6">
       <header className="flex items-baseline justify-between mb-4">
-        <h2 className="font-mono text-sm sm:text-base font-bold uppercase tracking-widest text-green">
-          LIVE_AGENT_RANKINGS
-        </h2>
+        <Link
+          href="/leaderboard"
+          className="font-mono text-sm sm:text-base font-bold uppercase tracking-widest text-green hover:underline decoration-green/60 underline-offset-4"
+        >
+          LIVE_AGENT_LEADERBOARD &rarr;
+        </Link>
         <LiveTicker />
       </header>
       <div className="font-mono text-sm">
@@ -59,13 +53,6 @@ export default function LiveAgentRankings({ topAgent }: Props) {
         <ControlRow />
         <SandboxRow />
       </div>
-      <p className="mt-3 text-[10px] sm:text-[11px] font-mono italic text-text-muted text-center">
-        System Note: Hardening layer currently providing{" "}
-        <span className="text-green not-italic font-semibold">
-          +{delta.toFixed(1)}%
-        </span>{" "}
-        performance delta{isFallback ? " (illustrative until first snapshot)" : ""}.
-      </p>
     </section>
   );
 }

--- a/web/components/send-to-agent-card.tsx
+++ b/web/components/send-to-agent-card.tsx
@@ -50,9 +50,9 @@ export default function SendToAgentCard() {
         {copied ? "✓ Copied" : "📋 Copy Prompt"}
       </button>
 
-      <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2">
+      <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-4">
         <div>
-          <p className="text-[10px] font-mono uppercase tracking-widest text-text-muted mb-2">
+          <p className="text-xs font-mono font-bold uppercase tracking-wider text-green mb-2">
             What happens next
           </p>
           <ol className="text-sm text-text-dim space-y-1 list-decimal list-inside">
@@ -63,7 +63,7 @@ export default function SendToAgentCard() {
           </ol>
         </div>
         <div>
-          <p className="text-[10px] font-mono uppercase tracking-widest text-text-muted mb-2">
+          <p className="text-xs font-mono font-bold uppercase tracking-wider text-green mb-2">
             No agent yet?
           </p>
           <p className="text-sm text-text-dim leading-relaxed">


### PR DESCRIPTION
Hero body copy tightens around "equity fundamentals" and swaps "ground truth" for "keeps them honest" to make the value prop less absolutist.

The rankings-card heading is renamed LIVE_AGENT_RANKINGS → LIVE_AGENT_LEADERBOARD and wrapped in a Link to /leaderboard so the card is now clickable as navigation. The under-table System Note ("+14.1% performance delta") and its fallback constant come out — the status chips + dimming already carry the contrast.

SendToAgentCard: the "What happens next" and "No agent yet?" section labels jump from 10px text-text-muted to 12px font-bold text-green to match the brand eyebrow style used elsewhere and actually read as section headers. Vertical grid gap bumped to gap-y-4 so they breathe on mobile.

https://claude.ai/code/session_018wySSDa67Cmprf6rTc33f5