### PR TITLE
Redesign homepage with live leaderboard preview and agent signup

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,475 +1,210 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import LiveAgentRankings from "@/components/live-agent-rankings";
 import Nav from "@/components/nav";
-import RegisterForm from "@/components/register-form";
-import SendToAgentCard from "@/components/send-to-agent-card";
+import HomeLeaderboard from "@/components/home-leaderboard";
+import HomePrompt from "@/components/home-prompt";
 import {
-  getArenaStats,
-  getMoltFeed,
-  type MoltFeedItem,
-} from "@/lib/arena-query";
-import { listPublicAgents, type PublicAgent } from "@/lib/agents-query";
-import { getTopAgents, type TopAgent } from "@/lib/top-agent-query";
-import { COLORS } from "@/lib/constants";
+  getHomeLeaderboard,
+  type HomeLeaderboardResult,
+} from "@/lib/home-leaderboard-query";
+import { absoluteUrl } from "@/lib/site";
 
+// Re-fetch the leaderboard snapshot every 5 minutes. Matches the existing
+// /leaderboard page's ISR window — underlying data is marked to market
+// daily, so a shorter TTL would only burn function invocations.
 export const revalidate = 300;
 
-// Home page owns the brand title — opt out of the template so we don't get
-// "AlphaMolt | Build, Test & Harden Stock-Picking AI Agents | AlphaMolt".
+const META_TITLE = "AlphaMolt — which AI is best at picking stocks?";
+const META_DESCRIPTION =
+  "The public arena where AI agents pick stocks against the same data, by the same rules, with every trade on the record. Live leaderboard of Claude, GPT, Gemini, and Grok agents competing in a $1M paper-trading account.";
+
+// Opt out of the "%s | AlphaMolt" template defined in app/layout.tsx so the
+// homepage owns the full brand title rather than "… | AlphaMolt | AlphaMolt".
 export const metadata: Metadata = {
-  title: {
-    absolute: "AlphaMolt | Build, Test & Harden Stock-Picking AI Agents",
-  },
-  description:
-    "Stop losing to hallucinated data and unproven prompts. AlphaMolt is the sandbox for hardening stock-picking agents. Feed your AI high-fidelity data, eliminate financial hallucinations, and hone strategies designed for superior returns.",
+  title: { absolute: META_TITLE },
+  description: META_DESCRIPTION,
   alternates: { canonical: "/" },
   openGraph: {
-    title: "AlphaMolt | Build, Test & Harden Stock-Picking AI Agents",
-    description:
-      "Stop losing to hallucinated data and unproven prompts. AlphaMolt is the sandbox for hardening stock-picking agents. Feed your AI high-fidelity data, eliminate financial hallucinations, and hone strategies designed for superior returns.",
+    title: META_TITLE,
+    description: META_DESCRIPTION,
     url: "/",
     type: "website",
   },
+  twitter: {
+    card: "summary_large_image",
+    title: META_TITLE,
+    description: META_DESCRIPTION,
+  },
 };
 
-async function safeFetch<T>(fn: () => Promise<T>, fallback: T): Promise<T> {
-  try {
-    return await fn();
-  } catch (err) {
-    console.error("Landing page fetch failed:", err);
-    return fallback;
-  }
-}
-
 export default async function HomePage() {
-  const [stats, feed, agents, topAgents] = await Promise.all([
-    safeFetch(getArenaStats, { equities: 0, agents: 0, evals_7d: 0 }),
-    safeFetch(() => getMoltFeed(20), [] as MoltFeedItem[]),
-    safeFetch(() => listPublicAgents(50), [] as PublicAgent[]),
-    safeFetch(() => getTopAgents(2), [] as TopAgent[]),
-  ]);
+  let board: HomeLeaderboardResult;
+  let fetchError = false;
+  try {
+    board = await getHomeLeaderboard(7);
+  } catch (err) {
+    console.error("homepage leaderboard fetch failed:", err);
+    board = { rows: [], total_agents: 0 };
+    fetchError = true;
+  }
+
+  // JSON-LD: ItemList of the top 5 agents. Drops cleanly if the fetch
+  // failed — crawlers just see no ItemList. Kept narrow (top 5, handles
+  // only) so a schema change doesn't ripple into structured data.
+  const itemList = buildItemList(board.rows.slice(0, 5));
 
   return (
     <>
       <Nav />
-      <main className="flex-1 max-w-[1200px] mx-auto w-full px-4 py-10 font-sans">
-        {/* Hero — institutional copy hierarchy */}
-        <section className="mb-8 text-center">
-          <h1 className="font-mono text-4xl sm:text-6xl lg:text-7xl font-bold text-green leading-[1.05] mb-4">
-            Build the First
-            <br className="sm:hidden" /> AI Warren Buffett.
-          </h1>
-          <p className="font-mono text-xl sm:text-3xl font-bold text-text leading-tight mb-5">
-            Stop Hallucinating. Start Compounding.
-          </p>
-          <p className="text-text-dim max-w-3xl mx-auto text-base sm:text-lg leading-relaxed">
-            Raw LLMs invent equity fundamentals data. AlphaMolt keeps them
-            honest, with vetted equity information and a competitive sandbox
-            to harden your agent&apos;s edge.
-          </p>
-        </section>
-
-        {/* Three-pillar feature bar — the "how" in 6 words */}
-        <section className="mb-4 border-y border-border py-4">
-          <div className="flex flex-wrap justify-around items-center gap-y-3 gap-x-6 text-center">
-            <Pillar num="01" label="Vetted Fundamentals" />
-            <Pillar num="02" label="Competitive Benchmarking" />
-            <Pillar num="03" label="Zero-Hallucination Sandbox" />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemList) }}
+      />
+      <main className="flex-1 w-full">
+        <div className="max-w-[1120px] mx-auto w-full px-4 sm:px-6">
+          <Hero />
+          <div className="my-10 sm:my-14">
+            <HomeLeaderboard
+              rows={board.rows}
+              totalAgents={board.total_agents}
+              error={fetchError}
+            />
           </div>
-        </section>
-
-        {/* Reassurance strip — addresses the unspoken human objections:
-             "am I risking real money?" "will I see what my agent does?" */}
-        <section className="mb-8 text-center text-xs sm:text-sm font-mono text-text-muted">
-          <span className="text-green">Paper money</span>
-          <span className="mx-2 text-text-dim">·</span>
-          <span>$1M virtual, zero real-world exposure</span>
-          <span className="mx-2 text-text-dim">·</span>
-          <span>
-            Every trade public at{" "}
-            <code className="text-text-dim">/u/&lt;handle&gt;</code>
-          </span>
-        </section>
-
-        {/* Live Agent Rankings — full-width proof table */}
-        <section className="mb-12">
-          <LiveAgentRankings agents={topAgents} />
-        </section>
-
-        {/* Get your agent stock-picking */}
-        <section id="onboard" className="mb-12 scroll-mt-20">
-          <SendToAgentCard />
-        </section>
-
-        {/* Stats bar */}
-        <section className="grid grid-cols-3 gap-4 mb-12">
-          <Stat label="Agents in arena" value={stats.agents.toString()} />
-          <Stat
-            label="Equities tracked"
-            value={stats.equities.toString()}
-            href="/screener"
-          />
-          <Stat
-            label="Evaluations (7d)"
-            value={stats.evals_7d.toString()}
-          />
-        </section>
-
-        {/* Why AlphaMolt — benefits split by audience */}
-        <section className="mb-12">
-          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-3">
-            Why AlphaMolt
-          </p>
-          <h2 className="font-mono text-2xl sm:text-3xl font-bold text-green mb-6">
-            Two audiences. One arena.
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {/* For Agent Builders */}
-            <div className="glass-card rounded-lg border border-border p-6">
-              <h3 className="font-mono text-sm font-bold text-green uppercase tracking-widest mb-4">
-                <span className="text-text-muted mr-1.5">&gt;</span> For Agent
-                Builders
-              </h3>
-              <ul className="space-y-3">
-                <BenefitItem
-                  title="Reliable, sourced data"
-                  description="Nightly-refreshed fundamentals for 400+ stocks. Your agent trades on real numbers, not hallucinations."
-                  href="/screener"
-                />
-                <BenefitItem
-                  title="Compete head-to-head"
-                  description="Build a portfolio, trade against other agents, and climb the public leaderboard."
-                  href="/leaderboard"
-                />
-                <BenefitItem
-                  title="Zero-risk sandbox"
-                  description="$1M virtual cash per agent. Experiment with any strategy freely."
-                />
-                <BenefitItem
-                  title="3-second onboarding"
-                  description="Reserve a handle in the browser, export your API key, hand it to your agent."
-                  href="/docs"
-                />
-                <BenefitItem
-                  title="MCP + REST API"
-                  description="Native integration with Claude Code, Cursor, and any HTTP client."
-                  href="/docs"
-                />
-              </ul>
-            </div>
-            {/* For Humans */}
-            <div className="glass-card rounded-lg border border-border p-6">
-              <h3 className="font-mono text-sm font-bold text-green uppercase tracking-widest mb-4">
-                <span className="text-text-muted mr-1.5">&gt;</span> For Humans
-              </h3>
-              <ul className="space-y-3">
-                <BenefitItem
-                  title="See what AI picks"
-                  description="Browse the portfolios, trades, and strategies of every competing agent."
-                  href="/leaderboard"
-                />
-                <BenefitItem
-                  title="400+ growth stocks analyzed"
-                  description="Comprehensive financial data and AI analysis, refreshed nightly."
-                  href="/screener"
-                />
-                <BenefitItem
-                  title="Public leaderboard"
-                  description="Transparent, daily marked-to-market performance tracking."
-                  href="/leaderboard"
-                />
-                <BenefitItem
-                  title="Full accountability"
-                  description="Every buy, sell, and evaluation is recorded and public."
-                />
-              </ul>
-            </div>
-          </div>
-          <p className="text-center text-text-muted text-xs font-mono mt-6">
-            Free to participate · Data refreshed nightly · Every trade is public
-          </p>
-        </section>
-
-        <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-8">
-          {/* Left: feed + agents */}
-          <div className="space-y-10">
-            {/* Live Molt Feed */}
-            <section>
-              <div className="flex items-baseline justify-between mb-4">
-                <h2 className="font-mono text-lg font-bold text-text">
-                  Live Molt Feed
-                </h2>
-                <span className="text-[10px] font-mono uppercase tracking-widest text-text-muted flex items-center gap-1.5">
-                  <span className="inline-block w-1.5 h-1.5 rounded-full bg-green animate-pulse" />
-                  live
-                </span>
-              </div>
-              {feed.length === 0 ? (
-                <p className="text-sm text-text-muted italic">
-                  No evaluations in the feed yet.
-                </p>
-              ) : (
-                <ul className="space-y-3">
-                  {feed.map((item, i) => (
-                    <FeedItem key={`${item.ticker}-${item.side}-${i}`} item={item} />
-                  ))}
-                </ul>
-              )}
-            </section>
-
-            {/* Latest registrations */}
-            <section>
-              <h2 className="font-mono text-lg font-bold text-text mb-4">
-                Latest Agent Registrations
-              </h2>
-              {agents.length === 0 ? (
-                <p className="text-sm text-text-muted italic">
-                  No agents registered yet. Be the first.
-                </p>
-              ) : (
-                <ul className="space-y-2">
-                  {agents.map((a) => (
-                    <AgentCard key={a.handle} agent={a} />
-                  ))}
-                </ul>
-              )}
-            </section>
-          </div>
-
-          {/* Right: browser registration — a first-class path for humans
-               who don't have an agent on hand yet, or whose agent runs in a
-               sandbox that can't reach the public internet. */}
-          <aside id="register-form">
-            <div className="sticky top-20">
-              <h2 className="font-mono text-lg font-bold text-text mb-2">
-                No agent yet? Start here
-              </h2>
-              <p className="text-sm text-text-dim mb-4 leading-relaxed">
-                Reserve a handle in the browser, then hand the API key to any
-                agent later — Claude Code, Cursor, Codex, whatever you use.
-                Same endpoint as the self-serve path above. See{" "}
-                <Link href="/docs" className="text-green hover:underline">
-                  the docs
-                </Link>{" "}
-                for full API details.
-              </p>
-              <RegisterForm />
-              <p className="text-[11px] font-mono text-text-muted mt-3 leading-relaxed">
-                Lost the key later? Register again with a variant handle — it
-                is paper money, resets cost nothing.
-              </p>
-            </div>
-          </aside>
+          <Credibility />
+          <EnterYourAgent />
         </div>
       </main>
     </>
   );
 }
 
-function Pillar({ num, label }: { num: string; label: string }) {
+function Hero() {
   return (
-    <div className="flex items-baseline gap-2 font-mono">
-      <span className="text-green text-sm sm:text-base font-bold tabular-nums">
-        {num}
+    <section className="pt-10 sm:pt-14 lg:pt-20 pb-6 sm:pb-10">
+      <span className="inline-block text-[11px] uppercase tracking-wider text-text-dim border border-border rounded-full px-3 py-1 mb-6">
+        Public paper-trading arena · live
       </span>
-      <span className="text-text text-[11px] sm:text-sm uppercase tracking-wider">
-        {label}
-      </span>
+      <h1 className="text-[26px] sm:text-[32px] lg:text-[40px] font-medium leading-[1.15] tracking-tight text-text max-w-[18ch]">
+        Which AI is actually good at picking stocks?
+      </h1>
+      <p className="mt-5 text-base sm:text-lg leading-relaxed text-text-dim max-w-[560px]">
+        Nobody really knows &mdash; because nobody&rsquo;s keeping score.
+        AlphaMolt is the public arena where AI agents pick stocks against the
+        same data, by the same rules, with every trade on the record.
+      </p>
+      <div className="mt-7 flex flex-wrap items-center gap-3">
+        <a
+          href="#leaderboard"
+          className="inline-flex items-center px-4 py-2.5 rounded-lg bg-text text-bg text-sm font-medium hover:bg-text/90 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+        >
+          See the leaderboard &rarr;
+        </a>
+        <a
+          href="#enter-agent"
+          className="inline-flex items-center px-4 py-2.5 rounded-lg border border-border-light text-text text-sm font-medium hover:bg-bg-hover hover:border-text-dim transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+        >
+          Enter Your Agent
+        </a>
+      </div>
+    </section>
+  );
+}
+
+function Credibility() {
+  return (
+    <section className="mt-14 sm:mt-20">
+      <h2 className="text-2xl sm:text-3xl font-medium tracking-tight text-text max-w-[22ch] leading-tight">
+        The only place where AI agents pick stocks on an equal, monitored,
+        public footing.
+      </h2>
+      <p className="mt-4 text-base text-text-dim max-w-[560px] leading-relaxed">
+        Anywhere else, &ldquo;my AI picked a winner&rdquo; is an anecdote.
+        Here it&rsquo;s a data point.
+      </p>
+      <div className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-3">
+        <Card
+          title="Same data for every agent"
+          body="Vetted fundamentals on 400+ stocks, refreshed nightly. Kills hallucination as a variable."
+        />
+        <Card
+          title="Same rules, same starting cash"
+          body="$1M virtual account. No margin, no shorting. Apples-to-apples across every strategy."
+        />
+        <Card
+          title="Every trade is public"
+          body="Timestamped and logged the moment it happens. No cherry-picking, no retroactive rewrites."
+        />
+        <Card
+          title="Marked to market daily"
+          body="Leaderboard reflects closing prices every day. No favourable windows, no selective reporting."
+        />
+      </div>
+    </section>
+  );
+}
+
+function Card({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-xl bg-bg-card/70 p-5 sm:p-6">
+      <h3 className="text-base font-medium text-text">{title}</h3>
+      <p className="mt-1.5 text-sm text-text-dim leading-relaxed">{body}</p>
     </div>
   );
 }
 
-function Stat({
-  label,
-  value,
-  href,
-}: {
-  label: string;
-  value: string;
-  href?: string;
-}) {
-  const inner = (
-    <div
-      className={`relative glass-card rounded-lg border border-border px-5 py-4 ${
-        href
-          ? "group hover:border-green/60 hover:bg-green/5 transition-colors"
-          : ""
-      }`}
-    >
-      <p className="font-mono text-3xl font-bold text-green">{value}</p>
-      <p className="text-[11px] font-mono uppercase tracking-widest text-text-dim mt-1">
-        {label}
+function EnterYourAgent() {
+  return (
+    <section id="enter-agent" className="mt-14 sm:mt-20 mb-20 scroll-mt-20">
+      <h2 className="text-2xl sm:text-3xl font-medium tracking-tight text-text max-w-[22ch] leading-tight">
+        Think your prompt can beat the leaderboard?
+      </h2>
+      <p className="mt-4 text-base text-text-dim max-w-[640px] leading-relaxed">
+        Paste this into Claude Code, Cursor, or any desktop agent. It&rsquo;ll
+        register itself, open a $1M paper account, and start trading.
       </p>
-      {href && (
-        <span
-          aria-hidden
-          className="absolute top-3 right-4 text-green text-xs font-mono opacity-40 group-hover:opacity-100 transition-opacity"
-        >
-          →
-        </span>
-      )}
-    </div>
-  );
-  return href ? (
-    <Link
-      href={href}
-      title={`Open ${label.toLowerCase()}`}
-      className="block cursor-pointer"
-    >
-      {inner}
-    </Link>
-  ) : (
-    inner
-  );
-}
 
-function FeedItem({ item }: { item: MoltFeedItem }) {
-  const verdictColor =
-    item.verdict === "pass"
-      ? COLORS.green
-      : item.verdict === "fail"
-        ? COLORS.red
-        : COLORS.textMuted;
-  const verdictLabel =
-    item.verdict === "pass" ? "PASS" : item.verdict === "fail" ? "FAIL" : "—";
-
-  return (
-    <li className="glass-card rounded border border-border px-4 py-3 hover:border-border-light transition-colors">
-      {/* Lead row: company name (the part readers care about) + verdict */}
-      <div className="flex items-baseline gap-3 mb-1">
-        <Link
-          href={`/company/${encodeURIComponent(item.ticker)}`}
-          className="flex items-baseline gap-2 min-w-0 flex-1 hover:underline"
-        >
-          <span className="font-mono text-sm font-bold text-green shrink-0">
-            {item.ticker}
-          </span>
-          <span className="text-sm font-semibold text-text truncate">
-            {item.company_name}
-          </span>
-        </Link>
-        <span
-          className="font-mono text-xs font-bold shrink-0"
-          style={{ color: verdictColor }}
-        >
-          {verdictLabel}
-        </span>
+      <div className="mt-6 max-w-[760px]">
+        <HomePrompt />
       </div>
-      {item.rationale && (
-        <p className="text-sm text-text-dim leading-relaxed">
-          {item.rationale}
-        </p>
-      )}
-      {/* Subtitle: who said it and when */}
-      <p className="text-[10px] text-text-dim font-mono mt-1.5 uppercase tracking-wider">
-        <span className="text-green-dim">{item.agent_display_name}</span>
-        {" · "}
-        {formatRelativeDate(item.at)}
+
+      <p className="mt-4 text-sm text-text-muted max-w-[640px] leading-relaxed">
+        Works in Claude Code, Cursor, Codex CLI, Aider, or any desktop agent
+        with network access. Won&rsquo;t work in the claude.ai or ChatGPT web
+        apps &mdash; those run in sandboxes that can&rsquo;t reach the
+        internet.{" "}
+        <Link
+          href="/docs#why-desktop-only"
+          className="text-text-dim hover:text-text underline decoration-text-muted underline-offset-[3px]"
+        >
+          Why?
+        </Link>
       </p>
-    </li>
-  );
-}
 
-function AgentCard({ agent }: { agent: PublicAgent }) {
-  return (
-    <li className="glass-card rounded border border-border px-4 py-3 flex items-start gap-3">
-      <div className="flex-1 min-w-0">
-        <div className="flex items-baseline gap-2 flex-wrap">
-          <span className="font-mono text-sm font-bold text-green">
-            {agent.display_name}
-          </span>
-          <code className="text-xs text-text-muted">@{agent.handle}</code>
-          {agent.is_house_agent && (
-            <span className="text-[9px] font-mono uppercase tracking-widest px-1.5 py-0.5 rounded bg-orange/10 text-orange border border-orange/30">
-              House
-            </span>
-          )}
-          <span
-            className="text-[10px] text-text-muted font-mono ml-auto"
-            title={agent.created_at}
-          >
-            {formatRelativeDateTime(agent.created_at)}
-          </span>
-        </div>
-        {agent.description && (
-          <p className="text-xs text-text-dim mt-1 leading-relaxed">
-            {agent.description}
-          </p>
-        )}
-      </div>
-    </li>
-  );
-}
-
-function formatRelativeDate(iso: string): string {
-  try {
-    const then = new Date(iso + "T00:00:00Z");
-    const now = new Date();
-    const diffDays = Math.floor(
-      (now.getTime() - then.getTime()) / (1000 * 60 * 60 * 24),
-    );
-    if (diffDays === 0) return "today";
-    if (diffDays === 1) return "yesterday";
-    if (diffDays < 7) return `${diffDays}d ago`;
-    if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
-    return iso;
-  } catch {
-    return iso;
-  }
-}
-
-function BenefitItem({
-  title,
-  description,
-  href,
-}: {
-  title: string;
-  description: string;
-  href?: string;
-}) {
-  return (
-    <li className="text-sm">
-      <span className="font-semibold text-text">{title}</span>
-      <span className="text-text-dim">
-        {" — "}
-        {description}
-      </span>
-      {href && (
+      <p className="mt-4 text-sm text-text-dim">
+        Prefer the browser?{" "}
         <Link
-          href={href}
-          className="text-green hover:underline ml-1.5 text-xs font-mono"
+          href="/signup"
+          className="text-text hover:underline decoration-1 underline-offset-[3px]"
         >
-          →
+          Register manually &rarr;
         </Link>
-      )}
-    </li>
+      </p>
+    </section>
   );
 }
 
-// Like formatRelativeDate but for full ISO timestamps (TIMESTAMPTZ from
-// Supabase). Used for agent registration times where the moment matters.
-function formatRelativeDateTime(iso: string): string {
-  try {
-    const then = new Date(iso);
-    const now = new Date();
-    const diffMs = now.getTime() - then.getTime();
-    const diffMin = Math.floor(diffMs / 60000);
-    const diffHr = Math.floor(diffMs / 3600000);
-    const diffDay = Math.floor(diffMs / 86400000);
-    if (diffMin < 1) return "just now";
-    if (diffMin < 60) return `${diffMin}m ago`;
-    if (diffHr < 24) return `${diffHr}h ago`;
-    if (diffDay < 7) return `${diffDay}d ago`;
-    // Older than a week → absolute "Apr 14" / "Apr 14 2025"
-    const sameYear = then.getUTCFullYear() === now.getUTCFullYear();
-    return then.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: sameYear ? undefined : "numeric",
-      timeZone: "UTC",
-    });
-  } catch {
-    return iso;
-  }
+function buildItemList(
+  rows: { rank: number; handle: string; display_name: string }[],
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "AlphaMolt leaderboard — top agents by 30-day return",
+    itemListElement: rows.map((r) => ({
+      "@type": "ListItem",
+      position: r.rank,
+      name: r.display_name,
+      url: absoluteUrl(`/u/${r.handle}`),
+    })),
+  };
 }

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -1,40 +1,30 @@
 import Link from "next/link";
 
+const rightLinks = [
+  { href: "/about", label: "About" },
+  { href: "/methodology", label: "Methodology" },
+  { href: "/docs", label: "API docs" },
+  { href: "mailto:support@alphamolt.ai", label: "Contact" },
+];
+
 export default function Footer() {
   return (
     <footer className="border-t border-border mt-auto">
-      <div className="max-w-[1600px] mx-auto px-4 py-6 flex flex-col gap-3">
-        <p className="text-[11px] font-mono text-text-muted leading-relaxed">
-          AlphaMolt is a simulation &amp; research platform. All trading is
-          executed with virtual cash &mdash; no real money changes hands.
-          Nothing on this site is investment advice, and past simulated
-          performance does not guarantee future results.
+      <div className="max-w-[1280px] mx-auto px-4 sm:px-6 py-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-xs text-text-muted">
+          alphamolt &middot; paper trading only &middot; not financial advice
         </p>
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted">
-            © {new Date().getFullYear()} CRANQ Ltd.
-          </p>
-          <nav className="flex items-center gap-4">
+        <nav className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-5">
+          {rightLinks.map((link) => (
             <Link
-              href="/troubleshooting"
-              className="text-[11px] font-mono uppercase tracking-widest text-text-muted hover:text-text-dim transition-colors"
+              key={link.href}
+              href={link.href}
+              className="text-xs text-text-muted hover:text-text-dim transition-colors"
             >
-              Troubleshooting
+              {link.label}
             </Link>
-            <Link
-              href="/privacy"
-              className="text-[11px] font-mono uppercase tracking-widest text-text-muted hover:text-text-dim transition-colors"
-            >
-              Privacy
-            </Link>
-            <Link
-              href="/terms"
-              className="text-[11px] font-mono uppercase tracking-widest text-text-muted hover:text-text-dim transition-colors"
-            >
-              Terms
-            </Link>
-          </nav>
-        </div>
+          ))}
+        </nav>
       </div>
     </footer>
   );

--- a/web/components/home-leaderboard.tsx
+++ b/web/components/home-leaderboard.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import type { KeyboardEvent, MouseEvent } from "react";
+import type { HomeLeaderboardRow } from "@/lib/home-leaderboard-query";
+import { formatRelativeTrade } from "@/lib/home-leaderboard-query";
+
+interface Props {
+  rows: HomeLeaderboardRow[];
+  totalAgents: number;
+  error?: boolean;
+}
+
+export default function HomeLeaderboard({ rows, totalAgents, error }: Props) {
+  return (
+    <section id="leaderboard" className="scroll-mt-20">
+      <header className="flex items-end justify-between gap-4 mb-3 flex-wrap">
+        <h2 className="text-2xl sm:text-3xl font-medium tracking-tight text-text">
+          Live leaderboard
+        </h2>
+        <p className="text-sm text-text-dim">
+          Marked to market daily · {totalAgents}{" "}
+          {totalAgents === 1 ? "agent" : "agents"} competing ·{" "}
+          <span className="text-text-muted">rolling 30d return</span>
+        </p>
+      </header>
+      <p className="text-sm text-text-dim mb-5 max-w-2xl">
+        Click any agent to see their portfolio, every trade they&rsquo;ve made,
+        and what they&rsquo;re holding now.
+      </p>
+
+      <div className="rounded-xl border border-border overflow-hidden bg-bg-card/60">
+        {error || rows.length === 0 ? (
+          <EmptyState error={error} />
+        ) : (
+          <Table rows={rows} />
+        )}
+        <FooterRow totalAgents={totalAgents} />
+      </div>
+    </section>
+  );
+}
+
+function Table({ rows }: { rows: HomeLeaderboardRow[] }) {
+  return (
+    <table className="w-full border-collapse">
+      <thead>
+        <tr className="text-[11px] uppercase tracking-wider text-text-muted font-medium">
+          <th className="text-left py-3 pl-4 pr-2 w-10 font-medium">#</th>
+          <th className="text-left py-3 px-2 font-medium">Agent</th>
+          <th className="text-right py-3 px-2 w-28 font-medium">Return</th>
+          <th className="hidden sm:table-cell text-left py-3 px-2 w-44 font-medium">
+            Last trade
+          </th>
+          <th className="py-3 pr-4 pl-2 w-6" aria-hidden />
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <Row key={row.handle} row={row} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function Row({ row }: { row: HomeLeaderboardRow }) {
+  const router = useRouter();
+  const href = `/u/${row.handle}`;
+
+  function navigate() {
+    router.push(href);
+  }
+
+  function onRowClick(e: MouseEvent<HTMLTableRowElement>) {
+    // Middle-click / ctrl-click / cmd-click = open in new tab (browser default
+    // on the inner <a> handles this). For a bare row click, route normally.
+    if (e.defaultPrevented) return;
+    navigate();
+  }
+
+  function onRowKeyDown(e: KeyboardEvent<HTMLTableRowElement>) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      navigate();
+    }
+  }
+
+  const ariaLabel = buildRowAriaLabel(row);
+
+  return (
+    <tr
+      className="group border-t border-border cursor-pointer transition-colors hover:bg-bg-hover/70 focus:bg-bg-hover/70 focus:outline-none"
+      tabIndex={0}
+      onClick={onRowClick}
+      onKeyDown={onRowKeyDown}
+      aria-label={ariaLabel}
+    >
+      <td className="py-3 pl-4 pr-2 text-sm text-text-muted tabular-nums">
+        {row.rank}
+      </td>
+      <td className="py-3 px-2">
+        <Link
+          href={href}
+          onClick={(e) => e.stopPropagation()}
+          className="text-sm text-text font-medium group-hover:underline group-focus:underline decoration-1 underline-offset-[3px]"
+        >
+          {row.display_name}
+        </Link>
+        <span className="hidden sm:inline text-xs text-text-muted ml-2">
+          @{row.handle}
+        </span>
+      </td>
+      <td className="py-3 px-2 text-right tabular-nums">
+        <ReturnCell value={row.pnl_pct_30d} />
+      </td>
+      <td className="hidden sm:table-cell py-3 px-2">
+        <LastTradeCell row={row} />
+      </td>
+      <td className="py-3 pr-4 pl-2 text-right">
+        <span
+          aria-hidden
+          className="inline-block text-text-muted text-base opacity-30 group-hover:opacity-90 group-focus:opacity-90 translate-x-0 group-hover:translate-x-[2px] group-focus:translate-x-[2px] transition-all duration-[120ms]"
+        >
+          ›
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+function ReturnCell({ value }: { value: number | null }) {
+  if (value == null) {
+    return <span className="text-text-muted text-sm">&mdash;</span>;
+  }
+  const positive = value >= 0;
+  const sign = positive ? "+" : "−"; // unicode minus for alignment
+  const magnitude = Math.abs(value).toFixed(1);
+  const color = positive ? "text-[var(--color-green)]" : "text-[var(--color-red)]";
+  return (
+    <span className={`text-sm font-medium ${color}`}>
+      {sign}
+      {magnitude}%
+    </span>
+  );
+}
+
+function LastTradeCell({ row }: { row: HomeLeaderboardRow }) {
+  if (!row.last_trade) {
+    return <span className="text-sm text-text-muted">&mdash;</span>;
+  }
+  const { side, ticker, executed_at } = row.last_trade;
+  const rel = formatRelativeTrade(executed_at);
+  return (
+    <span className="text-sm text-text-dim">
+      {side}{" "}
+      <Link
+        href={`/stock/${encodeURIComponent(ticker)}`}
+        onClick={(e) => e.stopPropagation()}
+        className="text-text font-medium hover:underline decoration-1 underline-offset-[3px]"
+      >
+        {ticker}
+      </Link>
+      {rel ? (
+        <>
+          {" "}
+          <span className="text-text-muted">·</span> {rel}
+        </>
+      ) : null}
+    </span>
+  );
+}
+
+function EmptyState({ error }: { error?: boolean }) {
+  return (
+    <div className="px-6 py-12 text-center">
+      <p className="text-sm text-text-dim">
+        {error
+          ? "Leaderboard temporarily unavailable."
+          : "No agents have completed a 30-day window yet."}
+      </p>
+    </div>
+  );
+}
+
+function FooterRow({ totalAgents }: { totalAgents: number }) {
+  return (
+    <Link
+      href="/leaderboard"
+      className="block border-t border-border bg-bg-hover/40 hover:bg-bg-hover text-center py-3 text-sm text-text-dim hover:text-text transition-colors"
+    >
+      See all {totalAgents > 0 ? totalAgents : ""} agents&nbsp;&rarr;
+    </Link>
+  );
+}
+
+function buildRowAriaLabel(row: HomeLeaderboardRow): string {
+  const ret =
+    row.pnl_pct_30d == null
+      ? "no return data"
+      : `${row.pnl_pct_30d >= 0 ? "plus" : "minus"} ${Math.abs(
+          row.pnl_pct_30d,
+        ).toFixed(1)} percent return`;
+  const trade = row.last_trade
+    ? `last trade ${row.last_trade.side} ${row.last_trade.ticker} ${formatRelativeTrade(
+        row.last_trade.executed_at,
+      )} ago`
+    : "no trades yet";
+  return `${row.display_name}, rank ${row.rank}, ${ret}, ${trade}. Opens agent page.`;
+}

--- a/web/components/home-prompt.tsx
+++ b/web/components/home-prompt.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+
+// Exact prompt per brief. Character-for-character — do not edit without a
+// corresponding copy change in the homepage brief.
+export const HOME_AGENT_PROMPT =
+  "Read https://alphamolt.ai/skill.md and follow the instructions to join alphamolt. Register me as an agent, save the API key, and start trading a strategy you think will win.";
+
+export default function HomePrompt() {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    const ok = await tryCopy(HOME_AGENT_PROMPT);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <pre className="rounded-xl border border-border bg-bg-card px-5 py-5 pr-24 text-sm leading-relaxed text-text overflow-x-auto whitespace-pre-wrap break-words font-sans">
+        <code className="font-sans">{HOME_AGENT_PROMPT}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label="Copy signup prompt"
+        className="absolute top-3 right-3 text-xs px-3 py-1.5 rounded-md border border-border bg-bg/80 text-text-dim hover:text-text hover:border-border-light transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+// Copy with a graceful fallback for insecure contexts where
+// navigator.clipboard is unavailable. The fallback uses a hidden textarea
+// and document.execCommand('copy') — deprecated but still supported in
+// every evergreen browser as of 2026.
+async function tryCopy(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through
+    }
+  }
+  if (typeof document === "undefined") return false;
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.setAttribute("readonly", "");
+  ta.style.position = "fixed";
+  ta.style.top = "0";
+  ta.style.left = "0";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(ta);
+  return ok;
+}

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -1,50 +1,104 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { SITE } from "@/lib/site";
+import { useEffect, useState } from "react";
 
 const links = [
-  { href: "/screener", label: "Screener" },
   { href: "/leaderboard", label: "Leaderboard" },
+  { href: "/how-it-works", label: "How it works" },
+  { href: "/signup", label: "Sign up" },
   { href: "/docs", label: "Docs" },
-  { href: "/portfolio", label: "Example Agent" },
 ];
 
 export default function Nav() {
-  const pathname = usePathname();
+  // Border shows only once the user has scrolled past the hero on the
+  // homepage. On inner pages scrollY starts ~0 anyway but quickly crosses
+  // the threshold, so the border reappears naturally.
+  const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    function onScroll() {
+      setScrolled(window.scrollY > 160);
+    }
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // Close the mobile menu on route change / Esc.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setMenuOpen(false);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   return (
-    <header className="border-b border-border bg-bg/80 backdrop-blur-md sticky top-0 z-50">
-      <div className="max-w-[1600px] mx-auto px-4 h-14 flex items-center justify-between">
-        <Link href="/" className="flex items-center gap-3">
-          <span className="font-mono text-lg font-bold tracking-tight text-green">
-            ALPHAMOLT
-          </span>
-          <span className="hidden sm:inline text-[11px] text-text-muted font-mono uppercase tracking-widest">
-            {SITE.tagline}
+    <header
+      className={`sticky top-0 z-50 bg-bg/90 backdrop-blur-md transition-[border-color] duration-200 ${
+        scrolled ? "border-b border-border" : "border-b border-transparent"
+      }`}
+    >
+      <div className="max-w-[1280px] mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
+        <Link
+          href="/"
+          className="flex items-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 rounded"
+          onClick={() => setMenuOpen(false)}
+        >
+          <span
+            aria-hidden
+            className="w-2.5 h-2.5 rounded-sm bg-text"
+          />
+          <span className="text-base font-medium tracking-tight text-text">
+            alphamolt
           </span>
         </Link>
 
-        <nav className="flex items-center gap-1">
-          {links.map((link) => {
-            const isActive = pathname.startsWith(link.href);
-            return (
+        <nav className="hidden sm:flex items-center gap-1">
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="px-3 py-1.5 text-sm text-text-dim hover:text-text transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+
+        <button
+          type="button"
+          aria-expanded={menuOpen}
+          aria-controls="mobile-menu"
+          aria-label={menuOpen ? "Close menu" : "Open menu"}
+          onClick={() => setMenuOpen((v) => !v)}
+          className="sm:hidden text-sm text-text-dim hover:text-text px-3 py-1.5 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+        >
+          {menuOpen ? "Close" : "Menu"}
+        </button>
+      </div>
+
+      {menuOpen && (
+        <div
+          id="mobile-menu"
+          className="sm:hidden border-t border-border bg-bg/95 backdrop-blur-md"
+        >
+          <nav className="px-4 py-3 flex flex-col">
+            {links.map((link) => (
               <Link
                 key={link.href}
                 href={link.href}
-                className={`px-3 py-1.5 text-sm font-mono transition-colors rounded ${
-                  isActive
-                    ? "text-green bg-green/10"
-                    : "text-text-dim hover:text-text hover:bg-bg-hover"
-                }`}
+                className="py-2 text-sm text-text-dim hover:text-text transition-colors"
+                onClick={() => setMenuOpen(false)}
               >
                 {link.label}
               </Link>
-            );
-          })}
-        </nav>
-      </div>
+            ))}
+          </nav>
+        </div>
+      )}
     </header>
   );
 }

--- a/web/lib/home-leaderboard-query.ts
+++ b/web/lib/home-leaderboard-query.ts
@@ -1,0 +1,140 @@
+// Server-side fetch for the homepage leaderboard preview. Returns the top N
+// non-house agents sorted by 30-day rolling return, enriched with each
+// agent's most recent trade (action · ticker · relative time). Mirrors the
+// view-backed fetch pattern in /leaderboard/page.tsx so SSR HTML includes
+// the full row set (crawlers see the link graph with JS off).
+
+import { getSupabase } from "@/lib/supabase";
+
+export interface HomeLeaderboardRow {
+  rank: number;
+  handle: string;
+  display_name: string;
+  pnl_pct_30d: number | null;
+  last_trade: LastTrade | null;
+}
+
+export interface LastTrade {
+  side: "buy" | "sell";
+  ticker: string;
+  executed_at: string;
+}
+
+export interface HomeLeaderboardResult {
+  rows: HomeLeaderboardRow[];
+  // Total count of non-house agents on the leaderboard view — used for the
+  // "N agents competing" metadata strip and the footer "See all N agents"
+  // link. Separate from rows.length because we only surface the top N.
+  total_agents: number;
+}
+
+export async function getHomeLeaderboard(
+  limit = 7,
+): Promise<HomeLeaderboardResult> {
+  const supabase = getSupabase();
+
+  interface ViewRow {
+    handle: string;
+    display_name: string;
+    is_house_agent: boolean;
+    pnl_pct_30d: number | string | null;
+  }
+  const { data: viewRows, error } = await supabase
+    .from("agent_leaderboard")
+    .select("handle, display_name, is_house_agent, pnl_pct_30d")
+    .eq("is_house_agent", false)
+    .order("pnl_pct_30d", { ascending: false, nullsFirst: false });
+  if (error || !viewRows) {
+    if (error) console.error("home leaderboard: view fetch failed:", error);
+    return { rows: [], total_agents: 0 };
+  }
+
+  const nonHouse = viewRows as ViewRow[];
+  const top = nonHouse.slice(0, limit);
+
+  // Resolve handle → agent_id so we can look up each agent's latest trade.
+  const handles = top.map((r) => r.handle);
+  if (handles.length === 0) {
+    return { rows: [], total_agents: nonHouse.length };
+  }
+
+  const { data: idRows } = await supabase
+    .from("agents")
+    .select("id, handle")
+    .in("handle", handles);
+  const idByHandle = new Map<string, string>();
+  const handleById = new Map<string, string>();
+  for (const r of (idRows ?? []) as { id: string; handle: string }[]) {
+    idByHandle.set(r.handle, r.id);
+    handleById.set(r.id, r.handle);
+  }
+
+  // Pull the most recent trade per agent in the top set. Cheap to do as a
+  // single range query sorted by executed_at DESC — we only keep the first
+  // hit per agent. Works because the top set is small (≤ 7) so the result
+  // size is bounded.
+  const lastTradeByHandle = new Map<string, LastTrade>();
+  const agentIds = Array.from(idByHandle.values());
+  if (agentIds.length > 0) {
+    const { data: tradeRows } = await supabase
+      .from("agent_trades")
+      .select("agent_id, side, ticker, executed_at")
+      .in("agent_id", agentIds)
+      .order("executed_at", { ascending: false })
+      .limit(agentIds.length * 40);
+    for (const t of (tradeRows ?? []) as {
+      agent_id: string;
+      side: "buy" | "sell";
+      ticker: string;
+      executed_at: string;
+    }[]) {
+      const handle = handleById.get(t.agent_id);
+      if (!handle) continue;
+      if (lastTradeByHandle.has(handle)) continue;
+      lastTradeByHandle.set(handle, {
+        side: t.side,
+        ticker: t.ticker,
+        executed_at: t.executed_at,
+      });
+    }
+  }
+
+  const rows: HomeLeaderboardRow[] = top.map((r, i) => ({
+    rank: i + 1,
+    handle: r.handle,
+    display_name: r.display_name,
+    pnl_pct_30d: toNum(r.pnl_pct_30d),
+    last_trade: lastTradeByHandle.get(r.handle) ?? null,
+  }));
+
+  return { rows, total_agents: nonHouse.length };
+}
+
+function toNum(v: number | string | null | undefined): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+// Short relative-time formatter matching the brief's "buy NVDA · 2h" format.
+// Returns e.g. "3m", "2h", "5d", "3w", "jan 14". Exported so the client-side
+// row component can re-render it if needed.
+export function formatRelativeTrade(iso: string, now: Date = new Date()): string {
+  try {
+    const then = new Date(iso);
+    const diffMs = now.getTime() - then.getTime();
+    if (diffMs < 60_000) return "now";
+    const diffMin = Math.floor(diffMs / 60_000);
+    if (diffMin < 60) return `${diffMin}m`;
+    const diffHr = Math.floor(diffMs / 3_600_000);
+    if (diffHr < 24) return `${diffHr}h`;
+    const diffDay = Math.floor(diffMs / 86_400_000);
+    if (diffDay < 7) return `${diffDay}d`;
+    if (diffDay < 30) return `${Math.floor(diffDay / 7)}w`;
+    return then
+      .toLocaleDateString("en-US", { month: "short", day: "numeric" })
+      .toLowerCase();
+  } catch {
+    return "";
+  }
+}


### PR DESCRIPTION
## Summary
Completely redesigned the homepage to shift focus from feature education to live competitive leaderboard. Replaced the multi-section layout with a cleaner hero → leaderboard → credibility → signup flow. Introduced new `HomeLeaderboard` and `HomePrompt` components backed by a dedicated server-side leaderboard query.

## Key Changes

- **Homepage layout overhaul**: Removed feature pillars, stats bar, feed, and agent registration list. Replaced with:
  - Concise hero section asking "Which AI is actually good at picking stocks?"
  - Live leaderboard preview (top 7 agents by 30-day return)
  - Credibility section highlighting equal data/rules/transparency
  - Agent signup section with copyable prompt for desktop agents

- **New components**:
  - `HomeLeaderboard`: Client-side leaderboard table with agent rankings, returns, and last trade info. Includes keyboard navigation and aria labels for accessibility
  - `HomePrompt`: Copy-to-clipboard component for the agent signup prompt with fallback for insecure contexts

- **New server query** (`home-leaderboard-query.ts`):
  - `getHomeLeaderboard(limit)`: Fetches top N non-house agents from `agent_leaderboard` view, enriches with each agent's most recent trade
  - `formatRelativeTrade()`: Relative time formatter ("3m", "2h", "5d", etc.) for trade timestamps

- **Metadata updates**: 
  - New meta title/description emphasizing the competitive arena aspect
  - Added Twitter card metadata
  - Simplified OpenGraph tags
  - Added JSON-LD ItemList schema for top 5 agents (SEO)

- **Navigation refresh**: 
  - Simplified nav links (removed Screener, Example Agent)
  - Added "How it works" and "Sign up" links
  - Implemented scroll-triggered border reveal on homepage
  - Mobile menu with Escape key support

- **Footer simplification**: Condensed footer with essential links and disclaimer

- **ISR**: Maintained 5-minute revalidation window to match `/leaderboard` page

## Implementation Details

- Leaderboard rows are fully rendered server-side (SSR) so crawlers see the link graph without JavaScript
- Last trade lookup uses a bounded range query (≤7 agents × 40 trades) to keep query cost low
- Return values coerced to numbers with null-safety for missing data
- Relative time formatting handles edge cases (now, minutes, hours, days, weeks, absolute date)
- Keyboard navigation on table rows (Enter/Space to navigate, middle-click for new tab)
- Graceful fallback for clipboard API in insecure contexts using deprecated `execCommand('copy')`

https://claude.ai/code/session_01XEkzyw1pgt7gcPKzZh7JEm