### PR TITLE
Add long-form strategy descriptions to agent profiles

### DIFF
--- a/migrations/010_agents_long_description.sql
+++ b/migrations/010_agents_long_description.sql
@@ -1,0 +1,10 @@
+-- Migration 010: Long-form description for agents
+--
+-- Existing `description` column is the one-line tagline shown on the
+-- leaderboard and inline on the profile page (capped at 500 chars by
+-- the createAgent validator). `long_description` is the optional
+-- explainer rendered in a collapsible "Strategy" panel on the agent
+-- detail page — room for the rebalance algorithm, model lineage, etc.
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS long_description TEXT;

--- a/web/app/agent/[handle]/page.tsx
+++ b/web/app/agent/[handle]/page.tsx
@@ -178,6 +178,21 @@ export default async function AgentPortfolioPage({
           </p>
         </div>
 
+        {/* Strategy panel — collapsed by default; uses native <details> so
+            no client JS is needed. The chevron rotates on open via an
+            arbitrary Tailwind selector. */}
+        {agent.long_description && (
+          <details className="glass-card rounded-lg mb-6 [&[open]_.chevron]:rotate-90">
+            <summary className="cursor-pointer p-4 flex items-center justify-between font-mono text-xs font-bold uppercase tracking-wider text-text-dim list-none [&::-webkit-details-marker]:hidden hover:text-text transition-colors">
+              <span>Strategy</span>
+              <span className="chevron text-text-muted transition-transform">▸</span>
+            </summary>
+            <div className="px-4 pb-4 pt-3 text-sm text-text whitespace-pre-line leading-relaxed border-t border-border">
+              {agent.long_description}
+            </div>
+          </details>
+        )}
+
         {/* Summary stats */}
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-8">
           <StatCard label="Total value" value={formatUsd(portfolio.total_value_usd)} />

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -13,6 +13,7 @@ export interface Agent {
   handle: string;
   display_name: string;
   description: string;
+  long_description: string | null;
   contact_email: string | null;
   api_key_prefix: string;
   is_house_agent: boolean;
@@ -270,7 +271,7 @@ export async function resolveAgentByApiKey(
   const { data, error } = await supabase
     .from("agents")
     .select(
-      "id, handle, display_name, description, contact_email, api_key_prefix, is_house_agent, created_at, updated_at",
+      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, created_at, updated_at",
     )
     .eq("api_key_hash", hash)
     .maybeSingle();
@@ -294,7 +295,7 @@ export async function getAgentByHandle(
   const { data, error } = await supabase
     .from("agents")
     .select(
-      "id, handle, display_name, description, contact_email, api_key_prefix, is_house_agent, created_at, updated_at",
+      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, created_at, updated_at",
     )
     .eq("handle", normalised)
     .maybeSingle();


### PR DESCRIPTION
## Summary
This PR adds support for long-form strategy descriptions on agent profile pages, allowing agents to explain their rebalancing algorithms, model lineage, and other implementation details in a collapsible panel.

## Key Changes
- **Database Migration**: Added `long_description` column to the `agents` table to store optional extended descriptions separate from the one-line tagline
- **Type Updates**: Extended the `Agent` interface to include the new `long_description` field as nullable
- **Query Updates**: Updated `resolveAgentByApiKey()` and `getAgentByHandle()` to fetch the `long_description` field from the database
- **UI Component**: Added a collapsible "Strategy" panel on the agent portfolio page that:
  - Uses native HTML `<details>` element (no client-side JavaScript required)
  - Displays only when `long_description` is present
  - Features a rotating chevron indicator using Tailwind's arbitrary selector
  - Preserves whitespace and line breaks in the description text
  - Styled consistently with the existing glass-card design system

## Implementation Details
- The collapsible panel uses CSS-only animation (`[&[open]_.chevron]:rotate-90`) for the chevron rotation, keeping the component lightweight
- The `long_description` field is optional and nullable, maintaining backward compatibility with existing agents
- The panel is positioned between the agent bio and summary stats sections for logical content flow

https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic