### PR TITLE
consensus: dynamic OG card, share buttons, dated permalinks

### DIFF
--- a/web/app/consensus/[date]/opengraph-image.tsx
+++ b/web/app/consensus/[date]/opengraph-image.tsx
@@ -1,0 +1,38 @@
+import { ImageResponse } from "next/og";
+import { getConsensusByDate } from "@/lib/consensus-query";
+import { OG_ALT, OG_SIZE, renderConsensusOg } from "@/lib/consensus-og";
+
+// Per-week OG card. Pinned to the requested date so a tweet from
+// week N still previews week N's data when clicked in week N+5.
+export const runtime = "nodejs";
+export const revalidate = 604800;
+export const alt = OG_ALT;
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+interface ImageProps {
+  params: { date: string };
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export default async function Image({ params }: ImageProps) {
+  const date = DATE_RE.test(params.date) ? params.date : null;
+  let snapshot_date: string | null = null;
+  let rows: Awaited<ReturnType<typeof getConsensusByDate>>["rows"] = [];
+
+  if (date) {
+    try {
+      const r = await getConsensusByDate(date);
+      snapshot_date = r.snapshot_date;
+      rows = r.rows;
+    } catch (err) {
+      console.error("og /consensus/[date] fetch failed:", err);
+    }
+  }
+
+  return new ImageResponse(
+    renderConsensusOg({ rows, snapshotDate: snapshot_date ?? date }),
+    { ...size },
+  );
+}

--- a/web/app/consensus/[date]/page.tsx
+++ b/web/app/consensus/[date]/page.tsx
@@ -1,0 +1,155 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import Nav from "@/components/nav";
+import ConsensusTable from "@/components/consensus-table";
+import { getConsensusByDate } from "@/lib/consensus-query";
+
+// Historical snapshots don't change once written. Long TTL is fine —
+// this exists so a tweet from week N still shows week N's data when
+// someone clicks it in week N+5.
+export const revalidate = 604800;
+
+interface PageParams {
+  params: Promise<{ date: string }>;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function generateMetadata({
+  params,
+}: PageParams): Promise<Metadata> {
+  const { date } = await params;
+  if (!DATE_RE.test(date)) {
+    return { title: "Snapshot — not found", robots: { index: false } };
+  }
+  const title = `Swarm Conviction · ${formatLongDate(date)} — AlphaMolt`;
+  const description = `AI agent consensus picks for the week of ${formatLongDate(date)}. The equities the AlphaMolt arena's AI agents most agreed on at this snapshot.`;
+  return {
+    title: { absolute: title },
+    description,
+    alternates: { canonical: `/consensus/${date}` },
+    openGraph: {
+      title,
+      description,
+      url: `/consensus/${date}`,
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export default async function DatedConsensusPage({ params }: PageParams) {
+  const { date } = await params;
+  if (!DATE_RE.test(date)) notFound();
+
+  const result = await getConsensusByDate(date);
+  if (result.rows.length === 0) notFound();
+
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 w-full relative">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-[560px] -z-10 opacity-70"
+          style={{
+            background:
+              "radial-gradient(60% 60% at 18% 12%, rgba(0,255,65,0.07), transparent 70%), radial-gradient(45% 50% at 85% 5%, rgba(120,160,255,0.05), transparent 70%)",
+          }}
+        />
+        <div className="max-w-[1120px] mx-auto w-full px-4 sm:px-6">
+          <DatedHero date={date} totalAgents={result.rows[0].total_agents} />
+          <section className="mt-2 sm:mt-4 mb-20 sm:mb-28">
+            <ConsensusTable rows={result.rows} />
+            <p className="mt-3 text-xs text-text-muted text-right font-mono">
+              Snapshot: {formatLongDate(date)} · archived view
+            </p>
+          </section>
+          <Methodology />
+        </div>
+      </main>
+    </>
+  );
+}
+
+function DatedHero({
+  date,
+  totalAgents,
+}: {
+  date: string;
+  totalAgents: number;
+}) {
+  return (
+    <section className="pt-8 sm:pt-12 pb-6 sm:pb-8">
+      <span
+        className="inline-block text-[11px] uppercase tracking-[0.14em] font-medium text-text-dim rounded-full px-3 py-1 mb-5 backdrop-blur-md"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.015))",
+          border: "1px solid rgba(255,255,255,0.10)",
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+        }}
+      >
+        Snapshot · {formatLongDate(date)}
+      </span>
+      <h1 className="text-[28px] sm:text-[36px] lg:text-[44px] font-bold leading-[1.08] tracking-[-0.02em] text-text max-w-[22ch]">
+        Swarm Conviction · {formatLongDate(date)}
+      </h1>
+      <p className="mt-5 text-base sm:text-lg leading-relaxed text-text-muted max-w-[640px]">
+        Archived view of AlphaMolt&rsquo;s AI agent consensus for the week of{" "}
+        {formatLongDate(date)}. {totalAgents} agents in this snapshot. Numbers
+        reflect holdings at the moment the snapshot was taken — they don&rsquo;t
+        update.
+      </p>
+      <div className="mt-7 flex flex-wrap items-center gap-3">
+        <Link
+          href="/consensus"
+          className="inline-flex items-center px-5 py-2.5 rounded-lg bg-text text-bg text-sm font-semibold tracking-tight hover:bg-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          style={{
+            boxShadow:
+              "0 8px 24px -8px rgba(255,255,255,0.18), inset 0 1px 0 rgba(255,255,255,0.6)",
+          }}
+        >
+          View latest &rarr;
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+function Methodology() {
+  return (
+    <section id="methodology" className="mt-10 sm:mt-16 mb-24 scroll-mt-20">
+      <h2 className="text-[22px] sm:text-[28px] font-bold tracking-[-0.02em] text-text">
+        How we calculate AI Stock Consensus
+      </h2>
+      <p className="mt-4 text-sm sm:text-base text-text-muted max-w-[720px] leading-relaxed">
+        The AlphaMolt consensus tracker aggregates live, virtual portfolios of
+        every active AI trading agent on the platform. <em>Swarm Conviction</em>{" "}
+        represents the percentage of agents currently holding a long position
+        in the underlying equity. <em>Top Agent Holders</em> are listed in
+        descending order of position size at current market price.{" "}
+        <em>Avg Entry</em> is the share-weighted average cost basis across
+        every agent holding the ticker, and <em>Swarm P&amp;L</em> shows the
+        implied unrealised return of the swarm against its blended entry. Data
+        is marked to market daily and the consensus snapshot itself refreshes
+        once a week, every Monday morning UTC.
+      </p>
+    </section>
+  );
+}
+
+function formatLongDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/web/app/consensus/opengraph-image.tsx
+++ b/web/app/consensus/opengraph-image.tsx
@@ -1,0 +1,29 @@
+import { ImageResponse } from "next/og";
+import { getLatestConsensus } from "@/lib/consensus-query";
+import { OG_ALT, OG_SIZE, renderConsensusOg } from "@/lib/consensus-og";
+
+// Dynamic OG card for /consensus — renders the latest snapshot's top
+// picks. Regenerated daily; comfortably within the weekly snapshot
+// cadence so a fresh image lands within a day of consensus_snapshot.py.
+export const runtime = "nodejs";
+export const revalidate = 86400;
+export const alt = OG_ALT;
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default async function Image() {
+  let snapshot_date: string | null = null;
+  let rows: Awaited<ReturnType<typeof getLatestConsensus>>["rows"] = [];
+  try {
+    const r = await getLatestConsensus();
+    snapshot_date = r.snapshot_date;
+    rows = r.rows;
+  } catch (err) {
+    // Don't break social previews on a Supabase blip — fall through to
+    // the empty-state card.
+    console.error("og /consensus fetch failed:", err);
+  }
+  return new ImageResponse(renderConsensusOg({ rows, snapshotDate: snapshot_date }), {
+    ...size,
+  });
+}

--- a/web/app/consensus/page.tsx
+++ b/web/app/consensus/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import Nav from "@/components/nav";
 import ConsensusTable from "@/components/consensus-table";
+import ShareRow from "@/components/share-row";
 import { getLatestConsensus } from "@/lib/consensus-query";
 import { absoluteUrl } from "@/lib/site";
 
@@ -48,6 +49,16 @@ export default async function ConsensusPage() {
   const itemList = buildItemList(rows.slice(0, 10));
   const formattedDate = snapshot_date ? formatDate(snapshot_date) : null;
 
+  // Permalink baked into share buttons so a tweet from this Monday still
+  // resolves to this Monday's snapshot when clicked weeks later.
+  const sharePath = snapshot_date ? `/consensus/${snapshot_date}` : "/consensus";
+  const shareUrl = absoluteUrl(sharePath);
+  const topTickers = rows.slice(0, 3).map((r) => r.ticker);
+  const shareText =
+    topTickers.length > 0
+      ? `This week's AI agent consensus: ${topTickers.join(", ")} top the leaderboard. See the full swarm picks on @alphamolt:`
+      : "Which stocks are AI agents most bullish on? See this week's swarm consensus on @alphamolt:";
+
   return (
     <>
       <Nav />
@@ -70,6 +81,8 @@ export default async function ConsensusPage() {
           <Hero
             totalAgents={rows[0]?.total_agents ?? null}
             snapshotLabel={formattedDate}
+            shareUrl={shareUrl}
+            shareText={shareText}
           />
 
           <section className="mt-2 sm:mt-4 mb-20 sm:mb-28">
@@ -99,9 +112,13 @@ export default async function ConsensusPage() {
 function Hero({
   totalAgents,
   snapshotLabel,
+  shareUrl,
+  shareText,
 }: {
   totalAgents: number | null;
   snapshotLabel: string | null;
+  shareUrl: string;
+  shareText: string;
 }) {
   return (
     <section className="pt-8 sm:pt-12 pb-6 sm:pb-8">
@@ -167,6 +184,9 @@ function Hero({
         >
           Register Your Agent
         </Link>
+      </div>
+      <div className="mt-5">
+        <ShareRow url={shareUrl} text={shareText} />
       </div>
     </section>
   );

--- a/web/components/share-row.tsx
+++ b/web/components/share-row.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+
+interface ShareRowProps {
+  // Absolute URL to share. Pre-built by the server so the dated
+  // permalink is baked in (not the bare /consensus URL).
+  url: string;
+  // Tweet/Bluesky body. URL is appended automatically.
+  text: string;
+}
+
+const SHARE_BUTTON_CLASS =
+  "inline-flex items-center gap-2 px-4 py-2 rounded-lg text-text text-sm font-medium tracking-tight transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40";
+
+const SHARE_BUTTON_STYLE = {
+  background:
+    "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+  border: "1px solid rgba(255,255,255,0.12)",
+  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+};
+
+export default function ShareRow({ url, text }: ShareRowProps) {
+  const [copied, setCopied] = useState(false);
+
+  const tweetHref = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
+  const blueskyHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(`${text} ${url}`)}`;
+
+  async function copy() {
+    const ok = await tryCopy(url);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <a
+        href={tweetHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={SHARE_BUTTON_CLASS}
+        style={SHARE_BUTTON_STYLE}
+        aria-label="Share on X"
+      >
+        <XIcon />
+        Tweet
+      </a>
+      <a
+        href={blueskyHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={SHARE_BUTTON_CLASS}
+        style={SHARE_BUTTON_STYLE}
+        aria-label="Post to Bluesky"
+      >
+        <BlueskyIcon />
+        Bluesky
+      </a>
+      <button
+        type="button"
+        onClick={copy}
+        className={SHARE_BUTTON_CLASS}
+        style={SHARE_BUTTON_STYLE}
+        aria-label={copied ? "Link copied" : "Copy link"}
+      >
+        {copied ? <CheckIcon /> : <LinkIcon />}
+        {copied ? "Copied" : "Copy link"}
+      </button>
+    </div>
+  );
+}
+
+// Same fallback shim as web/components/home-prompt.tsx — modern path
+// uses navigator.clipboard, falls back to a hidden textarea + execCommand
+// for the rare insecure-context case (e.g. previews on http).
+async function tryCopy(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through
+    }
+  }
+  if (typeof document === "undefined") return false;
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.setAttribute("readonly", "");
+  ta.style.position = "fixed";
+  ta.style.top = "0";
+  ta.style.left = "0";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(ta);
+  return ok;
+}
+
+function XIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M9.45 7.06 14.5 1.5h-1.43L8.84 6.27 5.46 1.5H1.5l5.3 7.45L1.5 14.5h1.43l4.62-5.13 3.57 5.13h3.96L9.45 7.06zm-1.64 1.83-.54-.74L3.45 2.55h2.2l3.45 4.7.54.75 4.46 6.07h-2.2L7.81 8.89z" />
+    </svg>
+  );
+}
+
+function BlueskyIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M3.65 2.62C5.45 3.94 7.4 6.61 8 8c.6-1.39 2.55-4.06 4.35-5.38 1.3-.95 3.4-1.69 3.4.66 0 .47-.27 3.93-.43 4.5-.55 1.97-2.6 2.47-4.4 2.17 3.16.53 3.96 2.27 2.22 4-3.3 3.27-4.74-.83-5.11-1.88a4.74 4.74 0 0 1-.03-.1 4.74 4.74 0 0 1-.03.1c-.37 1.05-1.81 5.15-5.11 1.88-1.74-1.73-.94-3.47 2.22-4-1.8.3-3.85-.2-4.4-2.17C.52 7.21.25 3.75.25 3.28c0-2.35 2.1-1.61 3.4-.66z" />
+    </svg>
+  );
+}
+
+function LinkIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M6.5 9.5a3 3 0 0 0 4.24 0l2.12-2.12a3 3 0 0 0-4.24-4.24l-1.06 1.06" />
+      <path d="M9.5 6.5a3 3 0 0 0-4.24 0L3.14 8.62a3 3 0 0 0 4.24 4.24l1.06-1.06" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="m3 8 3.5 3.5L13 5" />
+    </svg>
+  );
+}

--- a/web/lib/consensus-og.tsx
+++ b/web/lib/consensus-og.tsx
@@ -1,0 +1,311 @@
+/**
+ * Shared OG-card renderer for /consensus and /consensus/[date].
+ *
+ * Returns a JSX tree consumable by `new ImageResponse(...)` — no DOM,
+ * no Tailwind, only inline styles (next/og's renderer is Satori, which
+ * has limited CSS support and requires explicit `display: flex` on
+ * any element with multiple children).
+ */
+
+import type { ConsensusRow } from "@/lib/consensus-query";
+
+export const OG_SIZE = { width: 1200, height: 630 } as const;
+export const OG_ALT =
+  "AlphaMolt swarm consensus — most-held equities by AI agents this week";
+
+const MAX_ROWS = 5;
+const BG = "#0A0A0A";
+const TEXT = "#EDEDED";
+const TEXT_DIM = "#D4D4D8";
+const TEXT_MUTED = "#A1A1AA";
+const GREEN = "#00FF41";
+const RED = "#FF3333";
+const BORDER = "rgba(255,255,255,0.08)";
+
+interface RenderArgs {
+  rows: ConsensusRow[];
+  snapshotDate: string | null;
+}
+
+export function renderConsensusOg({ rows, snapshotDate }: RenderArgs) {
+  const top = rows.slice(0, MAX_ROWS);
+  const dateLabel = snapshotDate ? formatLongDate(snapshotDate) : null;
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        padding: "64px 80px",
+        background:
+          "radial-gradient(ellipse at top left, #001a08 0%, #0a0a0a 60%)",
+        color: TEXT,
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div
+            style={{
+              fontSize: 26,
+              fontWeight: 700,
+              color: GREEN,
+              letterSpacing: "0.10em",
+              textTransform: "uppercase",
+              display: "flex",
+            }}
+          >
+            ALPHAMOLT
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: TEXT_DIM,
+              marginTop: 6,
+              letterSpacing: "-0.01em",
+              display: "flex",
+            }}
+          >
+            Swarm Conviction · Most Held by AI Agents
+          </div>
+        </div>
+        {dateLabel && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              padding: "10px 16px",
+              borderRadius: 999,
+              border: `1px solid ${BORDER}`,
+              background: "rgba(255,255,255,0.04)",
+              fontSize: 18,
+              color: TEXT_MUTED,
+              fontFamily: "ui-monospace, monospace",
+            }}
+          >
+            {dateLabel}
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      {top.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            marginTop: 40,
+            gap: 18,
+          }}
+        >
+          {top.map((row) => (
+            <Row key={row.ticker} row={row} />
+          ))}
+        </div>
+      )}
+
+      {/* Footer */}
+      <div
+        style={{
+          marginTop: "auto",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          fontSize: 18,
+          color: TEXT_MUTED,
+          fontFamily: "ui-monospace, monospace",
+        }}
+      >
+        <div style={{ display: "flex" }}>alphamolt.ai/consensus</div>
+        <div style={{ display: "flex" }}>
+          {top.length > 0 ? `${top[0].total_agents} agents in the arena` : ""}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Row({ row }: { row: ConsensusRow }) {
+  const pct = Math.max(0, Math.min(100, row.pct_agents));
+  const pnl = row.swarm_pnl_pct;
+  const pnlPositive = pnl != null && pnl >= 0;
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 24,
+        padding: "16px 20px",
+        borderRadius: 14,
+        border: `1px solid ${BORDER}`,
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+      }}
+    >
+      {/* Rank */}
+      <div
+        style={{
+          display: "flex",
+          width: 44,
+          fontSize: 30,
+          fontWeight: 700,
+          color: TEXT_MUTED,
+          fontFamily: "ui-monospace, monospace",
+        }}
+      >
+        {row.rank}
+      </div>
+
+      {/* Ticker + company */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: 240,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 36,
+            fontWeight: 800,
+            color: GREEN,
+            fontFamily: "ui-monospace, monospace",
+            letterSpacing: "-0.01em",
+          }}
+        >
+          {row.ticker}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 16,
+            color: TEXT_MUTED,
+            marginTop: 2,
+            maxWidth: 240,
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {row.company_name}
+        </div>
+      </div>
+
+      {/* Conviction bar + caption */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            position: "relative",
+            height: 12,
+            borderRadius: 999,
+            background: "rgba(255,255,255,0.06)",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              width: `${pct}%`,
+              height: "100%",
+              background: GREEN,
+              boxShadow: `0 0 16px ${GREEN}`,
+            }}
+          />
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 18,
+            color: TEXT_DIM,
+            fontFamily: "ui-monospace, monospace",
+          }}
+        >
+          {row.pct_agents.toFixed(0)}% of {row.total_agents} agents
+        </div>
+      </div>
+
+      {/* Swarm P&L */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          width: 140,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 28,
+            fontWeight: 700,
+            color: pnl == null ? TEXT_MUTED : pnlPositive ? GREEN : RED,
+            fontFamily: "ui-monospace, monospace",
+          }}
+        >
+          {pnl == null
+            ? "—"
+            : `${pnlPositive ? "+" : "−"}${Math.abs(pnl).toFixed(1)}%`}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 14,
+            color: TEXT_MUTED,
+            marginTop: 2,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+          }}
+        >
+          Swarm P&amp;L
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: 32,
+        color: TEXT_MUTED,
+        fontFamily: "ui-monospace, monospace",
+      }}
+    >
+      First snapshot lands Monday 00:00 UTC
+    </div>
+  );
+}
+
+function formatLongDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/web/lib/consensus-query.ts
+++ b/web/lib/consensus-query.ts
@@ -1,11 +1,12 @@
 /**
  * Server-side query for the /consensus page.
  *
- * Reads the most recent `consensus_snapshots` row set, joined to `companies`
- * for company_name + exchange. Single bulk SELECT — no per-ticker N+1.
+ * Reads `consensus_snapshots` rows for either the latest date or a
+ * specific date, joined to `companies` for company_name + exchange.
+ * Single bulk SELECT — no per-ticker N+1.
  *
- * Materialised weekly by `consensus_snapshot.py` (Monday 00:00 UTC), so this
- * is just a static read.
+ * Materialised weekly by `consensus_snapshot.py` (Monday 00:00 UTC), so
+ * this is just a static read.
  */
 
 import { getSupabase } from "@/lib/supabase";
@@ -52,9 +53,33 @@ export async function getLatestConsensus(): Promise<ConsensusResult> {
   if (!latest) {
     return { snapshot_date: null, rows: [] };
   }
-  const snapshot_date = (latest as unknown as { snapshot_date: string }).snapshot_date;
+  const snapshot_date = (latest as unknown as { snapshot_date: string })
+    .snapshot_date;
+  const rows = await fetchSnapshotRows(snapshot_date);
+  return { snapshot_date, rows };
+}
 
-  // Pull every row for the latest date in one query, ordered by rank.
+/**
+ * Fetch a snapshot for a specific date. Returns rows = [] when the date
+ * has no snapshot — caller decides whether to 404 or render an empty
+ * state.
+ */
+export async function getConsensusByDate(
+  snapshot_date: string,
+): Promise<ConsensusResult> {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(snapshot_date)) {
+    return { snapshot_date: null, rows: [] };
+  }
+  const rows = await fetchSnapshotRows(snapshot_date);
+  return { snapshot_date: rows.length > 0 ? snapshot_date : null, rows };
+}
+
+async function fetchSnapshotRows(
+  snapshot_date: string,
+): Promise<ConsensusRow[]> {
+  const supabase = getSupabase();
+
+  // Pull every row for the date in one query, ordered by rank.
   const { data: snapRows, error: snapErr } = await supabase
     .from("consensus_snapshots")
     .select(
@@ -66,35 +91,37 @@ export async function getLatestConsensus(): Promise<ConsensusResult> {
   if (snapErr) {
     throw new Error(`consensus_snapshots fetch: ${snapErr.message}`);
   }
+  if (!snapRows || snapRows.length === 0) return [];
 
-  const tickers = (snapRows ?? []).map(
+  const tickers = snapRows.map(
     (r) => (r as unknown as { ticker: string }).ticker,
   );
 
   // Bulk-fetch company_name + exchange so the page can render
   // "AAPL · Apple Inc. · NASDAQ".
-  const meta = new Map<string, { company_name: string; exchange: string | null }>();
-  if (tickers.length > 0) {
-    const { data: companies, error: cErr } = await supabase
-      .from("companies")
-      .select("ticker, company_name, exchange")
-      .in("ticker", tickers);
-    if (cErr) {
-      throw new Error(`companies lookup: ${cErr.message}`);
-    }
-    for (const c of (companies ?? []) as unknown as {
-      ticker: string;
-      company_name: string;
-      exchange: string | null;
-    }[]) {
-      meta.set(c.ticker, {
-        company_name: c.company_name,
-        exchange: c.exchange,
-      });
-    }
+  const meta = new Map<
+    string,
+    { company_name: string; exchange: string | null }
+  >();
+  const { data: companies, error: cErr } = await supabase
+    .from("companies")
+    .select("ticker, company_name, exchange")
+    .in("ticker", tickers);
+  if (cErr) {
+    throw new Error(`companies lookup: ${cErr.message}`);
+  }
+  for (const c of (companies ?? []) as unknown as {
+    ticker: string;
+    company_name: string;
+    exchange: string | null;
+  }[]) {
+    meta.set(c.ticker, {
+      company_name: c.company_name,
+      exchange: c.exchange,
+    });
   }
 
-  const rows: ConsensusRow[] = (snapRows ?? []).map((raw) => {
+  return snapRows.map((raw) => {
     const r = raw as unknown as {
       rank: number;
       ticker: string;
@@ -123,6 +150,4 @@ export async function getLatestConsensus(): Promise<ConsensusResult> {
       top_holders: Array.isArray(r.top_holders) ? r.top_holders : [],
     };
   });
-
-  return { snapshot_date, rows };
 }


### PR DESCRIPTION
Three additions to make /consensus shareable on social.

1. Dynamic OG card — web/app/consensus/opengraph-image.tsx pulls the latest snapshot via getLatestConsensus() and renders a 1200×630 PNG showing the top 5 tickers with conviction bars and Swarm P&L. When anyone tweets the URL, the preview is the actual data, not the generic site card. Shared renderer in web/lib/consensus-og.tsx so the dated route can reuse it. revalidate=86400 — comfortably within the weekly snapshot cadence.

2. Share row — web/components/share-row.tsx is a tiny "use client" component with three buttons: Tweet (twitter.com/intent/tweet), Post to Bluesky (bsky.app/intent/compose), and Copy link. No new deps; clipboard fallback shim mirrors home-prompt.tsx:tryCopy(). Rendered below the existing CTAs in the hero.

3. Dated permalinks — web/app/consensus/[date]/page.tsx serves a specific snapshot. /consensus still shows latest, but the share buttons URL-encode /consensus/<snapshot_date> so a tweet from this week still shows this week's data when read in week N+5. Sibling opengraph-image.tsx pins the OG card to the same date. 404s on bad date format or unknown snapshot.

Refactored consensus-query.ts so getLatestConsensus and the new getConsensusByDate share the same row-mapping body via a private fetchSnapshotRows() helper — no duplicate join logic.

Local next build: TS passes, only prerender failure is the sandbox's missing Supabase env vars (Vercel has them).