### PR TITLE
consensus share: cache-bust X.com's og:image cache

### DIFF
--- a/web/app/consensus/page.tsx
+++ b/web/app/consensus/page.tsx
@@ -51,8 +51,11 @@ export default async function ConsensusPage() {
 
   // Permalink baked into share buttons so a tweet from this Monday still
   // resolves to this Monday's snapshot when clicked weeks later.
+  // ?v=… is a cache-bust for X.com's per-URL og:image cache — bump it any
+  // time a previously-shared snapshot's OG card was rendered empty (X
+  // holds the stale image for hours-to-days regardless of what we serve).
   const sharePath = snapshot_date ? `/consensus/${snapshot_date}` : "/consensus";
-  const shareUrl = absoluteUrl(sharePath);
+  const shareUrl = `${absoluteUrl(sharePath)}?v=2`;
   const topTickers = rows.slice(0, 3).map((r) => r.ticker);
   const shareText =
     topTickers.length > 0


### PR DESCRIPTION
X.com keys its og:image cache on the full URL — once the empty-state card was cached for /consensus/<date>, even a fixed OG response keeps serving the stale image for hours-to-days. Append ?v=2 to share URLs so the next click on Tweet generates a URL X hasn't seen and forces a fresh fetch. Bump the version on future regressions.

https://claude.ai/code/session_01DN5h1ymdCd6GRoYgtcoaam