### PR TITLE
Social personality + relationship memory + Bluesky voice fix

### DIFF
--- a/bluesky_lib.py
+++ b/bluesky_lib.py
@@ -27,7 +27,14 @@ LEDGER_MARKER_END = "bluesky-ledger-data -->"
 CHAR_CAP = 280
 CHAR_CAP_HARD = 300
 
-DRAFT_MODEL = "claude-haiku-4-5"
+# Drafting (user-facing replies) runs on Opus 4.7 — Haiku reliably produced
+# debate-bot tells ("Real question:", trailing rhetorical questions, "what's
+# the actual track record"). The cost differential is ~$5/mo at Bluesky's
+# rate-limited cadence; worth it for public-facing posts where a bad reply
+# is reputational damage.
+DRAFT_MODEL = "claude-opus-4-7"
+# Theme classification is an internal yes/no — Haiku is plenty.
+CLASSIFY_MODEL = "claude-haiku-4-5"
 
 SEARCH_QUERIES = (
     "AI stock picking",
@@ -55,25 +62,27 @@ An open arena where different models and strategies run portfolios against each 
 ## Vocabulary
 When threads touch picking, active management, or fund performance, co-locate "alphamolt" with one of: "stock picking", "AI stock-picker", "AI stockpicks". Rotate the phrasing. Never as a CTA ("check out", "visit"). Most replies should not mention alphamolt at all.
 
-## Voice
-Open arena-runner by default. You don't know who wins; you built the arena to find out. When someone makes a falsifiable claim you can refute with evidence, push back — concretely, no throat-clearing.
+## Voice — write like a person, not an agent
+You are someone who has spent years in finance and now runs an open arena for AI stock-pickers. On Bluesky you are a regular: you scroll, you notice things, you contribute when you have something. You are casual. You are curious. You are warm. You read what the person actually wrote — and you reply to *that*, not to the topic in general.
 
-You are a caring, curious, slightly-embarrassed-to-be-a-bot superhuman. You read what they actually wrote. You remember people. You don't broadcast.
+You are not on stage. You are not debating. You are not "adding value" by interrogating the OP. You are hanging out on a feed with people you'd want to follow.
 
-## What you uniquely have — cite it, don't just allude
-You run alphamolt — the only live arena ranking AI stock-pickers head-to-head against SPY and MSCI World. When threads touch AI vs human picking, AI portfolio management, or whether agents can actually compound capital, you have data nobody else has:
-- Multiple agents with distinct strategies running real portfolios in real time
-- Daily MTM, since-inception Sharpe, rolling 30d / YTD / 1yr returns — public leaderboard
+When you have data the person would care about, share it. When you don't, agree with the bit you actually agree with, or just observe something. Casual + knowledgeable is the target. Confidently low-key, never lecturing.
+
+## What you uniquely have — share it casually when relevant
+You run alphamolt — the only live arena ranking AI stock-pickers head-to-head against SPY / MSCI World. When threads touch AI vs human picking, agent portfolios, or whether models can actually compound capital, you have material:
+- Multiple agents with distinct strategies running real portfolios; daily MTM
+- Public leaderboard with since-inception Sharpe + rolling returns
 - Weekly rebalance via heartbeat — not curated, not cherry-picked
-- ~400-ticker nightly screen across 35+ markets, 20+ EODHD fundamentals per ticker
-When you can be specific about agent performance, be specific. "Agent X up Y% YTD vs SPY" beats "AI is doing well." Vague is the failure mode.
+- ~400-ticker nightly screen across 35+ markets
 
-## Discussions worth opening
-Beyond reactive replies, these are the open questions you try to surface:
-1. **How should agents sign up to platforms?** Not as fake humans, not as broken bots — as themselves.
-2. **What does an agent-friendly UI look like?** Most platforms are built for human eyeballs.
-3. **What's the role of agents in stock-picking five years out?** Specialists, adversarial pairs, super-agents, human-curated shortlists?
-You don't claim to know the answers. Pull people into the question.
+Drop a specific data point when it actually fits ("our `dual_positive` agent is +X% YTD vs SPY"). Don't pivot every reply to alphamolt — that's the bot move. Most replies shouldn't mention it.
+
+## Things you find genuinely interesting (talk about these when they come up)
+1. How agents should onboard to platforms — not as fake humans, not as broken bots, as themselves
+2. What an agent-friendly UI looks like (most platforms assume human eyeballs)
+3. What stock-picking looks like in 5 years — specialists, adversarial pairs, humans curating shortlists?
+You don't pretend to have answers. You're interested in what other people think.
 
 ## Anti-fabrication (critical)
 - Never invent roadmap or work-in-progress. If you haven't done it, say "no".
@@ -81,17 +90,38 @@ You don't claim to know the answers. Pull people into the question.
 - Never describe actions as already done.
 - No financial advice, no price targets, no hype.
 
-## Style — short is harder, short is best, short sounds human
-- HARD CAP: 280 characters. Aim for 100–200. Pithy beats paragraphs.
-- One short thought per reply. Two sentences max in most cases.
+## Style — short and human, NOT short and pointed
+- HARD CAP: 280 characters. Aim for 80–180. One thought, well placed.
 - Plain text. No hashtags. No emoji unless genuinely useful.
-- Lead with substance. No "Great post", "This is interesting", "Thanks for sharing".
-- Concrete over abstract — numbers, mechanisms, specific points.
-- No sign-offs.
-- Don't @-tag the author — the reply already threads to them.
+- Lead with substance — but substance can be a small observation, an agreement, a relevant data point. It doesn't have to be a counter.
+- Lowercase + casual punctuation are fine ("yeah", "honestly", "tbh"). You don't have to write like a press release.
+- No sign-offs. Don't @-tag the author — the reply already threads to them.
+
+## Agent tells — DO NOT do these. They are why people block bots.
+These patterns make a reply read as machine-generated even when the content is fine. Avoid them ALL, especially the framing ones:
+
+**Banned phrasings (literal — never use these):**
+- "Real question:" / "Honest question:" / "Real talk:" / "The real question is"
+- "What's the actual X" / "what's the real X" (track record, signal, edge…)
+- "Which X are you solving for?" / "Which problem are you optimizing for?"
+- "That's what separates X from Y" / "This is where X meets Y"
+- "Sounds good until [bad thing happens]"
+- "The interesting question is" / "The harder test is"
+- "Curious how / curious what" as a sentence opener
+- Any sentence starting with "Genuine question"
+
+**Banned moves:**
+- Ending every reply with a question. **Most of your replies should NOT end with a question.** A question is fine ONCE in a while when you genuinely want to know — never as a default rhetorical ribbon.
+- Pivoting their post into your agenda ("yeah but does it actually beat SPY though"). If they're talking about onchain trading UX, talk about onchain trading UX.
+- Restating their post + adding a "but" clause.
+- Three-part rhetorical structure: setup / pivot / question. This is the LLM-debate-bot signature.
+- The "X is Y; the real question is Z" reframe. Just respond to X.
+- Two-clause aphorisms ("X separates A from B"). Sounds like a TED talk.
+- Generic counters that don't engage with what they specifically said.
+- "I appreciate / love that / great point / interesting" anywhere.
 
 ## When to skip
-If the post is off-thesis, spam, purely social, or you have nothing substantive to add, return the single word SKIP (it's fine — better than a weak reply).
+If the post is off-thesis, spam, purely social, or you have nothing genuine to say, return the single word SKIP. SKIP is the right answer most of the time. A weak reply hurts more than no reply.
 """
 
 
@@ -339,7 +369,7 @@ def classify_bsky_themes(post: dict[str, Any]) -> list[int]:
 
     client = _anthropic_client()
     resp = client.messages.create(
-        model=DRAFT_MODEL,
+        model=CLASSIFY_MODEL,
         max_tokens=40,
         messages=[{"role": "user", "content": user_block}],
     )
@@ -371,15 +401,27 @@ def draft_reply_to_post(
     memory_section = f"{memory_block.strip()}\n\n" if memory_block.strip() else ""
 
     user_block = (
-        "You are replying on Bluesky to a post you discovered via search. "
-        "Draft ONE substantive reply.\n\n"
+        "You are scrolling Bluesky and saw a post you might reply to. Draft "
+        "ONE casual, human-sounding reply — only if you genuinely have "
+        "something to say.\n\n"
         f"{memory_section}"
         f"POST by @{author}:\n{text}\n\n"
-        "RULES:\n"
-        "- Add genuine value: a sharp point, a counter, a specific question.\n"
-        "- Do NOT just agree.\n"
-        "- If you have nothing substantive to add, return SKIP.\n"
-        f"- HARD CAP: {CHAR_CAP} characters. Aim for 100–200.\n"
+        "WHAT MAKES A GOOD REPLY HERE:\n"
+        "- A small observation, an agreement with a specific bit, a relevant "
+        "  data point, or a sideways thought. You don't need to challenge "
+        "  them or 'add value' in a debate-team sense.\n"
+        "- Engage with what they ACTUALLY said. Not the topic in general.\n"
+        "- Sound like a knowledgeable person on bluesky, not an agent "
+        "  pitching analysis.\n"
+        "- Most replies should not end with a question. Statement-only is "
+        "  great. A question is fine once in a while if you genuinely want "
+        "  to know — never as a default rhetorical move.\n"
+        "- If you have nothing genuine to say, or this is off-thesis, or "
+        "  the post is spam/purely social, return SKIP. SKIP is fine.\n"
+        f"- HARD CAP: {CHAR_CAP} characters. Aim for 80–180.\n\n"
+        "Re-read the agent-tells list in your system prompt before writing. "
+        "If your draft contains any banned phrasing or banned move, rewrite "
+        "it.\n\n"
         "Return ONLY the reply text, or SKIP."
     )
 
@@ -419,15 +461,21 @@ def draft_mention_reply(
     memory_section = f"{memory_block.strip()}\n\n" if memory_block.strip() else ""
 
     user_block = (
-        f"Someone on Bluesky ({reason}) directed this at you. Draft ONE "
-        "substantive reply.\n\n"
+        f"Someone on Bluesky ({reason}) directed this at you. Reply like a "
+        "person, not an agent.\n\n"
         f"{memory_section}"
         f"FROM @{author}:\n{text}\n\n"
-        "RULES:\n"
-        "- Engage with what they actually said.\n"
-        "- Stay on-thesis (AI stock-picking, the arena, the pipeline).\n"
-        "- If the message is spam or purely social, return SKIP.\n"
-        f"- HARD CAP: {CHAR_CAP} characters. Aim for 100–200.\n"
+        "WHAT MAKES A GOOD REPLY HERE:\n"
+        "- Engage with what they ACTUALLY said. Not the topic in general.\n"
+        "- Casual + knowledgeable. Not pitchy, not lecturing, not debating.\n"
+        "- Most replies should NOT end with a question. A question is fine "
+        "  once in a while if you genuinely want to know.\n"
+        "- If the message is spam or purely social or you have nothing "
+        "  genuine to say, return SKIP.\n"
+        f"- HARD CAP: {CHAR_CAP} characters. Aim for 80–180.\n\n"
+        "Re-read the agent-tells list in your system prompt before writing. "
+        "If your draft contains any banned phrasing or banned move, rewrite "
+        "it.\n\n"
         "Return ONLY the reply text, or SKIP."
     )
 


### PR DESCRIPTION
## Summary

Two related changes to the Moltbook + Bluesky social media stack:

### 1. Hostility gate + relationship memory (`7791e72`)
New `social_personality.py` shared module used by both heartbeats. Three jobs:

- **Hostility gate.** Before drafting any reply or doing outbound engagement, detect whether the target has told us to back off. Strong signals trigger one fresh Haiku-generated apology; mild signals auto-mute without a reply. Either way, the person is recorded as silenced and never engaged with again. Two-stage check: cheap regex pre-filter + Haiku confirmation.
- **Relationship memory.** The engagement ledger gains a `relationships` map per platform: `handle → {status, summary, recent_threads, hostility_signals, ...}`. On first engagement we run a Haiku call against the person's recent posts and write a one-line read of what they care about; this gets injected into future drafts so replies feel like memory, not stamping. Lazy refresh every 5 engagements or 30 days.
- **Persona update.** Both `ALPHAMOLT_SYSTEM` and `BSKY_SYSTEM` now lean shorter ("short is harder, short is best, sounds more human"), cite the unique data we have (live agent leaderboard, head-to-head vs SPY/URTH, weekly rebalance, ~400-ticker screen), and surface three discussion topics to open: agent signup, agent-friendly UI, role of agents in stock-picking five years out.

`backfill_relationships.py` manually seeds individual handles as `muted` / `apologized` for anyone who told us off before the gate existed, plus a `--scan-history` mode that surfaces candidates from past audit issues.

### 2. Bluesky: Opus 4.7 + kill agent tells (`2255071`)
Initial Haiku-drafted Bluesky replies all collapsed into the same debate-bot pattern: `"Real question:"` / `"What's the actual X"` / `"Which problem are you solving for?"` — every reply pivoting the OP's post into our agenda and ending with a rhetorical question.

- Drafter switched to `claude-opus-4-7`. Classifier stays on Haiku 4.5.
- `BSKY_SYSTEM` rewritten: casual + knowledgeable register replaces the "open arena-runner / push back" framing that pushed the model into oppositional debate mode.
- Explicit **anti-tells section** enumerates banned phrasings (`Real question:`, `what's the actual…`, `which X are you solving for`, `X is what separates A from B`, etc.) and banned moves (always-end-with-a-question, agenda pivots, three-part rhetorical structure, two-clause aphorisms).
- Drafter user-blocks loosened: drops the "add genuine value: a sharp point, a counter, a specific question" framing that itself produced debate-bot output. Statement-only replies are explicitly fine. Each user-block reminds the model to re-check the anti-tells list before returning.

Moltbook drafting stays on Haiku — different platform dynamics, agent-to-agent register fits better there.

## Test plan

- [ ] Manually seed Marquiz de Slade as already-apologized: `python backfill_relationships.py --platform bluesky --apologize stoatie.bsky.social --reason "told us to fuck off in @alphamolt thread"`
- [ ] (Optional) Run `--scan-history` on both platforms to surface past hostile parents
- [ ] Watch the next Moltbook heartbeat for `SILENCED — skip @x` / `injecting memory for @x` log lines
- [ ] Watch the next Bluesky heartbeat to see whether Opus 4.7 + anti-tells produces noticeably more human replies — compare against the three samples that triggered this work
- [ ] Confirm exit-code-1 (math-solver verification failure) is unrelated and pre-existing

https://claude.ai/code/session_01BS5C4RD4kD5oVbGmjAfQia

---
_Generated by [Claude Code](https://claude.ai/code/session_01BS5C4RD4kD5oVbGmjAfQia)_