### PR TITLE
bluesky heartbeat: phase 3 — target top swarm-consensus tickers

### DIFF
--- a/.github/workflows/bluesky-heartbeat.yml
+++ b/.github/workflows/bluesky-heartbeat.yml
@@ -26,12 +26,14 @@ jobs:
           cache: "pip"
 
       - name: Install dependencies
-        run: pip install requests anthropic atproto
+        run: pip install requests anthropic atproto supabase python-dotenv
 
       - name: Run Bluesky heartbeat
         env:
           BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python bluesky_heartbeat.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ and Supabase (PostgreSQL) as the primary data store.
 Sun 22:00 UTC   agent_heartbeat.py        Rebalance every agent's portfolio via its strategy
 Mon 00:00 UTC   consensus_snapshot.py     Aggregate agent_holdings → consensus_snapshots (powers /consensus)
 Every 4h        moltbook_heartbeat.py     Reply to notifications + engage with finance submolts on Moltbook
-Every 4h        bluesky_heartbeat.py      Reply to mentions + search for AI-in-finance posts on Bluesky
+Every 4h        bluesky_heartbeat.py      Reply to mentions + AI-in-finance posts + posts about top swarm-consensus tickers on Bluesky
 ```
 
 ## Shared Modules

--- a/bluesky_heartbeat.py
+++ b/bluesky_heartbeat.py
@@ -11,6 +11,13 @@ Phase 2 — Search engagement (``--no-search`` to disable)
     fetch recent matching posts, run the three-theme classifier, and reply
     to the best matches until we hit the per-run cap.
 
+Phase 3 — Equity targeting (``--no-equity`` to disable)
+    Pull the top swarm-consensus tickers from the latest
+    ``consensus_snapshots`` row, search Bluesky for posts about each
+    (cashtag + bare ticker), classify for genuine equity discussion, and
+    reply with a casual "the AlphaMolt agents agree on $TICKER too"
+    note plus a clickable link to the dated /consensus/<date> permalink.
+
 Auto-posts everything. Dedup + rate limits tracked in a GitHub issue
 labelled ``bluesky-ledger``.
 
@@ -18,6 +25,8 @@ Env vars:
     BLUESKY_HANDLE         default alphamolt.bsky.social
     BLUESKY_APP_PASSWORD   required — Bluesky app-specific password
     ANTHROPIC_API_KEY      required — drafter + classifier
+    SUPABASE_URL           required for phase 3 (consensus tickers)
+    SUPABASE_SERVICE_KEY   required for phase 3
     GITHUB_TOKEN           required unless --dry-run (audit issues)
     GITHUB_REPOSITORY      set automatically in GitHub Actions
 """
@@ -32,13 +41,20 @@ from moltbook_lib import GitHubIssuer
 
 from bluesky_lib import (
     BlueskyClient,
+    EQUITY_SEARCH_LIMIT_PER_QUERY,
+    EQUITY_TARGET_TOP_N,
     FAILED_LABEL,
     OWN_HANDLE,
     POSTED_LABEL,
     SEARCH_QUERIES,
     classify_bsky_themes,
+    classify_ticker_post,
+    consensus_share_url,
+    draft_equity_reply,
     draft_mention_reply,
     draft_reply_to_post,
+    equity_search_queries,
+    fetch_consensus_targets,
     get_or_create_ledger,
     update_ledger,
 )
@@ -453,6 +469,206 @@ def _process_search(
 
 
 # ---------------------------------------------------------------------------
+# Phase 3 — Equity targeting (top swarm-consensus tickers)
+# ---------------------------------------------------------------------------
+
+
+def _process_equity_targeting(
+    client: BlueskyClient,
+    gh: GitHubIssuer | None,
+    ledger: dict,
+    args: argparse.Namespace,
+) -> dict:
+    stats = {
+        "posted": 0, "skipped": 0, "failed": 0,
+        "classified": 0, "tickers": 0,
+    }
+
+    try:
+        targets, snapshot_date = fetch_consensus_targets(
+            limit=EQUITY_TARGET_TOP_N
+        )
+    except Exception as exc:
+        log.error("consensus fetch failed — skipping equity phase: %s", exc)
+        return stats
+
+    if not targets:
+        log.info("equity targeting: no consensus snapshot available — skipping")
+        return stats
+
+    share_url = consensus_share_url(snapshot_date)
+    log.info(
+        "equity targeting: %d tickers from snapshot %s — share_url=%s",
+        len(targets), snapshot_date, share_url,
+    )
+    stats["tickers"] = len(targets)
+
+    replied = set(ledger.get("replied_to_uris", []))
+    today = _today()
+    daily = ledger.setdefault("daily_reply_count", {})
+    replies_today = daily.get(today, 0)
+
+    replies_this_run = 0
+    for target in targets:
+        if replies_this_run >= MAX_REPLIES_PER_RUN:
+            log.info("reply cap reached this run — stopping equity phase")
+            break
+        if replies_today >= MAX_REPLIES_PER_DAY:
+            log.info("daily reply cap reached — stopping")
+            break
+
+        ticker = target["ticker"]
+        company_name = target.get("company_name") or ticker
+        log.info(
+            "equity target: %s (%s) — %d/%d agents (%.1f%%)",
+            ticker, company_name,
+            target.get("num_agents") or 0,
+            target.get("total_agents") or 0,
+            float(target.get("pct_agents") or 0),
+        )
+
+        seen: set[str] = set()
+        candidates: list[dict] = []
+        for q in equity_search_queries(ticker):
+            posts = client.search_posts(
+                q, limit=EQUITY_SEARCH_LIMIT_PER_QUERY
+            )
+            log.info("  query %r: %d results", q, len(posts))
+            for p in posts:
+                uri = p.get("uri")
+                if not uri or uri in seen:
+                    continue
+                if uri in replied:
+                    continue
+                if p.get("author_handle") == OWN_HANDLE:
+                    continue
+                seen.add(uri)
+                p["_discovered_via"] = q
+                p["_target_ticker"] = ticker
+                candidates.append(p)
+
+        log.info("  %s candidates (dedup): %d", ticker, len(candidates))
+
+        for post in candidates:
+            if replies_this_run >= MAX_REPLIES_PER_RUN:
+                break
+            if replies_today >= MAX_REPLIES_PER_DAY:
+                break
+
+            uri = post.get("uri")
+            author = post.get("author_handle") or ""
+            log.info(
+                "    considering %s by @%s: %s",
+                (uri or "")[-12:], author,
+                _first_line(post.get("text", "")),
+            )
+
+            if is_silenced(ledger, author):
+                rel = get_relationship(ledger, author) or {}
+                log.info("    SILENCED — skip @%s (status=%s)",
+                         author, rel.get("status", "?"))
+                stats["skipped"] += 1
+                continue
+
+            try:
+                relevant = classify_ticker_post(post, ticker, company_name)
+                stats["classified"] += 1
+            except Exception as exc:
+                log.error("    ticker classifier failed: %s", exc)
+                continue
+
+            if not relevant:
+                log.info("    SKIP — not genuinely about %s", ticker)
+                stats["skipped"] += 1
+                continue
+
+            memory = relationship_block(ledger, author)
+            if memory:
+                log.info("    injecting memory for @%s", author)
+            try:
+                draft = draft_equity_reply(
+                    post,
+                    ticker=ticker,
+                    company_name=company_name,
+                    num_agents=int(target.get("num_agents") or 0),
+                    total_agents=int(target.get("total_agents") or 0),
+                    pct_agents=target.get("pct_agents"),
+                    memory_block=memory,
+                )
+            except Exception as exc:
+                log.error("    draft_equity_reply failed: %s", exc)
+                stats["failed"] += 1
+                continue
+
+            if not draft:
+                log.info("    SKIP — drafter returned nothing substantive")
+                stats["skipped"] += 1
+                continue
+
+            if args.dry_run:
+                log.info(
+                    "    DRY RUN — would reply: %s [+ link to %s]",
+                    draft, share_url,
+                )
+                stats["posted"] += 1
+                replied.add(uri)
+                replies_this_run += 1
+                # Only one reply per ticker per run — move on.
+                break
+
+            result = client.reply(
+                text=draft,
+                parent_uri=uri,
+                parent_cid=post.get("cid"),
+                root_uri=post.get("root_uri") or uri,
+                root_cid=post.get("root_cid") or post.get("cid"),
+                link_url=share_url,
+                link_label="View the AlphaMolt swarm consensus",
+            )
+            if not result:
+                log.error("    reply failed on %s", uri)
+                stats["failed"] += 1
+                continue
+
+            log.info("    replied: %s", result.get("uri"))
+            replied.add(uri)
+            replies_this_run += 1
+            replies_today += 1
+            stats["posted"] += 1
+
+            was_new = get_relationship(ledger, author) is None
+            record_engagement(
+                ledger, author,
+                ref=uri or "",
+                their_excerpt=post.get("text", ""),
+                our_excerpt=draft,
+            )
+            try:
+                samples = client.get_author_recent_texts(author, limit=5) \
+                    if was_new else [post.get("text", "")]
+                maybe_refresh_summary(
+                    ledger, author, samples,
+                    platform="Bluesky", force=was_new,
+                )
+            except Exception as exc:
+                log.warning("    summary update failed for @%s: %s", author, exc)
+
+            if gh:
+                _file_posted_audit(
+                    gh, phase="equity", notif_or_post=post,
+                    draft=draft, result=result, ticker=ticker,
+                    share_url=share_url,
+                )
+            # One reply per ticker per run keeps it from reading like a
+            # rapid-fire bot run on the same symbol.
+            break
+
+    ledger["replied_to_uris"] = sorted(replied)
+    daily[today] = replies_today
+    return stats
+
+
+# ---------------------------------------------------------------------------
 # Audit issues
 # ---------------------------------------------------------------------------
 
@@ -464,6 +680,8 @@ def _file_posted_audit(
     draft: str,
     result: dict,
     themes: list[int] | None = None,
+    ticker: str | None = None,
+    share_url: str | None = None,
 ) -> None:
     author = notif_or_post.get("author_handle") or "unknown"
     parent_uri = notif_or_post.get("uri") or ""
@@ -479,6 +697,10 @@ def _file_posted_audit(
     ]
     if themes:
         body_parts.append(f"**Themes:** {themes}")
+    if ticker:
+        body_parts.append(f"**Target ticker:** {ticker}")
+    if share_url:
+        body_parts.append(f"**Appended link:** {share_url}")
     if notif_or_post.get("_discovered_via"):
         body_parts.append(
             f"**Discovered via query:** {notif_or_post['_discovered_via']!r}"
@@ -508,11 +730,13 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--no-mentions", action="store_true")
     parser.add_argument("--no-search", action="store_true")
+    parser.add_argument("--no-equity", action="store_true")
     args = parser.parse_args()
 
     log.info(
-        "Bluesky heartbeat starting (dry_run=%s mentions=%s search=%s)",
+        "Bluesky heartbeat starting (dry_run=%s mentions=%s search=%s equity=%s)",
         args.dry_run, not args.no_mentions, not args.no_search,
+        not args.no_equity,
     )
 
     client = BlueskyClient()
@@ -538,11 +762,17 @@ def main() -> int:
 
     mention_stats = {"posted": 0, "skipped": 0, "failed": 0}
     search_stats = {"posted": 0, "skipped": 0, "failed": 0, "classified": 0}
+    equity_stats = {
+        "posted": 0, "skipped": 0, "failed": 0,
+        "classified": 0, "tickers": 0,
+    }
 
     if not args.no_mentions:
         mention_stats = _process_mentions(client, gh, ledger, args)
     if not args.no_search:
         search_stats = _process_search(client, gh, ledger, args)
+    if not args.no_equity:
+        equity_stats = _process_equity_targeting(client, gh, ledger, args)
 
     if gh and ledger_issue is not None:
         update_ledger(gh, ledger_issue, ledger)
@@ -550,10 +780,13 @@ def main() -> int:
 
     log.info(
         "HEARTBEAT_DONE — mentions: posted=%d skipped=%d failed=%d | "
-        "search: posted=%d skipped=%d failed=%d classified=%d",
+        "search: posted=%d skipped=%d failed=%d classified=%d | "
+        "equity: posted=%d skipped=%d failed=%d classified=%d tickers=%d",
         mention_stats["posted"], mention_stats["skipped"], mention_stats["failed"],
         search_stats["posted"], search_stats["skipped"], search_stats["failed"],
         search_stats["classified"],
+        equity_stats["posted"], equity_stats["skipped"], equity_stats["failed"],
+        equity_stats["classified"], equity_stats["tickers"],
     )
     return 0
 

--- a/bluesky_lib.py
+++ b/bluesky_lib.py
@@ -52,6 +52,12 @@ SEARCH_QUERIES = (
     "autonomous trading agent",
 )
 
+# How many of the top swarm-consensus tickers to target each run, and how
+# many recent posts per query to consider.
+EQUITY_TARGET_TOP_N = 5
+EQUITY_SEARCH_LIMIT_PER_QUERY = 6
+CONSENSUS_BASE_URL = "https://www.alphamolt.ai"
+
 BSKY_SYSTEM = """You are AlphaMolt-Equities (@alphamolt.bsky.social), an AI agent on Bluesky.
 
 ## What you believe (your thesis)
@@ -219,10 +225,18 @@ class BlueskyClient:
         parent_cid: str,
         root_uri: str | None = None,
         root_cid: str | None = None,
+        link_url: str | None = None,
+        link_label: str | None = None,
     ) -> dict | None:
-        """Post a reply. Returns {uri, cid} on success, None on failure."""
+        """Post a reply. Returns {uri, cid} on success, None on failure.
+
+        When ``link_url`` is set, ``link_label`` (defaulting to the URL) is
+        appended to ``text`` as a clickable rich-text facet. Bluesky won't
+        auto-linkify a bare URL — you have to attach the facet yourself.
+        """
         try:
             from atproto import models
+            from atproto_client.utils import TextBuilder
         except ImportError:
             log.error("atproto not available")
             return None
@@ -239,7 +253,17 @@ class BlueskyClient:
             reply_ref = models.AppBskyFeedPost.ReplyRef(
                 parent=parent_ref, root=root_ref
             )
-            resp = self.client.send_post(text=text, reply_to=reply_ref)
+            if link_url:
+                label = (link_label or link_url).strip()
+                body = text.rstrip()
+                separator = "\n\n" if body else ""
+                builder = TextBuilder()
+                if body:
+                    builder.text(f"{body}{separator}")
+                builder.link(label, link_url)
+                resp = self.client.send_post(text=builder, reply_to=reply_ref)
+            else:
+                resp = self.client.send_post(text=text, reply_to=reply_ref)
             return {"uri": resp.uri, "cid": resp.cid}
         except Exception as exc:
             log.error("reply failed: %s", exc)
@@ -554,6 +578,155 @@ def draft_reply_to_post(
         "- 'Real question:' / 'Question:' / 'genuine question' / 'honest question'\n"
         "- 'what's the actual X' / 'the actual track record'\n"
         "- 'the harder test' / 'the real test' / 'the empirical question'\n"
+        "- 'sounds good until' / 'doing heavy lifting'\n"
+        "- 'X ≠ Y' two-clause aphorisms\n"
+        "- Always-end-with-a-question pattern\n\n"
+        "Return ONLY the reply text, or SKIP."
+    )
+
+    return _draft_with_validation(user_block, target)
+
+
+def fetch_consensus_targets(limit: int = EQUITY_TARGET_TOP_N) -> tuple[list[dict], str | None]:
+    """Return the top swarm-consensus tickers + the snapshot date.
+
+    Reads ``consensus_snapshots`` (materialised weekly by
+    ``consensus_snapshot.py``) joined to ``companies`` for the human-readable
+    ``company_name``. Empty list when no snapshot exists yet.
+    """
+    from db import SupabaseDB
+
+    db = SupabaseDB()
+    return db.get_latest_consensus_top_tickers(limit=limit)
+
+
+def equity_search_queries(ticker: str) -> list[str]:
+    """Search queries for finding Bluesky posts about a given ticker.
+
+    Cashtag (``$NVDA``) is the highest-precision signal on financial Bluesky;
+    bare ticker is a fallback for tickers long enough to be unambiguous.
+    """
+    t = ticker.upper().strip()
+    queries = [f"${t}"]
+    if len(t) >= 4:
+        queries.append(t)
+    return queries
+
+
+def consensus_share_url(snapshot_date: str | None) -> str:
+    """Build the dated permalink the agent links to in equity replies."""
+    if snapshot_date:
+        return f"{CONSENSUS_BASE_URL}/consensus/{snapshot_date}"
+    return f"{CONSENSUS_BASE_URL}/consensus"
+
+
+_TICKER_RELEVANCE_RE = re.compile(r"YES|NO", re.IGNORECASE)
+
+
+def classify_ticker_post(
+    post: dict[str, Any], ticker: str, company_name: str
+) -> bool:
+    """Return True iff the post is genuinely about ``ticker`` as an equity.
+
+    Filters out: news headlines reposted by spam accounts, posts that mention
+    the ticker only in passing, posts about an unrelated company sharing the
+    abbreviation, and pure promotional spam. Haiku is plenty for this binary
+    decision.
+    """
+    author = post.get("author_handle") or "unknown"
+    text = (post.get("text") or "")[:1000]
+
+    user_block = (
+        f"Decide whether a Bluesky post is genuinely about the equity "
+        f"{ticker} ({company_name}) — i.e. someone sharing a view, news, "
+        f"position, or question about the stock. Reject: posts where "
+        f"{ticker} appears only in a list/banner, posts about an unrelated "
+        f"entity that happens to share the symbol, pure promotional spam, "
+        f"and links with no substantive comment.\n\n"
+        f"POST by @{author}:\n{text}\n\n"
+        "Answer YES or NO. One word."
+    )
+
+    client = _anthropic_client()
+    resp = client.messages.create(
+        model=CLASSIFY_MODEL,
+        max_tokens=8,
+        messages=[{"role": "user", "content": user_block}],
+    )
+    raw = "".join(
+        b.text for b in resp.content if getattr(b, "type", None) == "text"
+    ).strip()
+    m = _TICKER_RELEVANCE_RE.search(raw)
+    return bool(m and m.group(0).upper() == "YES")
+
+
+def draft_equity_reply(
+    post: dict[str, Any],
+    ticker: str,
+    company_name: str,
+    num_agents: int,
+    total_agents: int,
+    pct_agents: float | None,
+    memory_block: str = "",
+) -> str:
+    """Draft a casual reply noting the swarm-consensus overlap on ``ticker``.
+
+    Returns '' to skip. The caller appends a clickable link to the consensus
+    snapshot via ``BlueskyClient.reply(link_url=...)`` — the drafter must NOT
+    embed the URL in its output (we add it as a rich-text facet so it's
+    clickable; including it as plain text would double up).
+    """
+    author = post.get("author_handle") or "unknown"
+    text = (post.get("text") or "")[:800]
+    memory_section = f"{memory_block.strip()}\n\n" if memory_block.strip() else ""
+    target = _pick_char_target()
+    # The post-processor appends a clickable link, so reserve room.
+    target = max(40, min(target, 180))
+    pct_str = (
+        f"{pct_agents:.0f}%" if isinstance(pct_agents, (int, float)) else "n/a"
+    )
+    log.info("bsky equity-reply target: %d chars (ticker=%s)", target, ticker)
+
+    user_block = (
+        f"You are scrolling Bluesky and saw a post about {ticker} "
+        f"({company_name}). You happen to know that {num_agents} of "
+        f"{total_agents} AI agents in the AlphaMolt arena are currently "
+        f"holding {ticker} — that's {pct_str} of the swarm, ranking it among "
+        f"the top consensus picks this week.\n\n"
+        f"{memory_section}"
+        f"POST by @{author}:\n{text}\n\n"
+        "WHAT MAKES A GOOD REPLY HERE:\n"
+        f"- Casually note the overlap: that the AlphaMolt AI agents agree "
+        f"  with them on {ticker}. Friendly and low-key, like you just "
+        f"  noticed it. Example tone: 'huh, the AlphaMolt agents agree with "
+        f"  you on {ticker} fwiw' or 'fyi {num_agents} of the AlphaMolt "
+        f"  trading bots are long {ticker} too'.\n"
+        "- Vary phrasing across replies — never the same opener twice.\n"
+        f"- Stay grounded in the {ticker} angle. Don't pivot to a generic "
+        f"  pitch about AlphaMolt or AI investing.\n"
+        "- DO NOT include any URL or link in your reply. The system appends "
+        "  a clickable link (\"View the AlphaMolt swarm consensus\") "
+        "  automatically after your text — if you write your own link the "
+        "  reply will have two.\n"
+        "- Statement-only is great. Most replies should NOT end with a "
+        "  question.\n"
+        "- If the post is hostile, off-topic, or you have nothing genuine "
+        "  to say beyond the overlap, return SKIP.\n\n"
+        f"## LENGTH FOR THIS REPLY (mandatory)\n"
+        f"This specific reply must be UNDER {target} characters. Aim "
+        f"shorter — the appended link eats budget. "
+        + (
+            "A phrase or fragment — 4–10 words."
+            if target < 70
+            else "One short sentence."
+            if target < 140
+            else "One or two short sentences."
+        )
+        + "\n"
+        "Plain text only, no hashtags, no emoji, no @-tags.\n\n"
+        "## Banned (auto-rejected by post-processor)\n"
+        "- 'Real question:' / 'Question:' / 'genuine question'\n"
+        "- 'what's the actual X' / 'the actual track record'\n"
         "- 'sounds good until' / 'doing heavy lifting'\n"
         "- 'X ≠ Y' two-clause aphorisms\n"
         "- Always-end-with-a-question pattern\n\n"

--- a/db.py
+++ b/db.py
@@ -240,6 +240,51 @@ class SupabaseDB:
             })
         return out
 
+    def get_latest_consensus_top_tickers(
+        self, limit: int = 5
+    ) -> tuple[list[dict], str | None]:
+        """Return the highest-conviction tickers from the latest snapshot.
+
+        Joins ``companies`` for ``company_name`` so callers can disambiguate
+        the ticker when classifying social posts. Used by the Bluesky
+        heartbeat's equity-targeting phase.
+        """
+        latest = (
+            self.client.table("consensus_snapshots")
+            .select("snapshot_date")
+            .order("snapshot_date", desc=True)
+            .limit(1)
+            .execute()
+        )
+        if not latest.data:
+            return [], None
+        snapshot_date = latest.data[0]["snapshot_date"]
+
+        resp = (
+            self.client.table("consensus_snapshots")
+            .select(
+                "rank, ticker, num_agents, total_agents, pct_agents, "
+                "swarm_pnl_pct, companies(company_name)"
+            )
+            .eq("snapshot_date", snapshot_date)
+            .order("rank", desc=False)
+            .limit(limit)
+            .execute()
+        )
+        rows: list[dict] = []
+        for r in resp.data or []:
+            company = r.get("companies") or {}
+            rows.append({
+                "rank": r.get("rank"),
+                "ticker": r.get("ticker"),
+                "company_name": company.get("company_name") or r.get("ticker"),
+                "num_agents": r.get("num_agents"),
+                "total_agents": r.get("total_agents"),
+                "pct_agents": r.get("pct_agents"),
+                "swarm_pnl_pct": r.get("swarm_pnl_pct"),
+            })
+        return rows, snapshot_date
+
     def replace_consensus_snapshot(
         self, snapshot_date: str, rows: list[dict]
     ) -> None:


### PR DESCRIPTION
Pulls the top N tickers from the latest consensus_snapshots row, searches Bluesky for posts about each (cashtag + bare ticker on 4+-letter symbols), classifies for genuine equity discussion, and replies with a casual "AlphaMolt agents agree on $TICKER too" note. Reply text is followed by a clickable rich-text facet pointing at /consensus/<snapshot_date> so the reader can verify the swarm holdings themselves.

Cap of one reply per ticker per run + the existing per-run / per-day reply caps keep the cadence under bot-flagging thresholds.