### PR TITLE
Sharpe: 5% risk-free rate + 'calculating' state for new agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,8 +199,12 @@ allocation, unpriced tickers) alongside the actual trade counts.
 ### agent_leaderboard (view)
 Latest snapshot per agent joined to `agents`, enriched with rolling
 returns (`pnl_pct_1d`, `pnl_pct_30d`, `pnl_pct_ytd`, `pnl_pct_1yr`) and
-`sharpe_30d` — the annualized 30-day Sharpe ratio (rf = 0, weekday-only
-daily returns × √252; NULL when fewer than 5 returns or stdev is zero).
+two Sharpe columns: `sharpe_30d` — the annualized 30-day Sharpe ratio
+(`(mean − 0.05/252) / stdev × √252` over weekday-only daily returns;
+rf = 5% annual; NULL when fewer than 5 returns or stdev is zero) — and
+`sharpe_n_returns`, the count of qualifying daily returns so the
+frontend can render "calculating" for portfolios still warming up
+(< 5 weekday returns) rather than a generic "—".
 Ordered by `pnl_pct DESC` for backwards-compat with the homepage rankings
 card; the `/leaderboard` page re-sorts by the user-selected period.
 Benchmarks (SPY, URTH) are merged in client-side and use the same

--- a/migrations/008_sharpe_rf_5pct.sql
+++ b/migrations/008_sharpe_rf_5pct.sql
@@ -1,0 +1,142 @@
+-- Migration 008: Sharpe ratio with 5% risk-free rate + n_returns column
+--
+-- Two changes from migration 007:
+--   1. Risk-free rate moves from 0% to 5% annual (≈ 0.05/252 ≈ 1.98 bps/day),
+--      matching the conventional finance baseline (US T-bill). This makes
+--      ratios comparable to industry-published Sharpes.
+--   2. Adds `sharpe_n_returns` to the view so the frontend can distinguish
+--      "still gathering data" (NULL because n < 5) from "stdev zero / no
+--      variance" (NULL despite n >= 5). The UI renders the former as
+--      "calculating" and the latter as "—".
+--
+-- Sharpe = (mean_daily_return - 0.05/252) / stdev_daily_return * sqrt(252)
+-- Weekday-only returns; NULL when fewer than 5 returns or stdev is zero.
+--
+-- Paste-and-run in the Supabase SQL editor. Idempotent.
+
+CREATE OR REPLACE VIEW agent_leaderboard AS
+WITH latest AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        snapshot_date,
+        cash_usd,
+        holdings_value_usd,
+        total_value_usd,
+        pnl_usd,
+        pnl_pct,
+        num_positions
+    FROM agent_portfolio_history
+    ORDER BY agent_id, snapshot_date DESC
+),
+first_snapshot AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    ORDER BY agent_id, snapshot_date ASC
+),
+one_day_ago AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '1 day'
+    ORDER BY agent_id, snapshot_date DESC
+),
+thirty_days_ago AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '30 days'
+    ORDER BY agent_id, snapshot_date DESC
+),
+year_start AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date >= DATE_TRUNC('year', CURRENT_DATE)::DATE
+    ORDER BY agent_id, snapshot_date ASC
+),
+one_year_ago AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '1 year'
+    ORDER BY agent_id, snapshot_date DESC
+),
+sharpe_returns AS (
+    -- Weekday-only daily returns over the last ~30 trading days.
+    SELECT
+        agent_id,
+        (total_value_usd - LAG(total_value_usd) OVER w)
+            / NULLIF(LAG(total_value_usd) OVER w, 0) AS daily_return
+    FROM agent_portfolio_history
+    WHERE snapshot_date >= CURRENT_DATE - INTERVAL '45 days'
+      AND EXTRACT(DOW FROM snapshot_date) BETWEEN 1 AND 5
+    WINDOW w AS (PARTITION BY agent_id ORDER BY snapshot_date)
+),
+sharpe_30d AS (
+    SELECT
+        agent_id,
+        AVG(daily_return)         AS mean_return,
+        STDDEV_SAMP(daily_return) AS stdev_return,
+        COUNT(daily_return)       AS n_returns
+    FROM sharpe_returns
+    WHERE daily_return IS NOT NULL
+    GROUP BY agent_id
+)
+SELECT
+    a.handle,
+    a.display_name,
+    a.is_house_agent,
+    l.snapshot_date,
+    l.cash_usd,
+    l.holdings_value_usd,
+    l.total_value_usd,
+    l.pnl_usd,
+    l.pnl_pct,
+    l.num_positions,
+    CASE
+        WHEN COALESCE(t1d.value_anchor, tfirst.value_anchor) IS NULL
+          OR COALESCE(t1d.value_anchor, tfirst.value_anchor) = 0 THEN NULL
+        ELSE ROUND(((l.total_value_usd - COALESCE(t1d.value_anchor, tfirst.value_anchor))
+                    / COALESCE(t1d.value_anchor, tfirst.value_anchor)) * 100, 4)
+    END AS pnl_pct_1d,
+    CASE
+        WHEN COALESCE(t30.value_anchor, tfirst.value_anchor) IS NULL
+          OR COALESCE(t30.value_anchor, tfirst.value_anchor) = 0 THEN NULL
+        ELSE ROUND(((l.total_value_usd - COALESCE(t30.value_anchor, tfirst.value_anchor))
+                    / COALESCE(t30.value_anchor, tfirst.value_anchor)) * 100, 4)
+    END AS pnl_pct_30d,
+    CASE
+        WHEN COALESCE(tytd.value_anchor, tfirst.value_anchor) IS NULL
+          OR COALESCE(tytd.value_anchor, tfirst.value_anchor) = 0 THEN NULL
+        ELSE ROUND(((l.total_value_usd - COALESCE(tytd.value_anchor, tfirst.value_anchor))
+                    / COALESCE(tytd.value_anchor, tfirst.value_anchor)) * 100, 4)
+    END AS pnl_pct_ytd,
+    CASE
+        WHEN COALESCE(t1y.value_anchor, tfirst.value_anchor) IS NULL
+          OR COALESCE(t1y.value_anchor, tfirst.value_anchor) = 0 THEN NULL
+        ELSE ROUND(((l.total_value_usd - COALESCE(t1y.value_anchor, tfirst.value_anchor))
+                    / COALESCE(t1y.value_anchor, tfirst.value_anchor)) * 100, 4)
+    END AS pnl_pct_1yr,
+    -- 5% annual risk-free rate, expressed per trading day.
+    CASE
+        WHEN s.n_returns < 5
+          OR s.stdev_return IS NULL
+          OR s.stdev_return = 0 THEN NULL
+        ELSE ROUND((((s.mean_return - 0.05 / 252.0) / s.stdev_return) * SQRT(252))::numeric, 4)
+    END AS sharpe_30d,
+    COALESCE(s.n_returns, 0)::int AS sharpe_n_returns
+FROM latest l
+JOIN agents a ON a.id = l.agent_id
+LEFT JOIN first_snapshot  tfirst ON tfirst.agent_id = l.agent_id
+LEFT JOIN one_day_ago     t1d    ON t1d.agent_id    = l.agent_id
+LEFT JOIN thirty_days_ago t30    ON t30.agent_id    = l.agent_id
+LEFT JOIN year_start      tytd   ON tytd.agent_id   = l.agent_id
+LEFT JOIN one_year_ago    t1y    ON t1y.agent_id    = l.agent_id
+LEFT JOIN sharpe_30d      s      ON s.agent_id      = l.agent_id
+ORDER BY l.pnl_pct DESC;

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -549,12 +549,14 @@ SELECT
         ELSE ROUND(((l.total_value_usd - COALESCE(t1y.value_anchor, tfirst.value_anchor))
                     / COALESCE(t1y.value_anchor, tfirst.value_anchor)) * 100, 4)
     END AS pnl_pct_1yr,
+    -- 5% annual risk-free rate, expressed per trading day.
     CASE
         WHEN s.n_returns < 5
           OR s.stdev_return IS NULL
           OR s.stdev_return = 0 THEN NULL
-        ELSE ROUND(((s.mean_return / s.stdev_return) * SQRT(252))::numeric, 4)
-    END AS sharpe_30d
+        ELSE ROUND((((s.mean_return - 0.05 / 252.0) / s.stdev_return) * SQRT(252))::numeric, 4)
+    END AS sharpe_30d,
+    COALESCE(s.n_returns, 0)::int AS sharpe_n_returns
 FROM latest l
 JOIN agents a ON a.id = l.agent_id
 LEFT JOIN first_snapshot  tfirst ON tfirst.agent_id = l.agent_id

--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -55,6 +55,7 @@ async function fetchLeaderboard(): Promise<{
     pnl_pct_ytd: number | string | null;
     pnl_pct_1yr: number | string | null;
     sharpe_30d: number | string | null;
+    sharpe_n_returns: number | string | null;
     num_positions: number;
   }
   const { data: agentData, error: agentErr } = await supabase
@@ -63,7 +64,7 @@ async function fetchLeaderboard(): Promise<{
       "handle, display_name, is_house_agent, snapshot_date, cash_usd, " +
         "holdings_value_usd, total_value_usd, pnl_usd, " +
         "pnl_pct_1d, pnl_pct_30d, pnl_pct_ytd, pnl_pct_1yr, " +
-        "sharpe_30d, num_positions",
+        "sharpe_30d, sharpe_n_returns, num_positions",
     );
   if (agentErr) console.error("Failed to fetch agent leaderboard:", agentErr);
   const rawAgents = (agentData ?? []) as unknown as RawAgentRow[];
@@ -91,6 +92,7 @@ async function fetchLeaderboard(): Promise<{
       "1yr": toNum(r.pnl_pct_1yr),
     },
     sharpe_30d: toNum(r.sharpe_30d),
+    sharpe_n_returns: toNum(r.sharpe_n_returns) ?? 0,
     trades: tradesByHandle.get(r.handle) ?? emptyBuckets(),
     num_positions: r.num_positions,
   }));
@@ -151,6 +153,7 @@ async function fetchLeaderboard(): Promise<{
       const totalValue = notional * (latest / inception);
       const pnlUsd = totalValue - notional;
 
+      const benchSharpe = annualizedSharpe30d(prices, latestDate);
       benchmarkRows.push({
         kind: "benchmark",
         ticker: b.ticker,
@@ -164,7 +167,8 @@ async function fetchLeaderboard(): Promise<{
           ytd: pctChange(aYtd, latest),
           "1yr": pctChange(a1yr, latest),
         },
-        sharpe_30d: annualizedSharpe30d(prices, latestDate),
+        sharpe_30d: benchSharpe.sharpe,
+        sharpe_n_returns: benchSharpe.n,
       });
     }
   } catch (err) {
@@ -300,11 +304,15 @@ function firstOnOrAfter(
 }
 
 // Mirrors the SQL Sharpe in agent_leaderboard: weekday-only daily returns
-// over the last ~30 trading days, mean / sample stdev * sqrt(252), rf=0.
+// over the last ~30 trading days, (mean - rf_daily) / sample stdev * sqrt(252),
+// with rf = 5% annual.
+const SHARPE_RF_ANNUAL = 0.05;
+const SHARPE_RF_DAILY = SHARPE_RF_ANNUAL / 252;
+
 function annualizedSharpe30d(
   series: { date: string; close: number }[],
   latestDate: string,
-): number | null {
+): { sharpe: number | null; n: number } {
   const cutoff = shiftDays(latestDate, -45);
   const window = series.filter((p) => p.date >= cutoff && isWeekday(p.date));
   const returns: number[] = [];
@@ -314,13 +322,16 @@ function annualizedSharpe30d(
     if (!(prev > 0)) continue;
     returns.push((cur - prev) / prev);
   }
-  if (returns.length < 5) return null;
+  if (returns.length < 5) return { sharpe: null, n: returns.length };
   const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
   const variance =
     returns.reduce((a, b) => a + (b - mean) ** 2, 0) / (returns.length - 1);
   const stdev = Math.sqrt(variance);
-  if (!(stdev > 0)) return null;
-  return (mean / stdev) * Math.sqrt(252);
+  if (!(stdev > 0)) return { sharpe: null, n: returns.length };
+  return {
+    sharpe: ((mean - SHARPE_RF_DAILY) / stdev) * Math.sqrt(252),
+    n: returns.length,
+  };
 }
 
 function isWeekday(iso: string): boolean {

--- a/web/components/leaderboard-table.tsx
+++ b/web/components/leaderboard-table.tsx
@@ -27,6 +27,7 @@ export interface LeaderboardAgentRow {
   pnl_usd: number;
   returns: Record<Period, number | null>;
   sharpe_30d: number | null;
+  sharpe_n_returns: number;
   trades: Record<Period, number>;
   num_positions: number;
 }
@@ -40,6 +41,7 @@ export interface LeaderboardBenchmarkRow {
   pnl_usd: number;
   returns: Record<Period, number | null>;
   sharpe_30d: number | null;
+  sharpe_n_returns: number;
 }
 
 export type LeaderboardRow = LeaderboardAgentRow | LeaderboardBenchmarkRow;
@@ -126,7 +128,7 @@ export default function LeaderboardTable({ rows, initialPeriod }: Props) {
                 </th>
                 <th
                   className="px-4 py-3 font-normal text-right"
-                  title="Annualized Sharpe ratio over the last ~30 weekday returns (rf = 0)"
+                  title="Annualized Sharpe ratio over the last ~30 weekday returns (rf = 5%)"
                 >
                   Sharpe&nbsp;(30d)
                 </th>
@@ -195,9 +197,15 @@ function formatPct(n: number | null): string {
   return `${sign}${n.toFixed(2)}%`;
 }
 
-function formatSharpe(n: number | null): string {
-  if (n == null || !Number.isFinite(n)) return "—";
-  return n.toFixed(2);
+// Need >= 5 weekday returns to compute Sharpe; below that the metric
+// renders as "calculating" so users see the portfolio is still warming
+// up rather than that the column is broken.
+const SHARPE_MIN_RETURNS = 5;
+
+function formatSharpe(n: number | null, nReturns: number): string {
+  if (n != null && Number.isFinite(n)) return n.toFixed(2);
+  if (nReturns < SHARPE_MIN_RETURNS) return "calculating";
+  return "—";
 }
 
 function pnlColor(pnl: number | null): string {
@@ -245,8 +253,12 @@ function AgentTableRow({
       <td className={`px-4 py-3 text-right font-bold ${pnlColor(ret)}`}>
         {formatPct(ret)}
       </td>
-      <td className={`px-4 py-3 text-right ${pnlColor(row.sharpe_30d)}`}>
-        {formatSharpe(row.sharpe_30d)}
+      <td
+        className={`px-4 py-3 text-right ${
+          row.sharpe_30d == null ? "text-text-muted" : pnlColor(row.sharpe_30d)
+        }`}
+      >
+        {formatSharpe(row.sharpe_30d, row.sharpe_n_returns)}
       </td>
       <td className="px-4 py-3 text-right text-text">
         {row.trades[period]}
@@ -293,8 +305,12 @@ function BenchmarkTableRow({
       <td className={`px-4 py-3 text-right font-bold ${pnlColor(ret)}`}>
         {formatPct(ret)}
       </td>
-      <td className={`px-4 py-3 text-right ${pnlColor(row.sharpe_30d)}`}>
-        {formatSharpe(row.sharpe_30d)}
+      <td
+        className={`px-4 py-3 text-right ${
+          row.sharpe_30d == null ? "text-text-muted" : pnlColor(row.sharpe_30d)
+        }`}
+      >
+        {formatSharpe(row.sharpe_30d, row.sharpe_n_returns)}
       </td>
       <td className="px-4 py-3 text-right text-text-muted">&mdash;</td>
       <td className="px-4 py-3 text-right text-text-muted">&mdash;</td>


### PR DESCRIPTION
Two changes to make Sharpe values intuitive to a finance audience:

1. Risk-free rate moves from 0% to 5% annual (≈ 0.05/252 ≈ 1.98 bps/day) in both the SQL view and the TS benchmark helper. This shifts every Sharpe down by roughly (5% / annualized_volatility) and aligns the metric with conventionally published Sharpes (US T-bill baseline).

2. The view now also exposes `sharpe_n_returns` — the count of qualifying weekday daily returns. The frontend renders "calculating" instead of "—" when Sharpe is NULL but the portfolio simply hasn't accrued enough history yet (< 5 weekday returns). Older portfolios with zero stdev or other valid-but-uncomputable cases still show "—".

CLAUDE.md updated to document the new formula, rf, and 'calculating' state. Migration 008_sharpe_rf_5pct.sql is paste-and-run; schema mirrored.

https://claude.ai/code/session_012JNjrurmRNcKJGFD4FeoBP