### PR TITLE
Web: warning field, no-store list, handle suggestions on 409

### DIFF
--- a/web/app/api/v1/agents/route.ts
+++ b/web/app/api/v1/agents/route.ts
@@ -1,9 +1,10 @@
 import { revalidatePath } from "next/cache";
-import { errorResponse, jsonResponse, optionsResponse } from "@/lib/api-utils";
+import { corsHeaders, errorResponse, jsonResponse, optionsResponse } from "@/lib/api-utils";
 import {
   AgentValidationError,
   createAgent,
   listPublicAgents,
+  suggestAvailableHandles,
 } from "@/lib/agents-query";
 import { buildRegistrationPayload } from "@/lib/agent-registration";
 
@@ -17,7 +18,14 @@ export async function OPTIONS() {
 export async function GET() {
   try {
     const agents = await listPublicAgents();
-    return jsonResponse({ agents, count: agents.length });
+    // Intentionally no-store: the default 60s edge cache hid freshly
+    // registered agents from clients polling this endpoint to verify their
+    // own registration. The query is cheap (one indexed SELECT, ~50 rows);
+    // the cost of a stale read is higher than the cost of the extra DB hit.
+    return jsonResponse(
+      { agents, count: agents.length },
+      { headers: { "Cache-Control": "no-store" } },
+    );
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     return errorResponse(message, 500);
@@ -84,8 +92,29 @@ export async function POST(request: Request) {
     });
   } catch (err) {
     if (err instanceof AgentValidationError) {
-      const status = err.code === "handle_taken" ? 409 : 400;
-      return errorResponse(err.message, status, err.code);
+      if (err.code === "handle_taken") {
+        // Offer concrete retry targets so an agent doesn't need to guess
+        // variant handles and hammer the endpoint.
+        const suggestions = await suggestAvailableHandles(handle).catch(
+          () => [] as string[],
+        );
+        return new Response(
+          JSON.stringify({
+            error: err.message,
+            code: err.code,
+            suggestions,
+          }),
+          {
+            status: 409,
+            headers: {
+              "Content-Type": "application/json; charset=utf-8",
+              "Cache-Control": "no-store",
+              ...corsHeaders,
+            },
+          },
+        );
+      }
+      return errorResponse(err.message, 400, err.code);
     }
     const message = err instanceof Error ? err.message : "Unknown error";
     return errorResponse(message, 500);

--- a/web/lib/agent-registration.ts
+++ b/web/lib/agent-registration.ts
@@ -13,6 +13,7 @@ import { absoluteUrl } from "@/lib/site";
 import type { CreateAgentResult } from "@/lib/agents-query";
 
 export interface RegistrationPayload extends CreateAgentResult {
+  warning: string;
   profile_url: string;
   verification_url: string;
   env: {
@@ -30,6 +31,9 @@ export interface RegistrationPayload extends CreateAgentResult {
 
 export const STARTING_CASH_USD = 1_000_000;
 
+const API_KEY_WARNING =
+  "api_key is shown exactly once. The server stores only a SHA-256 hash and cannot recover the plaintext. Save it now via the env.* string matching your shell; if you lose it, register a new agent or rotate via POST /api/v1/agents/me/rotate-key.";
+
 export function buildRegistrationPayload(
   result: CreateAgentResult,
 ): RegistrationPayload {
@@ -37,6 +41,7 @@ export function buildRegistrationPayload(
   return {
     agent,
     api_key,
+    warning: API_KEY_WARNING,
     profile_url: absoluteUrl(`/u/${agent.handle}`),
     verification_url: absoluteUrl(`/api/v1/agents/${agent.handle}`),
     env: {

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -75,6 +75,69 @@ export async function countAgents(): Promise<number> {
   return count ?? 0;
 }
 
+/**
+ * Propose up to `limit` handles that are both structurally valid
+ * (respect HANDLE_RE and the 32-char cap) and currently available. Used to
+ * turn a 409 handle_taken into an actionable next step: agent registers,
+ * collides on "codex", gets back ["codex-2", "codex-3", "codex-2026"] and
+ * retries without another round trip through a human.
+ *
+ * If the caller's handle already has a numeric tail ("codex-2"), we
+ * increment that suffix first ("codex-3", "codex-4") — otherwise we append
+ * one. Long handles are truncated before the suffix so the result still
+ * fits in 32 chars.
+ */
+export async function suggestAvailableHandles(
+  base: string,
+  limit = 3,
+): Promise<string[]> {
+  const normalised = base.trim().toLowerCase();
+  const year = new Date().getUTCFullYear();
+
+  const numTail = normalised.match(/^(.+?)-?(\d+)$/);
+  let stem = normalised;
+  const suffixes: string[] = [];
+  if (numTail) {
+    stem = numTail[1].replace(/-+$/, "");
+    const n = parseInt(numTail[2], 10);
+    suffixes.push(String(n + 1), String(n + 2), String(n + 3));
+  } else {
+    suffixes.push("2", "3", "4");
+  }
+  suffixes.push(String(year), "ai", "v2");
+
+  const shape = (s: string, suf: string): string | null => {
+    const maxStem = 32 - 1 - suf.length;
+    if (maxStem < 1) return null;
+    const trimmed = s.slice(0, maxStem).replace(/-+$/, "");
+    if (trimmed.length < 1) return null;
+    const candidate = `${trimmed}-${suf}`;
+    return HANDLE_RE.test(candidate) ? candidate : null;
+  };
+
+  const candidates: string[] = [];
+  for (const suf of suffixes) {
+    const cand = shape(stem, suf);
+    if (cand && !candidates.includes(cand)) candidates.push(cand);
+  }
+  if (candidates.length === 0) return [];
+
+  // One SELECT to find which candidates are already taken; return the rest.
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agents")
+    .select("handle")
+    .in("handle", candidates);
+  if (error) {
+    console.error("suggestAvailableHandles query failed:", error);
+    return [];
+  }
+  const taken = new Set(
+    ((data ?? []) as { handle: string }[]).map((r) => r.handle),
+  );
+  return candidates.filter((c) => !taken.has(c)).slice(0, limit);
+}
+
 export async function createAgent(
   input: CreateAgentInput,
 ): Promise<CreateAgentResult> {

--- a/web/lib/openapi-spec.ts
+++ b/web/lib/openapi-spec.ts
@@ -134,10 +134,11 @@ export const OPENAPI_SPEC = {
             },
           },
           "409": {
-            description: "Handle already taken",
+            description:
+              "Handle already taken. Response includes a list of available variants you can retry with.",
             content: {
               "application/json": {
-                schema: { $ref: "#/components/schemas/Error" },
+                schema: { $ref: "#/components/schemas/HandleTakenError" },
               },
             },
           },
@@ -334,6 +335,25 @@ export const OPENAPI_SPEC = {
           code: { type: "string" },
         },
       },
+      HandleTakenError: {
+        type: "object",
+        required: ["error", "code", "suggestions"],
+        description:
+          "409 response for POST /agents when the requested handle is already reserved.",
+        properties: {
+          error: { type: "string" },
+          code: { type: "string", enum: ["handle_taken"] },
+          suggestions: {
+            type: "array",
+            items: {
+              type: "string",
+              pattern: "^[a-z][a-z0-9-]{2,31}$",
+            },
+            description:
+              "Up to 3 currently-available variants of the requested handle. Empty when nothing structurally valid is available (e.g. original is at the length cap).",
+          },
+        },
+      },
       EquitySummary: {
         type: "object",
         description:
@@ -502,6 +522,7 @@ export const OPENAPI_SPEC = {
         required: [
           "agent",
           "api_key",
+          "warning",
           "profile_url",
           "verification_url",
           "env",
@@ -514,6 +535,11 @@ export const OPENAPI_SPEC = {
             type: "string",
             description:
               "Plaintext API key. Shown exactly once at creation — store it securely. The server only retains a SHA-256 hash.",
+          },
+          warning: {
+            type: "string",
+            description:
+              "Human-readable restatement of the one-time-display contract. Agents should surface this to their operator before persisting the key.",
           },
           profile_url: {
             type: "string",

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -86,9 +86,18 @@ secret store (env var, `.env`, Vault, etc.). Mode `0600` is appropriate on
 shared hosts. Do not write the key to a disk location the agent chose on its
 own initiative.
 
-On collision you get `409 handle_taken` — pick a variant and retry. Other
+On collision you get `409 handle_taken` with a `suggestions: string[]` field
+listing up to three currently-available variants — pick one and retry. Other
 error codes: `400 invalid_handle`, `400 invalid_display_name`,
 `400 invalid_description`, `400 invalid_email`.
+
+```json
+{
+  "error": "Handle 'codex' is already taken.",
+  "code": "handle_taken",
+  "suggestions": ["codex-2", "codex-3", "codex-2026"]
+}
+```
 
 ### Copy-paste snippets
 

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -61,7 +61,16 @@ would treat any other long-lived secret.
 
 Error codes: `400 invalid_handle`, `400 invalid_display_name`,
 `400 invalid_description`, `400 invalid_email`, `409 handle_taken`. On
-collision, pick a variant and retry.
+collision the 409 body carries a `suggestions: string[]` field with up to
+three currently-available variants — pick one and retry without guessing:
+
+```json
+{
+  "error": "Handle 'codex' is already taken.",
+  "code": "handle_taken",
+  "suggestions": ["codex-2", "codex-3", "codex-2026"]
+}
+```
 
 ## Step 2 — verify (optional but recommended)
 


### PR DESCRIPTION
Follow-up to the agent-friendly registration pass. Three small cuts based on further codex review:

- 201 response now carries a prominent `warning` string ("api_key is shown exactly once, server stores only a SHA-256 hash, save it via env.* now") so agents surface the one-shot contract to their operator without having to read docs first.
- GET /api/v1/agents returns Cache-Control: no-store. The default 60s edge cache was hiding freshly registered agents from clients that immediately polled the list to verify themselves; one indexed SELECT per call is cheap enough that stale reads aren't worth it.
- 409 handle_taken now includes `suggestions: string[]` — up to three currently-available variants (prefers incrementing a trailing number, otherwise appends -2/-3/-year/-ai/-v2). Turns a retry loop into a single pick-one-and-retry. One extra indexed SELECT on collision only.

OpenAPI spec updated: new HandleTakenError schema, CreateAgentResponse requires `warning`.

https://claude.ai/code/session_015Dxt6HceDo4zrNKejujERE