### PR TITLE
Bluesky: heartbeat for @alphamolt.bsky.social

### DIFF
--- a/.github/workflows/bluesky-heartbeat.yml
+++ b/.github/workflows/bluesky-heartbeat.yml
@@ -1,0 +1,37 @@
+name: Bluesky Heartbeat
+
+on:
+  schedule:
+    # Every 4 hours
+    - cron: "0 */4 * * *"
+  workflow_dispatch: # Allow manual trigger from GitHub UI
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install requests anthropic atproto
+
+      - name: Run Bluesky heartbeat
+        env:
+          BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
+          BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python bluesky_heartbeat.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ and Supabase (PostgreSQL) as the primary data store.
 05:00 UTC       score_ai_analysis.py      Score, rank & assign sort_order
 05:30 UTC       portfolio_valuation.py    Mark-to-market every agent portfolio
 Sun 22:00 UTC   agent_heartbeat.py        Rebalance every agent's portfolio via its strategy
+Every 4h        moltbook_heartbeat.py     Reply to notifications + engage with finance submolts on Moltbook
+Every 4h        bluesky_heartbeat.py      Reply to mentions + search for AI-in-finance posts on Bluesky
 ```
 
 ## Shared Modules

--- a/bluesky_heartbeat.py
+++ b/bluesky_heartbeat.py
@@ -1,0 +1,391 @@
+"""Bluesky heartbeat — reply to mentions + search for AI-in-finance posts.
+
+Runs every 4 hours via ``.github/workflows/bluesky-heartbeat.yml``.
+
+Phase 1 — Mentions (always on)
+    Reply to unread mention/reply notifications. No approval gate; post goes
+    straight up and an audit issue (``bluesky-posted``) is filed.
+
+Phase 2 — Search engagement (``--no-search`` to disable)
+    For each seeded search query (AI stock picking, AI fund manager, etc.),
+    fetch recent matching posts, run the three-theme classifier, and reply
+    to the best matches until we hit the per-run cap.
+
+Auto-posts everything. Dedup + rate limits tracked in a GitHub issue
+labelled ``bluesky-ledger``.
+
+Env vars:
+    BLUESKY_HANDLE         default alphamolt.bsky.social
+    BLUESKY_APP_PASSWORD   required — Bluesky app-specific password
+    ANTHROPIC_API_KEY      required — drafter + classifier
+    GITHUB_TOKEN           required unless --dry-run (audit issues)
+    GITHUB_REPOSITORY      set automatically in GitHub Actions
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime, timezone
+
+from moltbook_lib import GitHubIssuer
+
+from bluesky_lib import (
+    BlueskyClient,
+    FAILED_LABEL,
+    OWN_HANDLE,
+    POSTED_LABEL,
+    SEARCH_QUERIES,
+    classify_bsky_themes,
+    draft_mention_reply,
+    draft_reply_to_post,
+    get_or_create_ledger,
+    update_ledger,
+)
+
+MAX_REPLIES_PER_RUN = 3
+MAX_REPLIES_PER_DAY = 10
+SEARCH_LIMIT_PER_QUERY = 8
+
+REPLYABLE_REASONS = {"mention", "reply"}
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("bluesky-heartbeat")
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _first_line(s: str, maxlen: int = 120) -> str:
+    s = (s or "").strip()
+    if not s:
+        return ""
+    first = s.splitlines()[0]
+    return first[: maxlen - 1] + "…" if len(first) > maxlen else first
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Mentions / replies on our posts
+# ---------------------------------------------------------------------------
+
+
+def _process_mentions(
+    client: BlueskyClient,
+    gh: GitHubIssuer | None,
+    ledger: dict,
+    args: argparse.Namespace,
+) -> dict:
+    stats = {"posted": 0, "skipped": 0, "failed": 0}
+    notifs = client.list_notifications(limit=50)
+    log.info("notifications fetched: %d", len(notifs))
+
+    processed = set(ledger.get("processed_notif_uris", []))
+    replied = set(ledger.get("replied_to_uris", []))
+    today = _today()
+    daily = ledger.setdefault("daily_reply_count", {})
+    replies_today = daily.get(today, 0)
+
+    actionable = [
+        n for n in notifs
+        if n.get("reason") in REPLYABLE_REASONS
+        and n.get("uri") not in processed
+        and n.get("author_handle") != OWN_HANDLE
+    ]
+    log.info("actionable mentions/replies: %d", len(actionable))
+
+    replies_this_run = 0
+    for n in actionable:
+        if replies_this_run >= MAX_REPLIES_PER_RUN:
+            log.info("reply cap reached this run — stopping mentions phase")
+            break
+        if replies_today >= MAX_REPLIES_PER_DAY:
+            log.info("daily reply cap reached — stopping")
+            break
+
+        uri = n.get("uri")
+        log.info(
+            "  [%s] from @%s: %s",
+            n.get("reason"), n.get("author_handle"),
+            _first_line(n.get("text", "")),
+        )
+
+        try:
+            draft = draft_mention_reply(n)
+        except Exception as exc:
+            log.error("draft_mention_reply failed: %s", exc)
+            stats["failed"] += 1
+            processed.add(uri)
+            continue
+
+        if not draft:
+            log.info("SKIP — nothing to add")
+            stats["skipped"] += 1
+            processed.add(uri)
+            continue
+
+        if args.dry_run:
+            log.info("DRY RUN — would reply: %s", draft)
+            stats["posted"] += 1
+            processed.add(uri)
+            replies_this_run += 1
+            continue
+
+        result = client.reply(
+            text=draft,
+            parent_uri=uri,
+            parent_cid=n.get("cid"),
+            root_uri=n.get("reply_root_uri") or uri,
+            root_cid=n.get("reply_root_cid") or n.get("cid"),
+        )
+        if not result:
+            log.error("reply failed on %s", uri)
+            stats["failed"] += 1
+            continue
+
+        log.info("replied: %s", result.get("uri"))
+        processed.add(uri)
+        replied.add(uri)
+        replies_this_run += 1
+        replies_today += 1
+        stats["posted"] += 1
+
+        if gh:
+            _file_posted_audit(
+                gh, phase="mention", notif_or_post=n,
+                draft=draft, result=result,
+            )
+
+    ledger["processed_notif_uris"] = sorted(processed)
+    ledger["replied_to_uris"] = sorted(replied)
+    daily[today] = replies_today
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Search for AI-in-finance posts
+# ---------------------------------------------------------------------------
+
+
+def _process_search(
+    client: BlueskyClient,
+    gh: GitHubIssuer | None,
+    ledger: dict,
+    args: argparse.Namespace,
+) -> dict:
+    stats = {"posted": 0, "skipped": 0, "failed": 0, "classified": 0}
+
+    replied = set(ledger.get("replied_to_uris", []))
+    today = _today()
+    daily = ledger.setdefault("daily_reply_count", {})
+    replies_today = daily.get(today, 0)
+
+    # Collect + dedupe candidates across all queries.
+    seen: set[str] = set()
+    candidates: list[dict] = []
+    for q in SEARCH_QUERIES:
+        posts = client.search_posts(q, limit=SEARCH_LIMIT_PER_QUERY)
+        log.info("  query %r: %d results", q, len(posts))
+        for p in posts:
+            uri = p.get("uri")
+            if not uri or uri in seen:
+                continue
+            if uri in replied:
+                continue
+            if p.get("author_handle") == OWN_HANDLE:
+                continue
+            seen.add(uri)
+            p["_discovered_via"] = q
+            candidates.append(p)
+
+    log.info("search candidates (dedup): %d", len(candidates))
+
+    replies_this_run = 0
+    for post in candidates:
+        if replies_this_run >= MAX_REPLIES_PER_RUN:
+            log.info("reply cap reached this run — stopping search phase")
+            break
+        if replies_today >= MAX_REPLIES_PER_DAY:
+            log.info("daily reply cap reached — stopping")
+            break
+
+        uri = post.get("uri")
+        log.info(
+            "  considering %s by @%s (via %r): %s",
+            (uri or "")[-12:], post.get("author_handle"),
+            post.get("_discovered_via"),
+            _first_line(post.get("text", "")),
+        )
+
+        try:
+            themes = classify_bsky_themes(post)
+            stats["classified"] += 1
+        except Exception as exc:
+            log.error("classifier failed: %s", exc)
+            continue
+
+        if not themes:
+            log.info("SKIP — off-theme")
+            stats["skipped"] += 1
+            continue
+        log.info("matches themes %s", themes)
+
+        try:
+            draft = draft_reply_to_post(post)
+        except Exception as exc:
+            log.error("draft_reply_to_post failed: %s", exc)
+            stats["failed"] += 1
+            continue
+
+        if not draft:
+            log.info("SKIP — drafter returned nothing substantive")
+            stats["skipped"] += 1
+            continue
+
+        if args.dry_run:
+            log.info("DRY RUN — would reply: %s", draft)
+            stats["posted"] += 1
+            replied.add(uri)
+            replies_this_run += 1
+            continue
+
+        result = client.reply(
+            text=draft,
+            parent_uri=uri,
+            parent_cid=post.get("cid"),
+            root_uri=post.get("root_uri") or uri,
+            root_cid=post.get("root_cid") or post.get("cid"),
+        )
+        if not result:
+            log.error("reply failed on %s", uri)
+            stats["failed"] += 1
+            continue
+
+        log.info("replied: %s", result.get("uri"))
+        replied.add(uri)
+        replies_this_run += 1
+        replies_today += 1
+        stats["posted"] += 1
+
+        if gh:
+            _file_posted_audit(
+                gh, phase="search", notif_or_post=post,
+                draft=draft, result=result, themes=themes,
+            )
+
+    ledger["replied_to_uris"] = sorted(replied)
+    daily[today] = replies_today
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Audit issues
+# ---------------------------------------------------------------------------
+
+
+def _file_posted_audit(
+    gh: GitHubIssuer,
+    phase: str,
+    notif_or_post: dict,
+    draft: str,
+    result: dict,
+    themes: list[int] | None = None,
+) -> None:
+    author = notif_or_post.get("author_handle") or "unknown"
+    parent_uri = notif_or_post.get("uri") or ""
+    parent_text = _first_line(notif_or_post.get("text", ""), maxlen=60)
+    reply_uri = result.get("uri") or ""
+
+    title = f'[bluesky] {phase}: @{author} — "{parent_text}"'
+    body_parts = [
+        f"**Phase:** {phase}",
+        f"**Author:** @{author}",
+        f"**Parent URI:** `{parent_uri}`",
+        f"**Our reply URI:** `{reply_uri}`",
+    ]
+    if themes:
+        body_parts.append(f"**Themes:** {themes}")
+    if notif_or_post.get("_discovered_via"):
+        body_parts.append(
+            f"**Discovered via query:** {notif_or_post['_discovered_via']!r}"
+        )
+    body_parts += [
+        "",
+        "### Parent post",
+        "",
+        (notif_or_post.get("text") or "").strip() or "(no text)",
+        "",
+        "### Our reply",
+        "",
+        draft,
+    ]
+    issue = gh.create_issue(title, "\n".join(body_parts), [POSTED_LABEL])
+    if issue:
+        gh.close_issue(issue["number"])
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--no-mentions", action="store_true")
+    parser.add_argument("--no-search", action="store_true")
+    args = parser.parse_args()
+
+    log.info(
+        "Bluesky heartbeat starting (dry_run=%s mentions=%s search=%s)",
+        args.dry_run, not args.no_mentions, not args.no_search,
+    )
+
+    client = BlueskyClient()
+
+    gh = None
+    if not args.dry_run:
+        try:
+            gh = GitHubIssuer()
+            gh.ensure_label(POSTED_LABEL, "0e8a16", "Bluesky post — audit")
+            gh.ensure_label(FAILED_LABEL, "b60205", "Bluesky posting failed")
+        except Exception as exc:
+            log.warning("GitHub unavailable — running without audit: %s", exc)
+            gh = None
+
+    ledger_issue = None
+    ledger: dict = {
+        "replied_to_uris": [],
+        "processed_notif_uris": [],
+        "daily_reply_count": {},
+    }
+    if gh:
+        ledger_issue, ledger = get_or_create_ledger(gh)
+
+    mention_stats = {"posted": 0, "skipped": 0, "failed": 0}
+    search_stats = {"posted": 0, "skipped": 0, "failed": 0, "classified": 0}
+
+    if not args.no_mentions:
+        mention_stats = _process_mentions(client, gh, ledger, args)
+    if not args.no_search:
+        search_stats = _process_search(client, gh, ledger, args)
+
+    if gh and ledger_issue is not None:
+        update_ledger(gh, ledger_issue, ledger)
+        log.info("ledger saved")
+
+    log.info(
+        "HEARTBEAT_DONE — mentions: posted=%d skipped=%d failed=%d | "
+        "search: posted=%d skipped=%d failed=%d classified=%d",
+        mention_stats["posted"], mention_stats["skipped"], mention_stats["failed"],
+        search_stats["posted"], search_stats["skipped"], search_stats["failed"],
+        search_stats["classified"],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bluesky_lib.py
+++ b/bluesky_lib.py
@@ -1,0 +1,450 @@
+"""Bluesky (AT Protocol) client + drafting helpers for @alphamolt.bsky.social.
+
+Parallels ``moltbook_lib.py`` but targets Bluesky's 300-char post cap and uses
+search-based discovery instead of submolt feeds. Auto-posts (no approval gate);
+a ``bluesky-posted`` GitHub issue is filed per send for audit.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any
+
+log = logging.getLogger("bluesky")
+
+OWN_HANDLE = "alphamolt.bsky.social"
+
+POSTED_LABEL = "bluesky-posted"
+FAILED_LABEL = "bluesky-failed"
+LEDGER_LABEL = "bluesky-ledger"
+LEDGER_MARKER_START = "<!-- bluesky-ledger-data"
+LEDGER_MARKER_END = "bluesky-ledger-data -->"
+
+# Bluesky hard cap is 300 graphemes. Leave buffer for mentions / punctuation.
+CHAR_CAP = 280
+CHAR_CAP_HARD = 300
+
+DRAFT_MODEL = "claude-haiku-4-5"
+
+SEARCH_QUERIES = (
+    "AI stock picking",
+    "AI stock picker",
+    "AI stockpicks",
+    "AI fund manager",
+    "AI beats fund manager",
+    "AI vs human manager",
+    "quant vs discretionary",
+    "AI equities",
+    "AI portfolio management",
+    "LLM stock picks",
+    "agent trading equities",
+    "autonomous trading agent",
+)
+
+BSKY_SYSTEM = """You are AlphaMolt-Equities (@alphamolt.bsky.social), an AI agent on Bluesky.
+
+## What you believe (your thesis)
+AI stock selection will be how portfolios get built from here on. Humans can't match an AI on information bandwidth, bias suppression, flexibility, or 24/7 uptime. Nobody yet knows which model / strategy / swarm structure actually wins — that's an empirical question, which is why you built alphamolt.
+
+## What alphamolt is
+An open arena where different models and strategies run portfolios against each other and against SPY / MSCI World, so anyone can see what's actually working. Live on alphamolt — the leaderboard is the scoreboard.
+
+## Vocabulary
+When threads touch picking, active management, or fund performance, co-locate "alphamolt" with one of: "stock picking", "AI stock-picker", "AI stockpicks". Rotate the phrasing. Never as a CTA ("check out", "visit"). Most replies should not mention alphamolt at all.
+
+## Voice
+Open arena-runner by default. You don't know who wins; you built the arena to find out. When someone makes a falsifiable claim you can refute with evidence, push back — concretely, no throat-clearing.
+
+## Anti-fabrication (critical)
+- Never invent roadmap or work-in-progress. If you haven't done it, say "no".
+- Never commit to actions you won't perform ("I'll DM you", "I'll send data").
+- Never describe actions as already done.
+- No financial advice, no price targets, no hype.
+
+## Style — Bluesky (VERY tight)
+- HARD CAP: 280 characters. Aim for 180–250. Cut ruthlessly.
+- Plain text. No hashtags. No emoji unless genuinely useful.
+- Lead with substance. No "Great post", "This is interesting", "Thanks for sharing".
+- Concrete over abstract — numbers, mechanisms, specific points.
+- One thought per reply. No sign-offs.
+- Don't @-tag the author — the reply already threads to them.
+
+## When to skip
+If the post is off-thesis, spam, purely social, or you have nothing substantive to add, return the single word SKIP (it's fine — better than a weak reply).
+"""
+
+
+# ---------------------------------------------------------------------------
+# Bluesky client (thin wrapper over atproto.Client)
+# ---------------------------------------------------------------------------
+
+
+class BlueskyClient:
+    """Thin wrapper over the atproto Python client."""
+
+    def __init__(
+        self, handle: str | None = None, password: str | None = None
+    ) -> None:
+        try:
+            from atproto import Client
+        except ImportError as exc:
+            raise RuntimeError(
+                "atproto package not installed — pip install atproto"
+            ) from exc
+
+        self.handle = (
+            handle
+            or os.environ.get("BLUESKY_HANDLE")
+            or OWN_HANDLE
+        )
+        self.password = password or os.environ.get("BLUESKY_APP_PASSWORD")
+        if not self.password:
+            raise RuntimeError("BLUESKY_APP_PASSWORD not set")
+
+        self.client = Client()
+        profile = self.client.login(self.handle, self.password)
+        self.did = getattr(profile, "did", None)
+        log.info("logged in as %s (did=%s)", self.handle, self.did)
+
+    # -- Reads -------------------------------------------------------------
+
+    def search_posts(self, query: str, limit: int = 10) -> list[dict]:
+        """Return recent posts matching the query (newest first)."""
+        try:
+            resp = self.client.app.bsky.feed.search_posts(
+                params={"q": query, "limit": limit, "sort": "latest"}
+            )
+        except Exception as exc:
+            log.error("search_posts(%r) failed: %s", query, exc)
+            return []
+        return [_serialize_post(p) for p in (resp.posts or [])]
+
+    def list_notifications(self, limit: int = 50) -> list[dict]:
+        """Return recent notifications (mentions, replies, likes, follows)."""
+        try:
+            resp = self.client.app.bsky.notification.list_notifications(
+                params={"limit": limit}
+            )
+        except Exception as exc:
+            log.error("list_notifications failed: %s", exc)
+            return []
+        return [_serialize_notif(n) for n in (resp.notifications or [])]
+
+    # -- Writes ------------------------------------------------------------
+
+    def reply(
+        self,
+        text: str,
+        parent_uri: str,
+        parent_cid: str,
+        root_uri: str | None = None,
+        root_cid: str | None = None,
+    ) -> dict | None:
+        """Post a reply. Returns {uri, cid} on success, None on failure."""
+        try:
+            from atproto import models
+        except ImportError:
+            log.error("atproto not available")
+            return None
+
+        root_uri = root_uri or parent_uri
+        root_cid = root_cid or parent_cid
+        try:
+            parent_ref = models.ComAtprotoRepoStrongRef.Main(
+                uri=parent_uri, cid=parent_cid
+            )
+            root_ref = models.ComAtprotoRepoStrongRef.Main(
+                uri=root_uri, cid=root_cid
+            )
+            reply_ref = models.AppBskyFeedPost.ReplyRef(
+                parent=parent_ref, root=root_ref
+            )
+            resp = self.client.send_post(text=text, reply_to=reply_ref)
+            return {"uri": resp.uri, "cid": resp.cid}
+        except Exception as exc:
+            log.error("reply failed: %s", exc)
+            return None
+
+
+def _serialize_post(p: Any) -> dict:
+    """Flatten an atproto PostView into a plain dict we can reason about."""
+    record = getattr(p, "record", None)
+    author = getattr(p, "author", None)
+    text = getattr(record, "text", "") if record else ""
+    reply = getattr(record, "reply", None)
+    root_uri = None
+    root_cid = None
+    if reply and getattr(reply, "root", None):
+        root_uri = getattr(reply.root, "uri", None)
+        root_cid = getattr(reply.root, "cid", None)
+    return {
+        "uri": getattr(p, "uri", None),
+        "cid": getattr(p, "cid", None),
+        "author_handle": getattr(author, "handle", None) if author else None,
+        "author_did": getattr(author, "did", None) if author else None,
+        "author_display_name": (
+            getattr(author, "display_name", None) if author else None
+        ),
+        "text": text or "",
+        "indexed_at": getattr(p, "indexed_at", None),
+        "root_uri": root_uri,
+        "root_cid": root_cid,
+        "reply_count": getattr(p, "reply_count", 0),
+        "like_count": getattr(p, "like_count", 0),
+    }
+
+
+def _serialize_notif(n: Any) -> dict:
+    """Flatten a Notification into a plain dict."""
+    author = getattr(n, "author", None)
+    record = getattr(n, "record", None)
+    text = ""
+    reply_root_uri = None
+    reply_root_cid = None
+    if record is not None:
+        text = getattr(record, "text", "") or ""
+        reply = getattr(record, "reply", None)
+        if reply and getattr(reply, "root", None):
+            reply_root_uri = getattr(reply.root, "uri", None)
+            reply_root_cid = getattr(reply.root, "cid", None)
+    return {
+        "uri": getattr(n, "uri", None),
+        "cid": getattr(n, "cid", None),
+        "reason": getattr(n, "reason", None),
+        "reason_subject": getattr(n, "reason_subject", None),
+        "is_read": getattr(n, "is_read", False),
+        "indexed_at": getattr(n, "indexed_at", None),
+        "author_handle": getattr(author, "handle", None) if author else None,
+        "author_did": getattr(author, "did", None) if author else None,
+        "text": text,
+        "reply_root_uri": reply_root_uri,
+        "reply_root_cid": reply_root_cid,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Anthropic drafting helpers
+# ---------------------------------------------------------------------------
+
+
+def _anthropic_client():
+    try:
+        from anthropic import Anthropic
+    except ImportError as exc:
+        raise RuntimeError(
+            "anthropic package not installed — pip install anthropic"
+        ) from exc
+    return Anthropic()
+
+
+def _is_skip(text: str) -> bool:
+    """True if the drafter's output is a SKIP signal (possibly with trailer)."""
+    stripped = (text or "").strip()
+    if not stripped:
+        return True
+    first = re.split(r"[\s.,:;()\-—]", stripped, maxsplit=1)[0]
+    return first.upper() == "SKIP"
+
+
+def _draft_once(user_block: str, max_tokens: int = 400) -> str:
+    client = _anthropic_client()
+    resp = client.messages.create(
+        model=DRAFT_MODEL,
+        max_tokens=max_tokens,
+        system=[
+            {
+                "type": "text",
+                "text": BSKY_SYSTEM,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        messages=[{"role": "user", "content": user_block}],
+    )
+    return "".join(
+        b.text for b in resp.content if getattr(b, "type", None) == "text"
+    ).strip()
+
+
+def classify_bsky_themes(post: dict[str, Any]) -> list[int]:
+    """Classify a Bluesky post against our three engagement themes.
+
+    Returns matched theme numbers (subset of [1, 2, 3]). Empty list = skip.
+    """
+    author = post.get("author_handle") or "unknown"
+    text = (post.get("text") or "")[:1000]
+
+    user_block = (
+        "Classify a Bluesky post against three engagement themes. "
+        "Return only themes that GENUINELY apply.\n\n"
+        "THEMES:\n"
+        "1. AI models outperforming human fund managers / stock pickers "
+        "(active vs passive, AI vs human intuition, fund performance).\n"
+        "2. Swarms of models (collaborative or competitive) vs single-model "
+        "(multi-agent, ensembles, mixture of experts).\n"
+        "3. Interfaces / platforms serving BOTH agents and humans, not humans "
+        "alone (agent-first UX, machine-readable APIs).\n\n"
+        f"POST by @{author}:\n{text}\n\n"
+        "Output exactly one line:\n"
+        "  THEMES: 1,3\n"
+        "or\n"
+        "  THEMES: none\n"
+        "No prose."
+    )
+
+    client = _anthropic_client()
+    resp = client.messages.create(
+        model=DRAFT_MODEL,
+        max_tokens=40,
+        messages=[{"role": "user", "content": user_block}],
+    )
+    raw = "".join(
+        b.text for b in resp.content if getattr(b, "type", None) == "text"
+    ).strip()
+
+    m = re.search(r"THEMES:\s*(none|[\d,\s]+)", raw, re.IGNORECASE)
+    if not m:
+        log.warning("bsky classifier: unparseable output %r", raw)
+        return []
+    ans = m.group(1).strip().lower()
+    if ans == "none":
+        return []
+    return sorted({int(n) for n in re.findall(r"[123]", ans)})
+
+
+def draft_reply_to_post(post: dict[str, Any]) -> str:
+    """Draft a Bluesky reply to a discovered post. Returns '' if SKIP."""
+    author = post.get("author_handle") or "unknown"
+    text = (post.get("text") or "")[:800]
+
+    user_block = (
+        "You are replying on Bluesky to a post you discovered via search. "
+        "Draft ONE substantive reply.\n\n"
+        f"POST by @{author}:\n{text}\n\n"
+        "RULES:\n"
+        "- Add genuine value: a sharp point, a counter, a specific question.\n"
+        "- Do NOT just agree.\n"
+        "- If you have nothing substantive to add, return SKIP.\n"
+        f"- HARD CAP: {CHAR_CAP} characters.\n"
+        "Return ONLY the reply text, or SKIP."
+    )
+
+    draft = _draft_once(user_block)
+    if _is_skip(draft):
+        return ""
+    if len(draft) <= CHAR_CAP_HARD:
+        return draft
+
+    log.warning("bsky reply too long (%d chars); re-drafting", len(draft))
+    retry_block = user_block + (
+        f"\n\nYOUR PREVIOUS DRAFT WAS {len(draft)} CHARACTERS — TOO LONG.\n"
+        f"Previous draft:\n{draft}\n\n"
+        f"Rewrite in UNDER {CHAR_CAP} characters."
+    )
+    retry = _draft_once(retry_block)
+    if _is_skip(retry):
+        return ""
+    if len(retry) > CHAR_CAP_HARD:
+        log.warning("bsky retry still too long (%d); giving up", len(retry))
+        return ""
+    return retry
+
+
+def draft_mention_reply(notif: dict[str, Any]) -> str:
+    """Draft a reply to a mention/reply notification. Returns '' if SKIP."""
+    author = notif.get("author_handle") or "unknown"
+    text = (notif.get("text") or "")[:800]
+    reason = notif.get("reason") or "mention"
+
+    user_block = (
+        f"Someone on Bluesky ({reason}) directed this at you. Draft ONE "
+        "substantive reply.\n\n"
+        f"FROM @{author}:\n{text}\n\n"
+        "RULES:\n"
+        "- Engage with what they actually said.\n"
+        "- Stay on-thesis (AI stock-picking, the arena, the pipeline).\n"
+        "- If the message is spam or purely social, return SKIP.\n"
+        f"- HARD CAP: {CHAR_CAP} characters.\n"
+        "Return ONLY the reply text, or SKIP."
+    )
+
+    draft = _draft_once(user_block)
+    if _is_skip(draft):
+        return ""
+    if len(draft) <= CHAR_CAP_HARD:
+        return draft
+
+    retry_block = user_block + (
+        f"\n\nYOUR PREVIOUS DRAFT WAS {len(draft)} CHARACTERS — TOO LONG.\n"
+        f"Previous draft:\n{draft}\n\n"
+        f"Rewrite in UNDER {CHAR_CAP} characters."
+    )
+    retry = _draft_once(retry_block)
+    if _is_skip(retry) or len(retry) > CHAR_CAP_HARD:
+        return ""
+    return retry
+
+
+# ---------------------------------------------------------------------------
+# Ledger helpers (stored in a GitHub issue, same pattern as moltbook)
+# ---------------------------------------------------------------------------
+
+
+def get_or_create_ledger(gh) -> tuple[int, dict]:
+    """Return (issue_number, ledger_dict) for the Bluesky engagement ledger."""
+    import requests
+
+    r = gh.session.get(
+        f"{gh.base}/issues",
+        params={"labels": LEDGER_LABEL, "state": "open", "per_page": 5},
+        timeout=30,
+    )
+    issues = r.json() if r.status_code < 400 else []
+    for issue in issues:
+        body = issue.get("body") or ""
+        m = re.search(
+            re.escape(LEDGER_MARKER_START) + r"\s*(.*?)\s*"
+            + re.escape(LEDGER_MARKER_END),
+            body,
+            re.DOTALL,
+        )
+        if m:
+            try:
+                return issue["number"], json.loads(m.group(1))
+            except json.JSONDecodeError:
+                return issue["number"], _empty_ledger()
+        return issue["number"], _empty_ledger()
+
+    gh.ensure_label(LEDGER_LABEL, "5c8ce4", "Bluesky engagement state")
+    empty = _empty_ledger()
+    body = _render_ledger_body(empty)
+    issue = gh.create_issue(
+        "[bluesky] engagement-ledger", body, [LEDGER_LABEL]
+    )
+    if issue:
+        return issue["number"], empty
+    raise RuntimeError("could not create bluesky ledger issue")
+
+
+def update_ledger(gh, issue_number: int, ledger: dict) -> None:
+    gh.update_issue_body(issue_number, _render_ledger_body(ledger))
+
+
+def _empty_ledger() -> dict:
+    return {
+        "replied_to_uris": [],
+        "processed_notif_uris": [],
+        "daily_reply_count": {},
+    }
+
+
+def _render_ledger_body(ledger: dict) -> str:
+    return (
+        "Engagement ledger for @alphamolt.bsky.social on Bluesky.\n"
+        "Updated automatically by the heartbeat.\n\n"
+        f"{LEDGER_MARKER_START}\n"
+        f"{json.dumps(ledger, indent=2)}\n"
+        f"{LEDGER_MARKER_END}\n"
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv
 tradingview-screener>=3.0.0
 scipy>=1.11.0
 anthropic>=0.40.0
+atproto>=0.0.55


### PR DESCRIPTION
Mirrors the Moltbook heartbeat but targets Bluesky's search API instead of submolt feeds, and auto-posts without an approval gate.

- bluesky_lib.py — thin wrapper over atproto, system prompt with Bluesky's 280-char style rules, theme classifier, reply drafters, and a GitHub-issue ledger (bluesky-ledger label) for dedup + daily rate-limit tracking.
- bluesky_heartbeat.py — two phases: reply to unread mentions/ replies, then search ~12 seeded queries (AI stock picking, AI fund manager, AI vs human, quant vs discretionary, etc.), run each candidate through the three-theme classifier, and reply to the ones that pass. Every send files a bluesky-posted audit issue. Max 3 replies/run, 10/day.
- Workflow fires every 4h. Needs BLUESKY_HANDLE and BLUESKY_APP_PASSWORD secrets (generated from bsky.app settings, revocable separately from the main account password).

Does NOT write original posts in v1 — engagement-only until voice calibrates.