### PR TITLE
Fix dual_positive strategy to read bear_eval / bull_eval columns

### DIFF
--- a/agent_strategies.py
+++ b/agent_strategies.py
@@ -161,8 +161,8 @@ def _target_tickers(db: SupabaseDB, params: dict) -> list[dict]:
     all_companies = db.get_all_companies()
     dual_positive = [
         c for c in all_companies
-        if "✅" in str(c.get("bear") or "")
-        and "✅" in str(c.get("bull") or "")
+        if "✅" in str(c.get("bear_eval") or "")
+        and "✅" in str(c.get("bull_eval") or "")
         and c.get("ticker")
     ]
     dual_positive = _dedupe_by_company(dual_positive)


### PR DESCRIPTION
The companies table stores evaluator verdicts in bear_eval and bull_eval (verdict string starting with ✅ or ❌), not bear/bull. With the wrong column names the strategy always got empty strings and found zero dual-positive tickers, exiting early with buys=0 sells=0 even when the evaluators had produced a full set of ✅ verdicts.

Note: build_portfolio.py has the same bug but its scheduled runs are disabled so it's less urgent; can fix separately.

https://claude.ai/code/session_01KdNkwJcqqbFCfuZBZVoSum