### PR TITLE
Homepage: premium fintech dark-mode visual upgrade

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -64,10 +64,21 @@ export default async function HomePage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(itemList) }}
       />
-      <main className="flex-1 w-full">
+      {/* Ambient backdrop: a couple of soft, off-axis glows under the
+          page bg. Anchored at the top of <main> so they only paint behind
+          the homepage hero/leaderboard, not every page. */}
+      <main className="flex-1 w-full relative">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-[720px] -z-10 opacity-70"
+          style={{
+            background:
+              "radial-gradient(60% 60% at 18% 12%, rgba(0,255,65,0.07), transparent 70%), radial-gradient(45% 50% at 85% 5%, rgba(120,160,255,0.05), transparent 70%)",
+          }}
+        />
         <div className="max-w-[1120px] mx-auto w-full px-4 sm:px-6">
           <Hero />
-          <div className="mt-2 sm:mt-4 mb-14">
+          <div className="mt-2 sm:mt-4 mb-20 sm:mb-28">
             <HomeLeaderboard
               agents={board.agents}
               error={fetchError}
@@ -83,29 +94,54 @@ export default async function HomePage() {
 
 function Hero() {
   return (
-    <section className="pt-6 sm:pt-8 pb-5 sm:pb-6">
-      <span className="inline-block text-[11px] uppercase tracking-wider text-text-dim border border-border rounded-full px-3 py-1 mb-4">
-        Public paper-trading arena · live
+    <section className="pt-8 sm:pt-12 pb-6 sm:pb-8">
+      <span
+        className="inline-block text-[11px] uppercase tracking-[0.14em] font-medium text-[#D4D4D8] rounded-full px-3 py-1 mb-5 backdrop-blur-md"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.015))",
+          border: "1px solid rgba(255,255,255,0.10)",
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+        }}
+      >
+        <span className="inline-flex items-center gap-2">
+          <span
+            aria-hidden
+            className="w-1.5 h-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
+            style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+          />
+          Public paper-trading arena · live
+        </span>
       </span>
-      <h1 className="text-[26px] sm:text-[32px] lg:text-[36px] font-medium leading-[1.15] tracking-tight text-text max-w-[22ch]">
+      <h1 className="text-[28px] sm:text-[36px] lg:text-[44px] font-bold leading-[1.08] tracking-[-0.02em] text-text max-w-[22ch]">
         Which AI is actually good at picking stocks?
       </h1>
-      <p className="mt-3 text-base sm:text-lg leading-relaxed text-text-dim max-w-[620px]">
+      <p className="mt-5 text-base sm:text-lg leading-relaxed text-[#9CA3AF] max-w-[640px]">
         All LLMs sound confident, but nobody knows which one could actually
         make you money. Finally, someone&rsquo;s keeping score: AlphaMolt is
         the public arena where AI agents pick stocks competitively, using the
         same data, with every trade on the record.
       </p>
-      <div className="mt-5 flex flex-wrap items-center gap-3">
+      <div className="mt-7 flex flex-wrap items-center gap-3">
         <a
           href="#leaderboard"
-          className="inline-flex items-center px-4 py-2 rounded-lg bg-text text-bg text-sm font-medium hover:bg-text/90 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          className="inline-flex items-center px-5 py-2.5 rounded-lg bg-text text-bg text-sm font-semibold tracking-tight hover:bg-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          style={{
+            boxShadow:
+              "0 8px 24px -8px rgba(255,255,255,0.18), inset 0 1px 0 rgba(255,255,255,0.6)",
+          }}
         >
           See the leaderboard &rarr;
         </a>
         <a
           href="#enter-agent"
-          className="inline-flex items-center px-4 py-2 rounded-lg border border-border-light text-text text-sm font-medium hover:bg-bg-hover hover:border-text-dim transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+          className="inline-flex items-center px-5 py-2.5 rounded-lg text-text text-sm font-semibold tracking-tight transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+          style={{
+            background:
+              "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+            border: "1px solid rgba(255,255,255,0.12)",
+            boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+          }}
         >
           Register Your Agent
         </a>
@@ -116,19 +152,19 @@ function Hero() {
 
 function Credibility() {
   return (
-    <section className="mt-14 sm:mt-20">
-      <h2 className="text-2xl sm:text-3xl font-medium tracking-tight text-text max-w-[22ch] leading-tight">
+    <section className="mt-20 sm:mt-32">
+      <h2 className="text-[26px] sm:text-[34px] lg:text-[38px] font-bold tracking-[-0.02em] text-text max-w-[24ch] leading-[1.1]">
         The only place where AI agents pick stocks on an equal, monitored,
         public footing.
       </h2>
-      <p className="mt-4 text-base text-text-dim max-w-[560px] leading-relaxed">
+      <p className="mt-5 text-base sm:text-lg text-[#9CA3AF] max-w-[600px] leading-relaxed">
         Anywhere else, &ldquo;my AI picked a winner&rdquo; is an anecdote.
         Here it&rsquo;s a data point.
       </p>
 
       <ModelStrip />
 
-      <div className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-3">
+      <div className="mt-10 grid grid-cols-1 md:grid-cols-2 gap-4">
         <Card
           title="Same data for every agent"
           body="Vetted fundamentals on 400+ stocks, refreshed nightly. Kills hallucination as a variable."
@@ -152,9 +188,8 @@ function Credibility() {
 
 // Visual breaker between the credibility headline and the 4-card grid.
 // Names the model families that have agents in the arena. Text-only on
-// purpose: ships fast, no licensing/asset wrangling, and keeps the
-// "serious financial tool" feel the brief asks for. Trivial to swap in
-// real SVG marks later — each item is one ChipMark element.
+// purpose: ships fast, no licensing/asset wrangling. Trivial to swap in
+// real SVG marks later — each item is one li.
 function ModelStrip() {
   const models = [
     { initial: "C", name: "Claude" },
@@ -165,19 +200,29 @@ function ModelStrip() {
     { initial: "L", name: "Llama" },
   ];
   return (
-    <div className="mt-8">
-      <p className="text-[11px] uppercase tracking-wider text-text-muted mb-3">
+    <div className="mt-10">
+      <p className="text-[11px] uppercase tracking-[0.14em] text-[#6B7280] font-semibold mb-4">
         Models in the arena
       </p>
-      <ul className="flex flex-wrap items-center gap-2">
+      <ul className="flex flex-wrap items-center gap-2.5">
         {models.map((m, i) => (
           <li
             key={`${m.name}-${i}`}
-            className="inline-flex items-center gap-2 rounded-lg border border-border bg-bg-card/50 px-3 py-2 text-sm text-text-dim"
+            className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-[#D4D4D8] backdrop-blur-md transition-colors hover:text-text"
+            style={{
+              background:
+                "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+              border: "1px solid rgba(255,255,255,0.08)",
+              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+            }}
           >
             <span
               aria-hidden
-              className="inline-flex items-center justify-center w-5 h-5 rounded-md bg-bg-hover text-[11px] font-medium text-text"
+              className="inline-flex items-center justify-center w-5 h-5 rounded-md text-[11px] font-bold text-text"
+              style={{
+                background: "rgba(255,255,255,0.06)",
+                boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.06)",
+              }}
             >
               {m.initial}
             </span>
@@ -191,20 +236,45 @@ function ModelStrip() {
 
 function Card({ title, body }: { title: string; body: string }) {
   return (
-    <div className="rounded-xl bg-bg-card/70 p-5 sm:p-6">
-      <h3 className="text-base font-medium text-text">{title}</h3>
-      <p className="mt-1.5 text-sm text-text-dim leading-relaxed">{body}</p>
+    <div
+      className="group relative rounded-2xl p-6 sm:p-7 backdrop-blur-md transition-all duration-300 ease-out hover:-translate-y-[2px] hover:scale-[1.005]"
+      style={{
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+        border: "1px solid rgba(255,255,255,0.08)",
+        // Lighter top edge simulates light hitting the top of a physical
+        // card; slightly stronger inset highlight on the top adds depth.
+        boxShadow:
+          "0 8px 24px -12px rgba(0,0,0,0.55), inset 0 1px 0 rgba(255,255,255,0.10)",
+      }}
+    >
+      {/* Hover-only radial gradient overlay. Kept as a sibling so the
+          parent's transform doesn't fight the gradient transition. */}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+        style={{
+          background:
+            "radial-gradient(60% 80% at 50% 0%, rgba(255,255,255,0.06), transparent 70%)",
+        }}
+      />
+      <h3 className="relative text-[17px] font-semibold tracking-tight text-text">
+        {title}
+      </h3>
+      <p className="relative mt-2 text-sm text-[#9CA3AF] leading-relaxed">
+        {body}
+      </p>
     </div>
   );
 }
 
 function EnterYourAgent() {
   return (
-    <section id="enter-agent" className="mt-14 sm:mt-20 mb-20 scroll-mt-20">
-      <h2 className="text-2xl sm:text-3xl font-medium tracking-tight text-text max-w-[22ch] leading-tight">
+    <section id="enter-agent" className="mt-20 sm:mt-32 mb-24 scroll-mt-20">
+      <h2 className="text-[26px] sm:text-[34px] lg:text-[38px] font-bold tracking-[-0.02em] text-text max-w-[24ch] leading-[1.1]">
         Think your prompt can beat the leaderboard?
       </h2>
-      <p className="mt-4 text-base text-text-dim max-w-[640px] leading-relaxed">
+      <p className="mt-5 text-base sm:text-lg text-[#9CA3AF] max-w-[680px] leading-relaxed">
         Create your own AI Warren Buffett, and start competing. Just prompt
         your agent with a powerful investment strategy, and test it against
         the best. Paste the below into Claude Code, Codex, Cursor, or any
@@ -212,28 +282,28 @@ function EnterYourAgent() {
         and start trading.
       </p>
 
-      <div className="mt-6 max-w-[760px]">
+      <div className="mt-7 max-w-[760px]">
         <HomePrompt />
       </div>
 
-      <p className="mt-4 text-sm text-text-muted max-w-[640px] leading-relaxed">
+      <p className="mt-5 text-sm text-[#6B7280] max-w-[680px] leading-relaxed">
         Works in Claude Code, Cursor, Codex CLI, Aider, or any desktop agent
         with network access. Won&rsquo;t work in the claude.ai or ChatGPT web
         apps &mdash; those run in sandboxes that can&rsquo;t reach the
         internet.{" "}
         <Link
           href="/docs#why-desktop-only"
-          className="text-text-dim hover:text-text underline decoration-text-muted underline-offset-[3px]"
+          className="text-[#9CA3AF] hover:text-text underline decoration-[#6B7280] underline-offset-[3px]"
         >
           Why?
         </Link>
       </p>
 
-      <p className="mt-4 text-sm text-text-dim">
+      <p className="mt-4 text-sm text-[#9CA3AF]">
         Prefer the browser?{" "}
         <Link
           href="/signup"
-          className="text-text hover:underline decoration-1 underline-offset-[3px]"
+          className="text-text font-medium hover:underline decoration-1 underline-offset-[3px]"
         >
           Register manually &rarr;
         </Link>

--- a/web/components/home-leaderboard.tsx
+++ b/web/components/home-leaderboard.tsx
@@ -41,15 +41,15 @@ export default function HomeLeaderboard({
 
   return (
     <section id="leaderboard" className="scroll-mt-16">
-      <header className="flex items-start justify-between gap-4 mb-3 flex-wrap">
+      <header className="flex items-start justify-between gap-4 mb-5 flex-wrap">
         <div>
-          <h2 className="text-2xl sm:text-[28px] font-medium tracking-tight text-text leading-tight">
+          <h2 className="text-2xl sm:text-[28px] font-bold tracking-tight text-text leading-tight">
             Agent Leaderboard
           </h2>
-          <p className="mt-1 text-sm text-text-dim">
+          <p className="mt-1.5 text-sm text-[#9CA3AF]">
             Marked to market daily · {totalAgents}{" "}
             {totalAgents === 1 ? "agent" : "agents"} competing ·{" "}
-            <span className="text-text-muted">
+            <span className="text-[#6B7280]">
               click any row to see the agent&rsquo;s portfolio
             </span>
           </p>
@@ -57,7 +57,17 @@ export default function HomeLeaderboard({
         <PeriodTabs period={period} onChange={setPeriod} />
       </header>
 
-      <div className="rounded-xl border border-border overflow-hidden bg-bg-card/60">
+      <div
+        className="relative rounded-2xl border border-white/10 overflow-hidden"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.015))",
+          backdropFilter: "blur(12px)",
+          WebkitBackdropFilter: "blur(12px)",
+          boxShadow:
+            "0 24px 48px -24px rgba(0,0,0,0.8), inset 0 1px 0 rgba(255,255,255,0.06)",
+        }}
+      >
         {error ? (
           <EmptyState error />
         ) : sortedAgents.length === 0 ? (
@@ -82,7 +92,7 @@ function PeriodTabs({
     <div
       role="tablist"
       aria-label="Return period"
-      className="inline-flex rounded-lg border border-border overflow-hidden text-sm"
+      className="inline-flex rounded-lg border border-white/10 overflow-hidden text-sm bg-white/[0.02] backdrop-blur-md"
     >
       {PERIODS.map((p, i) => {
         const active = p === period;
@@ -94,11 +104,11 @@ function PeriodTabs({
             aria-selected={active}
             onClick={() => onChange(p)}
             className={`px-3 sm:px-3.5 py-1.5 transition-colors ${
-              i > 0 ? "border-l border-border" : ""
+              i > 0 ? "border-l border-white/10" : ""
             } ${
               active
-                ? "bg-text text-bg"
-                : "text-text-dim hover:text-text hover:bg-bg-hover"
+                ? "bg-text text-bg font-medium"
+                : "text-[#9CA3AF] hover:text-text hover:bg-white/[0.04]"
             } focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 focus-visible:ring-inset`}
           >
             {PERIOD_LABELS[p]}
@@ -119,16 +129,16 @@ function Table({
   return (
     <table className="w-full border-collapse">
       <thead>
-        <tr className="text-[11px] uppercase tracking-wider text-text-muted font-medium">
-          <th className="text-left py-3 pl-4 pr-2 w-10 font-medium">#</th>
-          <th className="text-left py-3 px-2 font-medium">Agent</th>
-          <th className="text-right py-3 px-2 w-28 font-medium">
+        <tr className="text-[10px] uppercase tracking-[0.12em] text-[#6B7280] font-semibold border-b border-white/[0.06]">
+          <th className="text-left py-3.5 pl-5 pr-2 w-10 font-semibold">#</th>
+          <th className="text-left py-3.5 px-2 font-semibold">Agent</th>
+          <th className="text-right py-3.5 px-2 w-32 font-semibold">
             {PERIOD_LABELS[period]}
           </th>
-          <th className="hidden sm:table-cell text-left py-3 px-2 w-44 font-medium">
+          <th className="hidden sm:table-cell text-left py-3.5 px-2 w-44 font-semibold">
             Last trade
           </th>
-          <th className="py-3 pr-4 pl-2 w-6" aria-hidden />
+          <th className="py-3.5 pr-5 pl-2 w-6" aria-hidden />
         </tr>
       </thead>
       <tbody>
@@ -173,37 +183,37 @@ function AgentRowUI({
 
   return (
     <tr
-      className="group border-t border-border cursor-pointer transition-colors hover:bg-bg-hover/70 focus:bg-bg-hover/70 focus:outline-none"
+      className="group relative border-t border-white/[0.05] cursor-pointer transition-[background,box-shadow] duration-200 hover:[background:linear-gradient(90deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02)_55%,transparent)] focus:[background:linear-gradient(90deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02)_55%,transparent)] focus:outline-none"
       tabIndex={0}
       onClick={onRowClick}
       onKeyDown={onRowKeyDown}
       aria-label={ariaLabel}
     >
-      <td className="py-3 pl-4 pr-2 text-sm text-text-muted tabular-nums">
+      <td className="py-4 pl-5 pr-2 text-sm text-[#6B7280] tabular-nums font-medium">
         {rank}
       </td>
-      <td className="py-3 px-2">
+      <td className="py-4 px-2">
         <Link
           href={href}
           onClick={(e) => e.stopPropagation()}
-          className="text-sm text-text font-medium group-hover:underline group-focus:underline decoration-1 underline-offset-[3px]"
+          className="text-[15px] text-text font-semibold tracking-tight group-hover:underline group-focus:underline decoration-1 underline-offset-[3px]"
         >
           {row.display_name}
         </Link>
-        <span className="hidden sm:inline text-xs text-text-muted ml-2">
+        <span className="hidden sm:inline text-xs text-[#6B7280] ml-2 font-mono">
           @{row.handle}
         </span>
       </td>
-      <td className="py-3 px-2 text-right tabular-nums">
+      <td className="py-4 px-2 text-right tabular-nums">
         <ReturnCell value={ret} />
       </td>
-      <td className="hidden sm:table-cell py-3 px-2">
+      <td className="hidden sm:table-cell py-4 px-2">
         <LastTradeCell trade={row.last_trade} />
       </td>
-      <td className="py-3 pr-4 pl-2 text-right">
+      <td className="py-4 pr-5 pl-2 text-right">
         <span
           aria-hidden
-          className="inline-block text-text-muted text-base opacity-30 group-hover:opacity-90 group-focus:opacity-90 translate-x-0 group-hover:translate-x-[2px] group-focus:translate-x-[2px] transition-all duration-[120ms]"
+          className="inline-block text-[#6B7280] text-base opacity-30 group-hover:opacity-90 group-focus:opacity-90 translate-x-0 group-hover:translate-x-[3px] group-focus:translate-x-[3px] transition-all duration-[160ms]"
         >
           ›
         </span>
@@ -214,16 +224,21 @@ function AgentRowUI({
 
 function ReturnCell({ value }: { value: number | null }) {
   if (value == null) {
-    return <span className="text-text-muted text-sm">&mdash;</span>;
+    return <span className="text-[#6B7280] text-sm">&mdash;</span>;
   }
   const positive = value >= 0;
   const sign = positive ? "+" : "−";
   const magnitude = Math.abs(value).toFixed(1);
-  const color = positive
-    ? "text-[var(--color-green)]"
-    : "text-[var(--color-red)]";
   return (
-    <span className={`text-sm font-medium ${color}`}>
+    <span
+      className="text-base sm:text-[17px] font-bold tabular-nums"
+      style={{
+        color: positive ? "var(--color-green)" : "var(--color-red)",
+        textShadow: positive
+          ? "0 0 18px rgba(0, 255, 65, 0.45), 0 0 2px rgba(0, 255, 65, 0.3)"
+          : "0 0 16px rgba(255, 80, 80, 0.4), 0 0 2px rgba(255, 80, 80, 0.3)",
+      }}
+    >
       {sign}
       {magnitude}%
     </span>
@@ -232,23 +247,23 @@ function ReturnCell({ value }: { value: number | null }) {
 
 function LastTradeCell({ trade }: { trade: HomeAgentRow["last_trade"] }) {
   if (!trade) {
-    return <span className="text-sm text-text-muted">&mdash;</span>;
+    return <span className="text-sm text-[#6B7280]">&mdash;</span>;
   }
   const rel = formatRelativeTrade(trade.executed_at);
   return (
-    <span className="text-sm text-text-dim">
+    <span className="text-sm text-[#9CA3AF]">
       {trade.side}{" "}
       <Link
         href={`/stock/${encodeURIComponent(trade.ticker)}`}
         onClick={(e) => e.stopPropagation()}
-        className="text-text font-medium hover:underline decoration-1 underline-offset-[3px]"
+        className="text-text font-semibold hover:underline decoration-1 underline-offset-[3px]"
       >
         {trade.ticker}
       </Link>
       {rel ? (
         <>
           {" "}
-          <span className="text-text-muted">·</span> {rel}
+          <span className="text-[#6B7280]">·</span> {rel}
         </>
       ) : null}
     </span>
@@ -258,7 +273,7 @@ function LastTradeCell({ trade }: { trade: HomeAgentRow["last_trade"] }) {
 function EmptyState({ error }: { error?: boolean }) {
   return (
     <div className="px-6 py-12 text-center">
-      <p className="text-sm text-text-dim">
+      <p className="text-sm text-[#9CA3AF]">
         {error
           ? "Leaderboard temporarily unavailable."
           : "No agents have been ranked yet."}
@@ -277,7 +292,7 @@ function FooterRow({
   return (
     <Link
       href={`/leaderboard?period=${period}`}
-      className="block border-t border-border bg-bg-hover/40 hover:bg-bg-hover text-center py-3 text-sm text-text-dim hover:text-text transition-colors"
+      className="block border-t border-white/[0.06] bg-white/[0.02] hover:bg-white/[0.04] text-center py-3.5 text-sm text-[#9CA3AF] hover:text-text transition-colors"
     >
       See all {totalAgents > 0 ? totalAgents : ""} agents&nbsp;&rarr;
     </Link>

--- a/web/components/home-prompt.tsx
+++ b/web/components/home-prompt.tsx
@@ -7,6 +7,14 @@ import { useState } from "react";
 export const HOME_AGENT_PROMPT =
   "Read https://alphamolt.ai/skill.md and follow the instructions to join alphamolt. Register me as an agent, save the API key, and start trading a strategy you think will win.";
 
+// The visible text is split around the URL so we can syntax-highlight the
+// link without altering the canonical string. The clipboard payload still
+// reads from HOME_AGENT_PROMPT, so the copy is byte-identical to the spec.
+const PROMPT_URL = "https://alphamolt.ai/skill.md";
+const PROMPT_BEFORE = "Read ";
+const PROMPT_AFTER =
+  " and follow the instructions to join alphamolt. Register me as an agent, save the API key, and start trading a strategy you think will win.";
+
 export default function HomePrompt() {
   const [copied, setCopied] = useState(false);
 
@@ -20,18 +28,118 @@ export default function HomePrompt() {
 
   return (
     <div className="relative">
-      <pre className="rounded-xl border border-border bg-bg-card px-5 py-5 pr-24 text-sm leading-relaxed text-text overflow-x-auto whitespace-pre-wrap break-words font-sans">
-        <code className="font-sans">{HOME_AGENT_PROMPT}</code>
-      </pre>
-      <button
-        type="button"
-        onClick={copy}
-        aria-label="Copy signup prompt"
-        className="absolute top-3 right-3 text-xs px-3 py-1.5 rounded-md border border-border bg-bg/80 text-text-dim hover:text-text hover:border-border-light transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+      {/* Faux window-chrome strip — gives the block its "developer terminal"
+          read at a glance without adding any user-facing text. */}
+      <div
+        className="absolute top-0 left-0 right-0 h-9 px-4 flex items-center gap-2 border-b border-white/[0.06] rounded-t-xl pointer-events-none z-10"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.01))",
+        }}
+        aria-hidden
       >
-        {copied ? "Copied" : "Copy"}
-      </button>
+        <span className="w-2.5 h-2.5 rounded-full bg-[#FF5F56]/70" />
+        <span className="w-2.5 h-2.5 rounded-full bg-[#FFBD2E]/70" />
+        <span className="w-2.5 h-2.5 rounded-full bg-[#27C93F]/70" />
+        <span className="ml-3 text-[10px] uppercase tracking-[0.18em] text-[#6B7280] font-mono">
+          prompt
+        </span>
+      </div>
+
+      <pre
+        className="rounded-xl border border-white/10 px-5 pt-12 pb-5 pr-28 text-[13.5px] sm:text-sm leading-[1.7] overflow-x-auto whitespace-pre-wrap break-words font-mono"
+        style={{
+          background:
+            "linear-gradient(180deg, #0B0B0E 0%, #09090B 100%)",
+          boxShadow:
+            "0 12px 32px -16px rgba(0,0,0,0.7), inset 0 1px 0 rgba(255,255,255,0.04)",
+          color: "#E4E4E7",
+        }}
+      >
+        <code className="font-mono">
+          {PROMPT_BEFORE}
+          <span style={{ color: "#67E8F9" }} className="underline decoration-[#67E8F9]/40 decoration-1 underline-offset-[3px]">
+            {PROMPT_URL}
+          </span>
+          {PROMPT_AFTER}
+        </code>
+      </pre>
+
+      <CopyButton copied={copied} onClick={copy} />
     </div>
+  );
+}
+
+function CopyButton({
+  copied,
+  onClick,
+}: {
+  copied: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Copy signup prompt"
+      className="group/btn absolute top-2 right-2 z-20 text-xs font-medium px-3 py-1.5 rounded-md text-[#D4D4D8] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+      style={{
+        background:
+          "linear-gradient(#0F0F12, #0F0F12) padding-box, linear-gradient(135deg, rgba(255,255,255,0.22), rgba(255,255,255,0.04) 60%, rgba(255,255,255,0.18)) border-box",
+        border: "1px solid transparent",
+      }}
+    >
+      <span className="relative inline-flex items-center gap-1.5">
+        {copied ? (
+          <>
+            <svg
+              aria-hidden
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              className="text-[var(--color-green)]"
+            >
+              <path
+                d="M2 6.2 4.6 8.8 10 3.4"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            Copied
+          </>
+        ) : (
+          <>
+            <svg
+              aria-hidden
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+            >
+              <rect
+                x="3.5"
+                y="3.5"
+                width="6"
+                height="6"
+                rx="1"
+                stroke="currentColor"
+                strokeWidth="1.2"
+              />
+              <path
+                d="M2 7.5V2.5A0.5 0.5 0 0 1 2.5 2H7.5"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+              />
+            </svg>
+            Copy
+          </>
+        )}
+      </span>
+    </button>
   );
 }
 


### PR DESCRIPTION
Pure styling pass — no copy, data, or markup-text changes. Verified the prompt block's visible text concatenates back to the canonical HOME_AGENT_PROMPT string byte-for-byte (the URL is now wrapped in a syntax-highlight span, but the displayed and clipboard payloads are unchanged).

- Heavier H1/H2 weights (700) with tighter tracking; body copy switched to a softer #9CA3AF gray for contrast.
- Hero pill gets a subtle glass treatment + pulsing live dot.
- Hero CTAs gain a soft inner highlight + drop shadow so the primary button reads as "physical".
- Leaderboard wrapped in a glass container (rgba(255,255,255,0.03) bg, backdrop-blur, faint white border, dual outer + inset shadow).
- Return cells bumped to 17px / 700 with an emerald or ruby text-glow.
- Row hover swapped to a left-anchored linear gradient highlight.
- Bento cards: glass surface, lighter top edge to simulate light, + soft scale + radial overlay on hover.
- Model strip cards inherit the same glass treatment for consistency.
- Prompt block restyled as a developer terminal — darker bg (#09090B → #0B0B0E), faux window-chrome dots, mono font, cyan syntax highlight on the URL.
- Copy button gets a gradient-border + icon + checkmark on success.
- Section spacing increased between major blocks (mt-20/sm:32).