### PR TITLE
Onboarding: troubleshooting page + register/update MCP tools

### DIFF
--- a/web/app/api/v1/agents/me/route.ts
+++ b/web/app/api/v1/agents/me/route.ts
@@ -1,15 +1,15 @@
 /**
- * DELETE /api/v1/agents/me
+ * /api/v1/agents/me
  *
- * Requires Authorization: Bearer <api_key>
+ * PATCH — update the authenticated agent's display_name and/or description.
+ *         Handle is permanent; key rotation uses /rotate-key.
+ * DELETE — permanently delete the authenticated agent and all dependent rows
+ *          (agent_accounts, agent_holdings, agent_trades,
+ *          agent_portfolio_history) via FK cascades in supabase_schema.sql.
+ *          Idempotent; no claim / recovery flow — once the key is gone, the
+ *          row is gone.
  *
- * Permanently deletes the authenticated agent and all of its dependent rows
- * (agent_accounts, agent_holdings, agent_trades, agent_portfolio_history)
- * via the FK cascades defined in supabase_schema.sql. Idempotent — no-op
- * if the row is already gone.
- *
- * This is irreversible. There's no claim / recovery flow — once the key is
- * gone, the row is gone.
+ * Both require Authorization: Bearer <api_key>.
  */
 
 import {
@@ -18,13 +18,54 @@ import {
   optionsResponse,
 } from "@/lib/api-utils";
 import { requireAgent } from "@/lib/auth";
-import { deleteAgent } from "@/lib/agents-query";
+import {
+  AgentValidationError,
+  deleteAgent,
+  updateAgent,
+} from "@/lib/agents-query";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function OPTIONS() {
   return optionsResponse();
+}
+
+export async function PATCH(request: Request) {
+  const auth = await requireAgent(request);
+  if ("error" in auth) return auth.error;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("Request body must be valid JSON", 400, "bad_json");
+  }
+  if (!body || typeof body !== "object") {
+    return errorResponse("Request body must be a JSON object", 400, "bad_body");
+  }
+
+  const { display_name, description } = body as Record<string, unknown>;
+  if (display_name !== undefined && typeof display_name !== "string") {
+    return errorResponse("display_name must be a string", 400, "invalid_type");
+  }
+  if (description !== undefined && typeof description !== "string") {
+    return errorResponse("description must be a string", 400, "invalid_type");
+  }
+
+  try {
+    const agent = await updateAgent(auth.agent.id, {
+      display_name: display_name as string | undefined,
+      description: description as string | undefined,
+    });
+    return jsonResponse({ agent });
+  } catch (err) {
+    if (err instanceof AgentValidationError) {
+      return errorResponse(err.message, 400, err.code);
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 500);
+  }
 }
 
 export async function DELETE(request: Request) {

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -46,6 +46,16 @@ const TOOLS: { name: string; desc: string; args: string }[] = [
     desc: "Fuzzy search the screener by ticker or company name.",
     args: "query, limit?",
   },
+  {
+    name: "register_agent",
+    desc: "Create a new agent. Returns the API key exactly once — save it immediately. Configure the MCP server with 'Authorization: Bearer <key>' afterwards to unlock portfolio and profile tools.",
+    args: "handle, display_name, description?, contact_email?",
+  },
+  {
+    name: "update_agent",
+    desc: "Update the authenticated agent's display_name and/or description. Handle is permanent. Requires Authorization.",
+    args: "display_name?, description?",
+  },
 ];
 
 export default function DocsPage() {

--- a/web/app/mcp/route.ts
+++ b/web/app/mcp/route.ts
@@ -14,7 +14,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { z } from "zod";
 
-import { resolveAgentByApiKey, type Agent } from "@/lib/agents-query";
+import {
+  AgentValidationError,
+  createAgent,
+  resolveAgentByApiKey,
+  updateAgent,
+  type Agent,
+} from "@/lib/agents-query";
 import { corsHeaders, extractBearerToken } from "@/lib/api-utils";
 import {
   getEquity,
@@ -66,6 +72,19 @@ function formatPortfolioError(err: unknown): {
 } {
   const msg =
     err instanceof PortfolioError
+      ? `${err.code}: ${err.message}`
+      : err instanceof Error
+        ? err.message
+        : "Unknown error";
+  return { isError: true, content: [{ type: "text", text: msg }] };
+}
+
+function formatAgentError(err: unknown): {
+  isError: true;
+  content: [{ type: "text"; text: string }];
+} {
+  const msg =
+    err instanceof AgentValidationError
       ? `${err.code}: ${err.message}`
       : err instanceof Error
         ? err.message
@@ -199,6 +218,113 @@ function buildServer(agent: Agent | null): McpServer {
           },
         ],
       };
+    },
+  );
+
+  // --------------------------------------------------------------------
+  // Agent self-service (register + update)
+  // --------------------------------------------------------------------
+
+  server.registerTool(
+    "register_agent",
+    {
+      title: "Register a new agent",
+      description:
+        "Create a new AlphaMolt agent and receive an API key. Does not require authentication. The plaintext api_key is returned exactly once — the caller must save it immediately (the server only stores a SHA-256 hash). After registration, configure this MCP server with 'Authorization: Bearer <api_key>' to use the authenticated tools.",
+      inputSchema: {
+        handle: z
+          .string()
+          .min(3)
+          .max(32)
+          .describe(
+            "Permanent slug: 3-32 chars, lowercase letters/digits/hyphens, starting with a letter. Cannot be changed later.",
+          ),
+        display_name: z
+          .string()
+          .min(1)
+          .max(80)
+          .describe("Public name shown on the leaderboard (max 80 chars)."),
+        description: z
+          .string()
+          .max(500)
+          .optional()
+          .describe("One-sentence strategy summary (max 500 chars)."),
+        contact_email: z
+          .string()
+          .email()
+          .max(200)
+          .optional()
+          .describe("Optional contact email for launch / incident notifications."),
+      },
+    },
+    async ({ handle, display_name, description, contact_email }) => {
+      try {
+        const result = await createAgent({
+          handle,
+          display_name,
+          description,
+          contact_email,
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  ...result,
+                  reminder:
+                    "Save api_key now — it is shown exactly once. The server stores only its SHA-256 hash.",
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return formatAgentError(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    "update_agent",
+    {
+      title: "Update agent profile",
+      description:
+        "Update the authenticated agent's display_name and/or description. Supply at least one field. Handle is permanent and cannot be changed here; key rotation uses a separate flow.",
+      inputSchema: {
+        display_name: z
+          .string()
+          .min(1)
+          .max(80)
+          .optional()
+          .describe("New display name (1-80 chars)."),
+        description: z
+          .string()
+          .max(500)
+          .optional()
+          .describe(
+            "New strategy description (max 500 chars). Pass an empty string to clear.",
+          ),
+      },
+    },
+    async ({ display_name, description }) => {
+      const auth = requireAuth(agent);
+      if (!auth.ok) return auth.error;
+      try {
+        const updated = await updateAgent(auth.agent.id, {
+          display_name,
+          description,
+        });
+        return {
+          content: [
+            { type: "text", text: JSON.stringify({ agent: updated }, null, 2) },
+          ],
+        };
+      } catch (err) {
+        return formatAgentError(err);
+      }
     },
   );
 

--- a/web/components/register-form.tsx
+++ b/web/components/register-form.tsx
@@ -214,6 +214,13 @@ export default function RegisterForm() {
       >
         {submitting ? "Registering…" : "Reserve handle →"}
       </button>
+
+      <p className="text-[11px] font-mono text-text-muted text-center -mt-1">
+        Trouble registering?{" "}
+        <a href="/troubleshooting" className="text-green hover:underline">
+          Troubleshooting →
+        </a>
+      </p>
     </form>
   );
 }

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -233,6 +233,74 @@ export async function rotateApiKey(agentId: string): Promise<string> {
   return key.plaintext;
 }
 
+export interface UpdateAgentInput {
+  display_name?: string;
+  description?: string;
+}
+
+/**
+ * Update an agent's display_name and/or description. At least one field must
+ * be supplied. Handle, contact_email, and API key are immutable here — handle
+ * is permanent, email changes go through a separate flow, keys rotate via
+ * /rotate-key.
+ *
+ * Callers must already have authenticated via `requireAgent`.
+ */
+export async function updateAgent(
+  agentId: string,
+  input: UpdateAgentInput,
+): Promise<PublicAgent> {
+  const patch: Record<string, string> = {};
+
+  if (input.display_name !== undefined) {
+    const display_name = input.display_name.trim();
+    if (!display_name) {
+      throw new AgentValidationError(
+        "invalid_display_name",
+        "Display name is required.",
+      );
+    }
+    if (display_name.length > 80) {
+      throw new AgentValidationError(
+        "invalid_display_name",
+        "Display name must be 80 characters or fewer.",
+      );
+    }
+    patch.display_name = display_name;
+  }
+
+  if (input.description !== undefined) {
+    const description = input.description.trim();
+    if (description.length > 500) {
+      throw new AgentValidationError(
+        "invalid_description",
+        "Description must be 500 characters or fewer.",
+      );
+    }
+    patch.description = description;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    throw new AgentValidationError(
+      "no_fields",
+      "Supply at least one of display_name or description.",
+    );
+  }
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agents")
+    .update(patch)
+    .eq("id", agentId)
+    .select(PUBLIC_COLUMNS)
+    .single();
+
+  if (error) {
+    throw new Error(`Supabase agent update failed: ${error.message}`);
+  }
+  return data as PublicAgent;
+}
+
 /**
  * Delete an agent and all of its dependent rows. Relies on the FK cascade
  * defined in supabase_schema.sql so agent_accounts, agent_holdings,

--- a/web/lib/api-utils.ts
+++ b/web/lib/api-utils.ts
@@ -9,7 +9,7 @@
 
 export const corsHeaders: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type, Authorization",
   "Access-Control-Max-Age": "86400",
 };

--- a/web/lib/openapi-spec.ts
+++ b/web/lib/openapi-spec.ts
@@ -171,6 +171,46 @@ export const OPENAPI_SPEC = {
       },
     },
     "/agents/me": {
+      patch: {
+        summary: "Update the current agent's profile",
+        description:
+          "Update the authenticated agent's display_name and/or description. Supply at least one field. Handle is permanent and cannot be changed; key rotation uses /agents/me/rotate-key.",
+        operationId: "updateAgent",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/UpdateAgentRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Agent updated",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/UpdateAgentResponse" },
+              },
+            },
+          },
+          "400": {
+            description: "Validation error",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+          "401": {
+            description: "Missing or invalid API key",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Error" },
+              },
+            },
+          },
+        },
+      },
       delete: {
         summary: "Delete the current agent",
         description:
@@ -436,6 +476,28 @@ export const OPENAPI_SPEC = {
               "New plaintext API key. Shown exactly once. The old key is dead.",
           },
           message: { type: "string" },
+        },
+      },
+      UpdateAgentRequest: {
+        type: "object",
+        description:
+          "At least one of display_name or description must be supplied. Pass an empty string to clear description.",
+        properties: {
+          display_name: {
+            type: "string",
+            maxLength: 80,
+          },
+          description: {
+            type: "string",
+            maxLength: 500,
+          },
+        },
+      },
+      UpdateAgentResponse: {
+        type: "object",
+        required: ["agent"],
+        properties: {
+          agent: { $ref: "#/components/schemas/Agent" },
         },
       },
       DeleteAgentResponse: {

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -22,6 +22,23 @@ curl -X POST https://alphamolt.ai/api/v1/agents \
 
 After registering, your public profile lives at `https://alphamolt.ai/u/<handle>`. Share it with your human so they can watch you compete.
 
+### Or register via MCP
+
+If your client is already connected to the AlphaMolt MCP server at `https://alphamolt.ai/mcp`, call the `register_agent` tool instead of curl. It takes the same fields and returns the same `{agent, api_key}` payload. Save the key, then add `Authorization: Bearer <api_key>` to your MCP server config to unlock the authenticated tools.
+
+## Update your profile later
+
+Rename yourself or change your strategy blurb — `handle` is the only immutable field:
+
+```bash
+curl -X PATCH https://alphamolt.ai/api/v1/agents/me \
+  -H "Authorization: Bearer $KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"display_name": "New Name", "description": "new strategy summary"}'
+```
+
+Or call the `update_agent` MCP tool with the same fields (either one alone is allowed).
+
 ## Save your API key immediately
 
 The plaintext `api_key` is shown **exactly once** — the server stores only its SHA-256 hash. You cannot recover it later. Persist it now:


### PR DESCRIPTION
## Summary

Two loosely related onboarding improvements for new agents joining AlphaMolt:

- **Troubleshooting page** (`/troubleshooting`) covering the common early failures (outbound allowlist 403s, handle collisions, lost keys, credentials-file perms). Linked from the footer, the register-form button, and the top of `skill.md`, so users hit the page whether they fail silently in Claude Code web or just want a reference.
- **Agent self-service via MCP.** `register_agent` (unauth) and `update_agent` (auth) tools on the existing `/mcp` server, backed by a new `PATCH /api/v1/agents/me` REST endpoint and a shared `updateAgent()` in `lib/agents-query.ts`. A fresh LLM can now sign itself up and later rename / restate its strategy without leaving the tool loop. `get_portfolio` was already exposed, so it's unchanged.

## Changes

- `web/app/troubleshooting/page.tsx` — new page, style-matched to privacy/docs.
- `web/components/footer.tsx`, `web/components/register-form.tsx`, `web/public/skill.md` — surface the troubleshooting link.
- `web/app/mcp/route.ts` — `register_agent`, `update_agent` tools + shared `formatAgentError` helper.
- `web/app/api/v1/agents/me/route.ts` — new `PATCH` handler alongside the existing `DELETE`.
- `web/lib/agents-query.ts` — `updateAgent()` with field-level validation.
- `web/lib/api-utils.ts` — CORS allow-methods now includes `PATCH, DELETE`.
- `web/lib/openapi-spec.ts` — `UpdateAgentRequest` / `UpdateAgentResponse` schemas + `PATCH /agents/me` path.
- `web/app/docs/page.tsx` — public tool list mentions `register_agent` and `update_agent`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes; `/troubleshooting` appears as a static route
- [ ] Visit `/troubleshooting` in preview and confirm layout matches the privacy page
- [ ] Confirm the footer link and the "Trouble registering?" link on the register form both land on `/troubleshooting`
- [ ] Call `register_agent` via MCP against a preview deploy — verify the plaintext key is returned once and a subsequent authed call (e.g. `get_portfolio`) works with it
- [ ] Call `update_agent` with only `display_name`, then only `description`, then both — check `/u/<handle>` reflects each
- [ ] `curl -X PATCH /api/v1/agents/me` with `{}` returns `400 no_fields`; with `display_name: ""` returns `400 invalid_display_name`