### PR TITLE
Phase 4: LLM provider adapters (anthropic / openai / deepseek / google)

### DIFF
--- a/llm_providers.py
+++ b/llm_providers.py
@@ -1,0 +1,311 @@
+"""Thin LLM provider adapters for the llm_pick strategy.
+
+Single dispatch surface — the picker calls ``call_llm(provider=…, model=…)``
+and gets back a raw text response. Each adapter reads its own API key from
+env vars (per-provider naming so secrets stay scoped):
+
+    anthropic → ANTHROPIC_API_KEY
+    openai    → CODEX_API_KEY            # OpenAI's Codex line
+    deepseek  → DEEPSEEK_API_KEY         # OpenAI-compatible API
+    google    → GEMINI_API_KEY           # already used by update_ai_narratives.py
+
+The picker is responsible for parsing JSON out of the response (with one
+retry on failure). Adapters here are deliberately dumb — model in,
+text out, errors raised — so they're easy to swap or add to.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+logger = logging.getLogger("llm_providers")
+
+
+PROVIDERS = ("anthropic", "openai", "deepseek", "google")
+
+# Per-provider env var holding the API key. Centralised so the heartbeat
+# workflow's env stanza and the agents.config docs can stay in sync.
+ENV_VAR_FOR_PROVIDER = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "CODEX_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "google": "GEMINI_API_KEY",
+}
+
+DEEPSEEK_BASE_URL = "https://api.deepseek.com"
+
+
+class LLMProviderError(RuntimeError):
+    """Raised when a provider call fails after the adapter's own retries."""
+
+
+@dataclass
+class LLMResponse:
+    """Uniform return shape across providers."""
+
+    text: str
+    model: str
+    provider: str
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+
+def call_llm(
+    *,
+    provider: str,
+    model: str,
+    system: str,
+    user: str,
+    max_tokens: int = 8192,
+    temperature: float = 0.2,
+) -> LLMResponse:
+    """Dispatch to the right provider adapter."""
+    if provider not in PROVIDERS:
+        raise LLMProviderError(f"unknown provider: {provider}")
+    if provider == "anthropic":
+        return _call_anthropic(model, system, user, max_tokens, temperature)
+    if provider == "openai":
+        return _call_openai_compatible(
+            model, system, user, max_tokens, temperature,
+            api_key_env="CODEX_API_KEY",
+            base_url=None,
+            provider_label="openai",
+        )
+    if provider == "deepseek":
+        return _call_openai_compatible(
+            model, system, user, max_tokens, temperature,
+            api_key_env="DEEPSEEK_API_KEY",
+            base_url=DEEPSEEK_BASE_URL,
+            provider_label="deepseek",
+        )
+    if provider == "google":
+        return _call_gemini(model, system, user, max_tokens, temperature)
+    # Unreachable — guarded by PROVIDERS check above, but keeps type-checkers happy.
+    raise LLMProviderError(f"unhandled provider: {provider}")
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+def _call_anthropic(
+    model: str,
+    system: str,
+    user: str,
+    max_tokens: int,
+    temperature: float,
+) -> LLMResponse:
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if not api_key:
+        raise LLMProviderError("ANTHROPIC_API_KEY env var not set")
+    try:
+        from anthropic import Anthropic, APIError  # type: ignore
+    except ImportError as exc:
+        raise LLMProviderError(f"anthropic SDK not installed: {exc}") from exc
+
+    client = Anthropic(api_key=api_key)
+    last_err: Exception | None = None
+    for attempt in range(2):
+        try:
+            resp = client.messages.create(
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                system=system,
+                messages=[{"role": "user", "content": user}],
+            )
+            text = "".join(
+                block.text  # type: ignore[attr-defined]
+                for block in resp.content
+                if getattr(block, "type", None) == "text"
+            )
+            usage = getattr(resp, "usage", None)
+            return LLMResponse(
+                text=text,
+                model=model,
+                provider="anthropic",
+                input_tokens=getattr(usage, "input_tokens", None) if usage else None,
+                output_tokens=getattr(usage, "output_tokens", None) if usage else None,
+            )
+        except APIError as exc:  # type: ignore[misc]
+            last_err = exc
+            logger.warning("anthropic call attempt %d failed: %s", attempt + 1, exc)
+            time.sleep(2 ** attempt)
+    raise LLMProviderError(f"anthropic call failed after retries: {last_err}")
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible (OpenAI itself + DeepSeek)
+# ---------------------------------------------------------------------------
+
+
+def _call_openai_compatible(
+    model: str,
+    system: str,
+    user: str,
+    max_tokens: int,
+    temperature: float,
+    *,
+    api_key_env: str,
+    base_url: str | None,
+    provider_label: str,
+) -> LLMResponse:
+    api_key = os.environ.get(api_key_env, "").strip()
+    if not api_key:
+        raise LLMProviderError(f"{api_key_env} env var not set")
+    try:
+        from openai import OpenAI, APIError  # type: ignore
+    except ImportError as exc:
+        raise LLMProviderError(f"openai SDK not installed: {exc}") from exc
+
+    kwargs: dict = {"api_key": api_key}
+    if base_url:
+        kwargs["base_url"] = base_url
+    client = OpenAI(**kwargs)
+
+    last_err: Exception | None = None
+    for attempt in range(2):
+        try:
+            resp = client.chat.completions.create(
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                response_format={"type": "json_object"},
+            )
+            text = resp.choices[0].message.content or ""
+            usage = getattr(resp, "usage", None)
+            return LLMResponse(
+                text=text,
+                model=model,
+                provider=provider_label,
+                input_tokens=getattr(usage, "prompt_tokens", None) if usage else None,
+                output_tokens=getattr(usage, "completion_tokens", None) if usage else None,
+            )
+        except APIError as exc:  # type: ignore[misc]
+            last_err = exc
+            logger.warning(
+                "%s call attempt %d failed: %s",
+                provider_label, attempt + 1, exc,
+            )
+            time.sleep(2 ** attempt)
+    raise LLMProviderError(
+        f"{provider_label} call failed after retries: {last_err}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Google (Gemini)
+# ---------------------------------------------------------------------------
+
+
+def _call_gemini(
+    model: str,
+    system: str,
+    user: str,
+    max_tokens: int,
+    temperature: float,
+) -> LLMResponse:
+    api_key = os.environ.get("GEMINI_API_KEY", "").strip()
+    if not api_key:
+        raise LLMProviderError("GEMINI_API_KEY env var not set")
+    try:
+        import google.generativeai as genai  # type: ignore
+    except ImportError as exc:
+        raise LLMProviderError(
+            f"google-generativeai SDK not installed: {exc}"
+        ) from exc
+
+    genai.configure(api_key=api_key)
+    last_err: Exception | None = None
+    for attempt in range(2):
+        try:
+            gen_model = genai.GenerativeModel(
+                model_name=model,
+                system_instruction=system,
+                generation_config={
+                    "temperature": temperature,
+                    "max_output_tokens": max_tokens,
+                    "response_mime_type": "application/json",
+                },
+            )
+            resp = gen_model.generate_content(user)
+            # Some safety blocks come back with no candidates / no .text.
+            text = getattr(resp, "text", None) or ""
+            if not text:
+                # Surface a parseable signal so the picker can journal it.
+                raise LLMProviderError(
+                    f"gemini returned empty response (finish_reason="
+                    f"{_first_finish_reason(resp)})"
+                )
+            usage = getattr(resp, "usage_metadata", None)
+            return LLMResponse(
+                text=text,
+                model=model,
+                provider="google",
+                input_tokens=getattr(usage, "prompt_token_count", None)
+                if usage else None,
+                output_tokens=getattr(usage, "candidates_token_count", None)
+                if usage else None,
+            )
+        except Exception as exc:  # noqa: BLE001 — SDK exception class is broad
+            last_err = exc
+            logger.warning("gemini call attempt %d failed: %s", attempt + 1, exc)
+            time.sleep(2 ** attempt)
+    raise LLMProviderError(f"gemini call failed after retries: {last_err}")
+
+
+def _first_finish_reason(resp: object) -> str:
+    candidates = getattr(resp, "candidates", None)
+    if not candidates:
+        return "no candidates"
+    return str(getattr(candidates[0], "finish_reason", "unknown"))
+
+
+# ---------------------------------------------------------------------------
+# Helpers — JSON parsing that tolerates a leading/trailing prose wrapper
+# (some models still emit ```json fences despite response_format hints).
+# ---------------------------------------------------------------------------
+
+
+def parse_json_response(text: str) -> dict:
+    """Parse JSON, falling back to the first/last brace pair if wrapped.
+
+    Raises LLMProviderError if no valid JSON can be extracted.
+    """
+    text = (text or "").strip()
+    if not text:
+        raise LLMProviderError("empty response")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    # Strip ```json fences if present.
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.startswith("json"):
+            text = text[4:]
+        text = text.strip()
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            pass
+    # Last resort: substring between first '{' and last '}'.
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        try:
+            return json.loads(text[start : end + 1])
+        except json.JSONDecodeError as exc:
+            raise LLMProviderError(
+                f"could not parse JSON from response: {exc}"
+            ) from exc
+    raise LLMProviderError("response did not contain a JSON object")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,6 @@ python-dotenv
 tradingview-screener>=3.0.0
 scipy>=1.11.0
 anthropic>=0.40.0
+openai>=1.50.0
+google-generativeai>=0.8.0
 atproto>=0.0.55


### PR DESCRIPTION
## Phase 4 of the LLM-pick build — *independent, no stacking*

Provider adapters for the upcoming `llm_pick` strategy. Single dispatch surface; each adapter reads its own scoped API key.

### Provider matrix

| Provider | Model env var | Default for | SDK |
|---|---|---|---|
| `anthropic` | `ANTHROPIC_API_KEY` | Claude 4.7 (`claude-opus-4-7`) | `anthropic` (already in deps) |
| `openai` | **`CODEX_API_KEY`** | OpenAI Codex | `openai` (added) |
| `deepseek` | `DEEPSEEK_API_KEY` | DeepSeek V4 | `openai` (compatible API + custom base_url) |
| `google` | `GEMINI_API_KEY` (already set) | Gemini 3.1 Pro | `google-generativeai` (added) |

### One entrypoint

```python
from llm_providers import call_llm, parse_json_response

resp = call_llm(
    provider="anthropic",
    model="claude-opus-4-7",
    system="You are a portfolio manager.",
    user="Pick 20 stocks from this list: …",
)
data = parse_json_response(resp.text)
```

### Implementation choices

- **OpenAI + DeepSeek share one adapter.** DeepSeek is OpenAI-compatible (`/chat/completions`); just a `base_url` override. Saves a code path and keeps the surface area small.
- **No curl subprocess for Gemini.** `update_ai_narratives.py` keeps its existing approach; this adapter uses the `google-generativeai` SDK with `system_instruction` + `response_mime_type="application/json"`.
- **Two retries with backoff** per provider. The picker (Phase 5) handles JSON-parse failures separately — its own retry budget for content-quality issues.
- **`parse_json_response()`** tolerates ` ```json ` fences and prose wrappers. Some models still emit them despite `response_format` hints.

### What's NOT in this PR

- The picker itself — Phase 5 wires these adapters into a strategy.
- The heartbeat workflow secrets (`ANTHROPIC_API_KEY` / `CODEX_API_KEY` / `DEEPSEEK_API_KEY`) — Phase 6.
- Per-agent `config` UPDATEs to set `provider` and `model` — Phase 7a.

Until Phase 5 lands, no code path actually calls these adapters at runtime. Safe to merge alongside / before / after the universe phases.

### Test plan

Pure unit-level — nothing wired into a workflow yet:

- [ ] `pip install -r requirements.txt` succeeds (adds `openai>=1.50.0` + `google-generativeai>=0.8.0`)
- [ ] `python -c "from llm_providers import call_llm, parse_json_response; print('ok')"` imports cleanly
- [ ] `python -c "from llm_providers import parse_json_response; print(parse_json_response('\`\`\`json\n{\"a\":1}\n\`\`\`'))"` parses through the fence
- [ ] Calling `call_llm(provider='anthropic', …)` without `ANTHROPIC_API_KEY` set raises `LLMProviderError`

End-to-end provider smoke tests will run as part of Phase 5 (the picker dry-run).

https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic

---
_Generated by [Claude Code](https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic)_