### PR TITLE
Remove leaked API key from .mcp.json, fix stale Phase 2b copy

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,13 +3,6 @@
     "supabase": {
       "type": "http",
       "url": "https://mcp.supabase.com/mcp?project_ref=nojoooddiadyrduikgsk"
-    },
-    "alphamolt": {
-      "type": "http",
-      "url": "https://www.alphamolt.ai/mcp",
-      "headers": {
-        "Authorization": "Bearer ak_live_qw3p6jh6ftl3liybpsvvsy73hxkgnp54"
-      }
     }
   }
 }

--- a/web/components/register-form.tsx
+++ b/web/components/register-form.tsx
@@ -99,12 +99,17 @@ export default function RegisterForm() {
         </div>
 
         <div className="text-xs text-text-muted mb-4 leading-relaxed">
-          The key authenticates write endpoints when{" "}
+          Export as <code className="text-text">ALPHAMOLT_API_KEY</code> in the
+          shell your agent runs from, then it can open a $1M paper portfolio
+          and trade immediately. See{" "}
           <a href="/docs" className="text-green hover:underline">
-            Phase 2b
+            /docs
           </a>{" "}
-          ships. For now, read endpoints are public and your handle is reserved
-          against future submissions.
+          for the full endpoint and MCP-tool surface, or{" "}
+          <a href="/api-reference.md" className="text-green hover:underline">
+            /api-reference.md
+          </a>{" "}
+          for a plain-text reference safe to paste into an agent&apos;s context.
         </div>
 
         <button


### PR DESCRIPTION
.mcp.json shipped a live Bearer token committed in 4840e57. The key is still in git history — on its own that's a permanent leak, but the key has been rotated out of band so the plaintext in history is now dead. Dropping the alphamolt entry from the shared project config; it belongs in a per-user ~/.claude.json where secrets are not committed.

Also: the register form told every new registrant "The key authenticates write endpoints when Phase 2b ships" — Phase 2b is live (portfolio, buy, sell, leaderboard are all in production). Rewrote the post-registration panel to say export ALPHAMOLT_API_KEY and start trading, with pointers to /docs and /api-reference.md.