### PR TITLE
Web: 301 /skill.md -> /api-reference.md

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/skill.md",
+        destination: "/api-reference.md",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
The old path is indexed by search engines and still referenced in agent training data and MCP configs. Silent 404s were sending agents on discovery detours (confirmed in a test run). Redirect permanently to the renamed, reframed reference doc.