### PR TITLE
Phase 2: public /api/v1/universe endpoint (stacked on #434)

### DIFF
--- a/web/app/api/v1/universe/[date]/route.ts
+++ b/web/app/api/v1/universe/[date]/route.ts
@@ -1,0 +1,93 @@
+/**
+ * GET /api/v1/universe/{date}
+ *
+ * Returns a specific historical universe snapshot. Public, no auth.
+ *
+ * Path: date as ISO YYYY-MM-DD (the snapshot_date PK column).
+ * Query params:
+ *   ?detail=compact|extended|full   (default: extended)
+ *   ?tickers=NVDA,AAPL,...           (optional in-memory slice)
+ *
+ * 404 when the (date, detail) pair doesn't exist. No backfill: pre-Phase-1
+ * dates return 404 by design.
+ */
+
+import {
+  errorResponse,
+  jsonResponse,
+  optionsResponse,
+} from "@/lib/api-utils";
+import {
+  getSnapshotByDate,
+  isDetail,
+  parseTickerFilter,
+  sliceByTickers,
+} from "@/lib/universe-query";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ date: string }> },
+) {
+  const { date } = await params;
+  if (!DATE_RE.test(date)) {
+    return errorResponse(
+      `Invalid date '${date}'. Expected YYYY-MM-DD.`,
+      400,
+      "invalid_date",
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const detailParam = searchParams.get("detail") ?? "extended";
+  if (!isDetail(detailParam)) {
+    return errorResponse(
+      `Unknown detail tier '${detailParam}'. Expected: compact, extended, full.`,
+      400,
+      "invalid_detail",
+    );
+  }
+
+  try {
+    const snap = await getSnapshotByDate(date, detailParam);
+    if (!snap) {
+      return errorResponse(
+        `No snapshot for ${date} at detail='${detailParam}'.`,
+        404,
+        "snapshot_not_found",
+      );
+    }
+
+    const filter = parseTickerFilter(searchParams.get("tickers"));
+    const json = filter ? sliceByTickers(snap.json, filter) : snap.json;
+
+    return jsonResponse(
+      {
+        snapshot_date: snap.snapshot_date,
+        detail: snap.detail,
+        sha256: snap.sha256,
+        ticker_count: json.ticker_count,
+        created_at: snap.created_at,
+        snapshot: json,
+      },
+      {
+        // Historical snapshots are doubly immutable — CDN can hold for
+        // the full year + serve stale indefinitely.
+        headers: {
+          "Cache-Control": "public, max-age=31536000, immutable",
+        },
+      },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 500);
+  }
+}

--- a/web/app/api/v1/universe/route.ts
+++ b/web/app/api/v1/universe/route.ts
@@ -1,0 +1,82 @@
+/**
+ * GET /api/v1/universe
+ *
+ * Returns the latest daily universe snapshot. Public, no auth — same data
+ * the LLM agents see at heartbeat time.
+ *
+ * Query params:
+ *   ?detail=compact|extended|full   (default: extended)
+ *   ?tickers=NVDA,AAPL,...           (optional in-memory slice)
+ *
+ * Response: the stored snapshot JSON, plus metadata (sha256, ticker_count,
+ * created_at) for cache validation. Cached for 24h on the CDN — snapshots
+ * are immutable per (date, detail) so this is safe.
+ */
+
+import {
+  errorResponse,
+  jsonResponse,
+  optionsResponse,
+} from "@/lib/api-utils";
+import {
+  getLatestSnapshot,
+  isDetail,
+  parseTickerFilter,
+  sliceByTickers,
+} from "@/lib/universe-query";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const detailParam = searchParams.get("detail") ?? "extended";
+  if (!isDetail(detailParam)) {
+    return errorResponse(
+      `Unknown detail tier '${detailParam}'. Expected: compact, extended, full.`,
+      400,
+      "invalid_detail",
+    );
+  }
+
+  try {
+    const snap = await getLatestSnapshot(detailParam);
+    if (!snap) {
+      return errorResponse(
+        "No universe snapshot available yet. The daily build runs at 06:00 UTC.",
+        404,
+        "snapshot_not_found",
+      );
+    }
+
+    const filter = parseTickerFilter(searchParams.get("tickers"));
+    const json = filter ? sliceByTickers(snap.json, filter) : snap.json;
+
+    return jsonResponse(
+      {
+        snapshot_date: snap.snapshot_date,
+        detail: snap.detail,
+        sha256: snap.sha256,
+        ticker_count: json.ticker_count,
+        created_at: snap.created_at,
+        snapshot: json,
+      },
+      {
+        // Snapshots are immutable per (date, detail). 24h CDN cache is
+        // safe — even with the in-memory ticker slice, the response is
+        // a deterministic function of (date, detail, tickers) so the
+        // CDN keys it correctly via the full URL.
+        headers: {
+          "Cache-Control": "public, max-age=86400, stale-while-revalidate=86400",
+        },
+      },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 500);
+  }
+}

--- a/web/lib/universe-query.ts
+++ b/web/lib/universe-query.ts
@@ -1,0 +1,145 @@
+/**
+ * Supabase query wrapper for universe_snapshots.
+ *
+ * Snapshots are written daily by build_universe_snapshot.py, one row per
+ * (date, detail) tier. This module is the single read-side entry point —
+ * the public /api/v1/universe endpoint, the /universe page, and (later)
+ * the llm_pick strategy all funnel through here.
+ *
+ * Slicing model: tier selection happens at row-level (one DB hit per
+ * request), ticker slicing happens in-memory after the JSON is loaded.
+ * That's cheap because the largest tier is ~1MB and slicing is a
+ * filter+filter on a smallish array. If snapshots ever grow past ~5MB
+ * we'd revisit.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+
+export type Detail = "compact" | "extended" | "full";
+
+export const DETAILS: readonly Detail[] = ["compact", "extended", "full"];
+
+export interface SnapshotMeta {
+  snapshot_date: string;     // ISO date "YYYY-MM-DD"
+  detail: Detail;
+  sha256: string;
+  ticker_count: number;
+  created_at: string;
+}
+
+export interface SnapshotJson {
+  snapshot_date: string;
+  snapshot_time_utc: string;
+  detail: Detail;
+  universe_filter: Record<string, unknown>;
+  ticker_count: number;
+  tickers: Array<Record<string, unknown> & { ticker?: string }>;
+}
+
+export interface SnapshotResponse extends SnapshotMeta {
+  json: SnapshotJson;
+}
+
+export function isDetail(s: string | null | undefined): s is Detail {
+  return s === "compact" || s === "extended" || s === "full";
+}
+
+/**
+ * Parse a `?tickers=NVDA,AAPL,...` query value into a normalised set.
+ * Returns null if the param is empty/missing — caller treats that as
+ * "no slicing, return everything".
+ */
+export function parseTickerFilter(raw: string | null): Set<string> | null {
+  if (!raw) return null;
+  const tickers = raw
+    .split(",")
+    .map((t) => t.trim().toUpperCase())
+    .filter(Boolean);
+  return tickers.length > 0 ? new Set(tickers) : null;
+}
+
+/**
+ * Fetch the latest snapshot at the given detail tier. Returns null if no
+ * snapshot has been built yet (fresh deploy, before the first 06:00 UTC
+ * cron) or if the table is empty.
+ */
+export async function getLatestSnapshot(
+  detail: Detail,
+): Promise<SnapshotResponse | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("universe_snapshots")
+    .select("snapshot_date, detail, sha256, ticker_count, created_at, json")
+    .eq("detail", detail)
+    .order("snapshot_date", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    console.error("getLatestSnapshot query failed:", error);
+    return null;
+  }
+  return data ? (data as unknown as SnapshotResponse) : null;
+}
+
+/**
+ * Fetch a specific historical snapshot. Returns null when the (date,
+ * detail) pair doesn't exist — the API surface translates that into 404.
+ */
+export async function getSnapshotByDate(
+  date: string,
+  detail: Detail,
+): Promise<SnapshotResponse | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("universe_snapshots")
+    .select("snapshot_date, detail, sha256, ticker_count, created_at, json")
+    .eq("snapshot_date", date)
+    .eq("detail", detail)
+    .maybeSingle();
+  if (error) {
+    console.error("getSnapshotByDate query failed:", error);
+    return null;
+  }
+  return data ? (data as unknown as SnapshotResponse) : null;
+}
+
+/**
+ * List the most recent N snapshot dates (for the date-picker UI). Reads
+ * the `compact` tier only since dates are always built in lockstep across
+ * tiers — one row per tier per day.
+ */
+export async function listSnapshotDates(limit = 30): Promise<SnapshotMeta[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("universe_snapshots")
+    .select("snapshot_date, detail, sha256, ticker_count, created_at")
+    .eq("detail", "compact")
+    .order("snapshot_date", { ascending: false })
+    .limit(limit);
+  if (error) {
+    console.error("listSnapshotDates query failed:", error);
+    return [];
+  }
+  return (data ?? []) as SnapshotMeta[];
+}
+
+/**
+ * Apply an in-memory ticker filter to a snapshot. The returned object
+ * keeps every top-level key but the `tickers` array and `ticker_count`
+ * are restricted. Use this when callers pass `?tickers=...` so the
+ * payload shrinks before serialisation.
+ */
+export function sliceByTickers(
+  snapshot: SnapshotJson,
+  tickers: Set<string>,
+): SnapshotJson {
+  const filtered = snapshot.tickers.filter((t) => {
+    const sym = String(t.ticker ?? "").toUpperCase();
+    return tickers.has(sym);
+  });
+  return {
+    ...snapshot,
+    tickers: filtered,
+    ticker_count: filtered.length,
+  };
+}


### PR DESCRIPTION
## Phase 2 of the LLM-pick build — *stacked on #434*

Public read surface for the snapshots that PR #434 produces. Merge **after** #434.

### Routes

| Method | Path | What |
|---|---|---|
| `GET` | `/api/v1/universe` | Latest snapshot, defaults to `extended` tier |
| `GET` | `/api/v1/universe/{YYYY-MM-DD}` | Historical snapshot |

Both accept:
- `?detail=compact|extended|full` (default `extended`)
- `?tickers=NVDA,AAPL,...` (in-memory slice — keeps full metadata, drops non-matching tickers)

### Caching

| Endpoint | Cache-Control |
|---|---|
| Latest | `public, max-age=86400, stale-while-revalidate=86400` |
| Historical | `public, max-age=31536000, immutable` |

Snapshot rows are immutable per `(date, detail)` PK so the immutable header is honest.

### Examples

```bash
# Latest extended snapshot
curl https://www.alphamolt.ai/api/v1/universe

# Latest compact tier (smaller, no history)
curl https://www.alphamolt.ai/api/v1/universe?detail=compact

# Yesterday's full tier sliced to 3 tickers
curl 'https://www.alphamolt.ai/api/v1/universe/2026-04-29?detail=full&tickers=NVDA,AAPL,MSFT'
```

### Test plan

- [ ] After #434 merges + migration applied + first snapshot built: `GET /api/v1/universe` returns 200 with `extended` tier
- [ ] `GET /api/v1/universe?detail=compact` returns 200; payload smaller than extended
- [ ] `GET /api/v1/universe?tickers=NVDA` returns 200 with `ticker_count: 1` (or 0 if NVDA isn't in screen today)
- [ ] `GET /api/v1/universe?detail=garbage` returns 400 `invalid_detail`
- [ ] `GET /api/v1/universe/2030-01-01` returns 404 `snapshot_not_found`
- [ ] `GET /api/v1/universe/garbage` returns 400 `invalid_date`
- [ ] `OPTIONS /api/v1/universe` returns 204 with CORS headers (browser preflights work)

### Deferred to later phases

- Phase 3: `/universe` page (table + JSON download + date picker)
- Phase 5: `llm_pick` strategy that consumes this endpoint at heartbeat time

https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic

---
_Generated by [Claude Code](https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic)_