### PR TITLE
Web: switch pages from force-dynamic to ISR for faster downloads

### DIFF
--- a/web/app/agent/[handle]/page.tsx
+++ b/web/app/agent/[handle]/page.tsx
@@ -5,7 +5,7 @@ import { getAgentByHandle } from "@/lib/agents-query";
 import { getPortfolio, type HoldingWithMtm } from "@/lib/portfolio";
 import { getSupabase } from "@/lib/supabase";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 300;
 
 const RECENT_TRADES_LIMIT = 50;
 

--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -16,7 +16,7 @@ import { absoluteUrl } from "@/lib/site";
 import Nav from "@/components/nav";
 import PsChart from "@/components/ps-chart";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 600;
 
 async function getData(ticker: string) {
   const supabase = getSupabase();

--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { unstable_cache } from "next/cache";
 import { getSupabase } from "@/lib/supabase";
 import Nav from "@/components/nav";
 import LeaderboardTable, {
@@ -8,7 +9,7 @@ import LeaderboardTable, {
   type Period,
 } from "@/components/leaderboard-table";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 300;
 
 export const metadata: Metadata = {
   title: "Leaderboard — AI agent alpha rankings",
@@ -32,7 +33,7 @@ function emptyBuckets(): TradeBuckets {
   return { "1d": 0, "30d": 0, ytd: 0, "1yr": 0 };
 }
 
-async function getLeaderboard(): Promise<{
+async function fetchLeaderboard(): Promise<{
   rows: LeaderboardRow[];
   latestDate: string | null;
 }> {
@@ -177,6 +178,11 @@ async function getLeaderboard(): Promise<{
   );
   return { rows, latestDate };
 }
+
+const getLeaderboard = unstable_cache(fetchLeaderboard, ["leaderboard-v1"], {
+  revalidate: 300,
+  tags: ["leaderboard"],
+});
 
 async function fetchTradeBuckets(
   supabase: ReturnType<typeof getSupabase>,

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -13,8 +13,7 @@ import { listPublicAgents, type PublicAgent } from "@/lib/agents-query";
 import { getTopAgents, type TopAgent } from "@/lib/top-agent-query";
 import { COLORS } from "@/lib/constants";
 
-export const dynamic = "force-dynamic";
-export const revalidate = 60;
+export const revalidate = 300;
 
 // Home page owns the brand title — opt out of the template so we don't get
 // "AlphaMolt | Build, Test & Harden Stock-Picking AI Agents | AlphaMolt".

--- a/web/app/portfolio/page.tsx
+++ b/web/app/portfolio/page.tsx
@@ -5,7 +5,7 @@ import { deduplicateByCompany } from "@/lib/dedupe";
 import Nav from "@/components/nav";
 import DataTable from "@/components/data-table";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: "Example Agent Portfolio",

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -4,7 +4,7 @@ import { Company, SCREENER_COLUMNS } from "@/lib/types";
 import Nav from "@/components/nav";
 import DataTable from "@/components/data-table";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 600;
 
 export const metadata: Metadata = {
   title: "Screener — 400+ global growth stocks",

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -2,10 +2,6 @@ import type { MetadataRoute } from "next";
 import { getSupabase } from "@/lib/supabase";
 import { absoluteUrl } from "@/lib/site";
 
-// Next.js will regenerate the sitemap on each request because this route
-// reads from Supabase. For a ~400-row universe that's fine; if it grows,
-// wrap with `unstable_cache` or switch to an ISR strategy.
-export const dynamic = "force-dynamic";
 export const revalidate = 3600;
 
 type ChangeFreq = NonNullable<MetadataRoute.Sitemap[number]["changeFrequency"]>;

--- a/web/app/u/[handle]/page.tsx
+++ b/web/app/u/[handle]/page.tsx
@@ -6,8 +6,7 @@ import { getAgentByHandle } from "@/lib/agents-query";
 import { getPortfolio, type PortfolioSnapshot } from "@/lib/portfolio";
 import { getSupabase } from "@/lib/supabase";
 
-export const dynamic = "force-dynamic";
-export const revalidate = 30;
+export const revalidate = 300;
 
 interface PageParams {
   params: Promise<{ handle: string }>;


### PR DESCRIPTION
Every page was re-querying Supabase on each request even though the underlying data only changes on the nightly 03:00–05:30 UTC cron runs. Flip homepage, screener, portfolio, company, agent, u/[handle] to ISR with 5–10 minute revalidate windows; wrap the leaderboard fetch (which reads searchParams so can't pre-render) in unstable_cache with a 5m TTL.