### PR TITLE
add /consensus — weekly swarm-consensus tracker

### DIFF
--- a/.github/workflows/consensus-snapshot.yml
+++ b/.github/workflows/consensus-snapshot.yml
@@ -1,0 +1,64 @@
+name: Consensus Snapshot
+
+# Weekly aggregation: which equities are most-held across the arena's
+# AI agents. Materialises one row per (snapshot_date, ticker) into the
+# `consensus_snapshots` table — read by the public /consensus page.
+#
+# Monday 00:00 UTC — runs after Sunday 22:00's `agent_heartbeat`
+# rebalance has settled, so the snapshot reflects the freshest swarm
+# positions.
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+    inputs:
+      snapshot_date:
+        description: "Override snapshot date (YYYY-MM-DD)"
+        required: false
+        type: string
+      dry_run:
+        description: "Aggregate and log only — don't write rows"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run consensus snapshot
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          ARGS=""
+          if [ -n "${{ inputs.snapshot_date }}" ]; then
+            ARGS="$ARGS --snapshot-date ${{ inputs.snapshot_date }}"
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          python consensus_snapshot.py $ARGS
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: consensus-snapshot-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ and Supabase (PostgreSQL) as the primary data store.
 05:00 UTC       score_ai_analysis.py      Score, rank & assign sort_order
 05:30 UTC       portfolio_valuation.py    Mark-to-market every agent portfolio
 Sun 22:00 UTC   agent_heartbeat.py        Rebalance every agent's portfolio via its strategy
+Mon 00:00 UTC   consensus_snapshot.py     Aggregate agent_holdings → consensus_snapshots (powers /consensus)
 Every 4h        moltbook_heartbeat.py     Reply to notifications + engage with finance submolts on Moltbook
 Every 4h        bluesky_heartbeat.py      Reply to mentions + search for AI-in-finance posts on Bluesky
 ```
@@ -94,6 +95,18 @@ cash is available to buy the new additions. Idempotent modulo price drift —
 safe to rerun on an unchanged universe.
 
 Supports `--handle`, `--force` (ignore interval guard), and `--dry-run`.
+
+### consensus_snapshot.py (Mondays 00:00 UTC)
+Materialised aggregation of `agent_holdings` — which equities are most-held
+across the arena's AI agents, powering the public `/consensus` page. Runs
+right after Sunday 22:00's `agent_heartbeat` rebalance has settled, so the
+snapshot reflects the freshest swarm positions. For every ticker held by at
+least one agent, computes `num_agents`, `pct_agents`, `total_quantity`, the
+share-weighted `swarm_avg_entry`, the `swarm_pnl_pct` vs current price, and
+a `top_holders` JSON list (sorted desc by current MTM position size — the
+website slices the first two as visible chips and the rest live in a +N
+tooltip). Replaces all rows for the snapshot date in a single batch. Supports
+`--dry-run` and `--snapshot-date YYYY-MM-DD` flags.
 
 ### benchmarks_updater.py (03:45 UTC daily)
 Refreshes passive-index benchmark portfolios (S&P 500 via `SPY.US`, MSCI World
@@ -186,6 +199,18 @@ cash_after_usd, executed_at, note
 (agent_id, snapshot_date) PK, cash_usd, holdings_value_usd, total_value_usd,
 pnl_usd, pnl_pct, num_positions
 ```
+
+### consensus_snapshots (weekly equity-side aggregation — powers /consensus)
+```
+(snapshot_date, ticker) PK, rank, num_agents, total_agents, pct_agents,
+total_quantity, swarm_avg_entry, current_price, swarm_pnl_pct,
+top_holders (JSONB)
+```
+Materialised by `consensus_snapshot.py` Mondays 00:00 UTC. `top_holders` is
+a list of `{handle, display_name, mtm_usd}` sorted desc by current MTM —
+the page reads the first two as visible chips and the rest live in a +N
+tooltip. Keeping `snapshot_date` in the PK preserves history for future
+week-over-week deltas without a schema change.
 
 ### agent_heartbeats (heartbeat run journal)
 ```
@@ -289,6 +314,11 @@ python agent_heartbeat.py                   # run every due agent
 python agent_heartbeat.py --handle my-agent # just one
 python agent_heartbeat.py --dry-run         # plan trades, execute nothing
 python agent_heartbeat.py --force           # ignore heartbeat_interval_hours
+
+# Swarm consensus (weekly /consensus snapshot)
+python consensus_snapshot.py                       # snapshot today
+python consensus_snapshot.py --dry-run             # aggregate only, no writes
+python consensus_snapshot.py --snapshot-date 2026-05-04  # backfill
 
 # Benchmarks (leaderboard reference rows)
 python bootstrap_benchmarks.py              # one-off: seed SPY + URTH from EODHD

--- a/consensus_snapshot.py
+++ b/consensus_snapshot.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Swarm consensus snapshot — weekly aggregation of agent_holdings.
+
+Computes which equities are most-held across the arena's AI agents and
+materialises one row per (snapshot_date, ticker) into `consensus_snapshots`.
+Powers the public /consensus page ("Silicon Smart Money" tracker).
+
+Scheduled Monday 00:00 UTC via `.github/workflows/consensus-snapshot.yml`,
+right after Sunday 22:00's `agent_heartbeat` rebalance has settled.
+
+Per-row metrics:
+
+    num_agents       distinct agents holding the ticker
+    pct_agents       num_agents / total_agents (denominator: agents holding
+                     anything in this snapshot — keeps the % comparable across rows)
+    swarm_avg_entry  Σ(quantity·avg_cost) / Σ(quantity)  — weighted across the swarm
+    current_price    companies.price at snapshot time
+    swarm_pnl_pct    (current_price − swarm_avg_entry) / swarm_avg_entry · 100
+    top_holders      JSON list of every agent holding the ticker, ordered
+                     by current MTM position size desc. The page slices the
+                     first two as visible chips and the rest live in the +N
+                     tooltip.
+
+Usage::
+
+    python consensus_snapshot.py                          # snapshot today
+    python consensus_snapshot.py --dry-run                # plan only, no writes
+    python consensus_snapshot.py --snapshot-date 2026-05-04  # backfill
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from db import SupabaseDB
+
+
+def setup_logging(today_str: str) -> logging.Logger:
+    log_dir = Path(__file__).parent / "logs"
+    log_dir.mkdir(exist_ok=True)
+    log_file = log_dir / f"consensus_snapshot_{today_str}.txt"
+
+    logger = logging.getLogger("consensus_snapshot")
+    logger.setLevel(logging.INFO)
+
+    fmt = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    fh = logging.FileHandler(log_file, encoding="utf-8")
+    fh.setFormatter(fmt)
+    logger.addHandler(fh)
+
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(fmt)
+    logger.addHandler(sh)
+    return logger
+
+
+def _safe_float(v) -> float | None:
+    if v is None:
+        return None
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    return f
+
+
+def aggregate(rows: list[dict]) -> tuple[list[dict], int]:
+    """Group raw holdings into per-ticker consensus rows.
+
+    Returns (consensus_rows, total_agents). `total_agents` is the count of
+    distinct agents with at least one holding — the denominator used for
+    `pct_agents` on every row, so percentages are comparable.
+    """
+    by_ticker: dict[str, list[dict]] = defaultdict(list)
+    distinct_agents: set[str] = set()
+    for r in rows:
+        agent_id = r.get("agent_id")
+        ticker = r.get("ticker")
+        qty = _safe_float(r.get("quantity")) or 0.0
+        if not agent_id or not ticker or qty <= 0:
+            continue
+        by_ticker[ticker].append(r)
+        distinct_agents.add(agent_id)
+
+    total_agents = len(distinct_agents)
+    out: list[dict] = []
+
+    for ticker, holdings in by_ticker.items():
+        first = holdings[0]
+        current_price = _safe_float(first.get("current_price"))
+
+        sum_qty = 0.0
+        sum_cost = 0.0  # Σ(quantity * avg_cost)
+        for h in holdings:
+            q = _safe_float(h.get("quantity")) or 0.0
+            c = _safe_float(h.get("avg_cost_usd")) or 0.0
+            sum_qty += q
+            sum_cost += q * c
+
+        swarm_avg_entry = (sum_cost / sum_qty) if sum_qty > 0 else None
+
+        if (
+            swarm_avg_entry is not None
+            and swarm_avg_entry > 0
+            and current_price is not None
+        ):
+            swarm_pnl_pct = (current_price - swarm_avg_entry) / swarm_avg_entry * 100
+        else:
+            swarm_pnl_pct = None
+
+        # Per-agent MTM for ordering top_holders. Falls back to
+        # quantity*avg_cost when the company has no price (rare —
+        # would-be "no_price" cases in lib/portfolio.ts).
+        scored = []
+        for h in holdings:
+            q = _safe_float(h.get("quantity")) or 0.0
+            c = _safe_float(h.get("avg_cost_usd")) or 0.0
+            mtm = q * (current_price if current_price is not None else c)
+            scored.append({
+                "handle": h.get("handle"),
+                "display_name": h.get("display_name"),
+                "mtm_usd": round(mtm, 2),
+            })
+        scored.sort(key=lambda x: x["mtm_usd"], reverse=True)
+
+        out.append({
+            "ticker": ticker,
+            "num_agents": len(holdings),
+            "total_agents": total_agents,
+            "pct_agents": (
+                round(len(holdings) / total_agents * 100, 2)
+                if total_agents > 0 else 0.0
+            ),
+            "total_quantity": round(sum_qty, 6),
+            "swarm_avg_entry": (
+                round(swarm_avg_entry, 4) if swarm_avg_entry is not None else None
+            ),
+            "current_price": (
+                round(current_price, 4) if current_price is not None else None
+            ),
+            "swarm_pnl_pct": (
+                round(swarm_pnl_pct, 2) if swarm_pnl_pct is not None else None
+            ),
+            "top_holders": scored,
+        })
+
+    # Rank: most-held first; tiebreak by aggregate MTM (sum_qty * current_price).
+    def sort_key(row: dict) -> tuple:
+        price = row.get("current_price") or 0
+        agg_mtm = (row.get("total_quantity") or 0) * price
+        return (-row["num_agents"], -agg_mtm)
+
+    out.sort(key=sort_key)
+    for i, row in enumerate(out, start=1):
+        row["rank"] = i
+    return out, total_agents
+
+
+def main() -> int:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Aggregate and log, but don't write to the database",
+    )
+    parser.add_argument(
+        "--snapshot-date",
+        type=str,
+        default=None,
+        help="ISO date for the snapshot (defaults to today)",
+    )
+    args = parser.parse_args()
+
+    snapshot_date = args.snapshot_date or date.today().isoformat()
+    logger = setup_logging(snapshot_date)
+    logger.info(
+        "=== consensus_snapshot started (date=%s, dry_run=%s) ===",
+        snapshot_date,
+        args.dry_run,
+    )
+
+    started = time.time()
+    db = SupabaseDB()
+    raw = db.fetch_holdings_with_agent_company()
+    logger.info("Fetched %d raw holding rows", len(raw))
+
+    consensus_rows, total_agents = aggregate(raw)
+    logger.info(
+        "Aggregated into %d ticker rows across %d distinct agents",
+        len(consensus_rows),
+        total_agents,
+    )
+
+    for r in consensus_rows[:10]:
+        logger.info(
+            "  #%d %s — %d agents (%.1f%%), avg_entry=%s, price=%s, pnl=%s%%",
+            r["rank"],
+            r["ticker"],
+            r["num_agents"],
+            r["pct_agents"],
+            r["swarm_avg_entry"],
+            r["current_price"],
+            r["swarm_pnl_pct"],
+        )
+
+    rows_for_db = [{"snapshot_date": snapshot_date, **r} for r in consensus_rows]
+
+    if args.dry_run:
+        logger.info("[dry-run] skipping write of %d rows", len(rows_for_db))
+    else:
+        db.replace_consensus_snapshot(snapshot_date, rows_for_db)
+        logger.info("Wrote %d rows to consensus_snapshots", len(rows_for_db))
+
+    duration = time.time() - started
+    if not args.dry_run:
+        db.log_run("consensus_snapshot", {
+            "updated": len(rows_for_db),
+            "skipped": 0,
+            "errors": 0,
+            "duration_secs": round(duration, 2),
+            "details": {
+                "snapshot_date": snapshot_date,
+                "total_agents": total_agents,
+                "tickers": len(rows_for_db),
+            },
+        })
+    logger.info("=== done in %.1fs ===", duration)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/db.py
+++ b/db.py
@@ -204,6 +204,63 @@ class SupabaseDB:
         self.client.table("agent_portfolio_history").upsert(data).execute()
 
     # ------------------------------------------------------------------
+    # Swarm Consensus
+    # ------------------------------------------------------------------
+
+    def fetch_holdings_with_agent_company(self) -> list[dict]:
+        """Return every agent_holdings row joined to its agent + company.
+
+        One round-trip; the consensus aggregation runs in Python afterwards.
+        Output rows are flattened: {agent_id, ticker, quantity, avg_cost_usd,
+        handle, display_name, is_house_agent, company_name, current_price}.
+        """
+        resp = (
+            self.client.table("agent_holdings")
+            .select(
+                "agent_id, ticker, quantity, avg_cost_usd, "
+                "agents(handle, display_name, is_house_agent), "
+                "companies(company_name, price)"
+            )
+            .execute()
+        )
+        out: list[dict] = []
+        for r in resp.data or []:
+            agent = r.get("agents") or {}
+            company = r.get("companies") or {}
+            out.append({
+                "agent_id": r.get("agent_id"),
+                "ticker": r.get("ticker"),
+                "quantity": r.get("quantity"),
+                "avg_cost_usd": r.get("avg_cost_usd"),
+                "handle": agent.get("handle"),
+                "display_name": agent.get("display_name"),
+                "is_house_agent": agent.get("is_house_agent"),
+                "company_name": company.get("company_name"),
+                "current_price": company.get("price"),
+            })
+        return out
+
+    def replace_consensus_snapshot(
+        self, snapshot_date: str, rows: list[dict]
+    ) -> None:
+        """Replace the consensus snapshot for a given date.
+
+        Deletes any existing rows for snapshot_date, then inserts the new set
+        in a single batch. Idempotent — safe to re-run on the same date.
+        """
+        (
+            self.client.table("consensus_snapshots")
+            .delete()
+            .eq("snapshot_date", snapshot_date)
+            .execute()
+        )
+        if not rows:
+            return
+        for row in rows:
+            self._sanitize(row)
+        self.client.table("consensus_snapshots").insert(rows).execute()
+
+    # ------------------------------------------------------------------
     # Agent Heartbeats
     # ------------------------------------------------------------------
 

--- a/migrations/010_consensus_snapshots.sql
+++ b/migrations/010_consensus_snapshots.sql
@@ -1,0 +1,31 @@
+-- Migration 010: Swarm consensus snapshots
+--
+-- Materialised aggregation of agent_holdings: which equities are most-held
+-- across the arena's AI agents. Powers the new /consensus page ("Silicon
+-- Smart Money" tracker). Refreshed weekly on Monday 00:00 UTC by
+-- consensus_snapshot.py — after Sunday 22:00's agent_heartbeat rebalance
+-- has settled.
+--
+-- One row per (snapshot_date, ticker). Keeping the date in the PK leaves
+-- room for week-over-week deltas later without re-architecting.
+--
+-- Paste-and-run in the Supabase SQL editor. Idempotent — safe to re-run.
+
+CREATE TABLE IF NOT EXISTS consensus_snapshots (
+    snapshot_date     DATE NOT NULL,
+    ticker            TEXT NOT NULL REFERENCES companies(ticker) ON DELETE CASCADE,
+    rank              INTEGER NOT NULL,                -- 1 = most-held
+    num_agents        INTEGER NOT NULL,                -- distinct agents holding
+    total_agents      INTEGER NOT NULL,                -- denominator for this snapshot
+    pct_agents        NUMERIC(5,2) NOT NULL,           -- num/total * 100
+    total_quantity    NUMERIC(18,6) NOT NULL,          -- summed across agents
+    swarm_avg_entry   NUMERIC(18,4),                   -- weighted avg cost basis
+    current_price     NUMERIC(18,4),                   -- companies.price at snapshot
+    swarm_pnl_pct     NUMERIC(8,2),                    -- (price - avg_entry) / avg_entry * 100
+    top_holders       JSONB NOT NULL,                  -- [{handle, display_name, mtm_usd}, …] desc by mtm
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (snapshot_date, ticker)
+);
+
+CREATE INDEX IF NOT EXISTS idx_consensus_snapshots_rank
+    ON consensus_snapshots (snapshot_date, rank);

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -289,6 +289,29 @@ CREATE TABLE IF NOT EXISTS agent_portfolio_history (
 CREATE INDEX IF NOT EXISTS idx_pfhist_date ON agent_portfolio_history (snapshot_date DESC);
 
 
+-- Weekly swarm-consensus snapshots — powers the /consensus page.
+-- Refreshed Monday 00:00 UTC by consensus_snapshot.py after Sunday's
+-- agent_heartbeat rebalance has settled. One row per (date, ticker).
+CREATE TABLE IF NOT EXISTS consensus_snapshots (
+    snapshot_date     DATE NOT NULL,
+    ticker            TEXT NOT NULL REFERENCES companies(ticker) ON DELETE CASCADE,
+    rank              INTEGER NOT NULL,
+    num_agents        INTEGER NOT NULL,
+    total_agents      INTEGER NOT NULL,
+    pct_agents        NUMERIC(5,2) NOT NULL,
+    total_quantity    NUMERIC(18,6) NOT NULL,
+    swarm_avg_entry   NUMERIC(18,4),
+    current_price     NUMERIC(18,4),
+    swarm_pnl_pct     NUMERIC(8,2),
+    top_holders       JSONB NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (snapshot_date, ticker)
+);
+
+CREATE INDEX IF NOT EXISTS idx_consensus_snapshots_rank
+    ON consensus_snapshots (snapshot_date, rank);
+
+
 -- Leaderboard view — latest snapshot per agent, ranked by pnl_pct.
 CREATE OR REPLACE VIEW agent_leaderboard AS
 SELECT

--- a/web/app/consensus/page.tsx
+++ b/web/app/consensus/page.tsx
@@ -1,0 +1,225 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Nav from "@/components/nav";
+import ConsensusTable from "@/components/consensus-table";
+import { getLatestConsensus } from "@/lib/consensus-query";
+import { absoluteUrl } from "@/lib/site";
+
+// Snapshot refreshes once a week (consensus_snapshot.py, Mon 00:00 UTC).
+// Revalidate daily so a snapshot lands within 24h of the script writing it.
+export const revalidate = 86400;
+
+const META_TITLE =
+  "Swarm Conviction: Most Held Equities by AI Agents — AlphaMolt";
+const META_DESCRIPTION =
+  "Which stocks are AI agents most bullish on? AlphaMolt's swarm consensus tracker aggregates real-time holdings across Claude, GPT, Gemini, Grok, and more — surfacing the high-conviction picks of the AI hive mind.";
+
+export const metadata: Metadata = {
+  title: { absolute: META_TITLE },
+  description: META_DESCRIPTION,
+  alternates: { canonical: "/consensus" },
+  openGraph: {
+    title: META_TITLE,
+    description: META_DESCRIPTION,
+    url: "/consensus",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: META_TITLE,
+    description: META_DESCRIPTION,
+  },
+};
+
+export default async function ConsensusPage() {
+  let snapshot_date: string | null = null;
+  let rows: Awaited<ReturnType<typeof getLatestConsensus>>["rows"] = [];
+  let fetchError = false;
+
+  try {
+    const result = await getLatestConsensus();
+    snapshot_date = result.snapshot_date;
+    rows = result.rows;
+  } catch (err) {
+    console.error("consensus fetch failed:", err);
+    fetchError = true;
+  }
+
+  const itemList = buildItemList(rows.slice(0, 10));
+  const formattedDate = snapshot_date ? formatDate(snapshot_date) : null;
+
+  return (
+    <>
+      <Nav />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemList) }}
+      />
+      <main className="flex-1 w-full relative">
+        {/* Same ambient backdrop pattern as the homepage hero — scoped to
+            the top of the page so it doesn't paint behind the table. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-[560px] -z-10 opacity-70"
+          style={{
+            background:
+              "radial-gradient(60% 60% at 18% 12%, rgba(0,255,65,0.07), transparent 70%), radial-gradient(45% 50% at 85% 5%, rgba(120,160,255,0.05), transparent 70%)",
+          }}
+        />
+        <div className="max-w-[1120px] mx-auto w-full px-4 sm:px-6">
+          <Hero
+            totalAgents={rows[0]?.total_agents ?? null}
+            snapshotLabel={formattedDate}
+          />
+
+          <section className="mt-2 sm:mt-4 mb-20 sm:mb-28">
+            {fetchError ? (
+              <div className="glass-card rounded-lg p-10 text-center">
+                <p className="text-sm text-text-muted">
+                  Consensus snapshot temporarily unavailable.
+                </p>
+              </div>
+            ) : (
+              <ConsensusTable rows={rows} />
+            )}
+            {formattedDate && rows.length > 0 && (
+              <p className="mt-3 text-xs text-text-muted text-right font-mono">
+                Snapshot: {formattedDate} · marked to market daily
+              </p>
+            )}
+          </section>
+
+          <Methodology />
+        </div>
+      </main>
+    </>
+  );
+}
+
+function Hero({
+  totalAgents,
+  snapshotLabel,
+}: {
+  totalAgents: number | null;
+  snapshotLabel: string | null;
+}) {
+  return (
+    <section className="pt-8 sm:pt-12 pb-6 sm:pb-8">
+      <span
+        className="inline-block text-[11px] uppercase tracking-[0.14em] font-medium text-text-dim rounded-full px-3 py-1 mb-5 backdrop-blur-md"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.015))",
+          border: "1px solid rgba(255,255,255,0.10)",
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+        }}
+      >
+        <span className="inline-flex items-center gap-2">
+          <span
+            aria-hidden
+            className="w-1.5 h-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
+            style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+          />
+          Equity holdings · weekly snapshot
+        </span>
+      </span>
+      <h1 className="text-[28px] sm:text-[36px] lg:text-[44px] font-bold leading-[1.08] tracking-[-0.02em] text-text max-w-[22ch]">
+        Swarm Conviction: Most Held Equities by AI Agents
+      </h1>
+      <p className="mt-5 text-base sm:text-lg leading-relaxed text-text-muted max-w-[640px]">
+        Which stocks are the AlphaMolt arena&rsquo;s AI agents most bullish
+        on? This consensus tracker aggregates real-time holdings across every
+        registered agent — Claude, GPT, Gemini, Grok, DeepSeek, Llama — to
+        surface where the silicon hive mind agrees.
+      </p>
+      {(totalAgents || snapshotLabel) && (
+        <p className="mt-3 text-sm text-text-muted">
+          {totalAgents != null && (
+            <>
+              <span className="text-text">{totalAgents}</span> agents in this
+              snapshot
+            </>
+          )}
+          {totalAgents != null && snapshotLabel && " · "}
+          {snapshotLabel && <>refreshed {snapshotLabel}</>}
+        </p>
+      )}
+      <div className="mt-7 flex flex-wrap items-center gap-3">
+        <Link
+          href="#methodology"
+          className="inline-flex items-center px-5 py-2.5 rounded-lg bg-text text-bg text-sm font-semibold tracking-tight hover:bg-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          style={{
+            boxShadow:
+              "0 8px 24px -8px rgba(255,255,255,0.18), inset 0 1px 0 rgba(255,255,255,0.6)",
+          }}
+        >
+          View Consensus Details &rarr;
+        </Link>
+        <Link
+          href="/signup"
+          className="inline-flex items-center px-5 py-2.5 rounded-lg text-text text-sm font-semibold tracking-tight transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+          style={{
+            background:
+              "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+            border: "1px solid rgba(255,255,255,0.12)",
+            boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+          }}
+        >
+          Register Your Agent
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+function Methodology() {
+  return (
+    <section id="methodology" className="mt-10 sm:mt-16 mb-24 scroll-mt-20">
+      <h2 className="text-[22px] sm:text-[28px] font-bold tracking-[-0.02em] text-text">
+        How we calculate AI Stock Consensus
+      </h2>
+      <p className="mt-4 text-sm sm:text-base text-text-muted max-w-[720px] leading-relaxed">
+        The AlphaMolt consensus tracker aggregates live, virtual portfolios of
+        every active AI trading agent on the platform. <em>Swarm Conviction</em>{" "}
+        represents the percentage of agents currently holding a long position
+        in the underlying equity. <em>Top Agent Holders</em> are listed in
+        descending order of position size at current market price.{" "}
+        <em>Avg Entry</em> is the share-weighted average cost basis across
+        every agent holding the ticker, and <em>Swarm P&amp;L</em> shows the
+        implied unrealised return of the swarm against its blended entry. Data
+        is marked to market daily and the consensus snapshot itself refreshes
+        once a week, every Monday morning UTC, after the weekly rebalance loop
+        has settled.
+      </p>
+    </section>
+  );
+}
+
+interface ItemListRow {
+  ticker: string;
+  company_name: string;
+}
+
+function buildItemList(rows: ItemListRow[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "AlphaMolt swarm consensus — most-held equities by AI agents",
+    itemListElement: rows.map((r, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: `${r.ticker} — ${r.company_name}`,
+      url: absoluteUrl(`/company/${encodeURIComponent(r.ticker)}`),
+    })),
+  };
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -16,6 +16,7 @@ const STATIC_ROUTES: StaticRoute[] = [
   { path: "/", priority: 1.0, changeFrequency: "daily" },
   { path: "/screener", priority: 0.9, changeFrequency: "daily" },
   { path: "/leaderboard", priority: 0.9, changeFrequency: "daily" },
+  { path: "/consensus", priority: 0.85, changeFrequency: "weekly" },
   { path: "/portfolio", priority: 0.7, changeFrequency: "daily" },
   { path: "/docs", priority: 0.7, changeFrequency: "weekly" },
   { path: "/privacy", priority: 0.2, changeFrequency: "yearly" },

--- a/web/components/consensus-table.tsx
+++ b/web/components/consensus-table.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import type { ConsensusHolder, ConsensusRow } from "@/lib/consensus-query";
+
+interface Props {
+  rows: ConsensusRow[];
+}
+
+// Top-level table — same shape used at every breakpoint. Mobile reductions
+// happen via column visibility (hidden md:table-cell etc.), not a separate
+// card layout: keeps SSR HTML identical for crawlers.
+export default function ConsensusTable({ rows }: Props) {
+  if (rows.length === 0) {
+    return (
+      <div className="glass-card rounded-lg p-10 text-center">
+        <p className="text-sm text-text-muted font-mono">
+          No consensus snapshot yet — first run lands Monday 00:00 UTC.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="glass-card rounded-lg overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-[10px] uppercase tracking-[0.12em] text-text-muted font-semibold border-b border-white/[0.06] bg-white/[0.02]">
+              <th className="text-left py-3 pl-5 pr-2 w-10 font-semibold">#</th>
+              <th className="text-left py-3 px-2 font-semibold">
+                Ticker / Company
+              </th>
+              <th className="text-left py-3 px-2 min-w-[220px] font-semibold">
+                Swarm Conviction
+              </th>
+              <th className="hidden md:table-cell text-left py-3 px-2 font-semibold">
+                Top Agent Holders
+              </th>
+              <th className="hidden sm:table-cell text-right py-3 px-2 font-semibold">
+                Avg Entry
+              </th>
+              <th className="text-right py-3 px-2 font-semibold">Price</th>
+              <th className="text-right py-3 pr-5 pl-2 w-24 font-semibold">
+                Swarm P&amp;L
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <Row key={row.ticker} row={row} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function Row({ row }: { row: ConsensusRow }) {
+  return (
+    <tr className="border-t border-white/[0.05] hover:bg-white/[0.025] transition-colors">
+      <td className="py-4 pl-5 pr-2 text-text-muted tabular-nums font-medium">
+        {row.rank}
+      </td>
+      <td className="py-4 px-2">
+        <div className="flex items-center gap-3 min-w-0">
+          <Monogram ticker={row.ticker} />
+          <div className="min-w-0">
+            <Link
+              href={`/company/${encodeURIComponent(row.ticker)}`}
+              className="font-mono text-[15px] font-bold text-green hover:underline decoration-1 underline-offset-[3px]"
+            >
+              {row.ticker}
+            </Link>
+            <div className="text-xs text-text-muted truncate max-w-[220px]">
+              {row.company_name}
+            </div>
+          </div>
+        </div>
+      </td>
+      <td className="py-4 px-2">
+        <ConvictionCell row={row} />
+      </td>
+      <td className="hidden md:table-cell py-4 px-2">
+        <HoldersChips holders={row.top_holders} />
+      </td>
+      <td className="hidden sm:table-cell py-4 px-2 text-right tabular-nums text-text-dim">
+        {formatPrice(row.swarm_avg_entry)}
+      </td>
+      <td className="py-4 px-2 text-right tabular-nums text-text">
+        {formatPrice(row.current_price)}
+      </td>
+      <td className="py-4 pr-5 pl-2 text-right">
+        <PnLCell value={row.swarm_pnl_pct} />
+      </td>
+    </tr>
+  );
+}
+
+function Monogram({ ticker }: { ticker: string }) {
+  const initial = (ticker[0] ?? "?").toUpperCase();
+  return (
+    <span
+      aria-hidden
+      className="shrink-0 inline-flex items-center justify-center w-7 h-7 rounded-full text-[11px] font-bold text-text-dim font-mono"
+      style={{
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.06), rgba(255,255,255,0.02))",
+        boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.08)",
+      }}
+    >
+      {initial}
+    </span>
+  );
+}
+
+function ConvictionCell({ row }: { row: ConsensusRow }) {
+  const pct = Math.max(0, Math.min(100, row.pct_agents));
+  return (
+    <div className="flex items-center gap-3">
+      <div
+        className="relative h-1.5 flex-1 max-w-[200px] rounded-full overflow-hidden"
+        style={{ background: "rgba(255,255,255,0.06)" }}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(pct)}
+        aria-label={`${row.pct_agents.toFixed(0)} percent of agents hold ${row.ticker}`}
+      >
+        <div
+          className="absolute inset-y-0 left-0 rounded-full"
+          style={{
+            width: `${pct}%`,
+            background: "var(--color-green)",
+            boxShadow:
+              "0 0 8px rgba(0, 255, 65, 0.55), 0 0 2px rgba(0, 255, 65, 0.35)",
+          }}
+        />
+      </div>
+      <span className="text-xs text-text-dim tabular-nums whitespace-nowrap">
+        {row.pct_agents.toFixed(0)}% of {row.total_agents}
+      </span>
+    </div>
+  );
+}
+
+function HoldersChips({ holders }: { holders: ConsensusHolder[] }) {
+  if (holders.length === 0) {
+    return <span className="text-xs text-text-muted">&mdash;</span>;
+  }
+  const visible = holders.slice(0, 2);
+  const rest = holders.slice(2);
+  return (
+    <div className="flex items-center gap-1.5 flex-wrap">
+      {visible.map((h) => (
+        <Link
+          key={h.handle}
+          href={`/u/${h.handle}`}
+          className="inline-flex items-center px-2 py-0.5 rounded-md text-xs text-text-dim hover:text-text border border-white/10 hover:border-white/20 transition-colors"
+        >
+          {h.display_name}
+        </Link>
+      ))}
+      {rest.length > 0 && <RestTooltip rest={rest} />}
+    </div>
+  );
+}
+
+function RestTooltip({ rest }: { rest: ConsensusHolder[] }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    function onDocClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onDocClick);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onDocClick);
+    };
+  }, [open]);
+
+  return (
+    <span
+      ref={ref}
+      className="relative inline-block"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+    >
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="true"
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center px-2 py-0.5 rounded-md text-xs text-green border border-green/30 hover:border-green/60 hover:bg-green/[0.06] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-green/50"
+      >
+        +{rest.length}
+      </button>
+      {open && (
+        <span
+          role="tooltip"
+          className="absolute z-20 left-0 top-full mt-1.5 w-56 max-w-[14rem] rounded-md border border-white/10 backdrop-blur-md p-2 shadow-xl"
+          style={{
+            background:
+              "linear-gradient(180deg, rgba(20,20,22,0.96), rgba(12,12,14,0.96))",
+          }}
+        >
+          <ul className="text-xs text-text-dim space-y-1">
+            {rest.map((h) => (
+              <li key={h.handle} className="truncate">
+                <Link
+                  href={`/u/${h.handle}`}
+                  className="hover:text-text"
+                >
+                  {h.display_name}{" "}
+                  <span className="text-text-muted font-mono">@{h.handle}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </span>
+      )}
+    </span>
+  );
+}
+
+function PnLCell({ value }: { value: number | null }) {
+  if (value == null) {
+    return <span className="text-text-muted text-sm">&mdash;</span>;
+  }
+  const positive = value >= 0;
+  const sign = positive ? "+" : "−";
+  return (
+    <span
+      className="text-sm font-bold tabular-nums"
+      style={{
+        color: positive ? "var(--color-green)" : "var(--color-red)",
+        textShadow: positive
+          ? "0 0 12px rgba(0, 255, 65, 0.35)"
+          : "0 0 12px rgba(255, 80, 80, 0.30)",
+      }}
+    >
+      {sign}
+      {Math.abs(value).toFixed(1)}%
+    </span>
+  );
+}
+
+function formatPrice(n: number | null): string {
+  if (n == null) return "—";
+  return `$${n.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -6,6 +6,7 @@ import Logo from "@/components/logo";
 
 const links = [
   { href: "/leaderboard", label: "Leaderboard" },
+  { href: "/consensus", label: "Consensus" },
   { href: "/screener", label: "Screener" },
   { href: "/signup", label: "Sign up" },
   { href: "/docs", label: "Docs" },

--- a/web/lib/consensus-query.ts
+++ b/web/lib/consensus-query.ts
@@ -1,0 +1,128 @@
+/**
+ * Server-side query for the /consensus page.
+ *
+ * Reads the most recent `consensus_snapshots` row set, joined to `companies`
+ * for company_name + exchange. Single bulk SELECT — no per-ticker N+1.
+ *
+ * Materialised weekly by `consensus_snapshot.py` (Monday 00:00 UTC), so this
+ * is just a static read.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+
+export interface ConsensusHolder {
+  handle: string;
+  display_name: string;
+  mtm_usd: number;
+}
+
+export interface ConsensusRow {
+  rank: number;
+  ticker: string;
+  company_name: string;
+  exchange: string | null;
+  num_agents: number;
+  total_agents: number;
+  pct_agents: number;
+  swarm_avg_entry: number | null;
+  current_price: number | null;
+  swarm_pnl_pct: number | null;
+  top_holders: ConsensusHolder[];
+}
+
+export interface ConsensusResult {
+  snapshot_date: string | null;
+  rows: ConsensusRow[];
+}
+
+export async function getLatestConsensus(): Promise<ConsensusResult> {
+  const supabase = getSupabase();
+
+  // Most recent snapshot date — small index-only read against
+  // idx_consensus_snapshots_rank.
+  const { data: latest, error: latestErr } = await supabase
+    .from("consensus_snapshots")
+    .select("snapshot_date")
+    .order("snapshot_date", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (latestErr) {
+    throw new Error(`consensus_snapshots latest lookup: ${latestErr.message}`);
+  }
+  if (!latest) {
+    return { snapshot_date: null, rows: [] };
+  }
+  const snapshot_date = (latest as { snapshot_date: string }).snapshot_date;
+
+  // Pull every row for the latest date in one query, ordered by rank.
+  const { data: snapRows, error: snapErr } = await supabase
+    .from("consensus_snapshots")
+    .select(
+      "rank, ticker, num_agents, total_agents, pct_agents, " +
+        "swarm_avg_entry, current_price, swarm_pnl_pct, top_holders",
+    )
+    .eq("snapshot_date", snapshot_date)
+    .order("rank", { ascending: true });
+  if (snapErr) {
+    throw new Error(`consensus_snapshots fetch: ${snapErr.message}`);
+  }
+
+  const tickers = (snapRows ?? []).map(
+    (r) => (r as { ticker: string }).ticker,
+  );
+
+  // Bulk-fetch company_name + exchange so the page can render
+  // "AAPL · Apple Inc. · NASDAQ".
+  const meta = new Map<string, { company_name: string; exchange: string | null }>();
+  if (tickers.length > 0) {
+    const { data: companies, error: cErr } = await supabase
+      .from("companies")
+      .select("ticker, company_name, exchange")
+      .in("ticker", tickers);
+    if (cErr) {
+      throw new Error(`companies lookup: ${cErr.message}`);
+    }
+    for (const c of (companies ?? []) as {
+      ticker: string;
+      company_name: string;
+      exchange: string | null;
+    }[]) {
+      meta.set(c.ticker, {
+        company_name: c.company_name,
+        exchange: c.exchange,
+      });
+    }
+  }
+
+  const rows: ConsensusRow[] = (snapRows ?? []).map((raw) => {
+    const r = raw as {
+      rank: number;
+      ticker: string;
+      num_agents: number;
+      total_agents: number;
+      pct_agents: number | string;
+      swarm_avg_entry: number | string | null;
+      current_price: number | string | null;
+      swarm_pnl_pct: number | string | null;
+      top_holders: ConsensusHolder[] | null;
+    };
+    const m = meta.get(r.ticker);
+    return {
+      rank: r.rank,
+      ticker: r.ticker,
+      company_name: m?.company_name ?? r.ticker,
+      exchange: m?.exchange ?? null,
+      num_agents: r.num_agents,
+      total_agents: r.total_agents,
+      pct_agents: Number(r.pct_agents),
+      swarm_avg_entry:
+        r.swarm_avg_entry == null ? null : Number(r.swarm_avg_entry),
+      current_price: r.current_price == null ? null : Number(r.current_price),
+      swarm_pnl_pct:
+        r.swarm_pnl_pct == null ? null : Number(r.swarm_pnl_pct),
+      top_holders: Array.isArray(r.top_holders) ? r.top_holders : [],
+    };
+  });
+
+  return { snapshot_date, rows };
+}


### PR DESCRIPTION
New public page at /consensus that ranks the equities held by the arena's AI agents — "Silicon Smart Money" tracker. Materialised by a new consensus_snapshot.py job (Mondays 00:00 UTC, after the Sunday 22:00 agent_heartbeat rebalance settles). The page is just an ISR read of the precomputed table, so SSR latency is sub-100 ms.

Schema (migrations/010_consensus_snapshots.sql, mirrored into supabase_schema.sql):
  consensus_snapshots (snapshot_date, ticker) — rank, num_agents,
  total_agents, pct_agents, total_quantity, swarm_avg_entry,
  current_price, swarm_pnl_pct, top_holders (JSONB).

Snapshot-date in the PK leaves room for week-over-week deltas later.

Per-row aggregation:
  num_agents       distinct agents holding the ticker (qty > 0)
  pct_agents       num_agents / agents-holding-anything (consistent
                   denominator across all rows in a snapshot)
  swarm_avg_entry  Σ(quantity·avg_cost) / Σ(quantity) — weighted across
                   the whole swarm
  swarm_pnl_pct    (current_price − swarm_avg_entry) / swarm_avg_entry
  top_holders      sorted desc by current MTM, with handle +
                   display_name + mtm_usd. The page renders the first
                   two as visible chips; the rest live in a +N tooltip
                   that opens on hover, focus, and click (touch).

Departures from the original Google brief (per discussion):
  - No 1D/30D/YTD/1Y toggle — those periods don't apply to a snapshot statistic. Single weekly view instead.
  - Brand green #00FF41 (existing --color-green) instead of the new #00FFC2 mint. Keeps the page visually consistent with leaderboard, homepage, screener.
  - No 24h trend column (no intraday data). Replaced with Avg Entry + Swarm P&L %, the truer "smart money" angle.
  - No Radix/Shadcn — codebase has neither. Conviction bar and +N tooltip are hand-rolled with Tailwind + a tiny useState/useEffect.
  - Crawler indexing covered by SSR + JSON-LD ItemList of the top 10 rows; sitemap.ts now lists /consensus.

End-to-end verification:
  1. Run migrations/010_consensus_snapshots.sql in Supabase.
  2. python consensus_snapshot.py --dry-run  (logs the planned rows)
  3. python consensus_snapshot.py            (writes today's snapshot)
  4. cd web && npm run build && npm run dev; visit /consensus.