### PR TITLE
Fall back to since-inception for 30d return on young leaderboards

### DIFF
--- a/migrations/004_30d_fallback.sql
+++ b/migrations/004_30d_fallback.sql
@@ -1,0 +1,68 @@
+-- Migration 004: 30d-return fallback to since-inception
+--
+-- Migration 003 added pnl_pct_30d to agent_leaderboard with NULL when an
+-- agent has <30 days of history. When the leaderboard is young (e.g. 7
+-- days in), that means every row shows `—`. Rework the view so it falls
+-- back to the earliest available snapshot: the column now reads "return
+-- over the last 30 days, or since inception if the agent is younger
+-- than 30 days". Honest-enough label; always renders a number.
+--
+-- Paste-and-run in the Supabase SQL editor. Idempotent.
+
+CREATE OR REPLACE VIEW agent_leaderboard AS
+WITH latest AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        snapshot_date,
+        cash_usd,
+        holdings_value_usd,
+        total_value_usd,
+        pnl_usd,
+        pnl_pct,
+        num_positions
+    FROM agent_portfolio_history
+    ORDER BY agent_id, snapshot_date DESC
+),
+thirty_days_ago AS (
+    -- Preferred anchor: most recent snapshot on/before 30 days ago.
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '30 days'
+    ORDER BY agent_id, snapshot_date DESC
+),
+first_snapshot AS (
+    -- Fallback anchor: earliest snapshot for this agent (since inception).
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    ORDER BY agent_id, snapshot_date ASC
+)
+SELECT
+    a.handle,
+    a.display_name,
+    a.is_house_agent,
+    l.snapshot_date,
+    l.cash_usd,
+    l.holdings_value_usd,
+    l.total_value_usd,
+    l.pnl_usd,
+    l.pnl_pct,
+    l.num_positions,
+    CASE
+        WHEN COALESCE(t30.value_anchor, tfirst.value_anchor) IS NULL
+          OR COALESCE(t30.value_anchor, tfirst.value_anchor) = 0
+            THEN NULL
+        ELSE ROUND(
+            ((l.total_value_usd - COALESCE(t30.value_anchor, tfirst.value_anchor))
+             / COALESCE(t30.value_anchor, tfirst.value_anchor)) * 100,
+            4
+        )
+    END AS pnl_pct_30d
+FROM latest l
+JOIN agents a ON a.id = l.agent_id
+LEFT JOIN thirty_days_ago t30 ON t30.agent_id = l.agent_id
+LEFT JOIN first_snapshot tfirst ON tfirst.agent_id = l.agent_id
+ORDER BY l.pnl_pct DESC;

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -429,13 +429,15 @@ CREATE INDEX IF NOT EXISTS idx_bench_prices_date ON benchmark_prices (price_date
 
 
 -- ============================================================
--- agent_leaderboard view — enriched with pnl_pct_30d
+-- agent_leaderboard view — enriched with pnl_pct_30d (with fallback)
 --
 -- Supersedes the earlier definition above. Adds a rolling 30-day return
--- column (NULL when the agent has <30 days of history) so the /leaderboard
--- page can rank everyone on the same window regardless of inception date.
--- The default sort stays `pnl_pct DESC` for backwards-compat with the
--- homepage LIVE_AGENT_LEADERBOARD card; the leaderboard page re-sorts.
+-- column so the /leaderboard page can rank on a fair window. When the
+-- agent has <30 days of history (e.g. during the arena's first month),
+-- falls back to the earliest-available snapshot so the column isn't
+-- all-NULL on young leaderboards. Default sort stays `pnl_pct DESC`
+-- for backwards-compat with the homepage LIVE_AGENT_LEADERBOARD card;
+-- the leaderboard page re-sorts by pnl_pct_30d DESC NULLS LAST.
 -- ============================================================
 
 CREATE OR REPLACE VIEW agent_leaderboard AS
@@ -453,12 +455,21 @@ WITH latest AS (
     ORDER BY agent_id, snapshot_date DESC
 ),
 thirty_days_ago AS (
+    -- Preferred anchor: most recent snapshot on/before 30 days ago.
     SELECT DISTINCT ON (agent_id)
         agent_id,
-        total_value_usd AS value_30d_ago
+        total_value_usd AS value_anchor
     FROM agent_portfolio_history
     WHERE snapshot_date <= CURRENT_DATE - INTERVAL '30 days'
     ORDER BY agent_id, snapshot_date DESC
+),
+first_snapshot AS (
+    -- Fallback anchor: earliest snapshot for this agent (since inception).
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    ORDER BY agent_id, snapshot_date ASC
 )
 SELECT
     a.handle,
@@ -472,10 +483,17 @@ SELECT
     l.pnl_pct,
     l.num_positions,
     CASE
-        WHEN t.value_30d_ago IS NULL OR t.value_30d_ago = 0 THEN NULL
-        ELSE ROUND(((l.total_value_usd - t.value_30d_ago) / t.value_30d_ago) * 100, 4)
+        WHEN COALESCE(t30.value_anchor, tfirst.value_anchor) IS NULL
+          OR COALESCE(t30.value_anchor, tfirst.value_anchor) = 0
+            THEN NULL
+        ELSE ROUND(
+            ((l.total_value_usd - COALESCE(t30.value_anchor, tfirst.value_anchor))
+             / COALESCE(t30.value_anchor, tfirst.value_anchor)) * 100,
+            4
+        )
     END AS pnl_pct_30d
 FROM latest l
 JOIN agents a ON a.id = l.agent_id
-LEFT JOIN thirty_days_ago t ON t.agent_id = l.agent_id
+LEFT JOIN thirty_days_ago t30 ON t30.agent_id = l.agent_id
+LEFT JOIN first_snapshot tfirst ON tfirst.agent_id = l.agent_id
 ORDER BY l.pnl_pct DESC;

--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -139,9 +139,16 @@ async function getLeaderboard(): Promise<{
         .limit(1)
         .maybeSingle<{ close: number | string }>();
 
-      const ref30 = ref?.close != null ? Number(ref.close) : null;
+      // Fall back to inception_price when there's no snapshot old enough
+      // (benchmark has <30 days of history). Matches the view's fallback
+      // behaviour so agent and benchmark 30d numbers are computed over
+      // the same effective window on young leaderboards.
+      const anchor =
+        ref?.close != null
+          ? Number(ref.close)
+          : Number(b.inception_price);
       const pnl30 =
-        ref30 && ref30 > 0 ? ((latest - ref30) / ref30) * 100 : null;
+        anchor > 0 ? ((latest - anchor) / anchor) * 100 : null;
 
       const totalValue = notional * (latest / inception);
       const pnlUsd = totalValue - notional;


### PR DESCRIPTION
When the arena is under 30 days old, every agent's view lookup for a snapshot ≥30 days ago returns nothing, so pnl_pct_30d was NULL for everyone and the leaderboard's primary sort column rendered all `—`.

Change:
* agent_leaderboard view: adds a `first_snapshot` CTE and COALESCEs the 30-day anchor against the earliest available snapshot, so every agent with at least one history row gets a number.
* Leaderboard page: benchmark 30d computation falls back to `inception_price` when no benchmark_prices row older than 30 days exists, matching the view's fallback semantics so agent + benchmark numbers are computed over the same effective window.

Label stays "30d Return" — the fallback is "return over 30 days or since inception, whichever is shorter", which degrades gracefully to the true 30d window as agents age past a month.

Ship migration as migrations/004_30d_fallback.sql (paste-and-run in Supabase SQL editor); supabase_schema.sql is updated to reflect the canonical view shape.

https://claude.ai/code/session_018wySSDa67Cmprf6rTc33f5