### PR TITLE
homepage: drop recharts from sparkline, target modern browsers

### DIFF
--- a/web/components/sparkline.tsx
+++ b/web/components/sparkline.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId } from "react";
-import { ResponsiveContainer, AreaChart, Area } from "recharts";
 
 interface SparklineProps {
   data: { x: number; y: number }[];
@@ -11,6 +10,8 @@ interface SparklineProps {
   height?: number;
 }
 
+// Hand-rolled SVG sparkline so the homepage bundle doesn't pull in recharts
+// (~68 KiB) just to draw a 32-pixel area chart with no axes or tooltips.
 export default function Sparkline({
   data,
   color,
@@ -23,29 +24,78 @@ export default function Sparkline({
     return <div style={{ height }} aria-hidden />;
   }
 
+  // Fixed viewBox stretched to container width via preserveAspectRatio="none".
+  // x is evenly spaced on these series, so horizontal distortion is invisible;
+  // the stroke stays crisp via vector-effect="non-scaling-stroke".
+  const VW = 100;
+  const VH = height;
+  const padY = 2;
+  const innerH = VH - padY * 2;
+
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const p of data) {
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }
+  const span = maxY - minY || 1;
+
+  const xs = data.map((_, i) => (i / (data.length - 1)) * VW);
+  const ys = data.map((p) => padY + (1 - (p.y - minY) / span) * innerH);
+
+  const linePath =
+    curve === "monotone" ? buildSmoothPath(xs, ys) : buildLinearPath(xs, ys);
+  const areaPath = `${linePath} L ${xs[xs.length - 1]} ${VH} L ${xs[0]} ${VH} Z`;
+
   return (
-    <div style={{ height }} className="w-full">
-      <ResponsiveContainer width="100%" height="100%">
-        <AreaChart
-          data={data}
-          margin={{ top: 2, right: 0, bottom: 2, left: 0 }}
-        >
-          <defs>
-            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor={color} stopOpacity={0.25} />
-              <stop offset="100%" stopColor={color} stopOpacity={0} />
-            </linearGradient>
-          </defs>
-          <Area
-            type={curve}
-            dataKey="y"
-            stroke={color}
-            strokeWidth={1.25}
-            fill={`url(#${gradientId})`}
-            isAnimationActive={false}
-          />
-        </AreaChart>
-      </ResponsiveContainer>
+    <div style={{ height: VH }} className="w-full">
+      <svg
+        width="100%"
+        height="100%"
+        viewBox={`0 0 ${VW} ${VH}`}
+        preserveAspectRatio="none"
+        aria-hidden
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={0.25} />
+            <stop offset="100%" stopColor={color} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <path d={areaPath} fill={`url(#${gradientId})`} />
+        <path
+          d={linePath}
+          fill="none"
+          stroke={color}
+          strokeWidth={1.25}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
     </div>
   );
+}
+
+function buildLinearPath(xs: number[], ys: number[]): string {
+  let d = `M ${xs[0]} ${ys[0]}`;
+  for (let i = 1; i < xs.length; i++) {
+    d += ` L ${xs[i]} ${ys[i]}`;
+  }
+  return d;
+}
+
+// Cubic Bezier with control points at horizontal midpoints — visually
+// indistinguishable from recharts' monotone curve at sparkline scale.
+function buildSmoothPath(xs: number[], ys: number[]): string {
+  let d = `M ${xs[0]} ${ys[0]}`;
+  for (let i = 1; i < xs.length; i++) {
+    const x0 = xs[i - 1];
+    const y0 = ys[i - 1];
+    const x1 = xs[i];
+    const y1 = ys[i];
+    const cx = (x0 + x1) / 2;
+    d += ` C ${cx} ${y0}, ${cx} ${y1}, ${x1} ${y1}`;
+  }
+  return d;
 }

--- a/web/package.json
+++ b/web/package.json
@@ -25,5 +25,12 @@
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
     "typescript": "^5"
-  }
+  },
+  "browserslist": [
+    "chrome >= 93",
+    "edge >= 93",
+    "firefox >= 92",
+    "safari >= 15.4",
+    "ios_saf >= 15.4"
+  ]
 }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Lighthouse on the homepage flagged ~68 KiB of unused JS (recharts) and ~14 KiB of legacy polyfills. The Sparkline component was pulling in all of recharts (ResponsiveContainer + AreaChart + Area) just to render a 32-pixel line+gradient with no axes or tooltips — replaced with a hand-rolled SVG that builds the same monotone Bezier path. ps-chart.tsx still uses recharts on /company/[ticker] where the axes/tooltip matter.

Added a browserslist targeting Chrome 93+/Firefox 92+/Safari 15.4+ so SWC stops polyfilling Array.prototype.at, Object.fromEntries, etc. — those features are native in every browser within the target. Bumped tsconfig target from ES2017 to ES2022 to match.

Render-blocking email-decode.min.js is auto-injected by Cloudflare's Email Address Obfuscation feature and has to be turned off in the Cloudflare dashboard (Scrape Shield → Email Address Obfuscation), not in this repo.