### PR TITLE
llm_providers: route GPT-5 to max_completion_tokens by model id

### DIFF
--- a/llm_providers.py
+++ b/llm_providers.py
@@ -176,18 +176,29 @@ def _call_openai_compatible(
         kwargs["base_url"] = base_url
     client = OpenAI(**kwargs)
 
+    # OpenAI's GPT-5+ family and reasoning models (o1/o3/o4) require
+    # `max_completion_tokens`; legacy chat models and DeepSeek still
+    # use `max_tokens`. Pick the right param name by model id rather
+    # than discovering it via a 400 on every call.
+    model_lower = model.lower()
+    needs_completion_tokens = (
+        provider_label == "openai"
+        and (
+            model_lower.startswith("gpt-5")
+            or model_lower.startswith("o1")
+            or model_lower.startswith("o3")
+            or model_lower.startswith("o4")
+        )
+    )
+    token_kwarg = (
+        {"max_completion_tokens": max_tokens}
+        if needs_completion_tokens
+        else {"max_tokens": max_tokens}
+    )
+
     last_err: Exception | None = None
-    # GPT-5+ models renamed `max_tokens` to `max_completion_tokens`. We try
-    # the legacy name first (DeepSeek + older OpenAI accept it) and fall
-    # back on the specific 400.
-    use_completion_tokens = False
     for attempt in range(2):
         try:
-            token_kwarg = (
-                {"max_completion_tokens": max_tokens}
-                if use_completion_tokens
-                else {"max_tokens": max_tokens}
-            )
             resp = client.chat.completions.create(
                 model=model,
                 temperature=temperature,
@@ -213,12 +224,6 @@ def _call_openai_compatible(
                 "%s call attempt %d failed: %s",
                 provider_label, attempt + 1, exc,
             )
-            if (
-                "max_completion_tokens" in str(exc).lower()
-                and not use_completion_tokens
-            ):
-                use_completion_tokens = True
-                continue  # retry immediately with the new param name
             time.sleep(2 ** attempt)
     raise LLMProviderError(
         f"{provider_label} call failed after retries: {last_err}"


### PR DESCRIPTION
## Summary

PR #466's retry-on-error logic for the GPT-5 `max_completion_tokens` param rename didn't actually work in production — both attempts came back with the same `"Use 'max_completion_tokens' instead"` error. Either the SDK was overriding the kwarg on the second attempt, or doing something internal on the 400 that I didn't anticipate.

Switching to a deterministic upfront decision: if the model id starts with `gpt-5`, `o1`, `o3`, or `o4` AND the provider is `openai`, send `max_completion_tokens`. Otherwise (legacy OpenAI, DeepSeek), send `max_tokens`. The provider gate prevents accidentally sending `max_completion_tokens` to DeepSeek if a DeepSeek model id ever shares a prefix.

## Test plan

- [ ] After merge: heartbeat `codex-tobyr-0423` (currently `gpt-5.4`) — runs without the 400
- [ ] DeepSeek (`fundamental-sentinel`) still works on its next run

https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ)_