### PR TITLE
consensus-query: cast through unknown so build passes

### DIFF
--- a/web/lib/consensus-query.ts
+++ b/web/lib/consensus-query.ts
@@ -52,7 +52,7 @@ export async function getLatestConsensus(): Promise<ConsensusResult> {
   if (!latest) {
     return { snapshot_date: null, rows: [] };
   }
-  const snapshot_date = (latest as { snapshot_date: string }).snapshot_date;
+  const snapshot_date = (latest as unknown as { snapshot_date: string }).snapshot_date;
 
   // Pull every row for the latest date in one query, ordered by rank.
   const { data: snapRows, error: snapErr } = await supabase
@@ -68,7 +68,7 @@ export async function getLatestConsensus(): Promise<ConsensusResult> {
   }
 
   const tickers = (snapRows ?? []).map(
-    (r) => (r as { ticker: string }).ticker,
+    (r) => (r as unknown as { ticker: string }).ticker,
   );
 
   // Bulk-fetch company_name + exchange so the page can render
@@ -82,7 +82,7 @@ export async function getLatestConsensus(): Promise<ConsensusResult> {
     if (cErr) {
       throw new Error(`companies lookup: ${cErr.message}`);
     }
-    for (const c of (companies ?? []) as {
+    for (const c of (companies ?? []) as unknown as {
       ticker: string;
       company_name: string;
       exchange: string | null;
@@ -95,7 +95,7 @@ export async function getLatestConsensus(): Promise<ConsensusResult> {
   }
 
   const rows: ConsensusRow[] = (snapRows ?? []).map((raw) => {
-    const r = raw as {
+    const r = raw as unknown as {
       rank: number;
       ticker: string;
       num_agents: number;


### PR DESCRIPTION
PR #574 (the /consensus page) merged but Vercel rejected the build — strict TS rejected the four direct \`as { … }\` casts on Supabase result rows, because the result type is a tagged union that includes \`GenericStringError\` and a direct cast claims overlap that doesn't exist:

  Type error: Conversion of type 'GenericStringError' to type
  '{ ticker: string; }' may be a mistake because neither type
  sufficiently overlaps with the other. If this was intentional,
  convert the expression to 'unknown' first.

Same idiom equities-query.ts:61 already uses (\`as unknown as Foo[]\`). Routed all four casts in consensus-query.ts through unknown — no runtime change, just makes the type assertion explicit.

Verified locally with \`next build\` — TS now passes. The remaining prerender failure is just missing SUPABASE_URL in the sandbox; Vercel has the env vars so the deploy will go through.