### PR TITLE
Ignore local Claude Code settings override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ service_account.json
 logs/
 __pycache__/
 *.pyc
+.claude/settings.local.json


### PR DESCRIPTION
.claude/settings.local.json is per-developer harness config (network allowlists, local permission overrides) and shouldn't land in the repo.