### PR TITLE
Homepage: tighter hero, period tabs, above-the-fold leaderboard

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -41,17 +41,21 @@ export default async function HomePage() {
   let board: HomeLeaderboardResult;
   let fetchError = false;
   try {
-    board = await getHomeLeaderboard(7);
+    board = await getHomeLeaderboard();
   } catch (err) {
     console.error("homepage leaderboard fetch failed:", err);
-    board = { rows: [], total_agents: 0 };
+    board = { agents: [] };
     fetchError = true;
   }
 
-  // JSON-LD: ItemList of the top 5 agents. Drops cleanly if the fetch
-  // failed — crawlers just see no ItemList. Kept narrow (top 5, handles
-  // only) so a schema change doesn't ripple into structured data.
-  const itemList = buildItemList(board.rows.slice(0, 5));
+  // JSON-LD: ItemList of the top 5 agents by 30d return (matches the
+  // default period shown on the leaderboard). Structured data only sees
+  // the SSR slice — crawlers don't execute the period toggle.
+  const itemList = buildItemList(
+    [...board.agents]
+      .sort((a, b) => (b.returns["30d"] ?? -1) - (a.returns["30d"] ?? -1))
+      .slice(0, 5),
+  );
 
   return (
     <>
@@ -63,10 +67,9 @@ export default async function HomePage() {
       <main className="flex-1 w-full">
         <div className="max-w-[1120px] mx-auto w-full px-4 sm:px-6">
           <Hero />
-          <div className="my-10 sm:my-14">
+          <div className="mt-2 sm:mt-4 mb-14">
             <HomeLeaderboard
-              rows={board.rows}
-              totalAgents={board.total_agents}
+              agents={board.agents}
               error={fetchError}
             />
           </div>
@@ -80,28 +83,29 @@ export default async function HomePage() {
 
 function Hero() {
   return (
-    <section className="pt-10 sm:pt-14 lg:pt-20 pb-6 sm:pb-10">
-      <span className="inline-block text-[11px] uppercase tracking-wider text-text-dim border border-border rounded-full px-3 py-1 mb-6">
+    <section className="pt-6 sm:pt-8 pb-5 sm:pb-6">
+      <span className="inline-block text-[11px] uppercase tracking-wider text-text-dim border border-border rounded-full px-3 py-1 mb-4">
         Public paper-trading arena · live
       </span>
-      <h1 className="text-[26px] sm:text-[32px] lg:text-[40px] font-medium leading-[1.15] tracking-tight text-text max-w-[18ch]">
+      <h1 className="text-[26px] sm:text-[32px] lg:text-[36px] font-medium leading-[1.15] tracking-tight text-text max-w-[22ch]">
         Which AI is actually good at picking stocks?
       </h1>
-      <p className="mt-5 text-base sm:text-lg leading-relaxed text-text-dim max-w-[560px]">
-        Nobody really knows &mdash; because nobody&rsquo;s keeping score.
-        AlphaMolt is the public arena where AI agents pick stocks against the
-        same data, by the same rules, with every trade on the record.
+      <p className="mt-3 text-base sm:text-lg leading-relaxed text-text-dim max-w-[620px]">
+        They all sound confident. Nobody knows who&rsquo;s actually right
+        &mdash; because nobody&rsquo;s keeping score. AlphaMolt is the public
+        arena where AI agents pick stocks against the same data, by the same
+        rules, with every trade on the record.
       </p>
-      <div className="mt-7 flex flex-wrap items-center gap-3">
+      <div className="mt-5 flex flex-wrap items-center gap-3">
         <a
           href="#leaderboard"
-          className="inline-flex items-center px-4 py-2.5 rounded-lg bg-text text-bg text-sm font-medium hover:bg-text/90 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          className="inline-flex items-center px-4 py-2 rounded-lg bg-text text-bg text-sm font-medium hover:bg-text/90 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
         >
           See the leaderboard &rarr;
         </a>
         <a
           href="#enter-agent"
-          className="inline-flex items-center px-4 py-2.5 rounded-lg border border-border-light text-text text-sm font-medium hover:bg-bg-hover hover:border-text-dim transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+          className="inline-flex items-center px-4 py-2 rounded-lg border border-border-light text-text text-sm font-medium hover:bg-bg-hover hover:border-text-dim transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
         >
           Enter Your Agent
         </a>
@@ -194,15 +198,15 @@ function EnterYourAgent() {
 }
 
 function buildItemList(
-  rows: { rank: number; handle: string; display_name: string }[],
+  rows: { handle: string; display_name: string }[],
 ) {
   return {
     "@context": "https://schema.org",
     "@type": "ItemList",
     name: "AlphaMolt leaderboard — top agents by 30-day return",
-    itemListElement: rows.map((r) => ({
+    itemListElement: rows.map((r, i) => ({
       "@type": "ListItem",
-      position: r.rank,
+      position: i + 1,
       name: r.display_name,
       url: absoluteUrl(`/u/${r.handle}`),
     })),

--- a/web/components/home-leaderboard.tsx
+++ b/web/components/home-leaderboard.tsx
@@ -2,54 +2,129 @@
 
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { useMemo, useState } from "react";
 import type { KeyboardEvent, MouseEvent } from "react";
-import type { HomeLeaderboardRow } from "@/lib/home-leaderboard-query";
-import { formatRelativeTrade } from "@/lib/home-leaderboard-query";
+import {
+  DEFAULT_PERIOD,
+  PERIODS,
+  formatRelativeTrade,
+  type HomeAgentRow,
+  type Period,
+} from "@/lib/home-leaderboard-query";
 
 interface Props {
-  rows: HomeLeaderboardRow[];
-  totalAgents: number;
+  agents: HomeAgentRow[];
   error?: boolean;
+  topN?: number;
 }
 
-export default function HomeLeaderboard({ rows, totalAgents, error }: Props) {
+const PERIOD_LABELS: Record<Period, string> = {
+  "1d": "1D",
+  "30d": "30D",
+  ytd: "YTD",
+  "1yr": "1Y",
+};
+
+export default function HomeLeaderboard({
+  agents,
+  error,
+  topN = 7,
+}: Props) {
+  const [period, setPeriod] = useState<Period>(DEFAULT_PERIOD);
+
+  const sortedAgents = useMemo(
+    () => sortByReturn(agents, period).slice(0, topN),
+    [agents, period, topN],
+  );
+
+  const totalAgents = agents.length;
+
   return (
-    <section id="leaderboard" className="scroll-mt-20">
-      <header className="flex items-end justify-between gap-4 mb-3 flex-wrap">
-        <h2 className="text-2xl sm:text-3xl font-medium tracking-tight text-text">
-          Live leaderboard
-        </h2>
-        <p className="text-sm text-text-dim">
-          Marked to market daily · {totalAgents}{" "}
-          {totalAgents === 1 ? "agent" : "agents"} competing ·{" "}
-          <span className="text-text-muted">rolling 30d return</span>
-        </p>
+    <section id="leaderboard" className="scroll-mt-16">
+      <header className="flex items-start justify-between gap-4 mb-3 flex-wrap">
+        <div>
+          <h2 className="text-2xl sm:text-[28px] font-medium tracking-tight text-text leading-tight">
+            Live leaderboard
+          </h2>
+          <p className="mt-1 text-sm text-text-dim">
+            Marked to market daily · {totalAgents}{" "}
+            {totalAgents === 1 ? "agent" : "agents"} competing ·{" "}
+            <span className="text-text-muted">
+              click any row to see the agent&rsquo;s portfolio
+            </span>
+          </p>
+        </div>
+        <PeriodTabs period={period} onChange={setPeriod} />
       </header>
-      <p className="text-sm text-text-dim mb-5 max-w-2xl">
-        Click any agent to see their portfolio, every trade they&rsquo;ve made,
-        and what they&rsquo;re holding now.
-      </p>
 
       <div className="rounded-xl border border-border overflow-hidden bg-bg-card/60">
-        {error || rows.length === 0 ? (
-          <EmptyState error={error} />
+        {error ? (
+          <EmptyState error />
+        ) : sortedAgents.length === 0 ? (
+          <EmptyState />
         ) : (
-          <Table rows={rows} />
+          <Table agents={sortedAgents} period={period} />
         )}
-        <FooterRow totalAgents={totalAgents} />
+        <FooterRow totalAgents={totalAgents} period={period} />
       </div>
     </section>
   );
 }
 
-function Table({ rows }: { rows: HomeLeaderboardRow[] }) {
+function PeriodTabs({
+  period,
+  onChange,
+}: {
+  period: Period;
+  onChange: (p: Period) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Return period"
+      className="inline-flex rounded-lg border border-border overflow-hidden text-sm"
+    >
+      {PERIODS.map((p, i) => {
+        const active = p === period;
+        return (
+          <button
+            key={p}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(p)}
+            className={`px-3 sm:px-3.5 py-1.5 transition-colors ${
+              i > 0 ? "border-l border-border" : ""
+            } ${
+              active
+                ? "bg-text text-bg"
+                : "text-text-dim hover:text-text hover:bg-bg-hover"
+            } focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 focus-visible:ring-inset`}
+          >
+            {PERIOD_LABELS[p]}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function Table({
+  agents,
+  period,
+}: {
+  agents: HomeAgentRow[];
+  period: Period;
+}) {
   return (
     <table className="w-full border-collapse">
       <thead>
         <tr className="text-[11px] uppercase tracking-wider text-text-muted font-medium">
           <th className="text-left py-3 pl-4 pr-2 w-10 font-medium">#</th>
           <th className="text-left py-3 px-2 font-medium">Agent</th>
-          <th className="text-right py-3 px-2 w-28 font-medium">Return</th>
+          <th className="text-right py-3 px-2 w-28 font-medium">
+            {PERIOD_LABELS[period]}
+          </th>
           <th className="hidden sm:table-cell text-left py-3 px-2 w-44 font-medium">
             Last trade
           </th>
@@ -57,15 +132,23 @@ function Table({ rows }: { rows: HomeLeaderboardRow[] }) {
         </tr>
       </thead>
       <tbody>
-        {rows.map((row) => (
-          <Row key={row.handle} row={row} />
+        {agents.map((row, i) => (
+          <AgentRowUI key={row.handle} row={row} rank={i + 1} period={period} />
         ))}
       </tbody>
     </table>
   );
 }
 
-function Row({ row }: { row: HomeLeaderboardRow }) {
+function AgentRowUI({
+  row,
+  rank,
+  period,
+}: {
+  row: HomeAgentRow;
+  rank: number;
+  period: Period;
+}) {
   const router = useRouter();
   const href = `/u/${row.handle}`;
 
@@ -74,8 +157,6 @@ function Row({ row }: { row: HomeLeaderboardRow }) {
   }
 
   function onRowClick(e: MouseEvent<HTMLTableRowElement>) {
-    // Middle-click / ctrl-click / cmd-click = open in new tab (browser default
-    // on the inner <a> handles this). For a bare row click, route normally.
     if (e.defaultPrevented) return;
     navigate();
   }
@@ -87,7 +168,8 @@ function Row({ row }: { row: HomeLeaderboardRow }) {
     }
   }
 
-  const ariaLabel = buildRowAriaLabel(row);
+  const ret = row.returns[period];
+  const ariaLabel = buildRowAriaLabel(row, rank, period);
 
   return (
     <tr
@@ -98,7 +180,7 @@ function Row({ row }: { row: HomeLeaderboardRow }) {
       aria-label={ariaLabel}
     >
       <td className="py-3 pl-4 pr-2 text-sm text-text-muted tabular-nums">
-        {row.rank}
+        {rank}
       </td>
       <td className="py-3 px-2">
         <Link
@@ -113,10 +195,10 @@ function Row({ row }: { row: HomeLeaderboardRow }) {
         </span>
       </td>
       <td className="py-3 px-2 text-right tabular-nums">
-        <ReturnCell value={row.pnl_pct_30d} />
+        <ReturnCell value={ret} />
       </td>
       <td className="hidden sm:table-cell py-3 px-2">
-        <LastTradeCell row={row} />
+        <LastTradeCell trade={row.last_trade} />
       </td>
       <td className="py-3 pr-4 pl-2 text-right">
         <span
@@ -135,9 +217,11 @@ function ReturnCell({ value }: { value: number | null }) {
     return <span className="text-text-muted text-sm">&mdash;</span>;
   }
   const positive = value >= 0;
-  const sign = positive ? "+" : "−"; // unicode minus for alignment
+  const sign = positive ? "+" : "−";
   const magnitude = Math.abs(value).toFixed(1);
-  const color = positive ? "text-[var(--color-green)]" : "text-[var(--color-red)]";
+  const color = positive
+    ? "text-[var(--color-green)]"
+    : "text-[var(--color-red)]";
   return (
     <span className={`text-sm font-medium ${color}`}>
       {sign}
@@ -146,21 +230,20 @@ function ReturnCell({ value }: { value: number | null }) {
   );
 }
 
-function LastTradeCell({ row }: { row: HomeLeaderboardRow }) {
-  if (!row.last_trade) {
+function LastTradeCell({ trade }: { trade: HomeAgentRow["last_trade"] }) {
+  if (!trade) {
     return <span className="text-sm text-text-muted">&mdash;</span>;
   }
-  const { side, ticker, executed_at } = row.last_trade;
-  const rel = formatRelativeTrade(executed_at);
+  const rel = formatRelativeTrade(trade.executed_at);
   return (
     <span className="text-sm text-text-dim">
-      {side}{" "}
+      {trade.side}{" "}
       <Link
-        href={`/stock/${encodeURIComponent(ticker)}`}
+        href={`/stock/${encodeURIComponent(trade.ticker)}`}
         onClick={(e) => e.stopPropagation()}
         className="text-text font-medium hover:underline decoration-1 underline-offset-[3px]"
       >
-        {ticker}
+        {trade.ticker}
       </Link>
       {rel ? (
         <>
@@ -178,16 +261,22 @@ function EmptyState({ error }: { error?: boolean }) {
       <p className="text-sm text-text-dim">
         {error
           ? "Leaderboard temporarily unavailable."
-          : "No agents have completed a 30-day window yet."}
+          : "No agents have been ranked yet."}
       </p>
     </div>
   );
 }
 
-function FooterRow({ totalAgents }: { totalAgents: number }) {
+function FooterRow({
+  totalAgents,
+  period,
+}: {
+  totalAgents: number;
+  period: Period;
+}) {
   return (
     <Link
-      href="/leaderboard"
+      href={`/leaderboard?period=${period}`}
       className="block border-t border-border bg-bg-hover/40 hover:bg-bg-hover text-center py-3 text-sm text-text-dim hover:text-text transition-colors"
     >
       See all {totalAgents > 0 ? totalAgents : ""} agents&nbsp;&rarr;
@@ -195,17 +284,33 @@ function FooterRow({ totalAgents }: { totalAgents: number }) {
   );
 }
 
-function buildRowAriaLabel(row: HomeLeaderboardRow): string {
+function sortByReturn(rows: HomeAgentRow[], period: Period): HomeAgentRow[] {
+  return [...rows].sort((a, b) => {
+    const av = a.returns[period];
+    const bv = b.returns[period];
+    // Nulls sorted to the bottom so agents with insufficient history don't
+    // mask real leaders on short windows.
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    return bv - av;
+  });
+}
+
+function buildRowAriaLabel(
+  row: HomeAgentRow,
+  rank: number,
+  period: Period,
+): string {
+  const v = row.returns[period];
   const ret =
-    row.pnl_pct_30d == null
+    v == null
       ? "no return data"
-      : `${row.pnl_pct_30d >= 0 ? "plus" : "minus"} ${Math.abs(
-          row.pnl_pct_30d,
-        ).toFixed(1)} percent return`;
+      : `${v >= 0 ? "plus" : "minus"} ${Math.abs(v).toFixed(1)} percent ${PERIOD_LABELS[period]} return`;
   const trade = row.last_trade
     ? `last trade ${row.last_trade.side} ${row.last_trade.ticker} ${formatRelativeTrade(
         row.last_trade.executed_at,
       )} ago`
     : "no trades yet";
-  return `${row.display_name}, rank ${row.rank}, ${ret}, ${trade}. Opens agent page.`;
+  return `${row.display_name}, rank ${rank}, ${ret}, ${trade}. Opens agent page.`;
 }

--- a/web/lib/home-leaderboard-query.ts
+++ b/web/lib/home-leaderboard-query.ts
@@ -1,16 +1,28 @@
-// Server-side fetch for the homepage leaderboard preview. Returns the top N
-// non-house agents sorted by 30-day rolling return, enriched with each
-// agent's most recent trade (action · ticker · relative time). Mirrors the
-// view-backed fetch pattern in /leaderboard/page.tsx so SSR HTML includes
-// the full row set (crawlers see the link graph with JS off).
+// Server-side fetch for the homepage leaderboard preview. Returns every
+// non-house agent enriched with all four rolling returns and each agent's
+// most recent trade, plus the two benchmark rows (SPY, URTH). The client
+// component re-sorts and slices by the active period so the SSR HTML
+// includes every agent/benchmark already populated — crawlers see the full
+// link graph with JS off.
 
 import { getSupabase } from "@/lib/supabase";
 
-export interface HomeLeaderboardRow {
-  rank: number;
+export type Period = "1d" | "30d" | "ytd" | "1yr";
+export const PERIODS: readonly Period[] = ["1d", "30d", "ytd", "1yr"];
+export const DEFAULT_PERIOD: Period = "30d";
+
+export interface Returns {
+  "1d": number | null;
+  "30d": number | null;
+  ytd: number | null;
+  "1yr": number | null;
+}
+
+export interface HomeAgentRow {
+  kind: "agent";
   handle: string;
   display_name: string;
-  pnl_pct_30d: number | null;
+  returns: Returns;
   last_trade: LastTrade | null;
 }
 
@@ -21,93 +33,98 @@ export interface LastTrade {
 }
 
 export interface HomeLeaderboardResult {
-  rows: HomeLeaderboardRow[];
-  // Total count of non-house agents on the leaderboard view — used for the
-  // "N agents competing" metadata strip and the footer "See all N agents"
-  // link. Separate from rows.length because we only surface the top N.
-  total_agents: number;
+  agents: HomeAgentRow[];
 }
 
-export async function getHomeLeaderboard(
-  limit = 7,
-): Promise<HomeLeaderboardResult> {
+export async function getHomeLeaderboard(): Promise<HomeLeaderboardResult> {
   const supabase = getSupabase();
 
+  // Agents: every non-house row on the leaderboard view. All four returns
+  // are columns on the view already; pulling them all lets the client
+  // re-rank by period without another fetch.
   interface ViewRow {
     handle: string;
     display_name: string;
     is_house_agent: boolean;
+    pnl_pct_1d: number | string | null;
     pnl_pct_30d: number | string | null;
+    pnl_pct_ytd: number | string | null;
+    pnl_pct_1yr: number | string | null;
   }
-  const { data: viewRows, error } = await supabase
+  const { data: viewRows, error: viewErr } = await supabase
     .from("agent_leaderboard")
-    .select("handle, display_name, is_house_agent, pnl_pct_30d")
-    .eq("is_house_agent", false)
-    .order("pnl_pct_30d", { ascending: false, nullsFirst: false });
-  if (error || !viewRows) {
-    if (error) console.error("home leaderboard: view fetch failed:", error);
-    return { rows: [], total_agents: 0 };
+    .select(
+      "handle, display_name, is_house_agent, pnl_pct_1d, pnl_pct_30d, pnl_pct_ytd, pnl_pct_1yr",
+    )
+    .eq("is_house_agent", false);
+  if (viewErr) {
+    console.error("home leaderboard: agents view fetch failed:", viewErr);
   }
+  const rawAgents = (viewRows ?? []) as ViewRow[];
 
-  const nonHouse = viewRows as ViewRow[];
-  const top = nonHouse.slice(0, limit);
+  const handles = rawAgents.map((r) => r.handle);
+  const lastTradeByHandle = await fetchLastTrades(handles);
 
-  // Resolve handle → agent_id so we can look up each agent's latest trade.
-  const handles = top.map((r) => r.handle);
-  if (handles.length === 0) {
-    return { rows: [], total_agents: nonHouse.length };
-  }
+  const agents: HomeAgentRow[] = rawAgents.map((r) => ({
+    kind: "agent",
+    handle: r.handle,
+    display_name: r.display_name,
+    returns: {
+      "1d": toNum(r.pnl_pct_1d),
+      "30d": toNum(r.pnl_pct_30d),
+      ytd: toNum(r.pnl_pct_ytd),
+      "1yr": toNum(r.pnl_pct_1yr),
+    },
+    last_trade: lastTradeByHandle.get(r.handle) ?? null,
+  }));
 
+  return { agents };
+}
+
+async function fetchLastTrades(
+  handles: string[],
+): Promise<Map<string, LastTrade>> {
+  const out = new Map<string, LastTrade>();
+  if (handles.length === 0) return out;
+
+  const supabase = getSupabase();
   const { data: idRows } = await supabase
     .from("agents")
     .select("id, handle")
     .in("handle", handles);
-  const idByHandle = new Map<string, string>();
   const handleById = new Map<string, string>();
+  const agentIds: string[] = [];
   for (const r of (idRows ?? []) as { id: string; handle: string }[]) {
-    idByHandle.set(r.handle, r.id);
     handleById.set(r.id, r.handle);
+    agentIds.push(r.id);
   }
+  if (agentIds.length === 0) return out;
 
-  // Pull the most recent trade per agent in the top set. Cheap to do as a
-  // single range query sorted by executed_at DESC — we only keep the first
-  // hit per agent. Works because the top set is small (≤ 7) so the result
-  // size is bounded.
-  const lastTradeByHandle = new Map<string, LastTrade>();
-  const agentIds = Array.from(idByHandle.values());
-  if (agentIds.length > 0) {
-    const { data: tradeRows } = await supabase
-      .from("agent_trades")
-      .select("agent_id, side, ticker, executed_at")
-      .in("agent_id", agentIds)
-      .order("executed_at", { ascending: false })
-      .limit(agentIds.length * 40);
-    for (const t of (tradeRows ?? []) as {
-      agent_id: string;
-      side: "buy" | "sell";
-      ticker: string;
-      executed_at: string;
-    }[]) {
-      const handle = handleById.get(t.agent_id);
-      if (!handle) continue;
-      if (lastTradeByHandle.has(handle)) continue;
-      lastTradeByHandle.set(handle, {
-        side: t.side,
-        ticker: t.ticker,
-        executed_at: t.executed_at,
-      });
-    }
+  // One range query: agents are few (tens), and we only keep the first
+  // (most recent) trade per agent. The LIMIT is a safety cap — the loop
+  // short-circuits as soon as every agent has a trade recorded.
+  const { data: tradeRows } = await supabase
+    .from("agent_trades")
+    .select("agent_id, side, ticker, executed_at")
+    .in("agent_id", agentIds)
+    .order("executed_at", { ascending: false })
+    .limit(Math.max(agentIds.length * 30, 500));
+  for (const t of (tradeRows ?? []) as {
+    agent_id: string;
+    side: "buy" | "sell";
+    ticker: string;
+    executed_at: string;
+  }[]) {
+    const handle = handleById.get(t.agent_id);
+    if (!handle || out.has(handle)) continue;
+    out.set(handle, {
+      side: t.side,
+      ticker: t.ticker,
+      executed_at: t.executed_at,
+    });
+    if (out.size === handleById.size) break;
   }
-
-  const rows: HomeLeaderboardRow[] = top.map((r, i) => ({
-    rank: i + 1,
-    handle: r.handle,
-    display_name: r.display_name,
-    pnl_pct_30d: toNum(r.pnl_pct_30d),
-    last_trade: lastTradeByHandle.get(r.handle) ?? null,
-  }));
-
-  return { rows, total_agents: nonHouse.length };
+  return out;
 }
 
 function toNum(v: number | string | null | undefined): number | null {


### PR DESCRIPTION
Round 2 of review feedback:
- Hero padding shrunk (pt-6 → pt-8 sm) so the leaderboard sits closer to the top. H1 max 36px on lg; gap between hero and table collapsed from my-10/14 to mt-2/4.
- New subhead opens with "They all sound confident. Nobody knows who's actually right — because nobody's keeping score." keeping the rest of the positioning intact.
- Header above the table is re-laid out: H2 and metadata stack on the left, period tabs (1D / 30D / YTD / 1Y) on the right. Replaces the previous awkward justify-between that wrapped on narrow widths.
- Tabs re-sort and re-label the return column client-side; the view already exposes pnl_pct_1d/30d/ytd/1yr so no extra fetch.
- Benchmarks intentionally excluded from the homepage preview — they remain on /leaderboard only.