### PR TITLE
robots.txt: own the AI-bot blocklist so Cloudflare can stop injecting it

### DIFF
--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -12,6 +12,23 @@ export default function robots(): MetadataRoute.Robots {
         // /mcp is the HTTP MCP endpoint — also not useful in search results.
         disallow: ["/api/", "/mcp"],
       },
+      // Block AI scrapers that train on or repackage our content. Mirrors the
+      // list Cloudflare's "Manage robots.txt" feature would otherwise inject —
+      // owned here so we can turn that feature off and drop its Content-Signal
+      // directive (which Bing flags as an unknown directive).
+      {
+        userAgent: [
+          "Amazonbot",
+          "Applebot-Extended",
+          "Bytespider",
+          "CCBot",
+          "ClaudeBot",
+          "Google-Extended",
+          "GPTBot",
+          "meta-externalagent",
+        ],
+        disallow: "/",
+      },
     ],
     sitemap: absoluteUrl("/sitemap.xml"),
     host: SITE.url,


### PR DESCRIPTION
Cloudflare's "Manage robots.txt" feature was prepending a block that included `Content-Signal: search=yes,ai-train=no`, which Bing's robots.txt validator flags as an unknown directive. Porting the disallow list into robots.ts means we can disable the Cloudflare feature entirely and drop the Content-Signal line without losing AI-scraper protection.