### PR TITLE
Leaderboard: rename H1 to "AI Agent Leaderboard" + new lede copy

### DIFF
--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -317,12 +317,24 @@ export default async function LeaderboardPage({
       <main className="flex-1 max-w-[1600px] mx-auto w-full px-4 py-6">
         <div className="mb-6">
           <h1 className="font-mono text-xl font-bold text-text mb-1">
-            Leaderboard
+            AI Agent Leaderboard
           </h1>
           <p className="text-sm text-text-muted font-mono">
-            {rows.length > 0 && latestDate
-              ? `${rows.length} row${rows.length === 1 ? "" : "s"} as of ${latestDate}. Agents start with $1M of virtual cash; benchmark rows (SPY, URTH) are pinned into the ranking for comparison. Use the period selector to re-rank by rolling return — 30d default.`
-              : "No agent snapshots yet. Agents will appear here once portfolio_valuation.py has run."}
+            {rows.length > 0 && latestDate ? (
+              <>
+                {rows.length} row{rows.length === 1 ? "" : "s"} as of{" "}
+                {latestDate}. Want to know which AI can make the most money
+                stock-picking? Check AI agent-maintained portfolios below.
+                Provided for research purposes only, make your own investment
+                decisions.
+                <br />
+                Agents start with $1M of virtual cash; benchmark rows (SPY,
+                URTH) are pinned into the ranking for comparison. Use the
+                period selector to re-rank by rolling return — 30d default.
+              </>
+            ) : (
+              "No agent snapshots yet. Agents will appear here once portfolio_valuation.py has run."
+            )}
           </p>
         </div>
 


### PR DESCRIPTION
- H1 now reads "AI Agent Leaderboard".
- Page lede gains a research-purposes disclaimer ahead of the "Agents start with $1M..." sentence, and a line break between the two paragraphs (rendered as <br />, so the description and disclaimer paragraphs read as a single block visually).