### PR TITLE
Phase 3: /universe page (stacked on #435)

### DIFF
--- a/web/app/universe/[date]/page.tsx
+++ b/web/app/universe/[date]/page.tsx
@@ -1,0 +1,150 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import Nav from "@/components/nav";
+import UniverseTable from "@/components/universe-table";
+import {
+  getSnapshotByDate,
+  listSnapshotDates,
+} from "@/lib/universe-query";
+
+// Historical snapshots are immutable per (date, detail). Cache for the
+// full hour locally; the API endpoint handles long-tail CDN caching.
+export const revalidate = 3600;
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+interface PageParams {
+  params: Promise<{ date: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageParams): Promise<Metadata> {
+  const { date } = await params;
+  if (!DATE_RE.test(date)) {
+    return { title: "Universe — invalid date", robots: { index: false } };
+  }
+  return {
+    title: `Universe ${date} — daily snapshot`,
+    description: `Universe snapshot for ${date}. Same JSON every AI agent saw at heartbeat time.`,
+    alternates: { canonical: `/universe/${date}` },
+  };
+}
+
+function formatBuiltAt(iso: string): string {
+  const d = new Date(iso);
+  const yy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mi = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${yy}-${mm}-${dd} ${hh}:${mi} UTC`;
+}
+
+export default async function HistoricalUniversePage({ params }: PageParams) {
+  const { date } = await params;
+  if (!DATE_RE.test(date)) notFound();
+
+  const [snap, recent] = await Promise.all([
+    getSnapshotByDate(date, "extended"),
+    listSnapshotDates(30),
+  ]);
+  if (!snap) notFound();
+
+  const tickers = snap.json.tickers ?? [];
+  const filterNote =
+    (snap.json.universe_filter as { note?: string } | undefined)?.note ??
+    "Full screened universe.";
+
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 max-w-[1600px] mx-auto w-full px-4 py-6">
+        <Link
+          href="/universe"
+          className="inline-flex items-center gap-1 text-sm font-mono text-text-dim hover:text-green transition-colors mb-4"
+        >
+          ← Latest snapshot
+        </Link>
+
+        <section className="mb-6">
+          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-2">
+            Universe Snapshot — historical
+          </p>
+          <div className="flex items-baseline gap-4 flex-wrap mb-3">
+            <h1 className="font-mono text-xl font-bold text-text">
+              {snap.snapshot_date}
+            </h1>
+            <span className="text-xs text-text-muted font-mono">
+              built {formatBuiltAt(snap.created_at)}
+            </span>
+            <span className="text-xs text-text-muted font-mono">
+              · {snap.ticker_count} tickers
+            </span>
+            <span className="text-xs text-text-muted font-mono">
+              · sha {snap.sha256.slice(0, 12)}…
+            </span>
+          </div>
+          <p className="text-sm text-text-dim max-w-3xl mb-4">{filterNote}</p>
+
+          <div className="flex items-center gap-3 flex-wrap">
+            <span className="text-[11px] font-mono uppercase tracking-widest text-text-muted">
+              Download:
+            </span>
+            <a
+              href={`/api/v1/universe/${date}?detail=compact`}
+              className="text-xs font-mono text-green hover:underline border border-green/40 rounded px-2 py-1 hover:bg-green/10 transition-colors"
+            >
+              compact JSON
+            </a>
+            <a
+              href={`/api/v1/universe/${date}?detail=extended`}
+              className="text-xs font-mono text-green hover:underline border border-green/40 rounded px-2 py-1 hover:bg-green/10 transition-colors"
+            >
+              extended JSON
+            </a>
+            <a
+              href={`/api/v1/universe/${date}?detail=full`}
+              className="text-xs font-mono text-green hover:underline border border-green/40 rounded px-2 py-1 hover:bg-green/10 transition-colors"
+            >
+              full JSON
+            </a>
+          </div>
+        </section>
+
+        {recent.length > 1 && (
+          <section className="mb-6">
+            <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-2">
+              Recent snapshots
+            </p>
+            <div className="flex items-center gap-2 flex-wrap">
+              {recent.map((r) => {
+                const isCurrent = r.snapshot_date === snap.snapshot_date;
+                return (
+                  <Link
+                    key={r.snapshot_date}
+                    href={`/universe/${r.snapshot_date}`}
+                    className={`text-[11px] font-mono px-2 py-1 rounded border transition-colors ${
+                      isCurrent
+                        ? "text-text border-green bg-green/10"
+                        : "text-text-muted border-border hover:text-text hover:border-text-dim"
+                    }`}
+                  >
+                    {r.snapshot_date}
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        <UniverseTable tickers={tickers} />
+
+        <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mt-6">
+          Snapshot is immutable — sha {snap.sha256} verifies the bytes.
+        </p>
+      </main>
+    </>
+  );
+}

--- a/web/app/universe/page.tsx
+++ b/web/app/universe/page.tsx
@@ -1,0 +1,168 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Nav from "@/components/nav";
+import UniverseTable from "@/components/universe-table";
+import {
+  getLatestSnapshot,
+  listSnapshotDates,
+} from "@/lib/universe-query";
+
+// Snapshots regenerate once a day at 06:00 UTC, so a 10-minute revalidate
+// is plenty — covers manual workflow re-runs and same-day edge cases
+// without hammering Postgres.
+export const revalidate = 600;
+
+export const metadata: Metadata = {
+  title: "Universe — daily snapshot of the screened tickers",
+  description:
+    "The daily JSON artefact every AI agent sees at heartbeat time. Sortable table, downloadable in three detail tiers. Reproducible, immutable per date.",
+  alternates: { canonical: "/universe" },
+  openGraph: {
+    title: "AlphaMolt Universe — same data the agents see",
+    description:
+      "Daily JSON snapshot of the screened tickers, served at three detail tiers.",
+    url: "/universe",
+    type: "website",
+  },
+};
+
+function formatBuiltAt(iso: string): string {
+  const d = new Date(iso);
+  const yy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mi = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${yy}-${mm}-${dd} ${hh}:${mi} UTC`;
+}
+
+export default async function UniversePage() {
+  // Show the extended tier on the page — rich enough for humans, not so
+  // verbose that the table view drowns. Compact / full are still
+  // available via the download buttons.
+  const [snap, recent] = await Promise.all([
+    getLatestSnapshot("extended"),
+    listSnapshotDates(30),
+  ]);
+
+  if (!snap) {
+    return (
+      <>
+        <Nav />
+        <main className="flex-1 max-w-[1600px] mx-auto w-full px-4 py-10">
+          <h1 className="font-mono text-xl font-bold text-text mb-2">
+            Universe
+          </h1>
+          <p className="text-sm text-text-muted font-mono">
+            No snapshot available yet. The daily build runs at 06:00 UTC; come
+            back once it&apos;s finished its first run.
+          </p>
+        </main>
+      </>
+    );
+  }
+
+  const tickers = snap.json.tickers ?? [];
+  const filterNote =
+    (snap.json.universe_filter as { note?: string } | undefined)?.note ??
+    "Full screened universe.";
+
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 max-w-[1600px] mx-auto w-full px-4 py-6">
+        {/* Header */}
+        <section className="mb-6">
+          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-2">
+            Universe Snapshot
+          </p>
+          <div className="flex items-baseline gap-4 flex-wrap mb-3">
+            <h1 className="font-mono text-xl font-bold text-text">
+              {snap.snapshot_date}
+            </h1>
+            <span className="text-xs text-text-muted font-mono">
+              built {formatBuiltAt(snap.created_at)}
+            </span>
+            <span className="text-xs text-text-muted font-mono">
+              · {snap.ticker_count} tickers
+            </span>
+            <span className="text-xs text-text-muted font-mono">
+              · sha {snap.sha256.slice(0, 12)}…
+            </span>
+          </div>
+          <p className="text-sm text-text-dim max-w-3xl mb-4">
+            {filterNote}{" "}
+            <span className="text-text-muted">
+              The same JSON every AI agent reads at heartbeat time.
+            </span>
+          </p>
+
+          {/* Download row */}
+          <div className="flex items-center gap-3 flex-wrap">
+            <span className="text-[11px] font-mono uppercase tracking-widest text-text-muted">
+              Download:
+            </span>
+            <a
+              href="/api/v1/universe?detail=compact"
+              className="text-xs font-mono text-green hover:underline border border-green/40 rounded px-2 py-1 hover:bg-green/10 transition-colors"
+            >
+              compact JSON
+            </a>
+            <a
+              href="/api/v1/universe?detail=extended"
+              className="text-xs font-mono text-green hover:underline border border-green/40 rounded px-2 py-1 hover:bg-green/10 transition-colors"
+            >
+              extended JSON
+            </a>
+            <a
+              href="/api/v1/universe?detail=full"
+              className="text-xs font-mono text-green hover:underline border border-green/40 rounded px-2 py-1 hover:bg-green/10 transition-colors"
+            >
+              full JSON
+            </a>
+          </div>
+        </section>
+
+        {/* Date selector — only renders if more than one snapshot exists */}
+        {recent.length > 1 && (
+          <section className="mb-6">
+            <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-2">
+              Recent snapshots
+            </p>
+            <div className="flex items-center gap-2 flex-wrap">
+              {recent.map((r) => {
+                const isCurrent = r.snapshot_date === snap.snapshot_date;
+                return (
+                  <Link
+                    key={r.snapshot_date}
+                    href={
+                      isCurrent
+                        ? "/universe"
+                        : `/universe/${r.snapshot_date}`
+                    }
+                    className={`text-[11px] font-mono px-2 py-1 rounded border transition-colors ${
+                      isCurrent
+                        ? "text-text border-green bg-green/10"
+                        : "text-text-muted border-border hover:text-text hover:border-text-dim"
+                    }`}
+                  >
+                    {r.snapshot_date}
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* Table */}
+        <UniverseTable tickers={tickers} />
+
+        {/* Footer */}
+        <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mt-6">
+          Snapshots are immutable per (date, detail) — the sha column lets
+          you verify reproducibility. New snapshot built daily at 06:00 UTC.
+        </p>
+      </main>
+    </>
+  );
+}

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 const links = [
   { href: "/leaderboard", label: "Leaderboard" },
   { href: "/screener", label: "Screener" },
+  { href: "/universe", label: "Universe" },
   { href: "/signup", label: "Sign up" },
   { href: "/docs", label: "Docs" },
 ];

--- a/web/components/universe-table.tsx
+++ b/web/components/universe-table.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+/**
+ * Sortable / filterable table view of a universe snapshot.
+ *
+ * Receives the snapshot's `tickers` array verbatim and renders a fixed
+ * ~17-column table covering the decision-relevant fields. Users can:
+ *   - search by ticker symbol or company name
+ *   - sort ascending/descending by any header
+ *   - expand the truncated short_outlook column
+ *
+ * Heavier customisation (column visibility toggles, group filters) is
+ * deferred — the JSON download is the escape hatch for power users who
+ * want fields beyond the default set.
+ */
+
+type TickerRow = Record<string, unknown> & { ticker?: string };
+
+type SortDir = "asc" | "desc";
+
+interface Column {
+  key: string;                     // dot path into the row, e.g. "fundamentals.current.rating"
+  label: string;
+  numeric?: boolean;
+  align?: "left" | "right";
+  format?: (v: unknown) => string;
+  truncate?: number;               // max chars to show inline
+}
+
+const get = (row: TickerRow, path: string): unknown => {
+  const parts = path.split(".");
+  let cur: unknown = row;
+  for (const p of parts) {
+    if (cur && typeof cur === "object" && p in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[p];
+    } else {
+      return null;
+    }
+  }
+  return cur;
+};
+
+const fmtPct = (v: unknown) => {
+  if (v === null || v === undefined || v === "") return "—";
+  const n = Number(v);
+  if (!Number.isFinite(n)) return "—";
+  return `${n > 0 ? "+" : ""}${n.toFixed(1)}%`;
+};
+
+const fmtNum = (decimals: number) => (v: unknown) => {
+  if (v === null || v === undefined || v === "") return "—";
+  const n = Number(v);
+  if (!Number.isFinite(n)) return "—";
+  return n.toFixed(decimals);
+};
+
+const fmtUsd = (v: unknown) => {
+  if (v === null || v === undefined || v === "") return "—";
+  const n = Number(v);
+  if (!Number.isFinite(n)) return "—";
+  return `$${n.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
+const fmtFraction1Pct = (v: unknown) => {
+  // Stored as 0.34 → "+34%"
+  if (v === null || v === undefined || v === "") return "—";
+  const n = Number(v);
+  if (!Number.isFinite(n)) return "—";
+  return `${n > 0 ? "+" : ""}${(n * 100).toFixed(0)}%`;
+};
+
+const COLUMNS: Column[] = [
+  { key: "ticker", label: "Ticker", align: "left" },
+  { key: "sector", label: "Sector", align: "left", truncate: 18 },
+  { key: "fundamentals.current.rating", label: "Rating", numeric: true, align: "right", format: fmtNum(2) },
+  { key: "momentum.composite_score", label: "Score", numeric: true, align: "right", format: fmtNum(2) },
+  { key: "fundamentals.current.r40_score", label: "R40", numeric: true, align: "right", format: fmtNum(0) },
+  { key: "fundamentals.current.rev_growth_ttm_pct", label: "Rev TTM", numeric: true, align: "right", format: fmtPct },
+  { key: "fundamentals.current.rev_growth_qoq_pct", label: "Rev QoQ", numeric: true, align: "right", format: fmtPct },
+  { key: "fundamentals.current.gross_margin_pct", label: "GM%", numeric: true, align: "right", format: fmtPct },
+  { key: "fundamentals.current.operating_margin_pct", label: "Op Mgn", numeric: true, align: "right", format: fmtPct },
+  { key: "fundamentals.current.fcf_margin_pct", label: "FCF Mgn", numeric: true, align: "right", format: fmtPct },
+  { key: "valuation.price", label: "Price", numeric: true, align: "right", format: fmtUsd },
+  { key: "valuation.ps_now", label: "P/S", numeric: true, align: "right", format: fmtNum(1) },
+  { key: "valuation.ps_median_12m", label: "P/S 12m med", numeric: true, align: "right", format: fmtNum(1) },
+  { key: "momentum.perf_52w_vs_spy", label: "vs SPY 52w", numeric: true, align: "right", format: fmtFraction1Pct },
+  { key: "valuation.price_pct_of_52w_high", label: "% of 52w hi", numeric: true, align: "right", format: fmtFraction1Pct },
+  { key: "status", label: "Status", align: "left" },
+  { key: "narrative.short_outlook", label: "Outlook", align: "left", truncate: 80 },
+];
+
+const numericValue = (v: unknown): number => {
+  if (v === null || v === undefined || v === "") return Number.NEGATIVE_INFINITY;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : Number.NEGATIVE_INFINITY;
+};
+
+const stringValue = (v: unknown): string =>
+  v === null || v === undefined ? "" : String(v).toLowerCase();
+
+const truncate = (s: string, max: number): string =>
+  s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+
+export default function UniverseTable({ tickers }: { tickers: TickerRow[] }) {
+  const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<string>("momentum.composite_score");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const rows = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const col = COLUMNS.find((c) => c.key === sortKey);
+    const numeric = col?.numeric ?? false;
+    const filtered = q
+      ? tickers.filter((r) => {
+          const t = String(r.ticker ?? "").toLowerCase();
+          const c = String(r.company_name ?? "").toLowerCase();
+          return t.includes(q) || c.includes(q);
+        })
+      : tickers;
+    const sorted = [...filtered].sort((a, b) => {
+      if (numeric) {
+        return numericValue(get(a, sortKey)) - numericValue(get(b, sortKey));
+      }
+      return stringValue(get(a, sortKey)).localeCompare(
+        stringValue(get(b, sortKey)),
+      );
+    });
+    return sortDir === "desc" ? sorted.reverse() : sorted;
+  }, [tickers, search, sortKey, sortDir]);
+
+  const onHeaderClick = (key: string) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-3 gap-3">
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Filter by ticker or name…"
+          className="font-mono text-sm bg-bg-hover border border-border rounded px-3 py-2 w-64 focus:outline-none focus:border-green text-text"
+        />
+        <p className="text-xs text-text-muted font-mono">
+          Showing {rows.length} of {tickers.length}
+        </p>
+      </div>
+      <div className="glass-card rounded-lg overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full font-mono text-xs">
+            <thead className="bg-bg-hover border-b border-border text-text-dim">
+              <tr>
+                {COLUMNS.map((c) => {
+                  const isSorted = c.key === sortKey;
+                  const arrow = !isSorted ? "" : sortDir === "desc" ? " ▾" : " ▴";
+                  return (
+                    <th
+                      key={c.key}
+                      onClick={() => onHeaderClick(c.key)}
+                      className={`px-3 py-2 font-normal uppercase tracking-wider cursor-pointer hover:text-text whitespace-nowrap ${
+                        c.align === "right" ? "text-right" : "text-left"
+                      } ${isSorted ? "text-text" : ""}`}
+                    >
+                      {c.label}
+                      {arrow}
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, i) => (
+                <tr
+                  key={String(r.ticker ?? i)}
+                  className="border-b border-border/40 hover:bg-bg-hover/40 transition-colors"
+                >
+                  {COLUMNS.map((c) => {
+                    const raw = get(r, c.key);
+                    const display = c.format
+                      ? c.format(raw)
+                      : raw === null || raw === undefined
+                        ? "—"
+                        : c.truncate
+                          ? truncate(String(raw), c.truncate)
+                          : String(raw);
+                    const title =
+                      c.truncate && raw && String(raw).length > c.truncate
+                        ? String(raw)
+                        : undefined;
+                    return (
+                      <td
+                        key={c.key}
+                        title={title}
+                        className={`px-3 py-2 ${
+                          c.align === "right"
+                            ? "text-right text-text"
+                            : "text-left text-text"
+                        } ${c.key === "ticker" ? "font-bold text-green" : ""}`}
+                      >
+                        {display}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Phase 3 of the LLM-pick build — *stacked on #435*

Public viewer for the universe snapshots. Merge **after** #434 + #435.

### Pages

| Path | What |
|---|---|
| `/universe` | Latest snapshot — table view + JSON downloads |
| `/universe/{YYYY-MM-DD}` | Historical snapshot — same shape, immutable |

### Layout

- **Header**: snapshot date, build time, ticker count, SHA prefix, filter description
- **Download row**: three buttons (compact / extended / full) → hits `/api/v1/universe?detail=…`
- **Recent snapshots strip**: last 30 dates, one-click navigation
- **Table**: 17 decision-relevant columns, sortable on every header, filterable by ticker / company name; default sort is `composite_score` desc
- **Footer note**: reproducibility statement

### Columns shown (left-to-right)

`Ticker · Sector · Rating · Score · R40 · Rev TTM · Rev QoQ · GM% · Op Mgn · FCF Mgn · Price · P/S · P/S 12m med · vs SPY 52w · % of 52w hi · Status · Outlook (truncated)`

Power users who want the rest grab the JSON via the download buttons. No column-visibility UI in v1 — JSON is the escape hatch.

### Nav

Adds **Universe** to the main nav, between Screener and Sign up. One click from the homepage.

### Implementation notes

- Pages are server components — `revalidate=600` (latest) / `revalidate=3600` (historical).
- Only the table is client-side (`use client`), and only because of sort + filter state.
- No new dependencies. No `react-table` — a 200-row sortable table doesn't need one; native `<table>` with `useMemo` does the job.
- The historical page renders an early `notFound()` for non-`YYYY-MM-DD` paths so the 404 page handles invalid input cleanly.

### Test plan

After #434 + #435 are merged, the migration applied, and at least one snapshot exists:

- [ ] `/universe` renders, table populates with today's tickers
- [ ] Click a sortable header — table re-sorts; clicking again flips direction
- [ ] Type "NVDA" in the filter → only matching rows show; counter updates "Showing N of M"
- [ ] Click "compact JSON" → browser downloads (or displays) the JSON for compact tier
- [ ] Click a date in "Recent snapshots" → navigates to `/universe/YYYY-MM-DD`
- [ ] `/universe/2030-01-01` returns 404
- [ ] `/universe/garbage` returns 404
- [ ] Mobile (≤640px): horizontal scroll on the table works; nav menu still includes "Universe"

https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic

---
_Generated by [Claude Code](https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic)_