### PR TITLE
consensus og: cacheable image, drop og:url, bump cache-bust

### DIFF
--- a/web/app/consensus/[date]/opengraph-image.tsx
+++ b/web/app/consensus/[date]/opengraph-image.tsx
@@ -34,6 +34,18 @@ export default async function Image({ params }: ImageProps) {
 
   return new ImageResponse(
     renderConsensusOg({ rows, snapshotDate: snapshot_date ?? date }),
-    { ...size },
+    {
+      ...size,
+      // Explicit CDN cache so X's OG fetcher gets a fast HIT instead of
+      // re-rendering on every poll (the route's `revalidate` alone wasn't
+      // populating Vercel's edge cache — every request was a MISS at
+      // ~1.5s, long enough to tickle X's preview timeout). s-maxage drives
+      // Vercel/Cloudflare; stale-while-revalidate keeps it fresh in the
+      // background after a snapshot lands.
+      headers: {
+        "Cache-Control":
+          "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800",
+      },
+    },
   );
 }

--- a/web/app/consensus/[date]/page.tsx
+++ b/web/app/consensus/[date]/page.tsx
@@ -32,7 +32,11 @@ export async function generateMetadata({
     openGraph: {
       title,
       description,
-      url: `/consensus/${date}`,
+      // Deliberately no `url` — X uses og:url as a cache key, and pinning
+      // it to the bare path made cache-bust query params (?v=N) a no-op
+      // because X kept resolving back to whatever it cached for the canonical
+      // URL. Letting X use the actually-fetched URL means each new ?v=
+      // bumps a fresh entry. Canonical above still covers SEO.
       type: "website",
     },
     twitter: {

--- a/web/app/consensus/opengraph-image.tsx
+++ b/web/app/consensus/opengraph-image.tsx
@@ -25,5 +25,9 @@ export default async function Image() {
   }
   return new ImageResponse(renderConsensusOg({ rows, snapshotDate: snapshot_date }), {
     ...size,
+    headers: {
+      "Cache-Control":
+        "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800",
+    },
   });
 }

--- a/web/app/consensus/page.tsx
+++ b/web/app/consensus/page.tsx
@@ -55,7 +55,7 @@ export default async function ConsensusPage() {
   // time a previously-shared snapshot's OG card was rendered empty (X
   // holds the stale image for hours-to-days regardless of what we serve).
   const sharePath = snapshot_date ? `/consensus/${snapshot_date}` : "/consensus";
-  const shareUrl = `${absoluteUrl(sharePath)}?v=2`;
+  const shareUrl = `${absoluteUrl(sharePath)}?v=3`;
   const topTickers = rows.slice(0, 3).map((r) => r.ticker);
   const shareText =
     topTickers.length > 0


### PR DESCRIPTION
X.com kept showing the consensus tweet card with no large image even after the OG renderer was fixed. Three reasons compounded:

1. Vercel edge wasn't caching the OG image at all — every request hit the function fresh at ~1.5s, brushing X's preview-fetch timeout. Set explicit s-maxage / stale-while-revalidate Cache-Control on ImageResponse so Vercel + Cloudflare hold it after the first render.

2. og:url was pinned to the bare path (no ?v=N), so X kept resolving freshly-shared URLs back to its previously-cached "broken" entry. Drop og:url from the dated page metadata; canonical alone is enough for SEO and X now keys cache off the actual fetched URL.

3. Bump share-URL cache-bust to ?v=3 so any URL X already cached as a no-image tweet from the prior version goes stale.

https://claude.ai/code/session_01DN5h1ymdCd6GRoYgtcoaam