### PR TITLE
Phase 7b: verbatim prompts panel on /u/&lt;handle&gt; for llm_pick agents

### DIFF
--- a/web/app/u/[handle]/page.tsx
+++ b/web/app/u/[handle]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import Nav from "@/components/nav";
+import LlmPromptsPanel from "@/components/llm-prompts-panel";
 import { getAgentByHandle } from "@/lib/agents-query";
 import { getPortfolio, type PortfolioSnapshot } from "@/lib/portfolio";
 import { getSupabase } from "@/lib/supabase";
@@ -141,6 +142,23 @@ export default async function ProfilePage({ params }: PageParams) {
               {agent.long_description}
             </div>
           </details>
+        )}
+
+        {/* Verbatim prompts panel — only for llm_pick agents. Same prompts
+            for every model; only the model varies. The trust story is
+            "show the question". */}
+        {agent.strategy === "llm_pick" && (
+          <LlmPromptsPanel
+            pickerMode={
+              (agent.config &&
+                typeof agent.config === "object" &&
+                typeof (agent.config as Record<string, unknown>)
+                  .picker_mode === "string"
+                ? ((agent.config as Record<string, unknown>)
+                    .picker_mode as string)
+                : undefined) ?? undefined
+            }
+          />
         )}
 
         {/* Portfolio summary */}

--- a/web/components/llm-prompts-panel.tsx
+++ b/web/components/llm-prompts-panel.tsx
@@ -1,0 +1,91 @@
+import {
+  STAGE1_SYSTEM_PROMPT,
+  STAGE1_USER_TEMPLATE,
+  STAGE2_SYSTEM_PROMPT,
+  STAGE2_USER_TEMPLATE,
+} from "@/lib/llm-prompts";
+
+/**
+ * Verbatim prompt panel for an llm_pick agent's profile page.
+ *
+ * Shows the exact templates each model is given. Placeholders like
+ * {snapshot_date} and {universe_json} are filled at heartbeat time from
+ * the daily universe snapshot — see /universe for the data side.
+ *
+ * Server component (no "use client"): native <details> handles toggle,
+ * no JS needed.
+ */
+export default function LlmPromptsPanel({
+  pickerMode,
+}: {
+  pickerMode?: string;
+}) {
+  const showTwoStage = (pickerMode ?? "two_stage") === "two_stage";
+
+  return (
+    <details className="glass-card rounded-lg border border-border mb-10 [&[open]_.chevron]:rotate-90">
+      <summary className="cursor-pointer px-5 py-4 flex items-center justify-between font-mono text-xs font-bold uppercase tracking-widest text-text-dim list-none [&::-webkit-details-marker]:hidden hover:text-text transition-colors">
+        <span>Prompts (verbatim)</span>
+        <span className="chevron text-text-muted transition-transform">▸</span>
+      </summary>
+      <div className="px-5 pb-5 pt-3 border-t border-border space-y-6">
+        <p className="text-sm text-text-dim leading-relaxed">
+          Every <code className="text-text">llm_pick</code> agent receives the
+          same prompts — only the model differs. Placeholders like{" "}
+          <code className="text-text">{`{snapshot_date}`}</code> and{" "}
+          <code className="text-text">{`{universe_json}`}</code> are filled at
+          heartbeat time from the{" "}
+          <a href="/universe" className="text-green hover:underline">
+            daily universe snapshot
+          </a>
+          .
+        </p>
+
+        {showTwoStage ? (
+          <>
+            <PromptBlock
+              title="Stage 1 — shortlist (system)"
+              body={STAGE1_SYSTEM_PROMPT}
+            />
+            <PromptBlock
+              title="Stage 1 — shortlist (user)"
+              body={STAGE1_USER_TEMPLATE}
+            />
+            <PromptBlock
+              title="Stage 2 — final picks (system)"
+              body={STAGE2_SYSTEM_PROMPT}
+            />
+            <PromptBlock
+              title="Stage 2 — final picks (user)"
+              body={STAGE2_USER_TEMPLATE}
+            />
+          </>
+        ) : (
+          <>
+            <PromptBlock
+              title="Single-pass picker (system)"
+              body={STAGE2_SYSTEM_PROMPT}
+            />
+            <PromptBlock
+              title="Single-pass picker (user)"
+              body={STAGE2_USER_TEMPLATE}
+            />
+          </>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function PromptBlock({ title, body }: { title: string; body: string }) {
+  return (
+    <div>
+      <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-2">
+        {title}
+      </p>
+      <pre className="text-xs font-mono text-text-dim bg-bg-hover/50 border border-border rounded p-3 whitespace-pre-wrap leading-relaxed overflow-x-auto">
+        {body}
+      </pre>
+    </div>
+  );
+}

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -17,6 +17,8 @@ export interface Agent {
   contact_email: string | null;
   api_key_prefix: string;
   is_house_agent: boolean;
+  strategy: string | null;
+  config: Record<string, unknown> | null;
   created_at: string;
   updated_at: string;
 }
@@ -271,7 +273,7 @@ export async function resolveAgentByApiKey(
   const { data, error } = await supabase
     .from("agents")
     .select(
-      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, created_at, updated_at",
+      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, strategy, config, created_at, updated_at",
     )
     .eq("api_key_hash", hash)
     .maybeSingle();
@@ -295,7 +297,7 @@ export async function getAgentByHandle(
   const { data, error } = await supabase
     .from("agents")
     .select(
-      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, created_at, updated_at",
+      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, strategy, config, created_at, updated_at",
     )
     .eq("handle", normalised)
     .maybeSingle();

--- a/web/lib/llm-prompts.ts
+++ b/web/lib/llm-prompts.ts
@@ -1,0 +1,72 @@
+/**
+ * Verbatim mirror of the LLM picker prompts from llm_picker.py.
+ *
+ * These constants exist so the agent profile page can render exactly
+ * what every LLM agent is told. THIS IS A MIRROR — keep it in sync with
+ * llm_picker.py manually. If the two ever drift, the runtime prompts
+ * (Python) win; this file is for display only.
+ *
+ * Why mirror instead of fetch from Python at request time?
+ *   - Static rendering, no runtime coupling between web → Python.
+ *   - Trivial diff in PR review when prompts change ("update both
+ *     llm_picker.py and llm-prompts.ts").
+ *   - Page renders even if the heartbeat repo is in transient state.
+ */
+
+export const STAGE1_SYSTEM_PROMPT = `You are a portfolio manager researching stocks for a $1M paper-money portfolio competing on a public leaderboard against other AI models.
+
+You will be given:
+1. A universe of screened companies with their current fundamentals.
+2. The current portfolio state (cash + holdings).
+
+Your task: pick UP TO 50 tickers you want to research further. You will get deeper historical data on those 50 in a follow-up call before making your final selection.
+
+Be selective. The shortlist should reflect YOUR strategy — momentum, value, growth, quality, contrarian, whatever you find compelling. Different models making different shortlists is the whole point of this exercise.
+
+Output strict JSON only. No prose, no markdown fences.`;
+
+export const STAGE1_USER_TEMPLATE = `UNIVERSE (compact tier, snapshot {snapshot_date}):
+{universe_json}
+
+CURRENT PORTFOLIO:
+{portfolio_json}
+
+OUTPUT SCHEMA (strict JSON, no other text):
+{
+  "shortlist": [
+    {"ticker": "XXX", "rationale": "<10-15 word reason>"}
+  ]
+}
+
+Pick UP TO {shortlist_max} tickers. Fewer is fine if you can't justify {shortlist_max}.
+Only tickers from the universe above are valid. Output JSON only.`;
+
+export const STAGE2_SYSTEM_PROMPT = `You are a portfolio manager finalizing a $1M paper-money portfolio.
+
+You shortlisted these tickers from a wider universe in a prior call. Now you have their full historical fundamentals. Pick the 15-25 stocks you'd actually want to hold for the next week with weights and per-pick rationale.
+
+Constraints:
+- Choose between 15 and 25 tickers from the shortlist (no others).
+- weight_pct values must sum to 95-100 (we keep a 0-5% cash reserve).
+- US-listed only.
+- One-line rationale per pick: what's the thesis?
+
+Output strict JSON only. No prose, no markdown fences.`;
+
+export const STAGE2_USER_TEMPLATE = `DEEP DATA on your shortlist (full tier, snapshot {snapshot_date}):
+{universe_json}
+
+YOUR STAGE 1 SHORTLIST (for context — your prior reasoning):
+{stage1_json}
+
+CURRENT PORTFOLIO:
+{portfolio_json}
+
+OUTPUT SCHEMA (strict JSON, no other text):
+{
+  "picks": [
+    {"ticker": "XXX", "weight_pct": <number 0-100>, "rationale": "<15-25 word thesis>"}
+  ]
+}
+
+Pick 15-25 tickers. weight_pct sum: 95-100. Output JSON only.`;


### PR DESCRIPTION
## Phase 7b of the LLM-pick build — *independent*

Verbatim prompts panel on the agent profile page for `llm_pick` agents. Closes the trust loop: anyone clicking through can read exactly what every LLM was told.

### What renders

A new collapsible panel appears below the existing **Strategy** panel when `agent.strategy === 'llm_pick'`. Inside it:

- A short callout: "Every llm_pick agent receives the same prompts — only the model differs. Placeholders like `{snapshot_date}` and `{universe_json}` are filled at heartbeat time from the daily universe snapshot."
- Stage 1 system prompt (verbatim)
- Stage 1 user template (verbatim, with placeholders intact)
- Stage 2 system prompt (verbatim)
- Stage 2 user template (verbatim, with placeholders intact)

For `picker_mode: "single_full"` agents, Stage 1 is hidden and the panel shows the single-pass template.

### Mirror, not single source

- Runtime prompts live in `llm_picker.py` (Python).
- Display prompts live in `web/lib/llm-prompts.ts` (TypeScript).
- These are **mirrors** — keep both updated. The Python ones win at runtime; the TS ones are display-only. PR review covers drift detection ("did you update both?").

### Why mirror instead of fetching from Python at request time?

- Static rendering — no runtime coupling between web app and Python repo.
- Page renders even if heartbeat repo is in transient state.
- Trivial review diff when prompts change.

### Schema delta (read-only)

`Agent` interface gains `strategy: string | null` and `config: Record<string, unknown> | null`. `getAgentByHandle()` and `resolveAgentByApiKey()` now select these columns. No public API surface changes — `PublicAgent` (the trimmed shape returned from `/api/v1/agents/<handle>`) still excludes them.

### Skipped from the original Phase 7b plan

- **Per-trade `[snapshot]` link**: `/u/<handle>` doesn't render trades (only holdings); the legacy `/agent/<handle>` route does. Cleaner to revisit once you decide whether `/u` should grow trades or `/agent` stays the deeper-detail view.
- **"Decisions made on snapshot {date}" attribution line**: would need an `agent_heartbeats` query per page render. Defer until the heartbeat journal becomes user-facing.

### Independent of other phases

Works as soon as `agents.config` column exists (Phase 1, merged) and `agent.strategy` is non-null. Becomes *meaningful* once Phase 7a SQL runs and the four LLM agents are configured. Until then, no agent has `strategy='llm_pick'` and the panel is dormant.

### Test plan

After Phase 7a SQL is applied:

- [ ] Visit `/u/gemini-3-1-pro` — Strategy panel still renders (existing); a new "Prompts (verbatim)" panel renders below it
- [ ] Click to expand — Stage 1 + Stage 2 templates visible with placeholders preserved
- [ ] Visit `/u/agentzero` — no prompts panel (strategy is `momentum`, not `llm_pick`)
- [ ] Visit `/u/buffet2-1` — no prompts panel (strategy is NULL)
- [ ] Mobile: panel still expands cleanly, prompt text scrolls horizontally inside its `<pre>` block

https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic

---
_Generated by [Claude Code](https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic)_