### PR TITLE
brand: SVG logo mark + nav + favicon

### DIFF
--- a/web/app/icon.svg
+++ b/web/app/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="32" fill="#15171A"/>
+  <path fill="#EDEDED" d="M 12 52 L 29 12 L 35 12 L 52 52 L 45 52 L 37 30 L 27 30 L 19 52 Z"/>
+  <line x1="15" y1="42" x2="45" y2="24" stroke="#00FF41" stroke-width="4" stroke-linecap="round"/>
+  <path d="M 51 21 L 41 20 L 46 29 Z" fill="#00FF41"/>
+</svg>

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -86,9 +86,6 @@ export const metadata: Metadata = {
       "max-video-preview": -1,
     },
   },
-  icons: {
-    icon: "/favicon.ico",
-  },
   category: "finance",
 };
 

--- a/web/components/logo.tsx
+++ b/web/components/logo.tsx
@@ -1,0 +1,55 @@
+/**
+ * AlphaMolt mark — dark rounded square, white "A" path (font-independent),
+ * green upward-arrow slashing through it. Same SVG geometry as app/icon.svg
+ * so the favicon and the nav logo stay visually identical.
+ */
+interface LogoProps {
+  size?: number;
+  className?: string;
+  title?: string;
+}
+
+export default function Logo({
+  size = 28,
+  className,
+  title,
+}: LogoProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      role={title ? "img" : undefined}
+      aria-hidden={title ? undefined : true}
+      aria-label={title}
+    >
+      {title && <title>{title}</title>}
+      {/* Dark circle background — matches the original mark. */}
+      <circle cx="32" cy="32" r="32" fill="#15171A" />
+      {/* Bold sans-serif "A" inscribed in the circle — single closed
+          path traced outside-then-inside so the inner counter is open
+          at the bottom (Λ-shape). The green slash visually sits where
+          a crossbar would be. */}
+      <path
+        fill="#EDEDED"
+        d="M 12 52 L 29 12 L 35 12 L 52 52 L 45 52 L 37 30 L 27 30 L 19 52 Z"
+      />
+      {/* Green diagonal stroke (lower-left → upper-right). */}
+      <line
+        x1="15"
+        y1="42"
+        x2="45"
+        y2="24"
+        stroke="#00FF41"
+        strokeWidth="4"
+        strokeLinecap="round"
+      />
+      {/* Arrowhead — isoceles triangle aligned with the line direction.
+          Same green as the line; overlap with the round cap is invisible
+          because both shapes share the fill. */}
+      <path d="M 51 21 L 41 20 L 46 29 Z" fill="#00FF41" />
+    </svg>
+  );
+}

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import Logo from "@/components/logo";
 
 const links = [
   { href: "/leaderboard", label: "Leaderboard" },
@@ -47,10 +48,7 @@ export default function Nav() {
           className="flex items-center gap-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 rounded"
           onClick={() => setMenuOpen(false)}
         >
-          <span
-            aria-hidden
-            className="w-2.5 h-2.5 rounded-sm bg-text"
-          />
+          <Logo size={24} title="AlphaMolt" />
           <span className="text-base font-medium tracking-tight text-text">
             alphamolt
           </span>


### PR DESCRIPTION
Approximation of the AlphaMolt mark in pure SVG: dark circle, bold sans-serif "A" drawn as a path (no font dependency), green diagonal arrow with arrowhead going lower-left to upper-right. The arrow sits where a crossbar would be, so the A reads as a standard capital even without one.

Same geometry powers two surfaces:
- web/components/logo.tsx — React component used in the nav (replaces the placeholder white square next to the wordmark).
- web/app/icon.svg — Next App Router auto-serves this as the primary favicon. The existing favicon.ico stays as the fallback for browsers without SVG favicon support (mainly Safari < 16.4).

Removed the explicit metadata.icons.icon override in layout.tsx so Next discovers both files via the file-based convention and emits both <link rel="icon"> tags automatically.