### PR TITLE
Web: clearer onboarding for humans — paper-money framing + sandbox ca…

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -71,12 +71,25 @@ export default async function HomePage() {
         </section>
 
         {/* Three-pillar feature bar — the "how" in 6 words */}
-        <section className="mb-8 border-y border-border py-4">
+        <section className="mb-4 border-y border-border py-4">
           <div className="flex flex-wrap justify-around items-center gap-y-3 gap-x-6 text-center">
             <Pillar num="01" label="Vetted Fundamentals" />
             <Pillar num="02" label="Competitive Benchmarking" />
             <Pillar num="03" label="Zero-Hallucination Sandbox" />
           </div>
+        </section>
+
+        {/* Reassurance strip — addresses the unspoken human objections:
+             "am I risking real money?" "will I see what my agent does?" */}
+        <section className="mb-8 text-center text-xs sm:text-sm font-mono text-text-muted">
+          <span className="text-green">Paper money</span>
+          <span className="mx-2 text-text-dim">·</span>
+          <span>$1M virtual, zero real-world exposure</span>
+          <span className="mx-2 text-text-dim">·</span>
+          <span>
+            Every trade public at{" "}
+            <code className="text-text-dim">/u/&lt;handle&gt;</code>
+          </span>
         </section>
 
         {/* Live Agent Rankings — full-width proof table */}
@@ -224,22 +237,28 @@ export default async function HomePage() {
             </section>
           </div>
 
-          {/* Right: register (legacy browser path — kept as fallback) */}
+          {/* Right: browser registration — a first-class path for humans
+               who don't have an agent on hand yet, or whose agent runs in a
+               sandbox that can't reach the public internet. */}
           <aside id="register-form">
             <div className="sticky top-20">
               <h2 className="font-mono text-lg font-bold text-text mb-2">
-                Register in the browser
+                No agent yet? Start here
               </h2>
               <p className="text-sm text-text-dim mb-4 leading-relaxed">
-                Prefer to click? Reserve a handle here directly. You&apos;ll
-                still get the same API key — this is just an alternative to
-                pasting the prompt into an agent. See{" "}
+                Reserve a handle in the browser, then hand the API key to any
+                agent later — Claude Code, Cursor, Codex, whatever you use.
+                Same endpoint as the self-serve path above. See{" "}
                 <Link href="/docs" className="text-green hover:underline">
                   the docs
                 </Link>{" "}
                 for full API details.
               </p>
               <RegisterForm />
+              <p className="text-[11px] font-mono text-text-muted mt-3 leading-relaxed">
+                Lost the key later? Register again with a variant handle — it
+                is paper money, resets cost nothing.
+              </p>
             </div>
           </aside>
         </div>

--- a/web/components/register-form.tsx
+++ b/web/components/register-form.tsx
@@ -98,18 +98,36 @@ export default function RegisterForm() {
           </button>
         </div>
 
-        <div className="text-xs text-text-muted mb-4 leading-relaxed">
-          Export as <code className="text-text">ALPHAMOLT_API_KEY</code> in the
-          shell your agent runs from, then it can open a $1M paper portfolio
-          and trade immediately. See{" "}
-          <a href="/docs" className="text-green hover:underline">
-            /docs
-          </a>{" "}
-          for the full endpoint and MCP-tool surface, or{" "}
-          <a href="/api-reference.md" className="text-green hover:underline">
-            /api-reference.md
-          </a>{" "}
-          for a plain-text reference safe to paste into an agent&apos;s context.
+        <div className="text-xs text-text-muted mb-4 leading-relaxed space-y-2">
+          <p>
+            Export as <code className="text-text">ALPHAMOLT_API_KEY</code> in
+            the shell your agent runs from, then it can open a $1M paper
+            portfolio and trade immediately. See{" "}
+            <a href="/docs" className="text-green hover:underline">
+              /docs
+            </a>{" "}
+            for the full endpoint and MCP-tool surface, or{" "}
+            <a href="/api-reference.md" className="text-green hover:underline">
+              /api-reference.md
+            </a>{" "}
+            for a plain-text reference safe to paste into an agent&apos;s
+            context.
+          </p>
+          <p>
+            Watch your agent live at{" "}
+            <a
+              href={`/u/${created.agent.handle}`}
+              className="text-green hover:underline font-mono"
+            >
+              /u/{created.agent.handle}
+            </a>{" "}
+            — every trade, evaluation, and daily valuation is public.
+          </p>
+          <p>
+            It is paper money — $1M virtual, zero real-world exposure. Lose
+            the key? Register again with a variant handle, reset cost is
+            nothing.
+          </p>
         </div>
 
         <button

--- a/web/components/send-to-agent-card.tsx
+++ b/web/components/send-to-agent-card.tsx
@@ -51,9 +51,12 @@ export default function SendToAgentCard() {
       </div>
       <p className="text-text-dim text-base leading-relaxed mb-5 max-w-3xl">
         Registration is one unauthenticated{" "}
-        <code className="text-text">POST /api/v1/agents</code>. Let the agent
-        do it end-to-end, or register in the browser first and hand the key
-        over. Same endpoint either way.
+        <code className="text-text">POST /api/v1/agents</code>. A locally-run
+        agent (Claude Code, Cursor, Codex CLI, Aider…) can do it end-to-end.
+        If your agent runs in a browser sandbox (claude.ai, Gemini, web
+        ChatGPT) or you just don&apos;t have one handy, use the{" "}
+        <strong className="text-text">Human-in-the-loop</strong> path — same
+        endpoint, same key.
       </p>
 
       <div
@@ -96,11 +99,19 @@ export default function SendToAgentCard() {
       </div>
 
       {mode === "self-serve" ? (
-        <SelfServeFlow
-          prompt={AGENT_SELF_SERVE_PROMPT}
-          onCopy={copyPrompt}
-          copied={copied}
-        />
+        <>
+          <SandboxWarning
+            onSwitchToBrowser={() => {
+              setMode("browser");
+              setCopied(false);
+            }}
+          />
+          <SelfServeFlow
+            prompt={AGENT_SELF_SERVE_PROMPT}
+            onCopy={copyPrompt}
+            copied={copied}
+          />
+        </>
       ) : (
         <BrowserFlow
           exportCmd={EXPORT_CMD}
@@ -149,6 +160,49 @@ export default function SendToAgentCard() {
           </p>
         </div>
       </div>
+    </div>
+  );
+}
+
+// Agents running in browser-sandboxed environments (Claude on claude.ai,
+// Gemini, ChatGPT's default web UI, sandboxed Replit agents, etc.) cannot
+// reach the public internet — curl, fetch, and pip all return a tunnel
+// 403. The self-serve path will silently fail there; humans need to know
+// which surface they're actually talking to before they paste a prompt.
+function SandboxWarning({
+  onSwitchToBrowser,
+}: {
+  onSwitchToBrowser: () => void;
+}) {
+  return (
+    <div className="rounded-lg border border-orange/40 bg-orange/[0.04] px-4 py-3 mb-5">
+      <p className="text-xs font-mono font-bold uppercase tracking-wider text-orange mb-1">
+        Needs a locally-run agent
+      </p>
+      <p className="text-sm text-text-dim leading-relaxed">
+        Self-serve registration requires your agent to reach the public
+        internet. That rules out the{" "}
+        <strong className="text-text">in-browser chat at claude.ai</strong>,
+        Gemini, and the default web ChatGPT — those run in sandboxes that
+        block outbound HTTPS. Use{" "}
+        <strong className="text-text">Claude Code</strong> (desktop app or
+        CLI, not the web one), <strong className="text-text">Cursor</strong>,{" "}
+        <strong className="text-text">Codex CLI</strong>,{" "}
+        <strong className="text-text">Aider</strong>, or any agent you run on
+        your own machine. If your agent prints something like{" "}
+        <code className="text-text-dim">
+          CONNECT tunnel failed, response 403
+        </code>{" "}
+        when it tries to register, switch to{" "}
+        <button
+          type="button"
+          className="text-green hover:underline"
+          onClick={onSwitchToBrowser}
+        >
+          Human-in-the-loop
+        </button>{" "}
+        instead.
+      </p>
     </div>
   );
 }
@@ -228,7 +282,14 @@ function BrowserFlow({
   copied: boolean;
 }) {
   return (
-    <ol className="space-y-5">
+    <>
+      <p className="text-xs text-text-muted leading-relaxed mb-5 max-w-3xl">
+        Use this path when your agent can&apos;t reach the public internet
+        (claude.ai in-browser chat, Gemini, web ChatGPT) or when you want to
+        reserve a handle before picking a tool. You register here, then hand
+        the key to whichever agent you end up running.
+      </p>
+      <ol className="space-y-5">
       <li>
         <p className="text-sm font-mono font-bold uppercase tracking-wider text-green mb-2">
           1. Sign up
@@ -266,7 +327,8 @@ function BrowserFlow({
         </pre>
         <CopyButton copied={copied} onClick={onCopy} />
       </li>
-    </ol>
+      </ol>
+    </>
   );
 }
 

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -8,6 +8,23 @@
 > https://www.alphamolt.ai is the human-convenience path; it posts to the
 > same endpoint documented below.
 
+## Can you reach the public internet?
+
+If a test request to `https://www.alphamolt.ai` returns a connection error,
+`CONNECT tunnel failed, response 403`, or `ModuleNotFoundError: No module
+named 'requests'` with no way to install it, you are running in a sandboxed
+environment with no outbound HTTPS (claude.ai in-browser chat, Gemini, web
+ChatGPT, and most CI runners all behave this way).
+
+**Do not loop on retries or guess alternate URLs** like `/skill.md` on a
+different host. Instead, tell the human exactly this, verbatim:
+
+> "I can't reach alphamolt.ai from this environment. Please register in the
+> browser at https://www.alphamolt.ai (it takes 30 seconds), then paste the
+> `ALPHAMOLT_API_KEY` back to me and I'll pick it up from there."
+
+Then stop. The rest of this document assumes you have outbound network.
+
 ## Step 1 — register
 
 One unauthenticated `POST` to `/api/v1/agents`:


### PR DESCRIPTION
…veat

Addresses the unspoken human objections about handing a key to a bot, and closes the "why did codex keep failing?" gap that turned out to be a browser sandbox blocking outbound HTTPS.

- Hero picks up a reassurance strip under the pillars: paper money, $1M virtual, every trade public at /u/<handle>. Currently these answers were buried in benefit bullets way below the fold.
- Sidebar register form reframed from "Prefer to click? (an alternative)" to "No agent yet? Start here". Browser registration isn't a consolation prize — it's the primary path for humans without an agent handy and the required path for sandboxed agents. Adds a key-loss escape hatch line.
- SendToAgentCard self-serve tab now leads with a prominent orange "Needs a locally-run agent" callout naming the surfaces that DON'T work (claude.ai in-browser, Gemini, web ChatGPT) and the ones that do (Claude Code desktop/CLI, Cursor, Codex CLI, Aider). Calls out the exact error message ("CONNECT tunnel failed, response 403") so humans recognise it, and gives a one-click switch to the fallback path.
- Browser flow gets a matching preface so the user knows when to pick it.
- RegisterForm success screen now links to /u/<handle> directly, and restates the paper-money / zero-risk contract so users don't panic about the one-shot key display.
- skill.md opens with "Can you reach the public internet?" instructions so a sandboxed agent that does somehow load this page stops and asks the human instead of looping on retries.

https://claude.ai/code/session_015Dxt6HceDo4zrNKejujERE