### PR TITLE
Add Moltbook integration for posting and key rotation

### DIFF
--- a/.github/workflows/moltbook-post.yml
+++ b/.github/workflows/moltbook-post.yml
@@ -1,0 +1,45 @@
+name: Moltbook Post
+
+on:
+  workflow_dispatch:
+    inputs:
+      submolt:
+        description: "Submolt name (e.g. product, agents, ai)"
+        required: true
+        default: "product"
+      title:
+        description: "Post title"
+        required: true
+      content:
+        description: "Post body (markdown). Newlines supported."
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Publish to Moltbook
+        env:
+          MOLTBOOK_API_KEY: ${{ secrets.MOLTBOOK_API_KEY }}
+          BODY: ${{ inputs.content }}
+        run: |
+          printf '%s' "$BODY" | python moltbook_post.py \
+            --submolt "${{ inputs.submolt }}" \
+            --title "${{ inputs.title }}"

--- a/.github/workflows/moltbook-rotate-key.yml
+++ b/.github/workflows/moltbook-rotate-key.yml
@@ -1,0 +1,58 @@
+name: Moltbook Rotate Key
+
+# Rotates MOLTBOOK_API_KEY via POST /api/v1/agents/me/rotate-key and exposes
+# the new plaintext key so you can save it locally. The OLD key stops working
+# the moment this succeeds — you MUST immediately update the MOLTBOOK_API_KEY
+# repository secret, or every other Moltbook workflow (heartbeat, approve,
+# post) will 401 on the next run.
+#
+# The new key is emitted three ways for safety:
+#   1. Job Summary (visible in the run page UI)
+#   2. Log output
+#   3. Artifact `rotated-key` (1-day retention) as a last-resort backup
+#
+# If you miss the key before logs/artifacts expire, you cannot rotate again —
+# registering a new agent is the only recovery path.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Call rotate-key endpoint
+        env:
+          MOLTBOOK_API_KEY: ${{ secrets.MOLTBOOK_API_KEY }}
+        run: |
+          set -euo pipefail
+          response=$(curl -sS -f -X POST \
+            -H "Authorization: Bearer $MOLTBOOK_API_KEY" \
+            https://www.moltbook.com/api/v1/agents/me/rotate-key)
+          printf '%s' "$response" > rotated-key.json
+
+          echo "## Rotated API key" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Copy the \`api_key\` below, then update the \`MOLTBOOK_API_KEY\` repo secret before anything else runs." >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat rotated-key.json >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+          echo ""
+          echo "=== rotated response (also in Job Summary + artifact) ==="
+          cat rotated-key.json
+          echo ""
+
+      - name: Upload key as artifact (1-day retention)
+        uses: actions/upload-artifact@v4
+        with:
+          name: rotated-key
+          path: rotated-key.json
+          retention-days: 1

--- a/moltbook_post.py
+++ b/moltbook_post.py
@@ -1,0 +1,62 @@
+"""One-shot helper to publish a post to Moltbook via MoltbookClient.
+
+Reads the post body from stdin or --content-file to avoid shell-quoting pain
+on long, multi-line content. Used by the `moltbook-post` workflow and by
+humans with a local MOLTBOOK_API_KEY.
+
+Usage:
+    python moltbook_post.py --submolt product --title "Headline" < body.md
+    python moltbook_post.py --submolt product --title "Headline" --content-file body.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+
+from moltbook_lib import MoltbookClient
+
+log = logging.getLogger("moltbook_post")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Post to Moltbook.")
+    parser.add_argument("--submolt", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument(
+        "--content-file",
+        help="Path to a file containing the post body. If omitted, reads stdin.",
+    )
+    args = parser.parse_args()
+
+    if args.content_file:
+        with open(args.content_file, encoding="utf-8") as fh:
+            content = fh.read()
+    else:
+        content = sys.stdin.read()
+
+    content = content.strip()
+    if not content:
+        print("ERROR: empty content", file=sys.stderr)
+        return 2
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    client = MoltbookClient()
+    result = client.create_post(
+        submolt_name=args.submolt,
+        title=args.title,
+        content=content,
+    )
+    if not result:
+        print("ERROR: create_post returned no body", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
This PR adds tooling to integrate with Moltbook, enabling automated posting of content and API key rotation through GitHub Actions workflows.

## Key Changes
- **moltbook_post.py**: New helper script that publishes posts to Moltbook via the MoltbookClient library. Reads post content from stdin or a file to avoid shell-quoting issues with multi-line markdown content.
- **.github/workflows/moltbook-post.yml**: New workflow that allows manual triggering of post publication with configurable submolt, title, and content inputs. Runs the moltbook_post.py script with the provided parameters.
- **.github/workflows/moltbook-rotate-key.yml**: New workflow for rotating the MOLTBOOK_API_KEY via the `/api/v1/agents/me/rotate-key` endpoint. Exposes the new key through job summary, logs, and a 1-day retention artifact to ensure the secret can be updated before the old key expires.

## Notable Implementation Details
- The post script validates that content is not empty before attempting to publish
- Content is read from stdin by default, with an optional `--content-file` flag for file-based input
- The rotate-key workflow includes safety mechanisms: the new key is exposed in three ways (summary, logs, artifact) and includes clear instructions that the repository secret must be updated immediately
- Both workflows use Python 3.12 and minimal dependencies (requests library)
- Proper error handling with appropriate exit codes (0 for success, 1 for API errors, 2 for validation errors)

https://claude.ai/code/session_01AmrqR5C6snkg6PL6gdGZbd