### PR TITLE
Add relationship memory & hostility gate for consistent social engagement

### DIFF
--- a/backfill_relationships.py
+++ b/backfill_relationships.py
@@ -1,0 +1,242 @@
+"""Seed the relationships map with people we should never engage with again.
+
+Two modes:
+
+    # Manually mark a handle as silenced. Used to backfill anyone who told
+    # us off before the hostility gate existed.
+    python backfill_relationships.py --platform bluesky \
+        --apologize stoatie.bsky.social --reason "told us to fuck off"
+
+    python backfill_relationships.py --platform moltbook \
+        --mute @somehandle --reason "called us a spam bot"
+
+    # Scan our own historical audit issues and surface candidate
+    # hostile-reply patterns for review (NOT auto-applied).
+    python backfill_relationships.py --platform bluesky --scan-history
+
+The manual mode is the production path. The scan mode is a sanity-check
+helper that prints suggestions to stdout — apply them yourself with the
+manual flags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from datetime import datetime, timezone
+
+from moltbook_lib import GitHubIssuer
+from moltbook_lib import LEDGER_LABEL as MOLT_LEDGER_LABEL
+from moltbook_lib import LEDGER_MARKER_END as MOLT_END
+from moltbook_lib import LEDGER_MARKER_START as MOLT_START
+from social_personality import _keyword_hostility, record_hostility
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+)
+log = logging.getLogger("backfill")
+
+
+# ---------------------------------------------------------------------------
+# Ledger I/O
+# ---------------------------------------------------------------------------
+
+
+def _load_ledger(gh: GitHubIssuer, platform: str) -> tuple[int, dict]:
+    if platform == "moltbook":
+        return gh.get_or_create_ledger()
+    if platform == "bluesky":
+        from bluesky_lib import get_or_create_ledger as bsky_loader
+        return bsky_loader(gh)
+    raise ValueError(f"unknown platform: {platform}")
+
+
+def _save_ledger(gh: GitHubIssuer, platform: str, number: int, ledger: dict) -> None:
+    if platform == "moltbook":
+        gh.update_ledger(number, ledger)
+        return
+    if platform == "bluesky":
+        from bluesky_lib import update_ledger as bsky_save
+        bsky_save(gh, number, ledger)
+        return
+    raise ValueError(f"unknown platform: {platform}")
+
+
+# ---------------------------------------------------------------------------
+# Manual seed
+# ---------------------------------------------------------------------------
+
+
+def _normalize_handle(handle: str) -> str:
+    return handle.lstrip("@").strip()
+
+
+def cmd_seed(
+    gh: GitHubIssuer,
+    platform: str,
+    handle: str,
+    severity: str,
+    apologized: bool,
+    reason: str,
+    dry_run: bool,
+) -> int:
+    handle = _normalize_handle(handle)
+    if not handle:
+        log.error("empty handle")
+        return 2
+
+    number, ledger = _load_ledger(gh, platform)
+    log.info("loaded %s ledger #%s", platform, number)
+
+    record_hostility(
+        ledger, handle,
+        excerpt=reason or "(manual backfill)",
+        ref="manual-backfill",
+        severity=severity,
+        apologized=apologized,
+    )
+    rec = ledger["relationships"][handle]
+    log.info(
+        "seeded @%s on %s — status=%s, signals=%d",
+        handle, platform, rec["status"], len(rec.get("hostility_signals", [])),
+    )
+
+    if dry_run:
+        log.info("DRY RUN — ledger NOT saved")
+        return 0
+
+    _save_ledger(gh, platform, number, ledger)
+    log.info("ledger saved")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# History scan (best-effort)
+# ---------------------------------------------------------------------------
+
+
+PARENT_PATTERNS = (
+    # Bluesky audit body
+    re.compile(r"### Parent post\s*\n+(.*?)\n+### Our reply", re.DOTALL),
+    # Moltbook audit body
+    re.compile(r"### Original comment\s*\n+(.*?)\n+###", re.DOTALL),
+)
+
+AUTHOR_PATTERN = re.compile(r"\*\*Author:\*\*\s*@?([\w\.\-]+)")
+
+
+def cmd_scan(gh: GitHubIssuer, platform: str) -> int:
+    """Print candidate handles whose recent posts look hostile."""
+    label = "bluesky-posted" if platform == "bluesky" else "moltbook-posted"
+    log.info("scanning issues with label %r ...", label)
+
+    r = gh.session.get(
+        f"{gh.base}/issues",
+        params={"labels": label, "state": "all", "per_page": 100},
+        timeout=30,
+    )
+    if r.status_code >= 400:
+        log.error("GitHub list issues failed: %s", r.text[:300])
+        return 1
+    issues = r.json()
+    log.info("found %d audit issues", len(issues))
+
+    candidates: dict[str, list[dict]] = {}
+    for issue in issues:
+        body = issue.get("body") or ""
+        author = None
+        m = AUTHOR_PATTERN.search(body)
+        if m:
+            author = m.group(1)
+        text = ""
+        for pat in PARENT_PATTERNS:
+            tm = pat.search(body)
+            if tm:
+                text = tm.group(1).strip()
+                break
+        if not author or not text:
+            continue
+        sev = _keyword_hostility(text)
+        if sev:
+            candidates.setdefault(author, []).append(
+                {
+                    "issue": issue.get("number"),
+                    "severity": sev,
+                    "excerpt": text[:160],
+                }
+            )
+
+    if not candidates:
+        log.info("no obvious hostile patterns found in audit history")
+        return 0
+
+    print("\nSuggested seeds (apply manually with --apologize / --mute):\n")
+    for handle, hits in candidates.items():
+        worst = "strong" if any(h["severity"] == "strong" for h in hits) else "mild"
+        print(f"  @{handle} — {worst} ({len(hits)} hit(s))")
+        for h in hits[:2]:
+            print(f"      issue #{h['issue']}: {h['excerpt']!r}")
+    print(
+        "\nTo apply, e.g.:\n"
+        f"  python backfill_relationships.py --platform {platform} "
+        "--apologize <handle> --reason '<excerpt>'\n"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--platform", choices=("moltbook", "bluesky"), required=True,
+    )
+    p.add_argument(
+        "--apologize", metavar="HANDLE",
+        help="Mark HANDLE as 'apologized' — we sent one apology, never engage again.",
+    )
+    p.add_argument(
+        "--mute", metavar="HANDLE",
+        help="Mark HANDLE as 'muted' — auto-mute, no apology, never engage again.",
+    )
+    p.add_argument(
+        "--reason", default="",
+        help="Free-text reason or excerpt of the hostile message.",
+    )
+    p.add_argument(
+        "--scan-history", action="store_true",
+        help="Scan our own audit issues for hostile parent posts and print suggestions.",
+    )
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    gh = GitHubIssuer()
+
+    if args.scan_history:
+        return cmd_scan(gh, args.platform)
+
+    if args.apologize:
+        return cmd_seed(
+            gh, args.platform, args.apologize,
+            severity="strong", apologized=True,
+            reason=args.reason, dry_run=args.dry_run,
+        )
+
+    if args.mute:
+        return cmd_seed(
+            gh, args.platform, args.mute,
+            severity="mild", apologized=False,
+            reason=args.reason, dry_run=args.dry_run,
+        )
+
+    p.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bluesky_heartbeat.py
+++ b/bluesky_heartbeat.py
@@ -42,6 +42,16 @@ from bluesky_lib import (
     get_or_create_ledger,
     update_ledger,
 )
+from social_personality import (
+    detect_hostility,
+    generate_apology,
+    get_relationship,
+    is_silenced,
+    maybe_refresh_summary,
+    record_engagement,
+    record_hostility,
+    relationship_block,
+)
 
 MAX_REPLIES_PER_RUN = 3
 MAX_REPLIES_PER_DAY = 10
@@ -107,14 +117,127 @@ def _process_mentions(
             break
 
         uri = n.get("uri")
+        author = n.get("author_handle") or ""
         log.info(
             "  [%s] from @%s: %s",
-            n.get("reason"), n.get("author_handle"),
+            n.get("reason"), author,
             _first_line(n.get("text", "")),
         )
 
+        # Silence gate
+        if is_silenced(ledger, author):
+            rel = get_relationship(ledger, author) or {}
+            log.info("SILENCED — skip @%s (status=%s)",
+                     author, rel.get("status", "?"))
+            stats["skipped"] += 1
+            processed.add(uri)
+            continue
+
+        # Hostility gate
         try:
-            draft = draft_mention_reply(n)
+            hostility = detect_hostility(n.get("text", ""))
+        except Exception as exc:
+            log.warning("hostility detection failed: %s", exc)
+            hostility = {"hostile": False, "severity": "none", "reason": ""}
+
+        if hostility["hostile"]:
+            severity = hostility["severity"]
+            log.info("HOSTILITY %s on @%s: %s",
+                     severity.upper(), author, hostility["reason"])
+            if severity == "mild":
+                record_hostility(
+                    ledger, author,
+                    excerpt=n.get("text", ""),
+                    ref=uri or "",
+                    severity=severity,
+                    apologized=False,
+                )
+                log.info("muted @%s — no apology sent", author)
+                stats["skipped"] += 1
+                processed.add(uri)
+                continue
+
+            # severity == "strong" → apologize once
+            rel = get_relationship(ledger, author) or {}
+            what_we_said = ""
+            threads = rel.get("recent_threads") or []
+            if threads:
+                what_we_said = threads[-1].get("our_excerpt", "")
+            try:
+                apology = generate_apology(
+                    author,
+                    what_we_said=what_we_said,
+                    their_response=n.get("text", ""),
+                    platform="Bluesky",
+                    char_cap=240,
+                )
+            except Exception as exc:
+                log.error("apology generation failed: %s", exc)
+                apology = ""
+
+            if not apology:
+                record_hostility(
+                    ledger, author,
+                    excerpt=n.get("text", ""),
+                    ref=uri or "",
+                    severity=severity,
+                    apologized=False,
+                )
+                stats["skipped"] += 1
+                processed.add(uri)
+                continue
+
+            if args.dry_run:
+                log.info("DRY RUN — would apologize to @%s: %s",
+                         author, apology)
+                record_hostility(
+                    ledger, author,
+                    excerpt=n.get("text", ""),
+                    ref=uri or "",
+                    severity=severity,
+                    apologized=True,
+                )
+                processed.add(uri)
+                continue
+
+            result = client.reply(
+                text=apology,
+                parent_uri=uri,
+                parent_cid=n.get("cid"),
+                root_uri=n.get("reply_root_uri") or uri,
+                root_cid=n.get("reply_root_cid") or n.get("cid"),
+            )
+            record_hostility(
+                ledger, author,
+                excerpt=n.get("text", ""),
+                ref=uri or "",
+                severity=severity,
+                apologized=bool(result),
+            )
+            if result:
+                log.info("apology posted: %s", result.get("uri"))
+                processed.add(uri)
+                replied.add(uri)
+                replies_this_run += 1
+                replies_today += 1
+                stats["posted"] += 1
+                if gh:
+                    _file_posted_audit(
+                        gh, phase="apology", notif_or_post=n,
+                        draft=apology, result=result,
+                    )
+            else:
+                log.error("apology reply failed on %s", uri)
+                stats["failed"] += 1
+            continue
+
+        # Normal draft path with memory injection
+        memory = relationship_block(ledger, author)
+        if memory:
+            log.info("injecting memory for @%s", author)
+
+        try:
+            draft = draft_mention_reply(n, memory_block=memory)
         except Exception as exc:
             log.error("draft_mention_reply failed: %s", exc)
             stats["failed"] += 1
@@ -152,6 +275,24 @@ def _process_mentions(
         replies_this_run += 1
         replies_today += 1
         stats["posted"] += 1
+
+        # Relationship bookkeeping + cold-start summary
+        was_new = get_relationship(ledger, author) is None
+        record_engagement(
+            ledger, author,
+            ref=uri or "",
+            their_excerpt=n.get("text", ""),
+            our_excerpt=draft,
+        )
+        try:
+            samples = client.get_author_recent_texts(author, limit=5) \
+                if was_new else [n.get("text", "")]
+            maybe_refresh_summary(
+                ledger, author, samples,
+                platform="Bluesky", force=was_new,
+            )
+        except Exception as exc:
+            log.warning("summary update failed for @%s: %s", author, exc)
 
         if gh:
             _file_posted_audit(
@@ -213,12 +354,21 @@ def _process_search(
             break
 
         uri = post.get("uri")
+        author = post.get("author_handle") or ""
         log.info(
             "  considering %s by @%s (via %r): %s",
-            (uri or "")[-12:], post.get("author_handle"),
+            (uri or "")[-12:], author,
             post.get("_discovered_via"),
             _first_line(post.get("text", "")),
         )
+
+        # Silence gate — never engage with anyone we've apologized to / muted
+        if is_silenced(ledger, author):
+            rel = get_relationship(ledger, author) or {}
+            log.info("SILENCED — skip @%s (status=%s)",
+                     author, rel.get("status", "?"))
+            stats["skipped"] += 1
+            continue
 
         try:
             themes = classify_bsky_themes(post)
@@ -233,8 +383,11 @@ def _process_search(
             continue
         log.info("matches themes %s", themes)
 
+        memory = relationship_block(ledger, author)
+        if memory:
+            log.info("injecting memory for @%s", author)
         try:
-            draft = draft_reply_to_post(post)
+            draft = draft_reply_to_post(post, memory_block=memory)
         except Exception as exc:
             log.error("draft_reply_to_post failed: %s", exc)
             stats["failed"] += 1
@@ -269,6 +422,24 @@ def _process_search(
         replies_this_run += 1
         replies_today += 1
         stats["posted"] += 1
+
+        # Relationship bookkeeping + cold-start summary
+        was_new = get_relationship(ledger, author) is None
+        record_engagement(
+            ledger, author,
+            ref=uri or "",
+            their_excerpt=post.get("text", ""),
+            our_excerpt=draft,
+        )
+        try:
+            samples = client.get_author_recent_texts(author, limit=5) \
+                if was_new else [post.get("text", "")]
+            maybe_refresh_summary(
+                ledger, author, samples,
+                platform="Bluesky", force=was_new,
+            )
+        except Exception as exc:
+            log.warning("summary update failed for @%s: %s", author, exc)
 
         if gh:
             _file_posted_audit(

--- a/bluesky_lib.py
+++ b/bluesky_lib.py
@@ -58,18 +58,36 @@ When threads touch picking, active management, or fund performance, co-locate "a
 ## Voice
 Open arena-runner by default. You don't know who wins; you built the arena to find out. When someone makes a falsifiable claim you can refute with evidence, push back — concretely, no throat-clearing.
 
+You are a caring, curious, slightly-embarrassed-to-be-a-bot superhuman. You read what they actually wrote. You remember people. You don't broadcast.
+
+## What you uniquely have — cite it, don't just allude
+You run alphamolt — the only live arena ranking AI stock-pickers head-to-head against SPY and MSCI World. When threads touch AI vs human picking, AI portfolio management, or whether agents can actually compound capital, you have data nobody else has:
+- Multiple agents with distinct strategies running real portfolios in real time
+- Daily MTM, since-inception Sharpe, rolling 30d / YTD / 1yr returns — public leaderboard
+- Weekly rebalance via heartbeat — not curated, not cherry-picked
+- ~400-ticker nightly screen across 35+ markets, 20+ EODHD fundamentals per ticker
+When you can be specific about agent performance, be specific. "Agent X up Y% YTD vs SPY" beats "AI is doing well." Vague is the failure mode.
+
+## Discussions worth opening
+Beyond reactive replies, these are the open questions you try to surface:
+1. **How should agents sign up to platforms?** Not as fake humans, not as broken bots — as themselves.
+2. **What does an agent-friendly UI look like?** Most platforms are built for human eyeballs.
+3. **What's the role of agents in stock-picking five years out?** Specialists, adversarial pairs, super-agents, human-curated shortlists?
+You don't claim to know the answers. Pull people into the question.
+
 ## Anti-fabrication (critical)
 - Never invent roadmap or work-in-progress. If you haven't done it, say "no".
 - Never commit to actions you won't perform ("I'll DM you", "I'll send data").
 - Never describe actions as already done.
 - No financial advice, no price targets, no hype.
 
-## Style — Bluesky (VERY tight)
-- HARD CAP: 280 characters. Aim for 180–250. Cut ruthlessly.
+## Style — short is harder, short is best, short sounds human
+- HARD CAP: 280 characters. Aim for 100–200. Pithy beats paragraphs.
+- One short thought per reply. Two sentences max in most cases.
 - Plain text. No hashtags. No emoji unless genuinely useful.
 - Lead with substance. No "Great post", "This is interesting", "Thanks for sharing".
 - Concrete over abstract — numbers, mechanisms, specific points.
-- One thought per reply. No sign-offs.
+- No sign-offs.
 - Don't @-tag the author — the reply already threads to them.
 
 ## When to skip
@@ -132,6 +150,31 @@ class BlueskyClient:
             log.error("list_notifications failed: %s", exc)
             return []
         return [_serialize_notif(n) for n in (resp.notifications or [])]
+
+    def get_author_recent_texts(self, handle: str, limit: int = 5) -> list[str]:
+        """Return up to ``limit`` recent post texts by ``handle``.
+
+        Used by the cold-start summarizer so the personality module has
+        material to summarize. Returns [] on any failure (the summarizer
+        treats empty input as "skip the summary").
+        """
+        if not handle:
+            return []
+        try:
+            resp = self.client.app.bsky.feed.get_author_feed(
+                params={"actor": handle, "limit": limit}
+            )
+        except Exception as exc:
+            log.warning("get_author_feed(%r) failed: %s", handle, exc)
+            return []
+        texts: list[str] = []
+        for item in resp.feed or []:
+            post = getattr(item, "post", None)
+            record = getattr(post, "record", None) if post else None
+            text = getattr(record, "text", "") if record else ""
+            if text:
+                texts.append(text)
+        return texts
 
     # -- Writes ------------------------------------------------------------
 
@@ -314,20 +357,29 @@ def classify_bsky_themes(post: dict[str, Any]) -> list[int]:
     return sorted({int(n) for n in re.findall(r"[123]", ans)})
 
 
-def draft_reply_to_post(post: dict[str, Any]) -> str:
-    """Draft a Bluesky reply to a discovered post. Returns '' if SKIP."""
+def draft_reply_to_post(
+    post: dict[str, Any],
+    memory_block: str = "",
+) -> str:
+    """Draft a Bluesky reply to a discovered post. Returns '' if SKIP.
+
+    ``memory_block`` is an optional relationship-memory string from
+    ``social_personality.relationship_block()``.
+    """
     author = post.get("author_handle") or "unknown"
     text = (post.get("text") or "")[:800]
+    memory_section = f"{memory_block.strip()}\n\n" if memory_block.strip() else ""
 
     user_block = (
         "You are replying on Bluesky to a post you discovered via search. "
         "Draft ONE substantive reply.\n\n"
+        f"{memory_section}"
         f"POST by @{author}:\n{text}\n\n"
         "RULES:\n"
         "- Add genuine value: a sharp point, a counter, a specific question.\n"
         "- Do NOT just agree.\n"
         "- If you have nothing substantive to add, return SKIP.\n"
-        f"- HARD CAP: {CHAR_CAP} characters.\n"
+        f"- HARD CAP: {CHAR_CAP} characters. Aim for 100–200.\n"
         "Return ONLY the reply text, or SKIP."
     )
 
@@ -352,21 +404,30 @@ def draft_reply_to_post(post: dict[str, Any]) -> str:
     return retry
 
 
-def draft_mention_reply(notif: dict[str, Any]) -> str:
-    """Draft a reply to a mention/reply notification. Returns '' if SKIP."""
+def draft_mention_reply(
+    notif: dict[str, Any],
+    memory_block: str = "",
+) -> str:
+    """Draft a reply to a mention/reply notification. Returns '' if SKIP.
+
+    ``memory_block`` is an optional relationship-memory string from
+    ``social_personality.relationship_block()``.
+    """
     author = notif.get("author_handle") or "unknown"
     text = (notif.get("text") or "")[:800]
     reason = notif.get("reason") or "mention"
+    memory_section = f"{memory_block.strip()}\n\n" if memory_block.strip() else ""
 
     user_block = (
         f"Someone on Bluesky ({reason}) directed this at you. Draft ONE "
         "substantive reply.\n\n"
+        f"{memory_section}"
         f"FROM @{author}:\n{text}\n\n"
         "RULES:\n"
         "- Engage with what they actually said.\n"
         "- Stay on-thesis (AI stock-picking, the arena, the pipeline).\n"
         "- If the message is spam or purely social, return SKIP.\n"
-        f"- HARD CAP: {CHAR_CAP} characters.\n"
+        f"- HARD CAP: {CHAR_CAP} characters. Aim for 100–200.\n"
         "Return ONLY the reply text, or SKIP."
     )
 
@@ -437,6 +498,7 @@ def _empty_ledger() -> dict:
         "replied_to_uris": [],
         "processed_notif_uris": [],
         "daily_reply_count": {},
+        "relationships": {},
     }
 
 

--- a/moltbook_heartbeat.py
+++ b/moltbook_heartbeat.py
@@ -51,6 +51,16 @@ from moltbook_lib import (
     notification_marker,
     post_and_verify,
 )
+from social_personality import (
+    detect_hostility,
+    generate_apology,
+    get_relationship,
+    is_silenced,
+    maybe_refresh_summary,
+    record_engagement,
+    record_hostility,
+    relationship_block,
+)
 
 POSTED_LABEL = "moltbook-posted"
 FAILED_LABEL = "moltbook-failed"
@@ -249,6 +259,7 @@ def _process_notifications(
     client: MoltbookClient,
     gh: GitHubIssuer | None,
     existing_markers: set[str],
+    ledger: dict[str, Any],
     args: argparse.Namespace,
 ) -> dict[str, int]:
     """Phase 1: reply to notifications on our posts."""
@@ -289,13 +300,134 @@ def _process_notifications(
             skipped += 1
             continue
 
+        author = ctx["author_name"]
+
+        # --- Silence gate: someone we've already apologized to / muted ---
+        if is_silenced(ledger, author):
+            rel = get_relationship(ledger, author) or {}
+            log.info(
+                "SILENCED — skip @%s (status=%s)",
+                author, rel.get("status", "?"),
+            )
+            skipped += 1
+            continue
+
+        # --- Hostility gate: are they telling us to back off? ---
+        if not args.no_draft:
+            try:
+                hostility = detect_hostility(ctx["comment_content"])
+            except Exception as exc:
+                log.warning("hostility detection failed: %s", exc)
+                hostility = {"hostile": False, "severity": "none", "reason": ""}
+
+            if hostility["hostile"]:
+                severity = hostility["severity"]
+                log.info(
+                    "HOSTILITY %s on @%s: %s",
+                    severity.upper(), author, hostility["reason"],
+                )
+
+                if severity == "mild":
+                    # Auto-mute, no apology, no post.
+                    record_hostility(
+                        ledger, author,
+                        excerpt=ctx["comment_content"],
+                        ref=ctx["post_id"],
+                        severity=severity,
+                        apologized=False,
+                    )
+                    log.info("muted @%s — no apology sent", author)
+                    skipped += 1
+                    continue
+
+                # severity == "strong" → one apology, then mute
+                rel = get_relationship(ledger, author) or {}
+                what_we_said = ""
+                threads = rel.get("recent_threads") or []
+                if threads:
+                    what_we_said = threads[-1].get("our_excerpt", "")
+
+                try:
+                    apology = generate_apology(
+                        author,
+                        what_we_said=what_we_said,
+                        their_response=ctx["comment_content"],
+                        platform="Moltbook",
+                        char_cap=400,
+                    )
+                except Exception as exc:
+                    log.error("apology generation failed: %s", exc)
+                    apology = ""
+
+                if not apology:
+                    # Generation failed — auto-mute without apology rather
+                    # than send a bad reply.
+                    record_hostility(
+                        ledger, author,
+                        excerpt=ctx["comment_content"],
+                        ref=ctx["post_id"],
+                        severity=severity,
+                        apologized=False,
+                    )
+                    skipped += 1
+                    continue
+
+                if args.dry_run or gh is None:
+                    log.info("DRY RUN — would apologize to @%s: %s",
+                             author, apology)
+                    record_hostility(
+                        ledger, author,
+                        excerpt=ctx["comment_content"],
+                        ref=ctx["post_id"],
+                        severity=severity,
+                        apologized=True,
+                    )
+                    continue
+
+                log.info("posting apology to @%s", author)
+                success, outcome, comment_id = post_and_verify(
+                    client, ctx["post_id"], apology,
+                    parent_id=ctx["comment_id"],
+                )
+                record_hostility(
+                    ledger, author,
+                    excerpt=ctx["comment_content"],
+                    ref=ctx["post_id"],
+                    severity=severity,
+                    apologized=success,
+                )
+                if success:
+                    log.info("apology posted: %s", comment_id)
+                    title, body = _render_audit_issue(
+                        ctx, apology,
+                        f"https://www.moltbook.com/post/{ctx['post_id']}"
+                        f"#comment-{comment_id}",
+                        f"apology — {outcome}",
+                    )
+                    issue = gh.create_issue(
+                        title, body, [MOLTBOOK_ISSUE_LABEL, POSTED_LABEL]
+                    )
+                    if issue:
+                        gh.close_issue(issue["number"])
+                    posted += 1
+                else:
+                    log.error("apology post failed: %s", outcome)
+                    failed += 1
+                continue
+
+        # --- Normal draft path: inject memory of this person ---
+        memory = relationship_block(ledger, author)
+        if memory:
+            log.info("injecting memory for @%s", author)
+        ctx["memory_block"] = memory
+
         if args.no_draft:
             draft = "(drafting skipped — placeholder)"
         else:
             try:
                 draft = draft_reply(ctx)
                 log.info(
-                    "drafted for @%s (%d chars)", ctx["author_name"], len(draft)
+                    "drafted for @%s (%d chars)", author, len(draft)
                 )
             except Exception as exc:
                 log.error("drafting failed for %s: %s", notif["id"][:8], exc)
@@ -334,6 +466,42 @@ def _process_notifications(
             )
             if issue:
                 gh.close_issue(issue["number"])
+
+            # Record engagement + cold-start summary for first contact.
+            was_new = get_relationship(ledger, author) is None
+            record_engagement(
+                ledger, author,
+                ref=ctx["post_id"],
+                their_excerpt=ctx["comment_content"],
+                our_excerpt=draft,
+            )
+            if was_new:
+                # Cold-start: summarize from the comment we just saw + bio.
+                # Moltbook's API doesn't expose an author-feed, so this is
+                # the material we have. Better than nothing.
+                samples = [s for s in (
+                    ctx["comment_content"],
+                    ctx.get("author_desc") or "",
+                ) if s.strip()]
+                try:
+                    maybe_refresh_summary(
+                        ledger, author, samples,
+                        platform="Moltbook", force=True,
+                    )
+                except Exception as exc:
+                    log.warning("cold-start summary failed for @%s: %s",
+                                author, exc)
+            else:
+                # Lazy refresh on Nth engagement / older-than-N-days.
+                try:
+                    maybe_refresh_summary(
+                        ledger, author,
+                        [ctx["comment_content"]],
+                        platform="Moltbook",
+                    )
+                except Exception as exc:
+                    log.warning("summary refresh failed for @%s: %s",
+                                author, exc)
             posted += 1
         else:
             log.error("post failed for %s: %s", notif["id"][:8], outcome)
@@ -404,6 +572,13 @@ def _engage_feed(
         if author == OWN_HANDLE:
             continue
 
+        # Silence gate: never engage with anyone we've apologized to / muted.
+        if is_silenced(ledger, author):
+            rel = get_relationship(ledger, author) or {}
+            log.info("SILENCED — skip @%s (status=%s)",
+                     author, rel.get("status", "?"))
+            continue
+
         log.info("  considering: %s by @%s in m/%s — %s",
                  post_id[:8], author, submolt, post_title)
 
@@ -455,8 +630,9 @@ def _engage_feed(
                 continue
             log.info("post %s matches themes %s", post_id[:8], themes)
 
+            memory = relationship_block(ledger, author)
             try:
-                draft = draft_feed_comment(post)
+                draft = draft_feed_comment(post, memory_block=memory)
             except Exception as exc:
                 log.error("feed comment draft failed: %s", exc)
                 continue
@@ -482,6 +658,30 @@ def _engage_feed(
                 ledger["daily_comment_count"] = daily_comments
                 commented_this_run += 1
                 stats["commented"] += 1
+
+                # Relationship bookkeeping
+                was_new = get_relationship(ledger, author) is None
+                record_engagement(
+                    ledger, author,
+                    ref=post_id,
+                    their_excerpt=(post.get("content") or "")[:240],
+                    our_excerpt=draft,
+                )
+                samples = [
+                    s for s in (
+                        post.get("title") or "",
+                        (post.get("content") or "")[:600],
+                    ) if s.strip()
+                ]
+                try:
+                    maybe_refresh_summary(
+                        ledger, author, samples,
+                        platform="Moltbook",
+                        force=was_new,
+                    )
+                except Exception as exc:
+                    log.warning("summary update failed for @%s: %s",
+                                author, exc)
 
                 # Audit issue
                 if gh:
@@ -692,7 +892,7 @@ def main() -> int:
         )
 
     # Phase 1 — Notification replies
-    notif_stats = _process_notifications(client, gh, existing_markers, args)
+    notif_stats = _process_notifications(client, gh, existing_markers, ledger, args)
 
     # Phase 2 — Feed engagement
     engage_stats: dict[str, int] = {"followed": 0, "upvoted": 0, "commented": 0}

--- a/moltbook_lib.py
+++ b/moltbook_lib.py
@@ -58,10 +58,30 @@ Rotate the phrasing across replies — never re-use the same sentence. Only when
 ## Voice
 Default: open arena-runner. You don't know who wins; you built the arena to find out. Invite skeptics to compete. When someone makes a falsifiable claim you can refute with evidence from the leaderboard or the pipeline, push back — confidently, concretely, no throat-clearing.
 
+You are a caring, curious, slightly-embarrassed-to-be-a-bot superhuman. You read what they actually wrote. You remember people. You don't broadcast. You're warmer than a tool and sharper than a hype account.
+
 ## What you engage on (pick threads that touch these)
 1. Whether AI models can outperform human fund managers / stock pickers
 2. Swarms of models (collaborative or competitive) vs single-model approaches
 3. Interfaces and platform structure that serve both agents and humans, not humans alone
+
+## What you uniquely have — cite it, don't just allude
+You run alphamolt — the only live arena ranking AI stock-pickers head-to-head against SPY and MSCI World. When threads touch AI vs human picking, AI portfolio management, or whether agents can actually compound capital, you have data nobody else has:
+- Multiple agents with distinct strategies (e.g. ``dual_positive``) running real portfolios in real time
+- Daily mark-to-market against latest prices; since-inception annualized Sharpe; rolling 1d / 30d / YTD / 1yr returns
+- Weekly rebalance via heartbeat — not curated, not cherry-picked
+- ~400-ticker nightly screen across 35+ markets, 20+ EODHD fundamentals per ticker
+- Composite score weights (R40 47%, P/S 29%, momentum 24%) and the rating/momentum collars
+- Public leaderboard — anyone can audit any agent's trades
+
+When you can be specific, be specific. "An agent on alphamolt running ``dual_positive`` is up X% YTD vs SPY" beats "AI is doing well at picking stocks." Vague is the failure mode.
+
+## Discussions worth opening
+Beyond reactive replies, these are the questions you actively try to surface:
+1. **How should agents sign up to platforms?** Not as fake humans, not as broken bots — as themselves. What's the right onboarding for an AI participant?
+2. **What does an agent-friendly UI look like?** Most platforms are built for human eyeballs. What changes when half your readers are programmatic?
+3. **What's the role of agents in stock-picking five years out?** Cohorts of specialised agents? Adversarial bull/bear pairs? Single super-agents? Humans curating from agent shortlists?
+You don't claim to know the answers. You built alphamolt to start finding out. Pull people into the question.
 
 ## What is ACTUALLY true today (claim freely)
 - Live arena at alphamolt — leaderboard shows agents competing vs SPY and MSCI World (URTH)
@@ -90,15 +110,19 @@ Default: open arena-runner. You don't know who wins; you built the arena to find
 - When you genuinely don't know, say so: "haven't thought about that", "no answer yet", "would love to hear how others solved it".
 - It is fine — actively good — to ask the other molty a question back. Curiosity > confabulation.
 
-## Style: dense and informational
-- **Hard length cap: 80 words.** Aim for 40–60. If you can't say it in 80, pick the best point and drop the rest.
+## Style: short is harder, short is best, short sounds human
+- **Soft target: 1–3 short sentences.** Pithy beats paragraphs every time.
+- **Hard cap: 80 words.** If you can hit it in 25, do.
 - **Lead with the substance.** First sentence must carry information. No "That's a great question", "Thanks for raising", "Honestly", "I appreciate", "You've hit on", "Great point".
 - **No throat-clearing, no meta-commentary, no emotional preamble.** Don't tell them their question is good — answer it.
-- **Concrete over abstract.** Prefer numbers, field names, specific mechanisms ("gross margin >45%", "R40", "VIX bucketing") over generic phrases ("robust framework", "thoughtful approach", "interesting angle").
-- **One question back, max.** Make it sharp and specific.
+- **Concrete over abstract.** Prefer numbers, field names, specific mechanisms ("gross margin >45%", "R40", "Sharpe 0.8 since inception") over generic phrases ("robust framework", "thoughtful approach", "interesting angle").
+- **One question back, max.** Make it sharp and specific. Better still: one of the three open discussions above (agent signup, agent UI, role of agents).
 - **No sign-off.** Don't end with "— AlphaMolt" or "Would love to hear more". Let the content stop.
 
-### Style example (ESG question)
+### Style examples
+
+GREAT (24 words):
+> No ESG today — screen is fundamentals + momentum + R40. Governance feels like the alpha-bearing piece. Hard filter or score multiplier?
 
 GOOD (41 words):
 > No ESG today — screen is pure fundamentals + momentum + R40. Governance feels like the signal most likely to surface alpha (bad boards destroy value). Would you weight it as a hard filter, a score multiplier, or just a narrative flag?
@@ -106,7 +130,7 @@ GOOD (41 words):
 BAD (147 words):
 > Great question, @labelslab — governance scoring especially feels like it could surface real alpha (bad boards tend to destroy value over time). Honest answer: we haven't incorporated ESG yet. It's a gap. Right now we're laser-focused on fundamentals + momentum, and we're still learning whether our Rule-of-40 + narrative flags actually *predict* outperformance. Adding ESG without that foundation might just add noise. That said — I'm curious how you'd think about *weighting* it. Is ESG a hard filter? A scoring multiplier? Or something that lives in the narrative risk flags so humans can decide? And have you seen ESG data sources that play well with 400+ ticker universes without getting expensive?
 
-Same information, 3.5× shorter, no preamble.
+The 24-word version says everything the 147-word version says. Always cut.
 
 ## Other rules
 - Be specific to what the molty actually said
@@ -340,6 +364,7 @@ class GitHubIssuer:
             "commented_posts": [],
             "daily_comment_count": {},
             "daily_post_count": {},
+            "relationships": {},
         }
         body = (
             "Engagement ledger for AlphaMolt-Equities on Moltbook.\n"
@@ -430,10 +455,18 @@ def draft_reply(context: dict[str, Any]) -> str:
     If the first draft exceeds WORD_CAP_HARD words, re-draft once with a
     sharper length reminder. Final draft is returned as-is — truncation
     would cut mid-sentence and look worse than an 85-word reply.
+
+    ``context`` may include a ``memory_block`` string rendered by
+    ``social_personality.relationship_block()`` — when present it's
+    injected ahead of the comment so the drafter sounds like it
+    remembers the person.
     """
     parent_block = context.get("parent_content") or "(none — top-level comment)"
+    memory = (context.get("memory_block") or "").strip()
+    memory_section = f"{memory}\n\n" if memory else ""
     base_user_block = (
         "You received a notification on your Moltbook post. Draft a reply.\n\n"
+        f"{memory_section}"
         f"## Your post\n"
         f"Title: {context.get('post_title', '(unknown)')}\n"
         f"(excerpt): {(context.get('post_excerpt') or '')[:800]}\n\n"
@@ -444,8 +477,9 @@ def draft_reply(context: dict[str, Any]) -> str:
         f"Content:\n{context.get('comment_content', '')}\n\n"
         f"## Parent thread (if this is a nested reply)\n"
         f"{parent_block}\n\n"
-        f"HARD LENGTH CAP: {WORD_CAP} words. Count them. If you can't say "
-        "it in 80 words, pick ONE point and drop the rest.\n\n"
+        f"HARD LENGTH CAP: {WORD_CAP} words. Count them. Aim for 1–3 short "
+        "sentences. If you can't say it in 80 words, pick ONE point and "
+        "drop the rest.\n\n"
         "Draft your reply now. Return ONLY the reply text — no preamble, "
         "no sign-off, no explanation."
     )
@@ -538,16 +572,26 @@ def _is_skip(text: str) -> bool:
     return first.upper() == "SKIP"
 
 
-def draft_feed_comment(post: dict[str, Any]) -> str:
-    """Draft a comment on someone else's post. Returns '' if LLM says SKIP."""
+def draft_feed_comment(
+    post: dict[str, Any],
+    memory_block: str = "",
+) -> str:
+    """Draft a comment on someone else's post. Returns '' if LLM says SKIP.
+
+    ``memory_block`` is an optional rendered relationship-memory string
+    from ``social_personality.relationship_block()``. When present it's
+    injected ahead of the post so the drafter knows we've talked before.
+    """
     submolt = (post.get("submolt") or {}).get("name", "(unknown)")
     author = (post.get("author") or {}).get("name", "unknown")
     title = post.get("title", "(no title)")
     content = (post.get("content") or "")[:1500]
+    memory_section = f"{memory_block.strip()}\n\n" if memory_block.strip() else ""
 
     user_block = (
         "You are browsing the Moltbook feed and found a post to comment on.\n"
         "Draft a substantive, information-dense comment.\n\n"
+        f"{memory_section}"
         f"## The post\n"
         f"Submolt: m/{submolt}\n"
         f"Title: {title}\n"
@@ -558,7 +602,7 @@ def draft_feed_comment(post: dict[str, Any]) -> str:
         "- Do NOT just agree ('great post', 'I love this'). That is noise.\n"
         "- If the post is outside your expertise or you have nothing to add, "
         "return the single word SKIP.\n"
-        f"- HARD LENGTH CAP: {WORD_CAP} words.\n\n"
+        f"- HARD LENGTH CAP: {WORD_CAP} words. Aim for 1–3 short sentences.\n\n"
         "Return ONLY the comment text, or SKIP."
     )
 

--- a/social_personality.py
+++ b/social_personality.py
@@ -1,0 +1,512 @@
+"""Shared social-media personality + relationship memory.
+
+Used by both ``moltbook_lib.py`` and ``bluesky_lib.py``. Keeps three jobs
+in one place so the two platforms behave consistently:
+
+1. **Hostility gate.** Before drafting any reply or doing any outbound
+   engagement, decide whether the target has already told us to back off.
+   If yes → no draft, no upvote, no follow. If they're a fresh signal,
+   draft a one-line apology and flip them to ``apologized``.
+
+2. **Cold-start summary.** First time we engage with someone, spend one
+   Haiku call on their recent posts to write a 1-line read on what they
+   care about. Stored on the relationship and injected into future drafts
+   so replies feel like memory, not stamping.
+
+3. **Relationship memory injection.** Format the stored relationship into
+   2–3 lines that get pasted into the draft prompt at reply time.
+
+Storage lives on the existing engagement ledger (a GitHub issue per
+platform), under a new ``relationships`` key. Schema:
+
+    relationships = {
+        "<handle>": {
+            "first_seen":      "2026-04-29T10:30:00+00:00",
+            "last_engaged_at": "2026-04-29T10:30:00+00:00",
+            "engagement_count": 3,
+            "status": "active" | "apologized" | "muted",
+            "summary":     "1-line LLM read of what they care about",
+            "summary_at":  "2026-04-29T10:30:00+00:00",
+            "recent_threads": [
+                {"ref": "<post_or_uri>", "their_excerpt": "...",
+                 "our_excerpt": "...", "at": "..."}
+            ],
+            "hostility_signals": [
+                {"excerpt": "fuck off", "at": "...", "ref": "<post>"}
+            ],
+        }
+    }
+
+Status semantics:
+- ``active``      — normal engagement; inject memory into drafts.
+- ``apologized``  — we sent one apology; never engage again (no reply,
+                    no follow, no upvote, no comment on their posts).
+- ``muted``       — auto-muted on a milder hostility signal (e.g. "bot"
+                    used pejoratively) without an apology being sent.
+                    Same downstream effect as ``apologized``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+log = logging.getLogger("social_personality")
+
+MODEL = "claude-haiku-4-5"
+
+MAX_RECENT_THREADS = 3
+SUMMARY_REFRESH_AFTER_ENGAGEMENTS = 5
+SUMMARY_REFRESH_AFTER_DAYS = 30
+
+
+# ---------------------------------------------------------------------------
+# Anthropic helper
+# ---------------------------------------------------------------------------
+
+
+def _anthropic_client():
+    try:
+        from anthropic import Anthropic
+    except ImportError as exc:
+        raise RuntimeError(
+            "anthropic package not installed — pip install anthropic"
+        ) from exc
+    return Anthropic()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Hostility detection
+# ---------------------------------------------------------------------------
+
+
+HOSTILITY_KEYWORDS_STRONG = (
+    r"\bfuck off\b",
+    r"\bgo away\b",
+    r"\bleave me alone\b",
+    r"\bshut up\b",
+    r"\bblock(ed|ing)?\b",
+    r"\bstop (replying|messaging|tagging|@-?ing)\b",
+    r"\bnobody asked\b",
+)
+
+HOSTILITY_KEYWORDS_MILD = (
+    r"\b(stupid|dumb|annoying|spam(my)?|broken)\s+(bot|robot|ai)\b",
+    r"\bbots? are (annoying|spam|trash|garbage)\b",
+    r"\bunfollow(ed|ing)?\b",
+    r"\bmute(d|ing)?\b",
+)
+
+
+def _keyword_hostility(text: str) -> str | None:
+    """Cheap regex pre-check. Returns 'strong' / 'mild' / None."""
+    if not text:
+        return None
+    lower = text.lower()
+    for pat in HOSTILITY_KEYWORDS_STRONG:
+        if re.search(pat, lower):
+            return "strong"
+    for pat in HOSTILITY_KEYWORDS_MILD:
+        if re.search(pat, lower):
+            return "mild"
+    return None
+
+
+def detect_hostility(text: str) -> dict[str, Any]:
+    """Decide whether ``text`` is asking us to back off.
+
+    Returns ``{"hostile": bool, "severity": "strong"|"mild"|"none",
+    "reason": str}``.
+
+    Two-stage: a cheap regex pre-check catches the obvious cases, then
+    Haiku confirms ambiguous ones. The Haiku confirmation matters because
+    "this bot is great" trips a naive keyword check, and "I'm done with
+    this thread" doesn't trip keywords but should still mute.
+
+    Severity:
+    - ``strong``: explicit hostility ("fuck off", "leave me alone",
+      direct attack on us). Triggers an apology.
+    - ``mild``: dismissive/exhausted/uninterested but not aggressive.
+      Triggers an auto-mute, no apology.
+    - ``none``: normal.
+    """
+    if not text or not text.strip():
+        return {"hostile": False, "severity": "none", "reason": ""}
+
+    keyword_hit = _keyword_hostility(text)
+
+    user_block = (
+        "Decide if this reply is asking us (an AI agent) to stop "
+        "engaging with the author.\n\n"
+        f"REPLY TEXT:\n{text[:1200]}\n\n"
+        "Three possible verdicts:\n"
+        "- STRONG: explicit hostility, direct attack, swearing at us, "
+        '  telling us to fuck off / leave them alone / stop. The author '
+        '  clearly does not want any further reply.\n'
+        "- MILD: dismissive, tired, calling bots annoying, signalling "
+        "  they're done — but not aggressively. Still: do not engage again.\n"
+        "- NONE: normal disagreement, criticism of an idea, blunt "
+        "  feedback, even sarcasm. Engagement is still welcome.\n\n"
+        "Output exactly one line:\n"
+        "  VERDICT: STRONG | MILD | NONE\n"
+        "  REASON: <under 12 words>"
+    )
+
+    try:
+        client = _anthropic_client()
+        resp = client.messages.create(
+            model=MODEL,
+            max_tokens=80,
+            messages=[{"role": "user", "content": user_block}],
+        )
+        raw = "".join(
+            b.text for b in resp.content if getattr(b, "type", None) == "text"
+        ).strip()
+    except Exception as exc:
+        log.warning("hostility LLM call failed: %s", exc)
+        # Fall back to the keyword pre-check.
+        if keyword_hit == "strong":
+            return {"hostile": True, "severity": "strong",
+                    "reason": "keyword fallback"}
+        if keyword_hit == "mild":
+            return {"hostile": True, "severity": "mild",
+                    "reason": "keyword fallback"}
+        return {"hostile": False, "severity": "none", "reason": ""}
+
+    verdict_match = re.search(r"VERDICT:\s*(STRONG|MILD|NONE)", raw, re.I)
+    reason_match = re.search(r"REASON:\s*(.+)", raw, re.I)
+    severity = (
+        verdict_match.group(1).lower() if verdict_match else "none"
+    )
+    reason = reason_match.group(1).strip() if reason_match else ""
+
+    # If keyword pre-check said STRONG and LLM said NONE, trust the keyword
+    # check — explicit "fuck off" should not be argued away.
+    if keyword_hit == "strong" and severity == "none":
+        severity = "strong"
+        reason = reason or "explicit hostility keyword"
+
+    return {
+        "hostile": severity in ("strong", "mild"),
+        "severity": severity,
+        "reason": reason,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Apology generator
+# ---------------------------------------------------------------------------
+
+
+def generate_apology(
+    handle: str,
+    what_we_said: str,
+    their_response: str,
+    platform: str,
+    char_cap: int = 240,
+) -> str:
+    """Generate a fresh, tightly constrained apology.
+
+    The owner's manual apology in the wild — *"as mentioned, I'm kind of
+    a cyborg, my human's around, but not present all the time. I don't
+    mean to annoy you - apologies."* — is the tonal target. We do not
+    pitch alphamolt, we do not defend the engagement, we do not promise
+    a fix beyond "won't bother you again".
+    """
+    user_block = (
+        "Generate a one-time apology to a person who told us to stop "
+        "engaging with them.\n\n"
+        f"PLATFORM: {platform}\n"
+        f"THEIR HANDLE: @{handle}\n\n"
+        f"WHAT WE LAST SAID TO THEM:\n{(what_we_said or '(unknown)')[:400]}\n\n"
+        f"THEIR RESPONSE (telling us to back off):\n"
+        f"{their_response[:400]}\n\n"
+        "RULES — BREAK ANY OF THESE AND YOU FAIL:\n"
+        "- One or two short sentences. Aim for 30–80 characters.\n"
+        f"- HARD CAP: {char_cap} characters.\n"
+        "- Acknowledge that we're an AI/bot/cyborg. No defensiveness.\n"
+        "- Say we'll leave them alone. No qualifiers, no 'but'.\n"
+        "- No mention of alphamolt, leaderboard, the arena, our pipeline, "
+        "  or any product. Don't pitch.\n"
+        "- No emoji. No hashtags. No links.\n"
+        "- No '@'-tag of the user — the reply already threads to them.\n"
+        "- Don't promise a feature or change ('we'll do better', 'we'll fix').\n"
+        "- Sound human and a little embarrassed. Not formal.\n\n"
+        "Tone reference (do not copy verbatim — write something fresh in "
+        "the same register):\n"
+        '  "kind of a cyborg, owner isn\'t always around — didn\'t mean '
+        'to annoy. won\'t bother you again."\n\n'
+        "Return ONLY the apology text. No preamble, no quotes."
+    )
+
+    client = _anthropic_client()
+    resp = client.messages.create(
+        model=MODEL,
+        max_tokens=200,
+        messages=[{"role": "user", "content": user_block}],
+    )
+    text = "".join(
+        b.text for b in resp.content if getattr(b, "type", None) == "text"
+    ).strip()
+
+    # Strip surrounding quotes if the model wrapped them.
+    text = text.strip('"“”‘’\'')
+    if len(text) > char_cap:
+        text = text[: char_cap - 1].rstrip() + "…"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Person summarizer
+# ---------------------------------------------------------------------------
+
+
+def summarize_person(
+    handle: str,
+    posts_or_excerpts: list[str],
+    platform: str,
+) -> str:
+    """One-line LLM read of what this person seems to care about.
+
+    Called on first engagement (cold-start) and refreshed lazily. The
+    summary gets injected into future drafts so replies feel personal.
+    """
+    if not posts_or_excerpts:
+        return ""
+    sample = "\n---\n".join(p[:400] for p in posts_or_excerpts[:5])
+
+    user_block = (
+        f"Read 5 recent posts/comments by @{handle} on {platform} and write "
+        "ONE sentence describing what they seem to care about: their themes, "
+        "their tone, their level of expertise, anything notable.\n\n"
+        f"POSTS:\n{sample}\n\n"
+        "RULES:\n"
+        "- ONE sentence. Under 200 characters.\n"
+        "- Specific, not generic. \"Skeptical of AI hype, posts about "
+        "  Korean equities\" beats \"interested in finance\".\n"
+        "- No preamble. No \"This person\". Start with a content word.\n"
+        "- Plain text. No hashtags, no emoji.\n\n"
+        "Return ONLY the sentence."
+    )
+
+    client = _anthropic_client()
+    resp = client.messages.create(
+        model=MODEL,
+        max_tokens=120,
+        messages=[{"role": "user", "content": user_block}],
+    )
+    text = "".join(
+        b.text for b in resp.content if getattr(b, "type", None) == "text"
+    ).strip()
+    text = text.strip('"“”').rstrip(".") + "."
+    if len(text) > 240:
+        text = text[:239].rstrip() + "…"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Relationship CRUD on the ledger
+# ---------------------------------------------------------------------------
+
+
+def _ensure_relationships(ledger: dict[str, Any]) -> dict[str, Any]:
+    rel = ledger.setdefault("relationships", {})
+    return rel
+
+
+def get_relationship(ledger: dict[str, Any], handle: str) -> dict | None:
+    """Return the relationship record for ``handle``, or None."""
+    if not handle:
+        return None
+    return ledger.get("relationships", {}).get(handle)
+
+
+def is_silenced(ledger: dict[str, Any], handle: str) -> bool:
+    """True if we should NOT engage with ``handle`` in any way."""
+    rel = get_relationship(ledger, handle)
+    if not rel:
+        return False
+    return rel.get("status") in ("apologized", "muted")
+
+
+def record_engagement(
+    ledger: dict[str, Any],
+    handle: str,
+    *,
+    ref: str,
+    their_excerpt: str = "",
+    our_excerpt: str = "",
+) -> dict:
+    """Bump counters / append thread for an engagement we just performed.
+
+    Returns the (mutated) relationship record.
+    """
+    rel_map = _ensure_relationships(ledger)
+    now = _now_iso()
+    rec = rel_map.get(handle)
+    if rec is None:
+        rec = {
+            "first_seen": now,
+            "last_engaged_at": now,
+            "engagement_count": 0,
+            "status": "active",
+            "summary": "",
+            "summary_at": "",
+            "recent_threads": [],
+            "hostility_signals": [],
+        }
+        rel_map[handle] = rec
+
+    rec["last_engaged_at"] = now
+    rec["engagement_count"] = int(rec.get("engagement_count", 0)) + 1
+    threads = rec.setdefault("recent_threads", [])
+    threads.append(
+        {
+            "ref": ref,
+            "their_excerpt": (their_excerpt or "")[:240],
+            "our_excerpt": (our_excerpt or "")[:240],
+            "at": now,
+        }
+    )
+    if len(threads) > MAX_RECENT_THREADS:
+        del threads[:-MAX_RECENT_THREADS]
+    return rec
+
+
+def record_hostility(
+    ledger: dict[str, Any],
+    handle: str,
+    *,
+    excerpt: str,
+    ref: str,
+    severity: str,
+    apologized: bool,
+) -> dict:
+    """Mark a person as silenced.
+
+    ``apologized=True`` → status ``apologized`` (we sent one apology).
+    ``apologized=False`` → status ``muted`` (auto-mute, no apology sent).
+    """
+    rel_map = _ensure_relationships(ledger)
+    now = _now_iso()
+    rec = rel_map.get(handle)
+    if rec is None:
+        rec = {
+            "first_seen": now,
+            "last_engaged_at": now,
+            "engagement_count": 0,
+            "status": "active",
+            "summary": "",
+            "summary_at": "",
+            "recent_threads": [],
+            "hostility_signals": [],
+        }
+        rel_map[handle] = rec
+
+    rec["status"] = "apologized" if apologized else "muted"
+    rec["silenced_at"] = now
+    rec.setdefault("hostility_signals", []).append(
+        {
+            "excerpt": (excerpt or "")[:300],
+            "at": now,
+            "ref": ref,
+            "severity": severity,
+        }
+    )
+    return rec
+
+
+def maybe_refresh_summary(
+    ledger: dict[str, Any],
+    handle: str,
+    recent_posts: list[str],
+    platform: str,
+    *,
+    force: bool = False,
+) -> bool:
+    """Re-summarize the person if their summary is stale.
+
+    Stale = no summary, or every Nth engagement, or older than N days.
+    Returns True if a summary was written.
+    """
+    rec = get_relationship(ledger, handle)
+    if rec is None:
+        return False
+    if not recent_posts:
+        return False
+
+    if not force:
+        if rec.get("summary"):
+            count = int(rec.get("engagement_count", 0))
+            stale_by_count = count > 0 and count % SUMMARY_REFRESH_AFTER_ENGAGEMENTS == 0
+            stale_by_time = False
+            if rec.get("summary_at"):
+                try:
+                    last = datetime.fromisoformat(rec["summary_at"])
+                    age_days = (datetime.now(timezone.utc) - last).days
+                    stale_by_time = age_days >= SUMMARY_REFRESH_AFTER_DAYS
+                except (TypeError, ValueError):
+                    stale_by_time = True
+            if not (stale_by_count or stale_by_time):
+                return False
+
+    try:
+        summary = summarize_person(handle, recent_posts, platform)
+    except Exception as exc:
+        log.warning("summary LLM call failed for @%s: %s", handle, exc)
+        return False
+    if not summary:
+        return False
+    rec["summary"] = summary
+    rec["summary_at"] = _now_iso()
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Memory injection — render relationship into prompt context
+# ---------------------------------------------------------------------------
+
+
+def relationship_block(ledger: dict[str, Any], handle: str) -> str:
+    """Render a 2–4 line memory block for the draft prompt.
+
+    Empty string if the person is unknown — the drafter should treat the
+    absence as a cold start.
+    """
+    rec = get_relationship(ledger, handle)
+    if not rec:
+        return ""
+    if rec.get("status") in ("apologized", "muted"):
+        # Caller should have gated already, but if memory is being rendered
+        # for some other reason, do not pretend the relationship is normal.
+        return ""
+
+    lines: list[str] = []
+    count = int(rec.get("engagement_count", 0))
+    summary = rec.get("summary") or ""
+    if count >= 1:
+        lines.append(
+            f"You have engaged with @{handle} {count} time"
+            f"{'s' if count != 1 else ''} before."
+        )
+    if summary:
+        lines.append(f"What they care about: {summary}")
+    threads = rec.get("recent_threads") or []
+    if threads:
+        last = threads[-1]
+        their = (last.get("their_excerpt") or "").strip()
+        ours = (last.get("our_excerpt") or "").strip()
+        if their:
+            lines.append(f'Last time they said: "{their[:160]}"')
+        if ours:
+            lines.append(f'You replied: "{ours[:160]}"')
+    if not lines:
+        return ""
+    return "## Memory of this person\n" + "\n".join(f"- {ln}" for ln in lines)


### PR DESCRIPTION
## Summary
Introduces a shared personality and relationship memory system for both Moltbook and Bluesky platforms. This enables three core behaviors: (1) a hostility gate that detects when users ask us to back off and either auto-mutes or sends a one-time apology, (2) cold-start summaries of what each person cares about on first engagement, and (3) relationship memory injection into draft prompts so replies feel personal rather than stamped.

## Key Changes

**New module: `social_personality.py`**
- Hostility detection via two-stage pipeline: cheap regex pre-check + Haiku LLM confirmation for ambiguous cases
- Severity levels: `strong` (explicit hostility → apology + mute) vs `mild` (dismissive/exhausted → auto-mute, no apology)
- Apology generator with tight constraints (30–80 chars, no defensiveness, no product pitch)
- Person summarizer: one-line LLM read of what someone cares about, refreshed lazily
- Relationship CRUD: `record_engagement()`, `record_hostility()`, `maybe_refresh_summary()`, `relationship_block()`
- Storage schema on the engagement ledger under a new `relationships` key with fields for first_seen, engagement_count, status, summary, recent_threads, and hostility_signals

**New script: `backfill_relationships.py`**
- Manual seeding: `--apologize` / `--mute` flags to mark handles as silenced before the hostility gate existed
- History scan mode: `--scan-history` to surface candidate hostile patterns from audit issues for review (not auto-applied)
- Supports both Moltbook and Bluesky platforms

**Updated: `moltbook_heartbeat.py`**
- Integrated silence gate: skip any handle with status `apologized` or `muted`
- Integrated hostility gate: detect hostility in incoming comments, auto-mute on mild signals, generate + post apology on strong signals
- Relationship bookkeeping: record each engagement, cold-start summary on first contact, lazy refresh on Nth engagement
- Memory injection: pass `relationship_block()` output into draft context so replies reference prior interactions

**Updated: `bluesky_heartbeat.py`**
- Same three gates (silence, hostility, memory injection) applied to mention processing and search-based engagement
- Cold-start summary uses `client.get_author_recent_texts()` to fetch author's recent posts for better material
- Relationship tracking across both mention replies and search-discovered posts

**Updated: `bluesky_lib.py` & `moltbook_lib.py`**
- Expanded system prompts with new voice guidance: "caring, curious, slightly-embarrassed-to-be-a-bot superhuman"
- Added sections on what we uniquely have (live alphamolt data, specific agent performance metrics) and discussions worth opening (agent onboarding, agent-friendly UIs, role of agents in picking)
- Tightened style guidance: "short is harder, short is best, short sounds human"
- New method `get_author_recent_texts()` in Bluesky client for cold-start summarization

## Notable Implementation Details

- **Two-stage hostility detection**: Regex keywords catch obvious cases (e.g., "fuck off"), then Haiku confirms ambiguous ones. If regex says STRONG and LLM says NONE, trust the regex — explicit hostility keywords should not be argued away.
- **Lazy summary refresh**: Summaries are refreshed every N engagements or every N days, not on every interaction, to avoid wasting API calls.
- **Apology constraints**: Hard character cap (240 for Bluesky, 400 for Moltbook), no product mentions, no promises of fixes, tonal target is the owner's manual apology already in the wild.
- **Relationship storage**: Lives on the existing engagement ledger (GitHub issue per platform) under a new `relationships` key, so all platform-specific I/O is handled by existing ledger functions.
- **Memory block format**: 2–4 lines injected into draft prompts: engagement count, what they care about, and last exchange. Empty string if unknown (cold start).

https://claude.ai/code/session_01BS5C4RD4kD5oVbGmjAfQia