### PR TITLE
consensus og: await params Promise (Next 16)

### DIFF
--- a/web/app/consensus/[date]/opengraph-image.tsx
+++ b/web/app/consensus/[date]/opengraph-image.tsx
@@ -11,13 +11,14 @@ export const size = OG_SIZE;
 export const contentType = "image/png";
 
 interface ImageProps {
-  params: { date: string };
+  params: Promise<{ date: string }>;
 }
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 export default async function Image({ params }: ImageProps) {
-  const date = DATE_RE.test(params.date) ? params.date : null;
+  const { date: rawDate } = await params;
+  const date = DATE_RE.test(rawDate) ? rawDate : null;
   let snapshot_date: string | null = null;
   let rows: Awaited<ReturnType<typeof getConsensusByDate>>["rows"] = [];
 


### PR DESCRIPTION
Dated /consensus/[date] OG image was reading params.date synchronously, but Next 16 made dynamic-route params a Promise. params.date was undefined, the date regex failed, and the renderer fell through to the empty-state card — exactly what's appearing as the embedded preview on shared X posts even though the snapshot has data.

The dated page itself was already on the new Promise API; only the OG image route was missed.

https://claude.ai/code/session_01DN5h1ymdCd6GRoYgtcoaam