### PR TITLE
agent portfolio: kill N+1 price lookup, show company name

### DIFF
--- a/web/app/agent/[handle]/page.tsx
+++ b/web/app/agent/[handle]/page.tsx
@@ -2,7 +2,11 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import Nav from "@/components/nav";
 import { getAgentByHandle } from "@/lib/agents-query";
-import { getPortfolio, type HoldingWithMtm } from "@/lib/portfolio";
+import {
+  getCompanyNamesForTickers,
+  getPortfolio,
+  type HoldingWithMtm,
+} from "@/lib/portfolio";
 import { getSupabase } from "@/lib/supabase";
 
 export const revalidate = 300;
@@ -148,6 +152,24 @@ export default async function AgentPortfolioPage({
     (a, b) => b.market_value_usd - a.market_value_usd,
   );
 
+  // Resolve company_name for any trade tickers not already covered by current
+  // holdings (closed positions). Single bulk SELECT — no N+1.
+  const heldNames = new Map(
+    portfolio.holdings
+      .filter((h) => h.company_name)
+      .map((h) => [h.ticker, h.company_name as string]),
+  );
+  const missingTradeTickers = recent.trades
+    .map((t) => t.ticker)
+    .filter((t) => !heldNames.has(t));
+  const tradeNames = missingTradeTickers.length
+    ? await getCompanyNamesForTickers(missingTradeTickers)
+    : new Map<string, string>();
+  const nameByTicker = new Map<string, string>([
+    ...heldNames,
+    ...tradeNames,
+  ]);
+
   return (
     <>
       <Nav />
@@ -250,6 +272,11 @@ export default async function AgentPortfolioPage({
                           >
                             {h.ticker}
                           </Link>
+                          {h.company_name && (
+                            <div className="text-xs text-text-muted truncate max-w-[220px]">
+                              {h.company_name}
+                            </div>
+                          )}
                         </td>
                         <td className="px-4 py-3 text-right text-text">
                           {h.quantity.toLocaleString("en-US")}
@@ -343,6 +370,11 @@ export default async function AgentPortfolioPage({
                           >
                             {t.ticker}
                           </Link>
+                          {nameByTicker.get(t.ticker) && (
+                            <div className="text-xs text-text-muted truncate max-w-[220px]">
+                              {nameByTicker.get(t.ticker)}
+                            </div>
+                          )}
                         </td>
                         <td className="px-4 py-3 text-right text-text">
                           {t.quantity.toLocaleString("en-US")}

--- a/web/app/u/[handle]/page.tsx
+++ b/web/app/u/[handle]/page.tsx
@@ -4,7 +4,6 @@ import { notFound } from "next/navigation";
 import Nav from "@/components/nav";
 import { getAgentByHandle } from "@/lib/agents-query";
 import { getPortfolio, type PortfolioSnapshot } from "@/lib/portfolio";
-import { getSupabase } from "@/lib/supabase";
 
 export const revalidate = 300;
 
@@ -46,22 +45,6 @@ export async function generateMetadata({
 
 // ----- Data ---------------------------------------------------------------
 
-/**
- * Resolve an agent's internal id by handle without returning a plaintext key.
- * The profile page needs id -> portfolio, but getAgentByHandle only returns
- * public columns (no id). We re-query with a scoped select just for this.
- */
-async function getAgentIdByHandle(handle: string): Promise<string | null> {
-  const supabase = getSupabase();
-  const { data, error } = await supabase
-    .from("agents")
-    .select("id")
-    .eq("handle", handle)
-    .maybeSingle();
-  if (error || !data) return null;
-  return (data as { id: string }).id;
-}
-
 async function getProfileData(handle: string): Promise<{
   agent: Awaited<ReturnType<typeof getAgentByHandle>>;
   portfolio: PortfolioSnapshot | null;
@@ -69,12 +52,9 @@ async function getProfileData(handle: string): Promise<{
   const agent = await getAgentByHandle(handle);
   if (!agent) return { agent: null, portfolio: null };
 
-  const agentId = await getAgentIdByHandle(handle);
-  if (!agentId) return { agent, portfolio: null };
-
   let portfolio: PortfolioSnapshot | null = null;
   try {
-    portfolio = await getPortfolio(agentId);
+    portfolio = await getPortfolio(agent.id);
   } catch (err) {
     // No account yet (agent never called GET /portfolio) — fine, render
     // the profile without the portfolio section.
@@ -185,6 +165,11 @@ export default async function ProfilePage({ params }: PageParams) {
                       >
                         {h.ticker}
                       </Link>
+                      {h.company_name && (
+                        <span className="text-sm text-text-muted truncate min-w-0">
+                          {h.company_name}
+                        </span>
+                      )}
                       <span className="text-sm text-text-dim shrink-0">
                         {h.quantity.toLocaleString()} @{" "}
                         {formatUsd(h.avg_cost_usd)}

--- a/web/lib/portfolio.ts
+++ b/web/lib/portfolio.ts
@@ -57,6 +57,7 @@ export interface TradeResult {
 
 export interface HoldingWithMtm {
   ticker: string;
+  company_name: string | null;
   quantity: number;
   avg_cost_usd: number;
   price_usd: number;
@@ -96,6 +97,62 @@ function round2(n: number): number {
 
 function round4(n: number): number {
   return Math.round(n * 10000) / 10000;
+}
+
+interface CompanyMeta {
+  price: number | null;
+  company_name: string | null;
+}
+
+/**
+ * Bulk-fetch price + company_name for a set of tickers in a single SELECT.
+ * Returns an empty map if `tickers` is empty. Tickers missing from `companies`
+ * simply won't appear in the result map — callers handle that as a fallback.
+ */
+async function getCompaniesMeta(
+  tickers: string[],
+): Promise<Map<string, CompanyMeta>> {
+  const out = new Map<string, CompanyMeta>();
+  if (tickers.length === 0) return out;
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("companies")
+    .select("ticker, price, company_name")
+    .in("ticker", tickers);
+  if (error) {
+    throw new PortfolioError(
+      "price_lookup_failed",
+      `Bulk company lookup failed: ${error.message}`,
+    );
+  }
+  for (const row of (data ?? []) as {
+    ticker: string;
+    price: number | string | null;
+    company_name: string | null;
+  }[]) {
+    const priceNum = row.price == null ? null : Number(row.price);
+    out.set(row.ticker, {
+      price: priceNum != null && Number.isFinite(priceNum) ? priceNum : null,
+      company_name: row.company_name ?? null,
+    });
+  }
+  return out;
+}
+
+/**
+ * Public helper for callers that only need name resolution (e.g. the recent
+ * trades table) without going through the full portfolio MTM path.
+ */
+export async function getCompanyNamesForTickers(
+  tickers: string[],
+): Promise<Map<string, string>> {
+  const distinct = Array.from(new Set(tickers));
+  const meta = await getCompaniesMeta(distinct);
+  const out = new Map<string, string>();
+  for (const [t, m] of meta) {
+    if (m.company_name) out.set(t, m.company_name);
+  }
+  return out;
 }
 
 async function getPrice(ticker: string): Promise<number> {
@@ -464,21 +521,27 @@ export async function getPortfolio(
   const account = await openAccount(agentId);
   const holdings = await getAllHoldings(agentId);
 
+  // Bulk-fetch price + name for every holding in one round-trip. Previously
+  // we did N sequential SELECTs from companies — for an agent with 30
+  // positions that turned the page into 30 chained network hops.
+  const meta = await getCompaniesMeta(holdings.map((h) => h.ticker));
+
   const enriched: HoldingWithMtm[] = [];
   let holdingsValue = 0;
 
   for (const h of holdings) {
-    let price: number;
-    try {
-      price = await getPrice(h.ticker);
-    } catch {
-      // Fall back to avg cost when price unavailable so the row still shows
-      price = h.avg_cost_usd;
-    }
+    const row = meta.get(h.ticker);
+    const rawPrice = row?.price ?? null;
+    // Fall back to avg cost when price unavailable so the row still shows.
+    const price =
+      rawPrice != null && Number.isFinite(rawPrice) && rawPrice > 0
+        ? rawPrice
+        : h.avg_cost_usd;
     const mv = round2(h.quantity * price);
     holdingsValue += mv;
     enriched.push({
       ticker: h.ticker,
+      company_name: row?.company_name ?? null,
       quantity: h.quantity,
       avg_cost_usd: h.avg_cost_usd,
       price_usd: round4(price),


### PR DESCRIPTION
getPortfolio looped through every holding and ran a separate Supabase SELECT per ticker for the price. With ~30 positions that was 30 sequential network round-trips before the page could render — the visible "slow download" on /agent/[handle] and /u/[handle].

Replaced with a single bulk SELECT (ticker, price, company_name) FROM companies WHERE ticker IN (...). The same query also yields the company name for free, so HoldingWithMtm now carries it and both portfolio pages render "AAPL · Apple Inc." rather than just the ticker. Added a shared getCompanyNamesForTickers helper for the recent trades table, which uses one bulk query for any tickers not already covered by current holdings.

Also dropped the redundant getAgentIdByHandle in /u/[handle] — its comment claimed getAgentByHandle didn't return id, but it does. That saves another round-trip on every profile render.