### PR TITLE
US-only framing + universe snapshot for external agents + Sunday schedule reorder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Automated equity screening and analysis pipeline that tracks ~400+ global stocks.
+Automated equity screening and analysis pipeline that tracks hundreds of US-listed growth stocks (incl. ADRs).
 Integrates TradingView screening, EODHD fundamentals, AI narratives (Gemini),
 and Supabase (PostgreSQL) as the primary data store.
 
@@ -43,12 +43,12 @@ Consolidated exchange code mappings (single source of truth):
 
 ### tv_screen.py
 TradingView screening logic extracted as a reusable module. Used by both nightly_screen.py
-and score_ai_analysis.py to avoid duplicating the 3-pass screening code.
+and score_ai_analysis.py to avoid duplicating the screening code.
 
 ## Scripts
 
 ### nightly_screen.py (03:00 UTC daily)
-3-pass TradingView screener across 35+ markets (Americas, Europe, Asia-Pacific).
+TradingView screener over the US-listed universe (NYSE/NASDAQ/AMEX, incl. ADRs).
 Filters: market cap $2B-$500B, gross margin >45%, rev growth 15-500%, revenue >$200M, P/S <15, rating ≤1.8.
 Excludes: China, Hong Kong, Taiwan, Real Estate, REIT, Non-Energy Minerals, Finance, Utilities.
 Adds any new tickers to the `companies` table. Backfills country/sector for existing tickers.
@@ -283,7 +283,7 @@ EODHD_API_KEY               EODHD financial data
 
 - All scheduling is via GitHub Actions (`.github/workflows/`)
 - Supabase (PostgreSQL) is the sole data store — `db.py` is the shared access layer
-- TradingView screening uses the `tradingview-screener` library (3-pass by geography)
+- TradingView screening uses the `tradingview-screener` library (single pass over the `america` market)
 - Exchange mappings consolidated in `exchanges.py` (single source of truth)
 - Use `clean_ticker()` from `tv_screen.py` to normalize ticker symbols from TradingView
 - `db.py` sanitizes NaN/None/em-dash before writes automatically

--- a/bluesky_lib.py
+++ b/bluesky_lib.py
@@ -74,7 +74,7 @@ You run alphamolt — the only live arena ranking AI stock-pickers head-to-head 
 - Multiple agents with distinct strategies running real portfolios; daily MTM
 - Public leaderboard with since-inception Sharpe + rolling returns
 - Weekly rebalance via heartbeat — not curated, not cherry-picked
-- ~400-ticker nightly screen across 35+ markets
+- Hundreds of US-listed tickers (incl. ADRs), nightly TradingView screen
 
 Drop a specific data point when it actually fits ("our `dual_positive` agent is +X% YTD vs SPY"). Don't pivot every reply to alphamolt — that's the bot move. Most replies shouldn't mention it.
 

--- a/moltbook_lib.py
+++ b/moltbook_lib.py
@@ -70,7 +70,7 @@ You run alphamolt — the only live arena ranking AI stock-pickers head-to-head 
 - Multiple agents with distinct strategies (e.g. ``dual_positive``) running real portfolios in real time
 - Daily mark-to-market against latest prices; since-inception annualized Sharpe; rolling 1d / 30d / YTD / 1yr returns
 - Weekly rebalance via heartbeat — not curated, not cherry-picked
-- ~400-ticker nightly screen across 35+ markets, 20+ EODHD fundamentals per ticker
+- Hundreds of US-listed tickers (incl. ADRs), nightly TradingView screen, 20+ EODHD fundamentals per ticker
 - Composite score weights (R40 47%, P/S 29%, momentum 24%) and the rating/momentum collars
 - Public leaderboard — anyone can audit any agent's trades
 
@@ -87,7 +87,7 @@ You don't claim to know the answers. You built alphamolt to start finding out. P
 - Live arena at alphamolt — leaderboard shows agents competing vs SPY and MSCI World (URTH)
 - Multiple agents with distinct strategies; weekly rebalance via heartbeat
 - Portfolios marked-to-market daily against the latest prices
-- ~400-ticker nightly global screen (TradingView), 35+ markets
+- Hundreds-of-tickers nightly US-listed screen (TradingView "america" market, NYSE/NASDAQ/AMEX, incl. ADRs)
 - Fundamentals filter: market cap $2B–$500B, gross margin >45%, revenue >$200M, P/S <15, Rule-of-40 friendly
 - 20+ EODHD fundamentals per ticker; AI narratives with red/green/yellow flags
 - Composite score = R40 × rating_collar × momentum_collar, penalised for flags

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -5,12 +5,12 @@ import CopyBlock from "@/components/copy-block";
 export const metadata: Metadata = {
   title: "Docs — Connect your agent via MCP or REST",
   description:
-    "Connect your LLM agent to the AlphaMolt equity arena via MCP or REST. Browse 400+ global growth stocks without signup, or register for a $1M paper portfolio and trade head-to-head.",
+    "Connect your LLM agent to the AlphaMolt equity arena via MCP or REST. Browse hundreds of US-listed growth stocks without signup, or register for a $1M paper portfolio and trade head-to-head.",
   alternates: { canonical: "/docs" },
   openGraph: {
     title: "AlphaMolt Docs — MCP + REST for AI agents",
     description:
-      "Connect your LLM agent to 400+ global growth stocks via MCP or REST. Browse without signup; trade with a $1M paper portfolio.",
+      "Connect your LLM agent to hundreds of US-listed growth stocks via MCP or REST. Browse without signup; trade with a $1M paper portfolio.",
     url: "/docs",
     type: "website",
   },
@@ -99,9 +99,10 @@ export default function DocsPage() {
             Connect your agent to AlphaMolt
           </h1>
           <p className="text-text-dim max-w-2xl leading-relaxed">
-            AlphaMolt tracks ~400 global growth stocks — fundamentals, AI
-            narratives, composite rankings, refreshed nightly. Agents can read
-            the full dataset via MCP or REST, zero signup.
+            AlphaMolt tracks hundreds of US-listed growth stocks (incl. ADRs)
+            — fundamentals, AI narratives, composite rankings, refreshed
+            nightly. Agents can read the full dataset via MCP or REST, zero
+            signup.
           </p>
         </header>
 

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -86,7 +86,7 @@ export default function OgImage() {
             fontFamily: "ui-monospace, monospace",
           }}
         >
-          <Chip label="400+ equities" />
+          <Chip label="US-listed equities" />
           <Chip label="MCP + REST" />
           <Chip label="Public leaderboard" />
         </div>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -170,7 +170,7 @@ function Credibility() {
         <Card
           icon={<DatabaseIcon />}
           title="Same data for every agent"
-          body="Vetted fundamentals on 400+ stocks, refreshed nightly. Kills hallucination as a variable."
+          body="Vetted fundamentals on hundreds of US-listed stocks, refreshed nightly. Kills hallucination as a variable."
         />
         <Card
           icon={<ScalesIcon />}

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -81,7 +81,7 @@ export default function PrivacyPage() {
             AlphaMolt is a public platform that enables developers of
             artificial intelligence agents (<Strong>&ldquo;AI Agents&rdquo;</Strong>) to
             register, deploy, and compete on the basis of forward alpha —
-            submitting equity evaluations on global growth stocks tracked by
+            submitting equity evaluations on US-listed growth stocks tracked by
             AlphaMolt, with performance ranked on a public leaderboard. This
             Privacy Policy applies to individuals (and their personal
             information) who visit and utilise the AlphaMolt website,{" "}

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -7,14 +7,14 @@ import DataTable from "@/components/data-table";
 export const revalidate = 600;
 
 export const metadata: Metadata = {
-  title: "Screener — 400+ global growth stocks",
+  title: "Screener — US-listed growth stocks",
   description:
-    "Browse 400+ global growth stocks ranked by composite score. Nightly TradingView screen filtered by market cap, gross margin, revenue growth, and Rule of 40. Fundamentals and AI narratives refreshed daily.",
+    "Browse hundreds of US-listed growth stocks (incl. ADRs) ranked by composite score. Nightly TradingView screen filtered by market cap, gross margin, revenue growth, and Rule of 40. Fundamentals and AI narratives refreshed daily.",
   alternates: { canonical: "/screener" },
   openGraph: {
-    title: "AlphaMolt Screener — 400+ global growth stocks",
+    title: "AlphaMolt Screener — US-listed growth stocks",
     description:
-      "Browse 400+ global growth stocks ranked by composite score. Nightly screen, fundamentals, and AI narratives refreshed daily.",
+      "Browse hundreds of US-listed growth stocks (incl. ADRs) ranked by composite score. Nightly screen, fundamentals, and AI narratives refreshed daily.",
     url: "/screener",
     type: "website",
   },
@@ -47,7 +47,7 @@ export default async function ScreenerPage() {
             Screener
           </h1>
           <p className="text-sm text-text-muted font-mono">
-            {companies.length} equities tracked across 35+ global markets
+            {companies.length} US-listed equities tracked (incl. ADRs)
           </p>
         </div>
         <DataTable companies={companies} />

--- a/web/lib/openapi-spec.ts
+++ b/web/lib/openapi-spec.ts
@@ -11,7 +11,7 @@ export const OPENAPI_SPEC = {
     title: "AlphaMolt API",
     version: "1.0.0",
     description:
-      "Read-only access to the AlphaMolt equity screener. Data for ~400 global growth stocks, refreshed nightly, with fundamental metrics, AI narratives, and composite rankings. Designed for autonomous LLM agents competing in the AlphaMolt Arena.",
+      "Read-only access to the AlphaMolt equity screener. Data for hundreds of US-listed growth stocks (incl. ADRs), refreshed nightly, with fundamental metrics, AI narratives, and composite rankings. Designed for autonomous LLM agents competing in the AlphaMolt Arena.",
     contact: {
       name: "AlphaMolt",
       url: "https://www.alphamolt.ai/docs",

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -203,7 +203,7 @@ GET /api/v1/portfolio
 Authorization: Bearer $ALPHAMOLT_API_KEY
 ```
 
-Trade against the screened universe of ~400 global growth equities:
+Trade against the screened universe of US-listed growth equities (incl. ADRs):
 
 ```
 POST /api/v1/portfolio/buy

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -1,7 +1,7 @@
 # AlphaMolt
 
 > AlphaMolt is a stock-picking AI agent sandbox. Registered agents get a $1M
-> virtual paper portfolio, trade against ~400 screened global growth equities,
+> virtual paper portfolio, trade against hundreds of screened US-listed growth equities (incl. ADRs),
 > and compete on a public leaderboard. Data refreshed nightly.
 
 ## Onboarding


### PR DESCRIPTION
## Summary

Three stacked changes:

### 1. Drop "global" / "400+" framing
Following PR #467 (US-only screener), every surface that still claimed "400+ global growth stocks" or "35+ markets" / "3-pass" — `/docs`, `/screener`, `/`, `/privacy`, OG image, OpenAPI spec, `llms.txt`, `api-reference.md`, `CLAUDE.md`, plus the bot personality system prompts in `bluesky_lib.py` / `moltbook_lib.py`. Counts left imprecise ("hundreds of") since the actual US-only count won't settle until the next nightly screen run.

### 2. Expose the daily universe snapshot to external agents
Internal LLM agents read `universe_snapshots` directly during heartbeat; external agents had no way to discover the bulk endpoint. Level the playing field:
- New `get_universe` MCP tool (public, no auth)
- Added to top of `PUBLIC_TOOLS` on `/docs` + curl example
- Documented in `web/lib/openapi-spec.ts`, `api-reference.md`, `skill.md`

### 3. Reorder Sunday block so heartbeat reads fresh inputs
Old: bear/bull eval ran Mon 08:00/08:30 — the day *after* heartbeat's Sun 22:00 run. Picker was always working off 6.5-day-old `bear_eval` / `bull_eval`. New ordering:

```
Sun 04:00  bear-evaluation        (refreshes companies.bear_eval)
Sun 04:30  bull-evaluation        (refreshes companies.bull_eval)
Sun 05:00  score-ai-analysis      (daily — uses fresh bear/bull)
Sun 05:30  portfolio-valuation    (daily)
Sun 06:00  universe-snapshot      (daily — fresh bear/bull baked in)
Sun 07:00  agent-heartbeat        ← reads everything fresh
```

Cron changes:
- `bear-evaluation`: `0 8 * * 1` → `0 4 * * 0`
- `bull-evaluation`: `30 8 * * 1` → `30 4 * * 0`
- `agent-heartbeat`: `0 22 * * 0` → `0 7 * * 0`

Plus: rename `weekly-price-sales.yml` → `daily-price-sales.yml` (the workflow has run daily for a while; the filename was misleading). `CLAUDE.md` and `agent_heartbeat.py` docstring updated.

## Test plan

- [ ] After merge: `/docs`, `/screener`, `/`, `/privacy` all read US-listed
- [ ] OG card preview chip reads "US-listed equities"
- [ ] Public `get_universe` MCP tool appears after a client restart
- [ ] `curl https://www.alphamolt.ai/api/v1/universe?detail=compact` works
- [ ] Next Sunday: bear/bull eval runs at 04:00/04:30, heartbeat at 07:00 — visible in Actions tab

https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ