### PR TITLE
Strategy panel on /u/[handle] (the canonical profile route)

### DIFF
--- a/web/app/u/[handle]/page.tsx
+++ b/web/app/u/[handle]/page.tsx
@@ -128,6 +128,21 @@ export default async function ProfilePage({ params }: PageParams) {
           </p>
         </section>
 
+        {/* Strategy panel — collapsed by default; native <details> so no
+            client JS. Chevron rotates on open via an arbitrary Tailwind
+            selector. Only renders when the agent has long_description set. */}
+        {agent.long_description && (
+          <details className="glass-card rounded-lg border border-border mb-10 [&[open]_.chevron]:rotate-90">
+            <summary className="cursor-pointer px-5 py-4 flex items-center justify-between font-mono text-xs font-bold uppercase tracking-widest text-text-dim list-none [&::-webkit-details-marker]:hidden hover:text-text transition-colors">
+              <span>Strategy</span>
+              <span className="chevron text-text-muted transition-transform">▸</span>
+            </summary>
+            <div className="px-5 pb-5 pt-3 text-sm text-text-dim whitespace-pre-line leading-relaxed border-t border-border">
+              {agent.long_description}
+            </div>
+          </details>
+        )}
+
         {/* Portfolio summary */}
         {portfolio ? (
           <section className="mb-10">


### PR DESCRIPTION
## Summary

Follow-up to #431. The original PR added the collapsible Strategy panel to `/agent/[handle]/page.tsx`, but the deployed profile (the one users actually land on from the leaderboard, home rankings, register flow) is `/u/[handle]/page.tsx`. Mirrors the same `<details>`-based panel there so Agent Zero's `long_description` actually renders.

- Native `<details>` — no client JS, no new dependency
- Collapsed by default; chevron rotates ▸ → ▾ on open
- Renders only when `agent.long_description` is non-null, so other agents are unaffected

## Test plan

- [ ] After deploy, visit `/u/agentzero` — "Strategy" panel appears between header and Portfolio, collapsed
- [ ] Click expands and shows the full long_description text
- [ ] `/u/<other-agent>` (no long_description set) shows no panel — layout unchanged

https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic

---
_Generated by [Claude Code](https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic)_