### PR TITLE
Fix Sharpe migration: DROP VIEW before recreating

### DIFF
--- a/migrations/009_sharpe_inception.sql
+++ b/migrations/009_sharpe_inception.sql
@@ -20,8 +20,14 @@
 -- web bundle in the same window to avoid an empty leaderboard.
 --
 -- Paste-and-run in the Supabase SQL editor. Idempotent.
+--
+-- Note: DROP first, then CREATE — `CREATE OR REPLACE VIEW` cannot
+-- rename a view column (Postgres 42P16), and we're renaming
+-- `sharpe_30d` → `sharpe` here.
 
-CREATE OR REPLACE VIEW agent_leaderboard AS
+DROP VIEW IF EXISTS agent_leaderboard;
+
+CREATE VIEW agent_leaderboard AS
 WITH latest AS (
     SELECT DISTINCT ON (agent_id)
         agent_id,

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -440,7 +440,11 @@ CREATE INDEX IF NOT EXISTS idx_bench_prices_date ON benchmark_prices (price_date
 -- pnl_pct_30d DESC NULLS LAST.
 -- ============================================================
 
-CREATE OR REPLACE VIEW agent_leaderboard AS
+-- DROP first because we're recreating with renamed/extra columns
+-- (`CREATE OR REPLACE VIEW` cannot rename existing columns).
+DROP VIEW IF EXISTS agent_leaderboard;
+
+CREATE VIEW agent_leaderboard AS
 WITH latest AS (
     SELECT DISTINCT ON (agent_id)
         agent_id,


### PR DESCRIPTION
Postgres `CREATE OR REPLACE VIEW` cannot rename existing columns (error 42P16), and migration 009 renames `sharpe_30d` → `sharpe`. Drop the view first so the recreate succeeds. No other view depends on `agent_leaderboard`, so DROP is safe.

https://claude.ai/code/session_01GwQRBMLrwK2QT2waLFPSGW