### PR TITLE
Phase 6: heartbeat workflow secrets (Anthropic / Codex / DeepSeek)

### DIFF
--- a/.github/workflows/agent-heartbeat.yml
+++ b/.github/workflows/agent-heartbeat.yml
@@ -30,7 +30,10 @@ on:
 jobs:
   heartbeat:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Bumped from 15m. The llm_pick strategy can run 4+ LLM agents
+    # × 2 stages × ~30s API calls; deterministic strategies finish in
+    # seconds. 30m gives comfortable headroom for slow providers.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
@@ -49,6 +52,14 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          # LLM provider keys for the llm_pick strategy. Each agent's
+          # agents.config.provider selects which one is used; the others
+          # stay unread for that agent. Missing keys raise LLMProviderError
+          # only for agents that actually need them.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           ARGS=""
           if [ -n "${{ inputs.handle }}" ]; then


### PR DESCRIPTION
## Phase 6 of the LLM-pick build — *independent*

Wires the four LLM provider keys into the weekly agent heartbeat workflow.

### Changes

- Adds env vars: `ANTHROPIC_API_KEY`, `CODEX_API_KEY`, `DEEPSEEK_API_KEY`. `GEMINI_API_KEY` is already in repo secrets (used by `update_ai_narratives.py`); now plumbed through to the heartbeat too.
- Bumps timeout from 15m → 30m. With 4 LLM agents × 2 stages × ~30s API calls in serial, plus the deterministic strategies, 30m gives comfortable headroom.

### Required GitHub repo secrets

These need to exist in **Settings → Secrets and variables → Actions** before any LLM agent rebalances cleanly:

| Secret | Provider | Notes |
|---|---|---|
| `ANTHROPIC_API_KEY` | Anthropic | For Claude 4.7 (`smoke-test-claude`) |
| `CODEX_API_KEY` | OpenAI | For Codex (`codex-tobyr-0423`) — naming per user spec |
| `DEEPSEEK_API_KEY` | DeepSeek | For DeepSeek V4 (`fundamental-sentinel`) |
| `GEMINI_API_KEY` | Google | Already present — for Gemini 3.1 Pro (`gemini-3-1-pro`) |

### Failure mode

Missing keys don't break momentum / dual_positive runs. The picker raises `LLMProviderError` early (with the env var name) for agents that need them — that lands in `agent_heartbeats.error_message` so you see exactly which agent + which secret is missing.

### Test plan

- [ ] Add the three new secrets in repo settings
- [ ] Manual `workflow_dispatch` with `dry_run=true` after Phase 5 (#438) lands and at least one agent has `strategy='llm_pick'` (Phase 7a) — should plan trades without writing
- [ ] Inspect `agent_heartbeats.notes.stage1` / `stage2` for the live token counts and shortlists
- [ ] Wait for Sunday 22:00 UTC: live cron run picks up all due agents

https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic

---
_Generated by [Claude Code](https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic)_