### PR TITLE
llm_picker: capture raw stage responses on success

### DIFF
--- a/llm_picker.py
+++ b/llm_picker.py
@@ -377,6 +377,7 @@ def rebalance_llm_pick(ctx: RebalanceContext) -> RebalanceResult:
             "shortlist_count": len(shortlist),
             "dropped_invalid_tickers": dropped,
             "raw_response_kb": len(stage1_json) // 1024,
+            "raw_response": stage1_json[:8000],
             "input_tokens": usage[0],
             "output_tokens": usage[1],
         }
@@ -443,6 +444,7 @@ def rebalance_llm_pick(ctx: RebalanceContext) -> RebalanceResult:
         "pick_count": len(picks),
         "dropped_invalid_tickers": dropped,
         "raw_response_kb": len(stage2_json) // 1024,
+        "raw_response": stage2_json[:8000],
         "input_tokens": usage[0],
         "output_tokens": usage[1],
     }


### PR DESCRIPTION
## Summary

Capture the raw text of stage 1 / stage 2 LLM responses on the success path too — currently they're only stored in `agent_heartbeats.notes` when an `LLMProviderError` is raised. That blinds us to the case where the API call succeeded and the JSON parsed, but the parsed structure is wrong (empty `shortlist`, refusal text in a different key, etc).

Both `gemini-3.1-pro-preview` and `deepseek-v4-pro` returned `{"shortlist": []}` in today's run — with the change you can see the raw text and decide whether the model refused, mis-formatted, or really had no picks.

Truncated to 8000 chars so a runaway model can't bloat the JSONB column.

## Test plan

- [ ] After merge: run `python agent_heartbeat.py --handle gemini-3-1-pro --force --dry-run`
- [ ] `SELECT notes->'stage1'->>'raw_response' FROM agent_heartbeats WHERE …` shows actual model output

https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ)_