### PR TITLE
Switch benchmark fetchers from EODHD to Yahoo Finance

### DIFF
--- a/.github/workflows/benchmarks-update.yml
+++ b/.github/workflows/benchmarks-update.yml
@@ -32,7 +32,6 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          EODHD_API_KEY: ${{ secrets.EODHD_API_KEY }}
         run: python benchmarks_updater.py
 
       - name: Upload logs

--- a/.github/workflows/bootstrap-benchmarks.yml
+++ b/.github/workflows/bootstrap-benchmarks.yml
@@ -36,11 +36,10 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Seed benchmarks from EODHD
+      - name: Seed benchmarks from Yahoo Finance
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
-          EODHD_API_KEY: ${{ secrets.EODHD_API_KEY }}
           TICKER: ${{ inputs.ticker }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |

--- a/benchmarks_updater.py
+++ b/benchmarks_updater.py
@@ -2,10 +2,14 @@
 """
 Nightly benchmark price refresh.
 
-For every row in the `benchmarks` table, fetches EODHD adjusted closes
-between (last stored price_date + 1) and today, appends them to
-benchmark_prices, and updates the parent `benchmarks` row's
-latest_price / latest_price_date.
+For every row in the `benchmarks` table, fetches daily adjusted closes
+from Yahoo Finance between (last stored price_date + 1) and today,
+appends them to benchmark_prices, and updates the parent `benchmarks`
+row's latest_price / latest_price_date.
+
+Yahoo is used instead of EODHD because the project's EODHD plan doesn't
+cover /api/eod/ for ETFs (403 Forbidden). Matches the same data source
+used by price_sales_updater.py.
 
 Runs from .github/workflows/benchmarks-update.yml at 03:45 UTC — just
 after eodhd_updater.py at 03:30 UTC, well before portfolio_valuation.py
@@ -17,10 +21,9 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 import sys
 import time
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -29,8 +32,7 @@ from dotenv import load_dotenv
 
 from db import SupabaseDB
 
-EODHD_BASE_URL = "https://eodhd.com/api"
-DELAY_BETWEEN_CALLS = 1  # seconds, match other eodhd scripts
+DELAY_BETWEEN_CALLS = 1  # seconds, match other scrapers
 
 
 def setup_logging() -> logging.Logger:
@@ -55,27 +57,68 @@ def setup_logging() -> logging.Logger:
     return logger
 
 
-def eodhd_eod(ticker: str, api_key: str, from_date: str, to_date: str,
-              logger: logging.Logger) -> list[dict[str, Any]] | None:
-    url = f"{EODHD_BASE_URL}/eod/{ticker}"
-    params = {
-        "api_token": api_key,
-        "fmt": "json",
-        "from": from_date,
-        "to": to_date,
-        "period": "d",
+def yahoo_ticker_for(storage_ticker: str) -> str:
+    """Translate a storage ticker (EODHD-style, e.g. 'SPY.US') to Yahoo's symbol."""
+    if storage_ticker.endswith(".US"):
+        return storage_ticker[:-3]
+    return storage_ticker
+
+
+def yahoo_daily(
+    storage_ticker: str,
+    from_date: date,
+    to_date: date,
+    logger: logging.Logger,
+) -> list[dict[str, Any]] | None:
+    """Fetch daily adjusted closes from Yahoo Finance between two dates."""
+    yticker = yahoo_ticker_for(storage_ticker)
+    url = f"https://query1.finance.yahoo.com/v8/finance/chart/{yticker}"
+    period1 = int(datetime.combine(from_date, datetime.min.time(),
+                                   tzinfo=timezone.utc).timestamp())
+    period2 = int(datetime.combine(to_date + timedelta(days=1), datetime.min.time(),
+                                   tzinfo=timezone.utc).timestamp())
+    params = {"interval": "1d", "period1": period1, "period2": period2}
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                      "AppleWebKit/537.36 (KHTML, like Gecko) "
+                      "Chrome/120.0.0.0 Safari/537.36",
     }
-    try:
-        resp = requests.get(url, params=params, timeout=30)
-        resp.raise_for_status()
-        data = resp.json()
-        if not isinstance(data, list):
-            logger.warning("EODHD %s: unexpected payload shape", ticker)
+
+    for attempt in range(3):
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            result = data.get("chart", {}).get("result") or []
+            if not result:
+                logger.warning("Yahoo %s: empty result", yticker)
+                return None
+            ts = result[0].get("timestamp") or []
+            adj = (
+                result[0].get("indicators", {})
+                .get("adjclose", [{}])[0]
+                .get("adjclose", [])
+            )
+            if not ts or not adj:
+                logger.warning("Yahoo %s: no timestamp / adjclose", yticker)
+                return None
+
+            rows = []
+            for t, c in zip(ts, adj):
+                if c is None:
+                    continue
+                d = datetime.fromtimestamp(t, tz=timezone.utc).date()
+                rows.append({"date": d.isoformat(), "adjusted_close": float(c)})
+            return rows if rows else None
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            wait = 2 ** (attempt + 1)
+            logger.warning("Yahoo %s attempt %d/3 failed (%s), retrying in %ds",
+                           yticker, attempt + 1, type(e).__name__, wait)
+            time.sleep(wait)
+        except Exception as e:
+            logger.error("Yahoo fetch failed for %s: %s", yticker, e)
             return None
-        return data
-    except Exception as e:
-        logger.error("EODHD EOD fetch failed for %s: %s", ticker, e)
-        return None
+    return None
 
 
 def update_benchmark(
@@ -84,26 +127,23 @@ def update_benchmark(
     display_name: str,
     latest_price_date: str | None,
     inception_date: str,
-    eodhd_key: str,
     dry_run: bool,
     logger: logging.Logger,
 ) -> dict[str, Any]:
     """Refresh a single benchmark. Returns per-ticker stats."""
     today = date.today()
 
-    # Fetch from the day AFTER the last stored price, or from inception if
-    # latest_price_date is missing (e.g. empty benchmark_prices for this ticker).
     if latest_price_date:
-        from_date = (date.fromisoformat(latest_price_date) + timedelta(days=1)).isoformat()
+        from_date = date.fromisoformat(latest_price_date) + timedelta(days=1)
     else:
-        from_date = inception_date
+        from_date = date.fromisoformat(inception_date)
 
-    if from_date > today.isoformat():
+    if from_date > today:
         logger.info("  %s: already up to date (last=%s)", ticker, latest_price_date)
         return {"ticker": ticker, "inserted": 0, "skipped": True}
 
-    logger.info("  %s: fetching %s → %s", ticker, from_date, today.isoformat())
-    series = eodhd_eod(ticker, eodhd_key, from_date, today.isoformat(), logger)
+    logger.info("  %s: fetching %s → %s", ticker, from_date.isoformat(), today.isoformat())
+    series = yahoo_daily(ticker, from_date, today, logger)
     if series is None:
         return {"ticker": ticker, "inserted": 0, "error": "fetch_failed"}
 
@@ -127,7 +167,6 @@ def update_benchmark(
                     ticker, len(rows), last_row["price_date"], last_row["close"])
         return {"ticker": ticker, "inserted": len(rows), "dry_run": True}
 
-    # Upsert prices, then bump the parent benchmarks row.
     db.client.table("benchmark_prices").upsert(
         rows, on_conflict="ticker,price_date"
     ).execute()
@@ -154,11 +193,6 @@ def main() -> int:
 
     logger = setup_logging()
     logger.info("=== benchmarks_updater started (dry_run=%s) ===", args.dry_run)
-
-    eodhd_key = os.environ.get("EODHD_API_KEY")
-    if not eodhd_key:
-        logger.error("EODHD_API_KEY env var is not set")
-        return 1
 
     db = SupabaseDB()
 
@@ -191,7 +225,6 @@ def main() -> int:
             bench["display_name"],
             bench.get("latest_price_date"),
             bench["inception_date"],
-            eodhd_key,
             args.dry_run,
             logger,
         )

--- a/bootstrap_benchmarks.py
+++ b/bootstrap_benchmarks.py
@@ -5,10 +5,15 @@ One-off seed for benchmark portfolios (S&P 500, MSCI World).
 For each (ticker, display_name) below:
   1. Picks an anchor date: MIN(inception_date) across agent_accounts,
      falling back to today if no accounts exist yet.
-  2. Hits EODHD /eod/{ticker} for the full range (anchor → today) and
-     inserts every (price_date, adjusted_close) into benchmark_prices.
+  2. Hits Yahoo Finance's chart API for daily adjusted closes between
+     anchor and today, and inserts every (price_date, adjusted_close)
+     into benchmark_prices.
   3. Upserts the benchmarks row with inception_date/price and
      latest_price/latest_price_date derived from the fetched series.
+
+Yahoo is used instead of EODHD because the project's EODHD plan doesn't
+cover /api/eod/ for ETFs (403 Forbidden). The shape of the data is
+identical; only the source changes.
 
 Idempotent — re-running refreshes prices and re-anchors inception only
 if necessary. Usage:
@@ -17,16 +22,16 @@ if necessary. Usage:
     python bootstrap_benchmarks.py --ticker SPY.US          # one only
     python bootstrap_benchmarks.py --dry-run                # compute only
 
-Env vars: SUPABASE_URL, SUPABASE_SERVICE_KEY, EODHD_API_KEY.
+Env vars: SUPABASE_URL, SUPABASE_SERVICE_KEY.
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
-import os
 import sys
-from datetime import date, timedelta
+import time
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 import requests
@@ -34,36 +39,85 @@ from dotenv import load_dotenv
 
 from db import SupabaseDB
 
-EODHD_BASE_URL = "https://eodhd.com/api"
-
+# (storage_ticker, display_name). storage_ticker is the row key in
+# the `benchmarks` table; yahoo_ticker_for() maps it to Yahoo's symbol.
 DEFAULT_BENCHMARKS = [
     ("SPY.US", "S&P 500 (SPY)"),
     ("URTH.US", "MSCI World (URTH)"),
 ]
 
 
-def eodhd_eod(ticker: str, api_key: str, from_date: str, to_date: str,
-              logger: logging.Logger) -> list[dict[str, Any]] | None:
-    """Fetch EODHD end-of-day prices for a ticker over a date range."""
-    url = f"{EODHD_BASE_URL}/eod/{ticker}"
-    params = {
-        "api_token": api_key,
-        "fmt": "json",
-        "from": from_date,
-        "to": to_date,
-        "period": "d",
+def yahoo_ticker_for(storage_ticker: str) -> str:
+    """Translate our storage ticker (EODHD-style) to Yahoo's symbol.
+
+    `.US` is dropped (Yahoo uses bare tickers for US listings). Other
+    suffixes can be mapped here if we ever add non-US benchmarks.
+    """
+    if storage_ticker.endswith(".US"):
+        return storage_ticker[:-3]
+    return storage_ticker
+
+
+def yahoo_daily(
+    storage_ticker: str,
+    from_date: date,
+    to_date: date,
+    logger: logging.Logger,
+) -> list[dict[str, Any]] | None:
+    """Fetch daily adjusted closes from Yahoo Finance between two dates.
+
+    Returns a list of {"date": "YYYY-MM-DD", "adjusted_close": float}
+    ordered ascending by date, or None on failure.
+    """
+    yticker = yahoo_ticker_for(storage_ticker)
+    url = f"https://query1.finance.yahoo.com/v8/finance/chart/{yticker}"
+    # Pad period2 by one day so today's bar isn't excluded on boundary.
+    period1 = int(datetime.combine(from_date, datetime.min.time(),
+                                   tzinfo=timezone.utc).timestamp())
+    period2 = int(datetime.combine(to_date + timedelta(days=1), datetime.min.time(),
+                                   tzinfo=timezone.utc).timestamp())
+    params = {"interval": "1d", "period1": period1, "period2": period2}
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                      "AppleWebKit/537.36 (KHTML, like Gecko) "
+                      "Chrome/120.0.0.0 Safari/537.36",
     }
-    try:
-        resp = requests.get(url, params=params, timeout=30)
-        resp.raise_for_status()
-        data = resp.json()
-        if not isinstance(data, list):
-            logger.warning("EODHD %s: unexpected payload shape", ticker)
+
+    for attempt in range(3):
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            result = data.get("chart", {}).get("result") or []
+            if not result:
+                logger.warning("Yahoo %s: empty result", yticker)
+                return None
+            ts = result[0].get("timestamp") or []
+            adj = (
+                result[0].get("indicators", {})
+                .get("adjclose", [{}])[0]
+                .get("adjclose", [])
+            )
+            if not ts or not adj:
+                logger.warning("Yahoo %s: no timestamp / adjclose", yticker)
+                return None
+
+            rows = []
+            for t, c in zip(ts, adj):
+                if c is None:
+                    continue
+                d = datetime.fromtimestamp(t, tz=timezone.utc).date()
+                rows.append({"date": d.isoformat(), "adjusted_close": float(c)})
+            return rows if rows else None
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            wait = 2 ** (attempt + 1)
+            logger.warning("Yahoo %s attempt %d/3 failed (%s), retrying in %ds",
+                           yticker, attempt + 1, type(e).__name__, wait)
+            time.sleep(wait)
+        except Exception as e:
+            logger.error("Yahoo fetch failed for %s: %s", yticker, e)
             return None
-        return data
-    except Exception as e:
-        logger.error("EODHD EOD fetch failed for %s: %s", ticker, e)
-        return None
+    return None
 
 
 def get_anchor_date(db: SupabaseDB, logger: logging.Logger) -> date:
@@ -89,24 +143,24 @@ def seed_benchmark(
     ticker: str,
     display_name: str,
     anchor: date,
-    eodhd_key: str,
     dry_run: bool,
     logger: logging.Logger,
 ) -> bool:
-    """Fetch EOD prices and seed benchmarks + benchmark_prices. Returns True on success."""
+    """Fetch prices and seed benchmarks + benchmark_prices. Returns True on success."""
     today = date.today()
     logger.info("Seeding %s (%s) from %s → %s", ticker, display_name, anchor, today)
 
-    series = eodhd_eod(ticker, eodhd_key, anchor.isoformat(), today.isoformat(), logger)
+    series = yahoo_daily(ticker, anchor, today, logger)
     if not series:
-        logger.error("%s: no EOD data returned; skipping", ticker)
+        logger.error("%s: no price data returned; skipping", ticker)
         return False
 
-    # Sort by date ascending (EODHD returns ascending by default but be defensive).
     series.sort(key=lambda r: r.get("date", ""))
 
-    # First row at or after anchor → inception row.
-    first = next((r for r in series if r.get("date") and r.get("adjusted_close") is not None), None)
+    first = next(
+        (r for r in series if r.get("date") and r.get("adjusted_close") is not None),
+        None,
+    )
     last = next(
         (r for r in reversed(series) if r.get("date") and r.get("adjusted_close") is not None),
         None,
@@ -129,7 +183,6 @@ def seed_benchmark(
         logger.info("  dry-run — skipping writes")
         return True
 
-    # Upsert benchmark row first (so FK on benchmark_prices is satisfied).
     db.client.table("benchmarks").upsert(
         {
             "ticker": ticker,
@@ -142,7 +195,6 @@ def seed_benchmark(
         on_conflict="ticker",
     ).execute()
 
-    # Bulk-upsert daily prices — batch to stay under Supabase payload limits.
     rows = [
         {
             "ticker": ticker,
@@ -178,11 +230,6 @@ def main() -> int:
     )
     logger = logging.getLogger("bootstrap_benchmarks")
 
-    eodhd_key = os.environ.get("EODHD_API_KEY")
-    if not eodhd_key:
-        logger.error("EODHD_API_KEY env var is not set")
-        return 1
-
     db = SupabaseDB()
     anchor = get_anchor_date(db, logger)
 
@@ -196,7 +243,7 @@ def main() -> int:
 
     ok = 0
     for ticker, name in targets:
-        if seed_benchmark(db, ticker, name, anchor, eodhd_key, args.dry_run, logger):
+        if seed_benchmark(db, ticker, name, anchor, args.dry_run, logger):
             ok += 1
 
     logger.info("Done. %d/%d benchmarks seeded.", ok, len(targets))


### PR DESCRIPTION
EODHD returned 403 Forbidden on /api/eod/SPY.US and /api/eod/URTH.US — the project's EODHD plan doesn't include end-of-day price access for ETFs. price_sales_updater.py already side-steps this by using Yahoo Finance's chart API for weekly prices; mirror that pattern here.

Changes:
* bootstrap_benchmarks.py + benchmarks_updater.py: replace the EODHD `/api/eod/` call with Yahoo's v8 chart endpoint (query1.finance.yahoo.com/v8/finance/chart/{ticker}) using period1/period2 Unix timestamps for exact date ranges and interval=1d for daily adjusted closes.
* Ticker translation: SPY.US → SPY, URTH.US → URTH via a yahoo_ticker_for() helper — the `.US` suffix stays as the row key so the DB convention stays consistent with EODHD-style tickers.
* Drop EODHD_API_KEY from both workflows' env; Yahoo doesn't need auth.
* Retry + User-Agent handling copied from the existing _yahoo_chart_request() pattern in price_sales_updater.py.

The schema, UI, and update cadence are unchanged.

https://claude.ai/code/session_018wySSDa67Cmprf6rTc33f5