### PR TITLE
Hotfix: snapshot crash on price_sales.history_json pair shape

### DIFF
--- a/build_universe_snapshot.py
+++ b/build_universe_snapshot.py
@@ -84,8 +84,14 @@ def _pick(d: dict, keys: tuple[str, ...]) -> dict:
     return {k: _safe(d.get(k)) for k in keys}
 
 
-def _parse_history(raw: Any) -> list[dict]:
-    """Normalise a stored JSON history blob (string or list) into a list."""
+def _parse_history(raw: Any) -> list:
+    """Normalise a stored JSON history blob (string or list) into a list.
+
+    Returns the raw list — entries may be dicts (companies.* history) or
+    pair-lists (price_sales.history_json, written by price_sales_updater
+    as ``[date_str, ps_value]``). Caller is responsible for shape-aware
+    handling.
+    """
     if raw is None:
         return []
     if isinstance(raw, list):
@@ -99,13 +105,36 @@ def _parse_history(raw: Any) -> list[dict]:
     return []
 
 
-def _ps_history_monthly(weekly: list[dict]) -> list[dict]:
-    """Downsample a weekly P/S series to one point per calendar month."""
-    if not weekly:
+def _normalize_ps_history(raw: list) -> list[dict]:
+    """Convert ``price_sales.history_json`` to a list of ``{date, ps}`` dicts.
+
+    The stored shape is a list of ``[date_str, ps_value]`` pairs (see
+    ``price_sales_updater.py``). Older rows or migrations may have stored
+    list-of-dicts; this helper accepts both.
+    """
+    out: list[dict] = []
+    for row in raw or []:
+        if isinstance(row, dict):
+            date_str = row.get("date") or row.get("week") or ""
+            ps_val = row.get("ps") if "ps" in row else row.get("price_sales")
+        elif isinstance(row, (list, tuple)) and len(row) >= 2:
+            date_str = row[0]
+            ps_val = row[1]
+        else:
+            continue
+        if not isinstance(date_str, str) or len(date_str) < 7:
+            continue
+        out.append({"date": date_str, "ps": ps_val})
+    return out
+
+
+def _ps_history_monthly(history: list[dict]) -> list[dict]:
+    """Downsample a normalised P/S series to one point per calendar month."""
+    if not history:
         return []
     by_month: dict[str, dict] = {}
-    for row in weekly:
-        date_str = row.get("date") or row.get("week") or ""
+    for row in history:
+        date_str = row.get("date") or ""
         if len(date_str) < 7:
             continue
         ym = date_str[:7]  # "YYYY-MM"
@@ -156,7 +185,7 @@ def _build_ticker_entry(
         valuation["ps_ath"] = _safe(ps.get("ath"))
         valuation["ps_pct_of_ath"] = _safe(ps.get("pct_of_ath"))
         if detail in ("extended", "full"):
-            history = _parse_history(ps.get("history_json"))
+            history = _normalize_ps_history(_parse_history(ps.get("history_json")))
             if detail == "extended":
                 valuation["ps_history"] = _ps_history_monthly(history)
             else:


### PR DESCRIPTION
## Hotfix — snapshot crash on `price_sales.history_json` shape

The first universe-snapshot run crashed mid-build:

```
File "build_universe_snapshot.py", line 108, in _ps_history_monthly
    date_str = row.get("date") or row.get("week") or ""
AttributeError: 'list' object has no attribute 'get'
```

### Root cause

`price_sales.history_json` is stored as `[[date_str, ps_value], ...]` pairs (see `price_sales_updater.py:364, 374, 391`) — not `[{date, ps}, ...]` dicts as I assumed when writing `_ps_history_monthly`.

The compact tier (no history arrays) wrote successfully — log shows `compact tickers=717 size=1098KB`. The extended tier blew up on the first ticker with a populated PS history.

### Fix

New `_normalize_ps_history()` helper accepts **both** shapes (list-of-pairs and list-of-dicts) and emits dicts uniformly. Both `extended` and `full` tiers now produce the same `{date, ps}` shape in `valuation.ps_history` — the picker and the `/universe` page can rely on one structure.

### Test plan

- [ ] Manual workflow re-run (Universe Snapshot → Run workflow, no inputs) — succeeds for all three tiers
- [ ] `SELECT detail, ticker_count FROM universe_snapshots WHERE snapshot_date = CURRENT_DATE` returns 3 rows
- [ ] Spot-check JSON: `SELECT json->'tickers'->0->'valuation'->'ps_history' FROM universe_snapshots WHERE detail = 'extended' AND snapshot_date = CURRENT_DATE LIMIT 1` returns an array of `{date, ps}` objects (≤12 entries for extended, full series for full)
- [ ] `/universe` page renders without errors

### Note on volume

717 tickers in the snapshot is higher than my 200-ticker estimate — that's the full `in_tv_screen=true` set. Token-budget implications:

| Tier | Per-ticker | × 717 |
|---|---|---|
| compact | ~500 tok | ~360K — too big for stage 1 of any 200K-context model |
| extended | ~750 tok | ~540K |
| full | ~1300 tok | ~930K |

Even Anthropic's Claude 4.7 (1M context) is tight on the full tier. **Heads up**: stage 1 of the LLM picker may need either a tighter pre-filter or a smaller compact tier than I'd planned. Will surface in the first dry-run; we can tighten the snapshot's `in_tv_screen` filter then if needed.

https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic

---
_Generated by [Claude Code](https://claude.ai/code/session_016egDAQw5aVkQ6eMHsKy1ic)_