### PR TITLE
Homepage: real visuals — sparklines, brand glyphs, card icons

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -166,18 +166,22 @@ function Credibility() {
 
       <div className="mt-10 grid grid-cols-1 md:grid-cols-2 gap-4">
         <Card
+          icon={<DatabaseIcon />}
           title="Same data for every agent"
           body="Vetted fundamentals on 400+ stocks, refreshed nightly. Kills hallucination as a variable."
         />
         <Card
+          icon={<ScalesIcon />}
           title="Same rules, same starting cash"
           body="$1M virtual account. No margin, no shorting. Apples-to-apples across every strategy."
         />
         <Card
+          icon={<LedgerIcon />}
           title="Every trade is public"
           body="Timestamped and logged the moment it happens. No cherry-picking, no retroactive rewrites."
         />
         <Card
+          icon={<CalendarTickIcon />}
           title="Marked to market daily"
           body="Leaderboard reflects closing prices every day. No favourable windows, no selective reporting."
         />
@@ -187,17 +191,18 @@ function Credibility() {
 }
 
 // Visual breaker between the credibility headline and the 4-card grid.
-// Names the model families that have agents in the arena. Text-only on
-// purpose: ships fast, no licensing/asset wrangling. Trivial to swap in
-// real SVG marks later — each item is one li.
+// Names the model families that have agents in the arena. Each chip
+// pairs a brand-evocative monochrome glyph with the model name — kept
+// abstract enough to avoid trademark issues while still reading as
+// "the LLMs you've heard of are competing here."
 function ModelStrip() {
-  const models = [
-    { initial: "C", name: "Claude" },
-    { initial: "G", name: "GPT" },
-    { initial: "G", name: "Gemini" },
-    { initial: "G", name: "Grok" },
-    { initial: "D", name: "DeepSeek" },
-    { initial: "L", name: "Llama" },
+  const models: { name: string; glyph: React.ReactNode }[] = [
+    { name: "Claude", glyph: <ClaudeGlyph /> },
+    { name: "GPT", glyph: <GptGlyph /> },
+    { name: "Gemini", glyph: <GeminiGlyph /> },
+    { name: "Grok", glyph: <GrokGlyph /> },
+    { name: "DeepSeek", glyph: <DeepSeekGlyph /> },
+    { name: "Llama", glyph: <LlamaGlyph /> },
   ];
   return (
     <div className="mt-10">
@@ -205,10 +210,10 @@ function ModelStrip() {
         Models in the arena
       </p>
       <ul className="flex flex-wrap items-center gap-2.5">
-        {models.map((m, i) => (
+        {models.map((m) => (
           <li
-            key={`${m.name}-${i}`}
-            className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-[#D4D4D8] backdrop-blur-md transition-colors hover:text-text"
+            key={m.name}
+            className="inline-flex items-center gap-2.5 rounded-lg pl-2.5 pr-3 py-2 text-sm text-[#D4D4D8] backdrop-blur-md transition-colors hover:text-text"
             style={{
               background:
                 "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
@@ -218,15 +223,15 @@ function ModelStrip() {
           >
             <span
               aria-hidden
-              className="inline-flex items-center justify-center w-5 h-5 rounded-md text-[11px] font-bold text-text"
+              className="inline-flex items-center justify-center w-6 h-6 rounded-md text-text"
               style={{
                 background: "rgba(255,255,255,0.06)",
                 boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.06)",
               }}
             >
-              {m.initial}
+              {m.glyph}
             </span>
-            <span>{m.name}</span>
+            <span className="font-medium">{m.name}</span>
           </li>
         ))}
       </ul>
@@ -234,7 +239,137 @@ function ModelStrip() {
   );
 }
 
-function Card({ title, body }: { title: string; body: string }) {
+// ----- Brand glyphs --------------------------------------------------------
+// Single-color, ~14px monochrome marks that read as the brand without
+// reproducing the trademark. All inherit currentColor so they pick up the
+// chip's text color.
+
+function ClaudeGlyph() {
+  // Eight-spoke sunburst — evokes the Anthropic mark.
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+    >
+      <line x1="8" y1="1.8" x2="8" y2="5.2" />
+      <line x1="8" y1="10.8" x2="8" y2="14.2" />
+      <line x1="1.8" y1="8" x2="5.2" y2="8" />
+      <line x1="10.8" y1="8" x2="14.2" y2="8" />
+      <line x1="3.6" y1="3.6" x2="5.6" y2="5.6" />
+      <line x1="10.4" y1="10.4" x2="12.4" y2="12.4" />
+      <line x1="3.6" y1="12.4" x2="5.6" y2="10.4" />
+      <line x1="10.4" y1="5.6" x2="12.4" y2="3.6" />
+    </svg>
+  );
+}
+
+function GptGlyph() {
+  // Three intersecting ellipses — knot-of-loops impression.
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.1"
+    >
+      <ellipse cx="8" cy="8" rx="2.5" ry="5.5" />
+      <ellipse
+        cx="8"
+        cy="8"
+        rx="2.5"
+        ry="5.5"
+        transform="rotate(60 8 8)"
+      />
+      <ellipse
+        cx="8"
+        cy="8"
+        rx="2.5"
+        ry="5.5"
+        transform="rotate(120 8 8)"
+      />
+    </svg>
+  );
+}
+
+function GeminiGlyph() {
+  // Four-pointed sparkle — Gemini's "asterisk" mark.
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+      <path d="M8 1.2 C 8.6 5 9 6.4 14.8 8 C 9 9.6 8.6 11 8 14.8 C 7.4 11 7 9.6 1.2 8 C 7 6.4 7.4 5 8 1.2 Z" />
+    </svg>
+  );
+}
+
+function GrokGlyph() {
+  // X — the xAI letterform.
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+    >
+      <line x1="3.4" y1="3.4" x2="12.6" y2="12.6" />
+      <line x1="12.6" y1="3.4" x2="3.4" y2="12.6" />
+    </svg>
+  );
+}
+
+function DeepSeekGlyph() {
+  // Double-chevron — a stylised wave / "depth" mark.
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2.8 5.5 L8 9.2 L13.2 5.5" />
+      <path d="M2.8 9.5 L8 13.2 L13.2 9.5" />
+    </svg>
+  );
+}
+
+function LlamaGlyph() {
+  // Two interlocking rings — infinity / Meta's lemniscate.
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+    >
+      <circle cx="5.6" cy="8" r="2.6" />
+      <circle cx="10.4" cy="8" r="2.6" />
+    </svg>
+  );
+}
+
+function Card({
+  icon,
+  title,
+  body,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}) {
   return (
     <div
       className="group relative rounded-2xl p-6 sm:p-7 backdrop-blur-md transition-all duration-300 ease-out hover:-translate-y-[2px] hover:scale-[1.005]"
@@ -258,6 +393,18 @@ function Card({ title, body }: { title: string; body: string }) {
             "radial-gradient(60% 80% at 50% 0%, rgba(255,255,255,0.06), transparent 70%)",
         }}
       />
+      <span
+        aria-hidden
+        className="relative inline-flex items-center justify-center w-9 h-9 rounded-lg mb-4 text-[var(--color-green)]"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(0,255,65,0.10), rgba(0,255,65,0.02))",
+          boxShadow:
+            "inset 0 0 0 1px rgba(0,255,65,0.18), 0 0 16px -4px rgba(0,255,65,0.18)",
+        }}
+      >
+        {icon}
+      </span>
       <h3 className="relative text-[17px] font-semibold tracking-tight text-text">
         {title}
       </h3>
@@ -265,6 +412,55 @@ function Card({ title, body }: { title: string; body: string }) {
         {body}
       </p>
     </div>
+  );
+}
+
+// ----- Card icons ----------------------------------------------------------
+// Lightweight monochrome SVG glyphs that inherit currentColor.
+
+function DatabaseIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+      <ellipse cx="10" cy="4.5" rx="6.5" ry="2.2" />
+      <path d="M3.5 4.5 V10 C 3.5 11.2 6.4 12.2 10 12.2 C 13.6 12.2 16.5 11.2 16.5 10 V4.5" />
+      <path d="M3.5 10 V15.5 C 3.5 16.7 6.4 17.7 10 17.7 C 13.6 17.7 16.5 16.7 16.5 15.5 V10" />
+    </svg>
+  );
+}
+
+function ScalesIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="10" y1="3.5" x2="10" y2="16.5" />
+      <line x1="6" y1="16.5" x2="14" y2="16.5" />
+      <path d="M3 11 L6 5 L9 11 Z" />
+      <path d="M11 11 L14 5 L17 11 Z" />
+      <path d="M3 11 C 3 12.4 4.3 13.2 6 13.2 C 7.7 13.2 9 12.4 9 11" />
+      <path d="M11 11 C 11 12.4 12.3 13.2 14 13.2 C 15.7 13.2 17 12.4 17 11" />
+    </svg>
+  );
+}
+
+function LedgerIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3.5" y="3" width="13" height="14" rx="1.5" />
+      <line x1="6.5" y1="7" x2="13.5" y2="7" />
+      <line x1="6.5" y1="10" x2="13.5" y2="10" />
+      <line x1="6.5" y1="13" x2="11" y2="13" />
+    </svg>
+  );
+}
+
+function CalendarTickIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="4.5" width="14" height="12" rx="1.5" />
+      <line x1="3" y1="8" x2="17" y2="8" />
+      <line x1="7" y1="3" x2="7" y2="6" />
+      <line x1="13" y1="3" x2="13" y2="6" />
+      <path d="M7.5 12.5 L9.5 14.5 L13 11" />
+    </svg>
   );
 }
 

--- a/web/components/home-leaderboard.tsx
+++ b/web/components/home-leaderboard.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import type { KeyboardEvent, MouseEvent } from "react";
+import Sparkline from "@/components/sparkline";
+import { COLORS } from "@/lib/constants";
 import {
   DEFAULT_PERIOD,
   PERIODS,
@@ -135,6 +137,12 @@ function Table({
           <th className="text-right py-3.5 px-2 w-32 font-semibold">
             {PERIOD_LABELS[period]}
           </th>
+          <th
+            className="hidden md:table-cell py-3.5 px-2 w-32 font-semibold text-left"
+            aria-label="30-day equity curve"
+          >
+            30D
+          </th>
           <th className="hidden sm:table-cell text-left py-3.5 px-2 w-44 font-semibold">
             Last trade
           </th>
@@ -207,6 +215,9 @@ function AgentRowUI({
       <td className="py-4 px-2 text-right tabular-nums">
         <ReturnCell value={ret} />
       </td>
+      <td className="hidden md:table-cell py-4 px-2">
+        <SparklineCell data={row.sparkline} positive={ret == null ? null : ret >= 0} />
+      </td>
       <td className="hidden sm:table-cell py-4 px-2">
         <LastTradeCell trade={row.last_trade} />
       </td>
@@ -242,6 +253,24 @@ function ReturnCell({ value }: { value: number | null }) {
       {sign}
       {magnitude}%
     </span>
+  );
+}
+
+function SparklineCell({
+  data,
+  positive,
+}: {
+  data: { x: number; y: number }[];
+  positive: boolean | null;
+}) {
+  if (data.length < 2) {
+    return <span className="text-xs text-[#6B7280]">&mdash;</span>;
+  }
+  const color = positive === false ? COLORS.red : COLORS.green;
+  return (
+    <div className="w-28 max-w-full">
+      <Sparkline data={data} color={color} />
+    </div>
   );
 }
 

--- a/web/lib/home-leaderboard-query.ts
+++ b/web/lib/home-leaderboard-query.ts
@@ -24,6 +24,9 @@ export interface HomeAgentRow {
   display_name: string;
   returns: Returns;
   last_trade: LastTrade | null;
+  // 30-day equity-curve points used by the inline row sparkline. May be
+  // empty if the agent has fewer than 2 history snapshots.
+  sparkline: { x: number; y: number }[];
 }
 
 export interface LastTrade {
@@ -64,6 +67,7 @@ export async function getHomeLeaderboard(): Promise<HomeLeaderboardResult> {
 
   const handles = rawAgents.map((r) => r.handle);
   const lastTradeByHandle = await fetchLastTrades(handles);
+  const sparklinesByHandle = await fetchSparklines(handles);
 
   const agents: HomeAgentRow[] = rawAgents.map((r) => ({
     kind: "agent",
@@ -76,6 +80,7 @@ export async function getHomeLeaderboard(): Promise<HomeLeaderboardResult> {
       "1yr": toNum(r.pnl_pct_1yr),
     },
     last_trade: lastTradeByHandle.get(r.handle) ?? null,
+    sparkline: sparklinesByHandle.get(r.handle) ?? [],
   }));
 
   return { agents };
@@ -123,6 +128,65 @@ async function fetchLastTrades(
       executed_at: t.executed_at,
     });
     if (out.size === handleById.size) break;
+  }
+  return out;
+}
+
+// Pulls the last ~30 days of total_value_usd snapshots for every agent the
+// homepage might show, in a single bulk query, then groups by handle. The
+// number of snapshots per agent is bounded by date range (≤ 30) so the
+// per-call result size stays small even with many agents.
+async function fetchSparklines(
+  handles: string[],
+): Promise<Map<string, { x: number; y: number }[]>> {
+  const out = new Map<string, { x: number; y: number }[]>();
+  if (handles.length === 0) return out;
+
+  const supabase = getSupabase();
+  const { data: idRows } = await supabase
+    .from("agents")
+    .select("id, handle")
+    .in("handle", handles);
+  const handleById = new Map<string, string>();
+  const agentIds: string[] = [];
+  for (const r of (idRows ?? []) as { id: string; handle: string }[]) {
+    handleById.set(r.id, r.handle);
+    agentIds.push(r.id);
+  }
+  if (agentIds.length === 0) return out;
+
+  const since = new Date();
+  since.setUTCDate(since.getUTCDate() - 30);
+  const sinceIso = since.toISOString().slice(0, 10);
+
+  const { data: rows } = await supabase
+    .from("agent_portfolio_history")
+    .select("agent_id, snapshot_date, total_value_usd")
+    .in("agent_id", agentIds)
+    .gte("snapshot_date", sinceIso)
+    .order("snapshot_date", { ascending: true });
+
+  // Group by handle; emit `{x: dayIndex, y: total_value_usd}` in date order.
+  const grouped = new Map<string, { date: string; y: number }[]>();
+  for (const r of (rows ?? []) as {
+    agent_id: string;
+    snapshot_date: string;
+    total_value_usd: number | string;
+  }[]) {
+    const handle = handleById.get(r.agent_id);
+    if (!handle) continue;
+    let bucket = grouped.get(handle);
+    if (!bucket) {
+      bucket = [];
+      grouped.set(handle, bucket);
+    }
+    bucket.push({ date: r.snapshot_date, y: Number(r.total_value_usd) });
+  }
+  for (const [handle, bucket] of grouped) {
+    out.set(
+      handle,
+      bucket.map((p, i) => ({ x: i, y: p.y })),
+    );
   }
   return out;
 }


### PR DESCRIPTION
Pure styling/asset additions — no copy changes (verified all 12 key strings preserved + prompt visible text matches HOME_AGENT_PROMPT byte-for-byte).

- Leaderboard rows: 30-day equity-curve sparkline column (hidden < md) reusing the existing Sparkline component. Color tracks the active period's return sign so a green curve with a red return cell immediately reads as "trending down". Data fetched in a single bulk query against agent_portfolio_history.
- Model strip: letter initials replaced with brand-evocative monochrome glyphs (sunburst / triple-ellipse / sparkle / X / double-chevron / dual-rings). Abstract enough to avoid trademark issues while still reading as the LLMs you've heard of.
- Credibility cards: each gets a 36px iconified badge (database / scales / ledger / calendar-check) with a faint emerald glow.
- Copy button: clipboard / checkmark icons swap on success.