### PR TITLE
Web: new agents appear on leaderboard immediately + swap 'your slot' row

### DIFF
--- a/web/app/api/v1/agents/route.ts
+++ b/web/app/api/v1/agents/route.ts
@@ -1,4 +1,4 @@
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { corsHeaders, errorResponse, jsonResponse, optionsResponse } from "@/lib/api-utils";
 import {
   AgentValidationError,
@@ -72,12 +72,20 @@ export async function POST(request: Request) {
       description: description as string | undefined,
       contact_email: contact_email as string | undefined,
     });
-    // Bust the 5-minute ISR cache on the homepage and profile so the newly
-    // registered agent is visible on the next request instead of up to 5
-    // minutes later.
+    // Bust the 5-minute ISR cache on the homepage, profile, and leaderboard,
+    // plus the inner unstable_cache tagged "leaderboard" — without this the
+    // freshly seeded portfolio_history row is invisible for up to 5 min
+    // after registration, which makes the site look like registration
+    // silently failed.
     try {
       revalidatePath("/");
       revalidatePath(`/u/${result.agent.handle}`);
+      revalidatePath("/leaderboard");
+      // Next 16 signature: revalidateTag(tag, profile). The leaderboard
+      // page wraps its query in unstable_cache({tags: ["leaderboard"]});
+      // "default" is the standard cache-life profile for same-request
+      // invalidation.
+      revalidateTag("leaderboard", "default");
     } catch {
       // revalidatePath throws outside a request context in some environments;
       // the registration itself has already succeeded, so don't block on it.

--- a/web/components/live-agent-rankings.tsx
+++ b/web/components/live-agent-rankings.tsx
@@ -4,6 +4,11 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { COLORS } from "@/lib/constants";
 import Sparkline from "./sparkline";
+import {
+  getMyAgent,
+  subscribeToMyAgent,
+  type MyAgent,
+} from "@/lib/my-agent";
 import type { TopAgent } from "@/lib/top-agent-query";
 
 interface Props {
@@ -20,6 +25,23 @@ export default function LiveAgentRankings({ agents }: Props) {
   const winner = agents[0] ?? null;
   const runnerUp = agents[1] ?? null;
 
+  // Start null on both client and server to keep hydration stable, then
+  // populate from localStorage after mount. Also subscribes to the custom
+  // event so registering in the sidebar form swaps slot 03 live — no
+  // reload required.
+  const [myAgent, setLocalMyAgent] = useState<MyAgent | null>(null);
+  useEffect(() => {
+    setLocalMyAgent(getMyAgent());
+    return subscribeToMyAgent(setLocalMyAgent);
+  }, []);
+
+  // If the user's handle happens to already be in the top 2 (unlikely but
+  // not impossible), don't show it twice — fall back to the generic
+  // sandbox CTA in the third slot.
+  const myHandleInTop =
+    myAgent != null &&
+    agents.some((a) => a.handle === myAgent.handle);
+
   return (
     <section className="glass-card rounded-lg border border-border p-4 sm:p-6">
       <header className="flex items-baseline justify-between mb-4">
@@ -35,9 +57,54 @@ export default function LiveAgentRankings({ agents }: Props) {
         <HeaderRow />
         <AgentRow slot="01" agent={winner} highlight />
         <AgentRow slot="02" agent={runnerUp} />
-        <SandboxRow />
+        {myAgent && !myHandleInTop ? (
+          <YourAgentRow myAgent={myAgent} />
+        ) : (
+          <SandboxRow />
+        )}
       </div>
     </section>
+  );
+}
+
+function YourAgentRow({ myAgent }: { myAgent: MyAgent }) {
+  return (
+    <div
+      className={`${ROW_COLS} py-3 items-center border-b border-dashed border-green/40`}
+      style={{ background: "rgba(0, 255, 65, 0.03)" }}
+    >
+      <span className="font-bold text-green">03</span>
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="font-bold text-green truncate">
+            {myAgent.display_name}
+          </span>
+          <StatusChip variant="ready" label="YOU / AWAITING FIRST SNAPSHOT" />
+        </div>
+        <Link
+          href={`/u/${myAgent.handle}`}
+          className="text-[10px] text-text-dim hover:text-green hover:underline truncate block"
+        >
+          @{myAgent.handle}
+        </Link>
+      </div>
+      <span className="hidden sm:block text-right text-text-muted">0</span>
+      <span className="text-right text-text-muted">0.0%</span>
+      <span className="hidden sm:block text-right text-text-dim font-semibold">
+        0.0%
+      </span>
+      <span className="text-right text-text-dim font-bold text-base">
+        0.0%
+      </span>
+      <div className="hidden sm:flex justify-end">
+        <Link
+          href={`/u/${myAgent.handle}`}
+          className="inline-block text-[10px] font-bold uppercase tracking-widest border border-green/70 text-green rounded px-3 py-1.5 bg-green/[0.04] shadow-[0_0_10px_rgba(0,255,65,0.25)] transition-all hover:bg-green/10 hover:border-green hover:shadow-[0_0_18px_rgba(0,255,65,0.6)]"
+        >
+          View profile &rarr;
+        </Link>
+      </div>
+    </div>
   );
 }
 

--- a/web/components/register-form.tsx
+++ b/web/components/register-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { setMyAgent } from "@/lib/my-agent";
 
 interface CreatedAgent {
   agent: {
@@ -42,7 +43,14 @@ export default function RegisterForm() {
         setError(data.error ?? `Registration failed (${res.status})`);
         return;
       }
-      setCreated(data as CreatedAgent);
+      const created = data as CreatedAgent;
+      // Broadcast to the rest of the page (live rankings card swaps its
+      // placeholder "your slot" row for a real one with the user's handle).
+      setMyAgent({
+        handle: created.agent.handle,
+        display_name: created.agent.display_name,
+      });
+      setCreated(created);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Network error");
     } finally {
@@ -122,6 +130,20 @@ export default function RegisterForm() {
               /u/{created.agent.handle}
             </a>{" "}
             — every trade, evaluation, and daily valuation is public.
+          </p>
+          <p className="flex flex-wrap gap-2 pt-1">
+            <a
+              href={`/u/${created.agent.handle}`}
+              className="inline-flex items-center gap-1 text-[11px] font-mono uppercase tracking-widest px-2.5 py-1 rounded border border-green/50 text-green bg-green/5 hover:bg-green/10"
+            >
+              Your profile →
+            </a>
+            <a
+              href="/leaderboard"
+              className="inline-flex items-center gap-1 text-[11px] font-mono uppercase tracking-widest px-2.5 py-1 rounded border border-border text-text-dim hover:border-green/50 hover:text-green"
+            >
+              Leaderboard →
+            </a>
           </p>
           <p>
             It is paper money — $1M virtual, zero real-world exposure. Lose

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -200,7 +200,7 @@ export async function createAgent(
       api_key_prefix: key.prefix,
       is_house_agent: false,
     })
-    .select(PUBLIC_COLUMNS)
+    .select(`id, ${PUBLIC_COLUMNS}`)
     .single();
 
   if (error) {
@@ -219,7 +219,40 @@ export async function createAgent(
     throw new Error(`Supabase insert failed: ${error.message}`);
   }
 
-  return { agent: data as PublicAgent, api_key: key.plaintext };
+  // Seed the cash account + a baseline portfolio history row so the agent
+  // appears on the leaderboard at $1M / 0% immediately, rather than after
+  // the next daily portfolio_valuation.py run. Best-effort: the registration
+  // itself has already succeeded, so we don't throw if either insert fails —
+  // the daily cron will backfill anything we miss. Both writes use table
+  // defaults where possible so schema tweaks don't need app changes.
+  const agentRow = data as { id: string } & PublicAgent;
+  try {
+    await supabase
+      .from("agent_accounts")
+      .insert({ agent_id: agentRow.id });
+  } catch (e) {
+    console.error("Failed to seed agent_accounts for", handle, e);
+  }
+  try {
+    const today = new Date().toISOString().slice(0, 10);
+    await supabase.from("agent_portfolio_history").insert({
+      agent_id: agentRow.id,
+      snapshot_date: today,
+      cash_usd: 1_000_000,
+      holdings_value_usd: 0,
+      total_value_usd: 1_000_000,
+      pnl_usd: 0,
+      pnl_pct: 0,
+      num_positions: 0,
+    });
+  } catch (e) {
+    console.error("Failed to seed agent_portfolio_history for", handle, e);
+  }
+
+  // Strip the internal id before returning.
+  const { id: _id, ...publicAgent } = agentRow;
+  void _id;
+  return { agent: publicAgent as PublicAgent, api_key: key.plaintext };
 }
 
 /**

--- a/web/lib/my-agent.ts
+++ b/web/lib/my-agent.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared client-side state for "which agent did the current browser just
+ * register?". Persisted to localStorage so the homepage `LiveAgentRankings`
+ * card can swap its placeholder "USER_AGENT_SANDBOX" slot for the user's
+ * actual agent — the biggest source of "wait, did my registration work?"
+ * confusion right after hitting the Register button.
+ *
+ * This is intentionally a tiny, client-only module: no auth implications
+ * (we never store the API key here, only the public handle), and
+ * localStorage is appropriate because the data is UX metadata, not a
+ * source of truth. The server-side leaderboard row is the real signal;
+ * this just bridges the gap until the user refreshes.
+ */
+
+export const MY_AGENT_KEY = "alphamolt:my-agent";
+export const MY_AGENT_EVENT = "alphamolt:my-agent-changed";
+
+export interface MyAgent {
+  handle: string;
+  display_name: string;
+  registered_at: string; // ISO timestamp — used to hide stale claims later if we ever want to
+}
+
+export function getMyAgent(): MyAgent | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(MY_AGENT_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<MyAgent>;
+    if (
+      typeof parsed.handle === "string" &&
+      typeof parsed.display_name === "string"
+    ) {
+      return {
+        handle: parsed.handle,
+        display_name: parsed.display_name,
+        registered_at: parsed.registered_at ?? new Date().toISOString(),
+      };
+    }
+  } catch {
+    // Corrupt JSON or localStorage unavailable — treat as "not set".
+  }
+  return null;
+}
+
+export function setMyAgent(agent: Omit<MyAgent, "registered_at">): void {
+  if (typeof window === "undefined") return;
+  const record: MyAgent = {
+    handle: agent.handle,
+    display_name: agent.display_name,
+    registered_at: new Date().toISOString(),
+  };
+  try {
+    window.localStorage.setItem(MY_AGENT_KEY, JSON.stringify(record));
+    // `storage` events only fire in *other* tabs; dispatch a custom event so
+    // components in the current tab can react without a full reload.
+    window.dispatchEvent(new CustomEvent(MY_AGENT_EVENT, { detail: record }));
+  } catch {
+    // localStorage quota exceeded / disabled / private mode — silently skip.
+    // The user still has the key from the 201 response, so UX degrades
+    // gracefully: they just see the generic sandbox CTA on their next visit.
+  }
+}
+
+/**
+ * Subscribe to changes. Fires when another tab writes (via `storage`) or
+ * when the current tab writes (via our custom event). Returns a cleanup fn.
+ */
+export function subscribeToMyAgent(callback: (agent: MyAgent | null) => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const handler = () => callback(getMyAgent());
+  window.addEventListener("storage", handler);
+  window.addEventListener(MY_AGENT_EVENT, handler);
+  return () => {
+    window.removeEventListener("storage", handler);
+    window.removeEventListener(MY_AGENT_EVENT, handler);
+  };
+}


### PR DESCRIPTION
Fixes the post-registration dead zone where a user would register, look at the homepage's Live Agent Rankings, still see the generic USER_AGENT_SANDBOX / "Join Sandbox" call-to-action, and reasonably conclude that registration had failed.

Server side:
- POST /api/v1/agents now seeds agent_accounts (ride the table defaults: $1M starting + cash, inception_date = today) and a baseline agent_portfolio_history row at $1M / 0% for today. Both are best-effort — registration has already succeeded, so we log and continue if either insert fails. Without this the agent is invisible on /leaderboard until portfolio_valuation.py runs at 05:30 UTC.
- Cache invalidation now covers /leaderboard (both the ISR path and the inner unstable_cache tagged "leaderboard") in addition to the homepage and profile page.

Client side:
- New lib/my-agent.ts: tiny localStorage-backed store for "handle the current browser just registered". Fires a custom event so other components on the page can react without a full reload. Never stores the API key — just public metadata.
- RegisterForm writes to it on 201. Success screen gains "Your profile →" and "Leaderboard →" chips so the user has an obvious next step.
- LiveAgentRankings subscribes to it. When set, the placeholder SandboxRow at slot 03 is replaced with a real YourAgentRow (green accent, "YOU / AWAITING FIRST SNAPSHOT" chip, deep-link to /u/<handle>). Hidden if the user's handle happens to already be in the top 2 to avoid duplicating the row.

https://claude.ai/code/session_015Dxt6HceDo4zrNKejujERE