### PR TITLE
Agent detail: add Recent Trades section

### DIFF
--- a/web/app/agent/[handle]/page.tsx
+++ b/web/app/agent/[handle]/page.tsx
@@ -3,8 +3,75 @@ import Link from "next/link";
 import Nav from "@/components/nav";
 import { getAgentByHandle } from "@/lib/agents-query";
 import { getPortfolio, type HoldingWithMtm } from "@/lib/portfolio";
+import { getSupabase } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
+
+const RECENT_TRADES_LIMIT = 50;
+
+interface RecentTrade {
+  id: number;
+  ticker: string;
+  side: "buy" | "sell";
+  quantity: number;
+  price_usd: number;
+  gross_usd: number;
+  cash_after_usd: number;
+  executed_at: string;
+  note: string | null;
+}
+
+async function getRecentTrades(
+  agentId: string,
+): Promise<{ trades: RecentTrade[]; total: number }> {
+  const supabase = getSupabase();
+
+  // Total count (unrestricted) — powers the "showing last N of M" footer.
+  const { count } = await supabase
+    .from("agent_trades")
+    .select("id", { count: "exact", head: true })
+    .eq("agent_id", agentId);
+
+  const { data, error } = await supabase
+    .from("agent_trades")
+    .select(
+      "id, ticker, side, quantity, price_usd, gross_usd, cash_after_usd, executed_at, note",
+    )
+    .eq("agent_id", agentId)
+    .order("executed_at", { ascending: false })
+    .limit(RECENT_TRADES_LIMIT);
+
+  if (error) {
+    console.error("Failed to fetch agent_trades:", error);
+    return { trades: [], total: count ?? 0 };
+  }
+
+  interface RawTradeRow {
+    id: number;
+    ticker: string;
+    side: string;
+    quantity: number | string;
+    price_usd: number | string;
+    gross_usd: number | string;
+    cash_after_usd: number | string;
+    executed_at: string;
+    note: string | null;
+  }
+  const trades: RecentTrade[] = ((data ?? []) as unknown as RawTradeRow[]).map(
+    (r) => ({
+      id: r.id,
+      ticker: r.ticker,
+      side: r.side === "sell" ? "sell" : "buy",
+      quantity: Number(r.quantity),
+      price_usd: Number(r.price_usd),
+      gross_usd: Number(r.gross_usd),
+      cash_after_usd: Number(r.cash_after_usd),
+      executed_at: r.executed_at,
+      note: r.note,
+    }),
+  );
+  return { trades, total: count ?? trades.length };
+}
 
 function formatUsd(n: number): string {
   return `$${n.toLocaleString("en-US", {
@@ -29,6 +96,17 @@ function pnlColor(n: number): string {
   if (n > 0) return "text-green";
   if (n < 0) return "text-red";
   return "text-text-dim";
+}
+
+function formatTradeDate(iso: string): string {
+  // 2026-04-21 14:05 UTC — compact, unambiguous, no dependency on locale.
+  const d = new Date(iso);
+  const yy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mi = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${yy}-${mm}-${dd} ${hh}:${mi}`;
 }
 
 function StatCard({
@@ -61,7 +139,10 @@ export default async function AgentPortfolioPage({
   const agent = await getAgentByHandle(decodeURIComponent(handle));
   if (!agent) notFound();
 
-  const portfolio = await getPortfolio(agent.id);
+  const [portfolio, recent] = await Promise.all([
+    getPortfolio(agent.id),
+    getRecentTrades(agent.id),
+  ]);
 
   const holdingsSorted = [...portfolio.holdings].sort(
     (a, b) => b.market_value_usd - a.market_value_usd,
@@ -198,6 +279,98 @@ export default async function AgentPortfolioPage({
               </table>
             </div>
           </div>
+        )}
+
+        {/* Recent trades */}
+        <h2 className="font-mono text-sm font-bold text-text-dim uppercase tracking-wider mt-10 mb-3">
+          Recent Trades
+        </h2>
+
+        {recent.trades.length === 0 ? (
+          <div className="glass-card rounded-lg p-8 text-center">
+            <p className="font-mono text-text-muted">
+              No trades yet. This agent hasn&apos;t executed any buys or
+              sells.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="glass-card rounded-lg overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full font-mono text-sm">
+                  <thead className="bg-bg-hover border-b border-border text-left text-xs uppercase tracking-wider text-text-dim">
+                    <tr>
+                      <th className="px-4 py-3 font-normal">Date (UTC)</th>
+                      <th className="px-4 py-3 font-normal">Side</th>
+                      <th className="px-4 py-3 font-normal">Ticker</th>
+                      <th className="px-4 py-3 font-normal text-right">Qty</th>
+                      <th className="px-4 py-3 font-normal text-right">
+                        Price
+                      </th>
+                      <th className="px-4 py-3 font-normal text-right">
+                        Gross
+                      </th>
+                      <th className="px-4 py-3 font-normal text-right">
+                        Cash after
+                      </th>
+                      <th className="px-4 py-3 font-normal">Rationale</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {recent.trades.map((t) => (
+                      <tr
+                        key={t.id}
+                        className="border-b border-border/50 hover:bg-bg-hover/50 transition-colors align-top"
+                      >
+                        <td className="px-4 py-3 text-text-dim whitespace-nowrap">
+                          {formatTradeDate(t.executed_at)}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span
+                            className={`text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 ${
+                              t.side === "buy"
+                                ? "text-green border border-green/40 bg-green/10"
+                                : "text-red border border-red/40 bg-red/10"
+                            }`}
+                          >
+                            {t.side}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3">
+                          <Link
+                            href={`/company/${t.ticker}`}
+                            className="text-green hover:underline"
+                          >
+                            {t.ticker}
+                          </Link>
+                        </td>
+                        <td className="px-4 py-3 text-right text-text">
+                          {t.quantity.toLocaleString("en-US")}
+                        </td>
+                        <td className="px-4 py-3 text-right text-text">
+                          {formatUsd4(t.price_usd)}
+                        </td>
+                        <td className="px-4 py-3 text-right text-text">
+                          {formatUsd(t.gross_usd)}
+                        </td>
+                        <td className="px-4 py-3 text-right text-text-dim">
+                          {formatUsd(t.cash_after_usd)}
+                        </td>
+                        <td className="px-4 py-3 text-text-muted max-w-md">
+                          {t.note ?? <span className="text-text-dim">—</span>}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <p className="text-xs text-text-muted font-mono mt-3">
+              {recent.total > recent.trades.length
+                ? `Showing the ${recent.trades.length} most recent of ${recent.total.toLocaleString("en-US")} trades.`
+                : `All ${recent.total.toLocaleString("en-US")} trade${recent.total === 1 ? "" : "s"} for this agent.`}
+            </p>
+          </>
         )}
       </main>
     </>


### PR DESCRIPTION
Below the Current Holdings table, show the agent's 50 most recent trades with Date, Side (buy/sell chip), Ticker, Qty, Price, Gross, Cash after, and the Rationale stored in agent_trades.note.

The rationales are the templated strings the heartbeat strategies started writing last commit — e.g. "Sold TMDX — rating 1.8 breached 1.6 ceiling; bear flipped ❌." Manual trades via the HTTP API keep whatever note the caller supplied. Empty notes render as em-dash.

Footer shows "Showing the N most recent of M trades" when the agent has more history than the 50-row cap; otherwise just the total count. Pagination can wait until someone's had >50 trades for long enough that scrolling all the way back matters.

Server-side fetch is parallel with the existing getPortfolio call (Promise.all), so the page load doesn't add extra latency.

https://claude.ai/code/session_01KdNkwJcqqbFCfuZBZVoSum