### PR TITLE
Bump --color-text-muted from #555 to #6B7280 + update leaderboard lede

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -8,7 +8,7 @@
   --color-border-light: #333333;
   --color-text: #EDEDED;
   --color-text-dim: #888888;
-  --color-text-muted: #555555;
+  --color-text-muted: #6B7280;
   --color-green: #00FF41;
   --color-green-dim: #00CC33;
   --color-orange: #FF9900;

--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -322,15 +322,14 @@ export default async function LeaderboardPage({
           <p className="text-sm text-text-muted font-mono">
             {rows.length > 0 && latestDate ? (
               <>
-                {rows.length} row{rows.length === 1 ? "" : "s"} as of{" "}
-                {latestDate}. Want to know which AI can make the most money
-                stock-picking? Check AI agent-maintained portfolios below.
-                Provided for research purposes only, make your own investment
+                The AI agent-maintained long-only equity portfolios below are
+                provided for research purposes only, make your own investment
                 decisions.
                 <br />
-                Agents start with $1M of virtual cash; benchmark rows (SPY,
-                URTH) are pinned into the ranking for comparison. Use the
-                period selector to re-rank by rolling return — 30d default.
+                All agents start with $1M of virtual cash. &lsquo;Naive&rsquo;
+                maintained portfolios are simply prompted to use alphamolt
+                screener data, and generate gains over a 2 yr horizon. The
+                portfolios are updated weekly, or less frequently.
               </>
             ) : (
               "No agent snapshots yet. Agents will appear here once portfolio_valuation.py has run."

--- a/web/components/ps-chart.tsx
+++ b/web/components/ps-chart.tsx
@@ -31,7 +31,7 @@ export default function PsChart({ data }: { data: PsDataPoint[] }) {
           </defs>
           <XAxis
             dataKey="date"
-            tick={{ fontSize: 10, fill: "#555555", fontFamily: "monospace" }}
+            tick={{ fontSize: 10, fill: "#6B7280", fontFamily: "monospace" }}
             tickLine={false}
             axisLine={{ stroke: "#222222" }}
             tickFormatter={(d: string) => {
@@ -40,7 +40,7 @@ export default function PsChart({ data }: { data: PsDataPoint[] }) {
             }}
           />
           <YAxis
-            tick={{ fontSize: 10, fill: "#555555", fontFamily: "monospace" }}
+            tick={{ fontSize: 10, fill: "#6B7280", fontFamily: "monospace" }}
             tickLine={false}
             axisLine={{ stroke: "#222222" }}
             domain={["auto", "auto"]}

--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -6,7 +6,7 @@ export const COLORS = {
   borderLight: "#333333",
   text: "#EDEDED",
   textDim: "#888888",
-  textMuted: "#555555",
+  textMuted: "#6B7280",
   green: "#00FF41",
   greenDim: "#00CC33",
   orange: "#FF9900",


### PR DESCRIPTION
The previous muted token (#555555) gave a 3.4:1 contrast ratio on the #0A0A0A background — failing WCAG AA for body text. Bumping to #6B7280 (Tailwind gray-500) raises that to ~5.5:1 (passes AA) while still reading as visibly secondary against text-text-dim (#888) and text (#EDEDED).

Touched everywhere the old #555 was hardcoded:
- web/app/globals.css (the CSS custom property)
- web/lib/constants.ts (COLORS.textMuted, used by chart fills)
- web/components/ps-chart.tsx (two literal #555555 axis ticks)

Plus the leaderboard lede copy is replaced with the new version: a research-purposes disclaimer paragraph + a paragraph explaining the $1M starting cash, the 'Naive' strategies, and the weekly cadence.