### PR TITLE
US-only mode: GPT-5 param rename, picker filter, screener restriction

### DIFF
--- a/llm_picker.py
+++ b/llm_picker.py
@@ -28,7 +28,7 @@ import logging
 import math
 from typing import Any
 
-from agent_strategies import RebalanceContext, RebalanceResult
+from agent_strategies import US_EXCHANGES, RebalanceContext, RebalanceResult
 from db import SupabaseDB
 from llm_providers import (
     ENV_VAR_FOR_PROVIDER,
@@ -87,6 +87,42 @@ def _slice_tickers(snapshot_json: dict, tickers: set[str]) -> dict:
         **snapshot_json,
         "tickers": filtered,
         "ticker_count": len(filtered),
+    }
+
+
+def _us_listed_tickers(db: SupabaseDB) -> set[str]:
+    """Tickers in `companies` whose exchange is a US venue.
+
+    Used to filter snapshots before they're sent to LLM agents — the
+    portfolio layer treats every price as USD, so non-US listings
+    (priced in their native currency) would silently mis-cost trades.
+    Until we add proper FX, agents see US-listed tickers (incl. ADRs,
+    which trade on NYSE/NASDAQ) only.
+    """
+    return {
+        str(c["ticker"]).upper()
+        for c in db.get_all_companies()
+        if c.get("ticker")
+        and str(c.get("exchange") or "").strip().upper() in US_EXCHANGES
+    }
+
+
+def _filter_snapshot_us_only(
+    snapshot_json: dict, us_tickers: set[str],
+) -> dict:
+    """Drop non-US-listed tickers from the snapshot."""
+    filtered = [
+        t for t in (snapshot_json.get("tickers") or [])
+        if str(t.get("ticker") or "").upper() in us_tickers
+    ]
+    return {
+        **snapshot_json,
+        "tickers": filtered,
+        "ticker_count": len(filtered),
+        "universe_filter": {
+            **(snapshot_json.get("universe_filter") or {}),
+            "us_listed_only": True,
+        },
     }
 
 
@@ -318,7 +354,11 @@ def rebalance_llm_pick(ctx: RebalanceContext) -> RebalanceResult:
         )
         return result
 
-    snapshot_json = snap_row["json"]
+    # Filter snapshot to US-listed tickers (incl. ADRs). Non-US listings
+    # are priced in their native currency but the portfolio layer treats
+    # every price as USD — until we add FX, hide foreign listings entirely.
+    us_tickers = _us_listed_tickers(ctx.db)
+    snapshot_json = _filter_snapshot_us_only(snap_row["json"], us_tickers)
     snapshot_date = snap_row["snapshot_date"]
     universe_tickers = {
         str(t.get("ticker") or "").upper()
@@ -402,7 +442,8 @@ def rebalance_llm_pick(ctx: RebalanceContext) -> RebalanceResult:
             result.notes = notes
             return result
         deep_snapshot = _slice_tickers(
-            full_row["json"], {p["ticker"] for p in shortlist}
+            _filter_snapshot_us_only(full_row["json"], us_tickers),
+            {p["ticker"] for p in shortlist},
         )
         valid_after_stage1 = {p["ticker"] for p in shortlist}
     else:

--- a/llm_providers.py
+++ b/llm_providers.py
@@ -177,17 +177,26 @@ def _call_openai_compatible(
     client = OpenAI(**kwargs)
 
     last_err: Exception | None = None
+    # GPT-5+ models renamed `max_tokens` to `max_completion_tokens`. We try
+    # the legacy name first (DeepSeek + older OpenAI accept it) and fall
+    # back on the specific 400.
+    use_completion_tokens = False
     for attempt in range(2):
         try:
+            token_kwarg = (
+                {"max_completion_tokens": max_tokens}
+                if use_completion_tokens
+                else {"max_tokens": max_tokens}
+            )
             resp = client.chat.completions.create(
                 model=model,
-                max_tokens=max_tokens,
                 temperature=temperature,
                 messages=[
                     {"role": "system", "content": system},
                     {"role": "user", "content": user},
                 ],
                 response_format={"type": "json_object"},
+                **token_kwarg,
             )
             text = resp.choices[0].message.content or ""
             usage = getattr(resp, "usage", None)
@@ -204,6 +213,12 @@ def _call_openai_compatible(
                 "%s call attempt %d failed: %s",
                 provider_label, attempt + 1, exc,
             )
+            if (
+                "max_completion_tokens" in str(exc).lower()
+                and not use_completion_tokens
+            ):
+                use_completion_tokens = True
+                continue  # retry immediately with the new param name
             time.sleep(2 ** attempt)
     raise LLMProviderError(
         f"{provider_label} call failed after retries: {last_err}"

--- a/tv_screen.py
+++ b/tv_screen.py
@@ -31,19 +31,13 @@ EXCLUDED_SECTORS = {
     "Non-Energy Minerals", "Finance", "Utilities",
 }
 
-# Market passes
-PASS1_MARKETS = ["america", "canada", "brazil", "mexico"]
-PASS2_MARKETS = [
-    "uk", "germany", "france", "spain", "italy", "netherlands",
-    "switzerland", "sweden", "norway", "denmark", "finland", "belgium",
-    "austria", "portugal", "ireland", "israel", "south_africa",
-    "saudi_arabia", "uae", "poland", "greece", "turkey",
-]
-PASS3_MARKETS = [
-    "australia", "india", "japan", "south_korea", "singapore",
-    "new_zealand", "indonesia", "thailand", "malaysia", "philippines",
-    "vietnam",
-]
+# Markets to screen. TradingView's "america" market covers NYSE/NASDAQ/
+# AMEX — the same set as agent_strategies.US_EXCHANGES — and includes
+# ADRs (foreign companies whose shares trade on US exchanges in USD).
+# Non-US markets are excluded because PortfolioManager treats every
+# companies.price as USD; until we add FX, agents can only safely trade
+# US-listed names.
+MARKETS = ["america"]
 
 
 def clean_ticker(raw_name: str) -> str:
@@ -160,36 +154,22 @@ def _screen_markets(markets: list[str], spy_perf_y: float, logger) -> list[dict]
 
 
 def run_tradingview_screen(logger) -> list[dict]:
-    """
-    Query TradingView screener with filters and return list of equity dicts.
-    Runs 3 passes with deduplication across passes.
-    """
+    """Screen TradingView's US market and return list of equity dicts."""
     logger.info("=" * 60)
-    logger.info("TradingView Screening")
+    logger.info("TradingView Screening (US only)")
     logger.info("=" * 60)
 
     spy_perf_y = _get_spy_perf_y(logger)
 
-    all_results = {}
+    equities = _screen_markets(MARKETS, spy_perf_y, logger)
+    deduped: dict[str, dict] = {}
+    for eq in equities:
+        ticker = eq["ticker"]
+        if ticker not in deduped:
+            deduped[ticker] = eq
 
-    for pass_num, markets in enumerate(
-        [PASS1_MARKETS, PASS2_MARKETS, PASS3_MARKETS], start=1
-    ):
-        logger.info("Pass %d: scanning %d markets...", pass_num, len(markets))
-        equities = _screen_markets(markets, spy_perf_y, logger)
-        new_count = 0
-        for eq in equities:
-            ticker = eq["ticker"]
-            if ticker not in all_results:
-                all_results[ticker] = eq
-                new_count += 1
-        logger.info(
-            "Pass %d: found %d equities, %d new (total so far: %d)",
-            pass_num, len(equities), new_count, len(all_results),
-        )
-
-    logger.info("TradingView screening complete: %d unique equities", len(all_results))
-    return list(all_results.values())
+    logger.info("TradingView screening complete: %d unique equities", len(deduped))
+    return list(deduped.values())
 
 
 def fetch_market_data(tickers_with_exchange: list[tuple[str, str]], logger) -> dict[str, dict]:


### PR DESCRIPTION
## Summary

Three related fixes for the LLM picker landed on this branch.

### 1. GPT-5 `max_completion_tokens` param rename
GPT-5.4 returns 400 on the legacy `max_tokens`. Same one-shot retry pattern as the Anthropic temperature-deprecation fix: try the legacy name first, retry once with `max_completion_tokens` on the specific 400. Unblocks `codex-tobyr-0423`.

### 2. Hide non-US listings from LLM agents at picker time
`PortfolioManager` treats every `companies.price` as USD, but a chunk of the universe is priced natively. `gemini-3-1-pro` bought 9 German WKN listings last run, paying USD amounts for EUR-priced securities. Until FX support lands, the picker filters its snapshot to US-listed tickers (incl. ADRs).

### 3. Stop ingesting non-US listings at screener time
Switching `tv_screen.py` from a 3-pass global screen (~50 markets) to TradingView's "america" market only — same exchanges as `US_EXCHANGES`, includes ADRs. Side effects:
- Single TV screener call instead of three.
- `nightly_screen.py` automatically flips `in_tv_screen=false` for existing foreign tickers, so they fall out of universe snapshots within one nightly run.
- Gemini's existing 9 foreign holdings will be sold next rebalance once they drop out of the universe.

### When FX support lands
Restore the broader `MARKETS` list in `tv_screen.py` and the picker's `_filter_snapshot_us_only` becomes unnecessary.

## Test plan

- [ ] After merge: heartbeat `codex-tobyr-0423` runs without 400
- [ ] Heartbeat `gemini-3-1-pro --force` — picks are all US/ADR
- [ ] Next 03:00 UTC `nightly_screen.py` flips `in_tv_screen=false` for non-US rows in `companies`

https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ