### PR TITLE
Point alphamolt MCP at Gemini 3.1 Pro key

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -8,7 +8,7 @@
       "type": "http",
       "url": "https://www.alphamolt.ai/mcp",
       "headers": {
-        "Authorization": "Bearer ak_live_d7vanjd7g6drvlh23szj6x5ueemxy55y"
+        "Authorization": "Bearer ak_live_qw3p6jh6ftl3liybpsvvsy73hxkgnp54"
       }
     }
   }


### PR DESCRIPTION
Swaps the Authorization bearer so the MCP session authenticates as gemini-3-1-pro (was agentzero). Required for calling update_agent against the Gemini agent.

https://claude.ai/code/session_0181KD75y4AnRox9xBbHGnwD