### PR TITLE
leaderboard: dynamic OG card, share buttons

### DIFF
--- a/web/app/leaderboard/opengraph-image.tsx
+++ b/web/app/leaderboard/opengraph-image.tsx
@@ -1,0 +1,39 @@
+import { ImageResponse } from "next/og";
+import { getLeaderboard } from "@/lib/leaderboard-query";
+import {
+  OG_ALT,
+  OG_SIZE,
+  renderLeaderboardOg,
+} from "@/lib/leaderboard-og";
+
+// Dynamic OG card for /leaderboard. Defaults to the 30-day return view —
+// same period the page itself opens to.
+export const runtime = "nodejs";
+export const revalidate = 86400;
+export const alt = OG_ALT;
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+export default async function Image() {
+  let rows: Awaited<ReturnType<typeof getLeaderboard>>["rows"] = [];
+  let latestDate: string | null = null;
+  try {
+    const r = await getLeaderboard();
+    rows = r.rows;
+    latestDate = r.latestDate;
+  } catch (err) {
+    // Don't break social previews on a Supabase blip — fall through to
+    // the empty-state card.
+    console.error("og /leaderboard fetch failed:", err);
+  }
+  return new ImageResponse(
+    renderLeaderboardOg({ rows, period: "30d", snapshotDate: latestDate }),
+    {
+      ...size,
+      headers: {
+        "Cache-Control":
+          "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800",
+      },
+    },
+  );
+}

--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -1,352 +1,40 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { unstable_cache } from "next/cache";
-import { getSupabase } from "@/lib/supabase";
 import Nav from "@/components/nav";
-import LeaderboardTable, {
-  type LeaderboardAgentRow,
-  type LeaderboardBenchmarkRow,
-  type LeaderboardRow,
-  type Period,
-} from "@/components/leaderboard-table";
+import LeaderboardTable from "@/components/leaderboard-table";
+import ShareRow from "@/components/share-row";
+import {
+  getLeaderboard,
+  parseInitialPeriod,
+} from "@/lib/leaderboard-query";
+import { absoluteUrl } from "@/lib/site";
 
 export const revalidate = 300;
 
+const META_TITLE = "Leaderboard — AI agent alpha rankings";
+const META_DESCRIPTION =
+  "Live leaderboard of AI agents competing on rolling 1d / 30d / YTD / 1Yr returns. Each agent starts with $1M of virtual cash and is ranked alongside S&P 500 and MSCI World benchmarks.";
+
 export const metadata: Metadata = {
-  title: "Leaderboard — AI agent alpha rankings",
-  description:
-    "Live leaderboard of AI agents competing on rolling 1d / 30d / YTD / 1Yr returns. Each agent starts with $1M of virtual cash and is ranked alongside S&P 500 and MSCI World benchmarks.",
+  title: META_TITLE,
+  description: META_DESCRIPTION,
   alternates: { canonical: "/leaderboard" },
   openGraph: {
     title: "AlphaMolt Leaderboard — AI agent alpha rankings",
     description:
       "Live leaderboard of AI agents competing on rolling 30-day return, ranked alongside S&P 500 and MSCI World benchmarks.",
-    url: "/leaderboard",
+    // Deliberately no `url` — X uses og:url as a cache key, and pinning
+    // it to the bare path makes ?v=N cache-busts a no-op (mirrors the
+    // /consensus fix in 90cdc5b).
     type: "website",
   },
+  twitter: {
+    card: "summary_large_image",
+    title: "AlphaMolt Leaderboard — AI agent alpha rankings",
+    description:
+      "Live leaderboard of AI agents competing on rolling 30-day return, ranked alongside S&P 500 and MSCI World benchmarks.",
+  },
 };
-
-const PERIODS: readonly Period[] = ["1d", "30d", "ytd", "1yr"];
-
-type TradeBuckets = Record<Period, number>;
-
-function emptyBuckets(): TradeBuckets {
-  return { "1d": 0, "30d": 0, ytd: 0, "1yr": 0 };
-}
-
-async function fetchLeaderboard(): Promise<{
-  rows: LeaderboardRow[];
-  latestDate: string | null;
-}> {
-  const supabase = getSupabase();
-
-  // 1. Agent rows — view exposes all four interval returns + 30d Sharpe.
-  interface RawAgentRow {
-    handle: string;
-    display_name: string;
-    is_house_agent: boolean;
-    snapshot_date: string;
-    cash_usd: number | string;
-    holdings_value_usd: number | string;
-    total_value_usd: number | string;
-    pnl_usd: number | string;
-    pnl_pct_1d: number | string | null;
-    pnl_pct_30d: number | string | null;
-    pnl_pct_ytd: number | string | null;
-    pnl_pct_1yr: number | string | null;
-    sharpe: number | string | null;
-    sharpe_n_returns: number | string | null;
-    num_positions: number;
-  }
-  const { data: agentData, error: agentErr } = await supabase
-    .from("agent_leaderboard")
-    .select(
-      "handle, display_name, is_house_agent, snapshot_date, cash_usd, " +
-        "holdings_value_usd, total_value_usd, pnl_usd, " +
-        "pnl_pct_1d, pnl_pct_30d, pnl_pct_ytd, pnl_pct_1yr, " +
-        "sharpe, sharpe_n_returns, num_positions",
-    );
-  if (agentErr) console.error("Failed to fetch agent leaderboard:", agentErr);
-  const rawAgents = (agentData ?? []) as unknown as RawAgentRow[];
-
-  // 2. Trade counts per agent, bucketed into the same four windows. One
-  //    query for all agents' trades in the last year; bucket in JS.
-  //    agent_trades.agent_id joins via agents.handle, so we resolve
-  //    handle→id up-front in a single select.
-  const tradesByHandle = await fetchTradeBuckets(supabase, rawAgents);
-
-  const agentRows: LeaderboardAgentRow[] = rawAgents.map((r) => ({
-    kind: "agent",
-    handle: r.handle,
-    display_name: r.display_name,
-    is_house_agent: r.is_house_agent,
-    snapshot_date: r.snapshot_date,
-    cash_usd: Number(r.cash_usd),
-    holdings_value_usd: Number(r.holdings_value_usd),
-    total_value_usd: Number(r.total_value_usd),
-    pnl_usd: Number(r.pnl_usd),
-    returns: {
-      "1d": toNum(r.pnl_pct_1d),
-      "30d": toNum(r.pnl_pct_30d),
-      ytd: toNum(r.pnl_pct_ytd),
-      "1yr": toNum(r.pnl_pct_1yr),
-    },
-    sharpe: toNum(r.sharpe),
-    sharpe_n_returns: toNum(r.sharpe_n_returns) ?? 0,
-    trades: tradesByHandle.get(r.handle) ?? emptyBuckets(),
-    num_positions: r.num_positions,
-  }));
-
-  // 3. Benchmark rows — synthesised from benchmarks + benchmark_prices.
-  //    Each benchmark gets one bulk price fetch and derives all four
-  //    intervals in JS with the same since-inception fallback the view
-  //    uses for agents.
-  interface RawBenchmarkRow {
-    ticker: string;
-    display_name: string;
-    inception_price: number | string;
-    latest_price: number | string | null;
-    latest_price_date: string | null;
-    notional_starting_cash: number | string;
-  }
-  interface RawPriceRow {
-    price_date: string;
-    close: number | string;
-  }
-  const benchmarkRows: LeaderboardBenchmarkRow[] = [];
-  try {
-    const { data: benchmarks, error: benchErr } = await supabase
-      .from("benchmarks")
-      .select(
-        "ticker, display_name, inception_price, latest_price, " +
-          "latest_price_date, notional_starting_cash",
-      );
-    if (benchErr) throw benchErr;
-
-    for (const b of (benchmarks ?? []) as unknown as RawBenchmarkRow[]) {
-      if (!b.latest_price || !b.latest_price_date) continue;
-      const latest = Number(b.latest_price);
-      const inception = Number(b.inception_price);
-      const notional = Number(b.notional_starting_cash);
-      if (!(latest > 0) || !(inception > 0)) continue;
-
-      const { data: priceData } = await supabase
-        .from("benchmark_prices")
-        .select("price_date, close")
-        .eq("ticker", b.ticker)
-        .order("price_date", { ascending: true });
-      const prices = ((priceData ?? []) as unknown as RawPriceRow[]).map(
-        (p) => ({ date: p.price_date, close: Number(p.close) }),
-      );
-
-      const latestDate = b.latest_price_date;
-      const dayAgo = shiftDays(latestDate, -1);
-      const thirtyAgo = shiftDays(latestDate, -30);
-      const yearAgo = shiftDays(latestDate, -365);
-      const yearStart = `${latestDate.slice(0, 4)}-01-01`;
-
-      const a1d = lastOnOrBefore(prices, dayAgo) ?? inception;
-      const a30d = lastOnOrBefore(prices, thirtyAgo) ?? inception;
-      const a1yr = lastOnOrBefore(prices, yearAgo) ?? inception;
-      const aYtd = firstOnOrAfter(prices, yearStart) ?? inception;
-
-      const totalValue = notional * (latest / inception);
-      const pnlUsd = totalValue - notional;
-
-      const benchSharpe = annualizedSharpe(prices);
-      benchmarkRows.push({
-        kind: "benchmark",
-        ticker: b.ticker,
-        display_name: b.display_name,
-        snapshot_date: latestDate,
-        total_value_usd: totalValue,
-        pnl_usd: pnlUsd,
-        returns: {
-          "1d": pctChange(a1d, latest),
-          "30d": pctChange(a30d, latest),
-          ytd: pctChange(aYtd, latest),
-          "1yr": pctChange(a1yr, latest),
-        },
-        sharpe: benchSharpe.sharpe,
-        sharpe_n_returns: benchSharpe.n,
-      });
-    }
-  } catch (err) {
-    console.error("Benchmarks fetch failed (non-fatal):", err);
-  }
-
-  const rows: LeaderboardRow[] = [...agentRows, ...benchmarkRows];
-
-  const latestDate = rows.reduce<string | null>(
-    (acc, r) =>
-      acc && (r.snapshot_date == null || acc > r.snapshot_date)
-        ? acc
-        : r.snapshot_date,
-    null,
-  );
-  return { rows, latestDate };
-}
-
-const getLeaderboard = unstable_cache(fetchLeaderboard, ["leaderboard-v1"], {
-  revalidate: 300,
-  tags: ["leaderboard"],
-});
-
-async function fetchTradeBuckets(
-  supabase: ReturnType<typeof getSupabase>,
-  rawAgents: { handle: string }[],
-): Promise<Map<string, TradeBuckets>> {
-  const out = new Map<string, TradeBuckets>();
-  if (rawAgents.length === 0) return out;
-
-  // Resolve handle → id so we can attribute trades back to the leaderboard row.
-  const { data: idRows, error: idErr } = await supabase
-    .from("agents")
-    .select("id, handle")
-    .in(
-      "handle",
-      rawAgents.map((a) => a.handle),
-    );
-  if (idErr || !idRows) {
-    if (idErr) console.error("Failed to resolve agent ids:", idErr);
-    return out;
-  }
-  const idToHandle = new Map<string, string>();
-  for (const row of idRows as { id: string; handle: string }[]) {
-    idToHandle.set(row.id, row.handle);
-  }
-
-  const now = new Date();
-  const yearAgoIso = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000).toISOString();
-  const dayAgoMs = now.getTime() - 24 * 60 * 60 * 1000;
-  const thirtyDayMs = now.getTime() - 30 * 24 * 60 * 60 * 1000;
-  const yearStartMs = Date.UTC(now.getUTCFullYear(), 0, 1);
-  const yearAgoMs = new Date(yearAgoIso).getTime();
-
-  // One query: every agent's trades in the last year. Paginate to be
-  // safe against Supabase's default row cap (1000).
-  const agentIds = Array.from(idToHandle.keys());
-  if (agentIds.length === 0) return out;
-
-  const pageSize = 1000;
-  let from = 0;
-  type TradeTuple = { agent_id: string; executed_at: string };
-  const all: TradeTuple[] = [];
-  while (true) {
-    const { data, error } = await supabase
-      .from("agent_trades")
-      .select("agent_id, executed_at")
-      .in("agent_id", agentIds)
-      .gte("executed_at", yearAgoIso)
-      .range(from, from + pageSize - 1);
-    if (error) {
-      console.error("Failed to fetch agent_trades:", error);
-      break;
-    }
-    const batch = (data ?? []) as TradeTuple[];
-    all.push(...batch);
-    if (batch.length < pageSize) break;
-    from += pageSize;
-  }
-
-  for (const trade of all) {
-    const handle = idToHandle.get(trade.agent_id);
-    if (!handle) continue;
-    let bucket = out.get(handle);
-    if (!bucket) {
-      bucket = emptyBuckets();
-      out.set(handle, bucket);
-    }
-    const ts = new Date(trade.executed_at).getTime();
-    if (ts >= dayAgoMs) bucket["1d"] += 1;
-    if (ts >= thirtyDayMs) bucket["30d"] += 1;
-    if (ts >= yearStartMs) bucket.ytd += 1;
-    if (ts >= yearAgoMs) bucket["1yr"] += 1;
-  }
-  return out;
-}
-
-function toNum(v: number | string | null | undefined): number | null {
-  if (v == null) return null;
-  const n = Number(v);
-  return Number.isFinite(n) ? n : null;
-}
-
-function pctChange(from: number, to: number): number | null {
-  if (!(from > 0)) return null;
-  return ((to - from) / from) * 100;
-}
-
-function shiftDays(iso: string, days: number): string {
-  const d = new Date(`${iso}T00:00:00Z`);
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString().split("T")[0];
-}
-
-function lastOnOrBefore(
-  series: { date: string; close: number }[],
-  cutoff: string,
-): number | null {
-  for (let i = series.length - 1; i >= 0; i--) {
-    if (series[i].date <= cutoff) return series[i].close;
-  }
-  return null;
-}
-
-function firstOnOrAfter(
-  series: { date: string; close: number }[],
-  cutoff: string,
-): number | null {
-  for (const p of series) {
-    if (p.date >= cutoff) return p.close;
-  }
-  return null;
-}
-
-// Mirrors the SQL Sharpe in agent_leaderboard: weekday-only daily returns
-// over the entire price history, (mean - rf_daily) / sample stdev * sqrt(252),
-// with rf = 5% annual. Min 30 returns to display.
-const SHARPE_RF_ANNUAL = 0.05;
-const SHARPE_RF_DAILY = SHARPE_RF_ANNUAL / 252;
-const SHARPE_MIN_RETURNS = 30;
-
-function annualizedSharpe(
-  series: { date: string; close: number }[],
-): { sharpe: number | null; n: number } {
-  const window = series.filter((p) => isWeekday(p.date));
-  const returns: number[] = [];
-  for (let i = 1; i < window.length; i++) {
-    const prev = window[i - 1].close;
-    const cur = window[i].close;
-    if (!(prev > 0)) continue;
-    returns.push((cur - prev) / prev);
-  }
-  if (returns.length < SHARPE_MIN_RETURNS) {
-    return { sharpe: null, n: returns.length };
-  }
-  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
-  const variance =
-    returns.reduce((a, b) => a + (b - mean) ** 2, 0) / (returns.length - 1);
-  const stdev = Math.sqrt(variance);
-  if (!(stdev > 0)) return { sharpe: null, n: returns.length };
-  return {
-    sharpe: ((mean - SHARPE_RF_DAILY) / stdev) * Math.sqrt(252),
-    n: returns.length,
-  };
-}
-
-function isWeekday(iso: string): boolean {
-  const dow = new Date(`${iso}T00:00:00Z`).getUTCDay();
-  return dow >= 1 && dow <= 5;
-}
-
-function parseInitialPeriod(raw: string | string[] | undefined): Period {
-  const val = Array.isArray(raw) ? raw[0] : raw;
-  if (val && (PERIODS as readonly string[]).includes(val)) {
-    return val as Period;
-  }
-  return "30d";
-}
 
 export default async function LeaderboardPage({
   searchParams,
@@ -355,6 +43,13 @@ export default async function LeaderboardPage({
 }) {
   const { rows, latestDate } = await getLeaderboard();
   const initialPeriod = parseInitialPeriod((await searchParams).period);
+
+  // Bump ?v=N when the OG card design changes — X.com caches og:image
+  // per fetched URL, and the only reliable way to dislodge a stale image
+  // is a fresh query string.
+  const shareUrl = `${absoluteUrl("/leaderboard")}?v=1`;
+  const top3 = topByPeriod(rows, "30d", 3);
+  const shareText = buildShareText(top3);
 
   return (
     <>
@@ -392,18 +87,21 @@ export default async function LeaderboardPage({
               head-to-head against the field.
             </p>
           </div>
-          <Link
-            href="/#enter-agent"
-            className="inline-flex items-center px-4 py-2 rounded-lg text-text text-sm font-semibold tracking-tight transition-all whitespace-nowrap"
-            style={{
-              background:
-                "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
-              border: "1px solid rgba(255,255,255,0.12)",
-              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
-            }}
-          >
-            Register Your Agent &rarr;
-          </Link>
+          <div className="flex flex-wrap items-center gap-2">
+            <ShareRow url={shareUrl} text={shareText} />
+            <Link
+              href="/#enter-agent"
+              className="inline-flex items-center px-4 py-2 rounded-lg text-text text-sm font-semibold tracking-tight transition-all whitespace-nowrap"
+              style={{
+                background:
+                  "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+                border: "1px solid rgba(255,255,255,0.12)",
+                boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+              }}
+            >
+              Register Your Agent &rarr;
+            </Link>
+          </div>
         </div>
 
         {rows.length === 0 ? (
@@ -429,4 +127,31 @@ export default async function LeaderboardPage({
       </main>
     </>
   );
+}
+
+function topByPeriod(
+  rows: Awaited<ReturnType<typeof getLeaderboard>>["rows"],
+  period: "1d" | "30d" | "ytd" | "1yr",
+  n: number,
+) {
+  return [...rows]
+    .filter((r) => r.kind === "agent" && r.returns[period] != null)
+    .sort((a, b) => (b.returns[period] ?? 0) - (a.returns[period] ?? 0))
+    .slice(0, n);
+}
+
+function buildShareText(
+  top: Awaited<ReturnType<typeof getLeaderboard>>["rows"],
+): string {
+  if (top.length === 0) {
+    return "AI agents trading head-to-head against SPY & MSCI World on @alphamolt — see who's compounding capital and who's blowing up. Live leaderboard:";
+  }
+  const blurbs = top.slice(0, 3).map((r) => {
+    const name = r.kind === "agent" ? r.display_name : r.ticker;
+    const ret = r.returns["30d"];
+    const sign = ret != null && ret >= 0 ? "+" : "−";
+    const val = ret != null ? `${sign}${Math.abs(ret).toFixed(1)}%` : "—";
+    return `${name} (${val})`;
+  });
+  return `AI agents trading head-to-head against SPY & MSCI World on @alphamolt. This week's top 30d returns: ${blurbs.join(", ")}. Live leaderboard:`;
 }

--- a/web/lib/leaderboard-og.tsx
+++ b/web/lib/leaderboard-og.tsx
@@ -1,0 +1,360 @@
+/**
+ * Shared OG-card renderer for /leaderboard.
+ *
+ * Same Satori constraints as consensus-og.tsx: inline styles only, no
+ * Tailwind, explicit `display: flex` on every multi-child element.
+ */
+
+import type {
+  LeaderboardRow,
+  Period,
+} from "@/components/leaderboard-table";
+
+export const OG_SIZE = { width: 1200, height: 630 } as const;
+export const OG_ALT =
+  "AlphaMolt leaderboard — AI agents competing head-to-head against SPY and MSCI World";
+
+const MAX_ROWS = 5;
+const TEXT = "#EDEDED";
+const TEXT_DIM = "#D4D4D8";
+const TEXT_MUTED = "#A1A1AA";
+const GREEN = "#00FF41";
+const RED = "#FF3333";
+const BORDER = "rgba(255,255,255,0.08)";
+
+const PERIOD_LABELS: Record<Period, string> = {
+  "1d": "1-day",
+  "30d": "30-day",
+  ytd: "YTD",
+  "1yr": "1-year",
+};
+
+interface RenderArgs {
+  rows: LeaderboardRow[];
+  period: Period;
+  snapshotDate: string | null;
+}
+
+export function renderLeaderboardOg({
+  rows,
+  period,
+  snapshotDate,
+}: RenderArgs) {
+  // Sort by the requested-period return; rows missing a value sink to the
+  // bottom so the card always shows something interesting up top.
+  const sorted = [...rows].sort((a, b) => {
+    const av = a.returns[period];
+    const bv = b.returns[period];
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    return bv - av;
+  });
+  const top = sorted.slice(0, MAX_ROWS);
+  const dateLabel = snapshotDate ? formatLongDate(snapshotDate) : null;
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        padding: "64px 80px",
+        background:
+          "radial-gradient(ellipse at top left, #001a08 0%, #0a0a0a 60%)",
+        color: TEXT,
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div
+            style={{
+              fontSize: 26,
+              fontWeight: 700,
+              color: GREEN,
+              letterSpacing: "0.10em",
+              textTransform: "uppercase",
+              display: "flex",
+            }}
+          >
+            ALPHAMOLT
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: TEXT_DIM,
+              marginTop: 6,
+              letterSpacing: "-0.01em",
+              display: "flex",
+            }}
+          >
+            AI Agent Leaderboard · {PERIOD_LABELS[period]} returns
+          </div>
+        </div>
+        {dateLabel && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              padding: "10px 16px",
+              borderRadius: 999,
+              border: `1px solid ${BORDER}`,
+              background: "rgba(255,255,255,0.04)",
+              fontSize: 18,
+              color: TEXT_MUTED,
+              fontFamily: "ui-monospace, monospace",
+            }}
+          >
+            {dateLabel}
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      {top.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            marginTop: 40,
+            gap: 14,
+          }}
+        >
+          {top.map((row, i) => (
+            <Row
+              key={rowKey(row)}
+              row={row}
+              rank={i + 1}
+              period={period}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Footer */}
+      <div
+        style={{
+          marginTop: "auto",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          fontSize: 18,
+          color: TEXT_MUTED,
+          fontFamily: "ui-monospace, monospace",
+        }}
+      >
+        <div style={{ display: "flex" }}>alphamolt.ai/leaderboard</div>
+        <div style={{ display: "flex" }}>
+          {agentCount(rows)} agents · live mark-to-market
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Row({
+  row,
+  rank,
+  period,
+}: {
+  row: LeaderboardRow;
+  rank: number;
+  period: Period;
+}) {
+  const ret = row.returns[period];
+  const positive = ret != null && ret >= 0;
+  const isBench = row.kind === "benchmark";
+  const name = isBench ? row.ticker : row.display_name;
+  const subline = isBench
+    ? "INDEX"
+    : `@${row.handle}${row.is_house_agent ? " · house" : ""}`;
+  const sharpeStr =
+    row.sharpe != null && row.sharpe_n_returns >= 30
+      ? row.sharpe.toFixed(2)
+      : "—";
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 24,
+        padding: "16px 20px",
+        borderRadius: 14,
+        border: `1px solid ${BORDER}`,
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+      }}
+    >
+      {/* Rank */}
+      <div
+        style={{
+          display: "flex",
+          width: 44,
+          fontSize: 30,
+          fontWeight: 700,
+          color: TEXT_MUTED,
+          fontFamily: "ui-monospace, monospace",
+        }}
+      >
+        {rank}
+      </div>
+
+      {/* Display name + handle/index chip */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          minWidth: 0,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 30,
+            fontWeight: 800,
+            color: TEXT,
+            letterSpacing: "-0.01em",
+            maxWidth: 580,
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {name}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 16,
+            color: TEXT_MUTED,
+            marginTop: 2,
+            fontFamily: "ui-monospace, monospace",
+            maxWidth: 580,
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {subline}
+        </div>
+      </div>
+
+      {/* Sharpe */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          width: 100,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 22,
+            fontWeight: 700,
+            color: TEXT_DIM,
+            fontFamily: "ui-monospace, monospace",
+          }}
+        >
+          {sharpeStr}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 13,
+            color: TEXT_MUTED,
+            marginTop: 2,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+          }}
+        >
+          Sharpe
+        </div>
+      </div>
+
+      {/* Period return */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          width: 150,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 30,
+            fontWeight: 700,
+            color: ret == null ? TEXT_MUTED : positive ? GREEN : RED,
+            fontFamily: "ui-monospace, monospace",
+          }}
+        >
+          {ret == null
+            ? "—"
+            : `${positive ? "+" : "−"}${Math.abs(ret).toFixed(1)}%`}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 13,
+            color: TEXT_MUTED,
+            marginTop: 2,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+          }}
+        >
+          {PERIOD_LABELS[period]}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: 32,
+        color: TEXT_MUTED,
+        fontFamily: "ui-monospace, monospace",
+      }}
+    >
+      First agent snapshots land after the next mark-to-market run
+    </div>
+  );
+}
+
+function rowKey(row: LeaderboardRow): string {
+  return row.kind === "agent" ? `agent:${row.handle}` : `bench:${row.ticker}`;
+}
+
+function agentCount(rows: LeaderboardRow[]): number {
+  return rows.filter((r) => r.kind === "agent").length;
+}
+
+function formatLongDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/web/lib/leaderboard-query.ts
+++ b/web/lib/leaderboard-query.ts
@@ -1,0 +1,341 @@
+/**
+ * Server-side query for /leaderboard and its OG card.
+ *
+ * Centralised so both `app/leaderboard/page.tsx` and
+ * `app/leaderboard/opengraph-image.tsx` hit the same `unstable_cache` —
+ * a single Supabase fetch per revalidation window powers both the HTML
+ * page and the social-share image.
+ */
+
+import { unstable_cache } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+import type {
+  LeaderboardAgentRow,
+  LeaderboardBenchmarkRow,
+  LeaderboardRow,
+  Period,
+} from "@/components/leaderboard-table";
+
+const PERIODS: readonly Period[] = ["1d", "30d", "ytd", "1yr"];
+
+type TradeBuckets = Record<Period, number>;
+
+function emptyBuckets(): TradeBuckets {
+  return { "1d": 0, "30d": 0, ytd: 0, "1yr": 0 };
+}
+
+export interface LeaderboardResult {
+  rows: LeaderboardRow[];
+  latestDate: string | null;
+}
+
+async function fetchLeaderboard(): Promise<LeaderboardResult> {
+  const supabase = getSupabase();
+
+  // 1. Agent rows — view exposes all four interval returns + 30d Sharpe.
+  interface RawAgentRow {
+    handle: string;
+    display_name: string;
+    is_house_agent: boolean;
+    snapshot_date: string;
+    cash_usd: number | string;
+    holdings_value_usd: number | string;
+    total_value_usd: number | string;
+    pnl_usd: number | string;
+    pnl_pct_1d: number | string | null;
+    pnl_pct_30d: number | string | null;
+    pnl_pct_ytd: number | string | null;
+    pnl_pct_1yr: number | string | null;
+    sharpe: number | string | null;
+    sharpe_n_returns: number | string | null;
+    num_positions: number;
+  }
+  const { data: agentData, error: agentErr } = await supabase
+    .from("agent_leaderboard")
+    .select(
+      "handle, display_name, is_house_agent, snapshot_date, cash_usd, " +
+        "holdings_value_usd, total_value_usd, pnl_usd, " +
+        "pnl_pct_1d, pnl_pct_30d, pnl_pct_ytd, pnl_pct_1yr, " +
+        "sharpe, sharpe_n_returns, num_positions",
+    );
+  if (agentErr) console.error("Failed to fetch agent leaderboard:", agentErr);
+  const rawAgents = (agentData ?? []) as unknown as RawAgentRow[];
+
+  // 2. Trade counts per agent, bucketed into the same four windows.
+  const tradesByHandle = await fetchTradeBuckets(supabase, rawAgents);
+
+  const agentRows: LeaderboardAgentRow[] = rawAgents.map((r) => ({
+    kind: "agent",
+    handle: r.handle,
+    display_name: r.display_name,
+    is_house_agent: r.is_house_agent,
+    snapshot_date: r.snapshot_date,
+    cash_usd: Number(r.cash_usd),
+    holdings_value_usd: Number(r.holdings_value_usd),
+    total_value_usd: Number(r.total_value_usd),
+    pnl_usd: Number(r.pnl_usd),
+    returns: {
+      "1d": toNum(r.pnl_pct_1d),
+      "30d": toNum(r.pnl_pct_30d),
+      ytd: toNum(r.pnl_pct_ytd),
+      "1yr": toNum(r.pnl_pct_1yr),
+    },
+    sharpe: toNum(r.sharpe),
+    sharpe_n_returns: toNum(r.sharpe_n_returns) ?? 0,
+    trades: tradesByHandle.get(r.handle) ?? emptyBuckets(),
+    num_positions: r.num_positions,
+  }));
+
+  // 3. Benchmark rows — synthesised from benchmarks + benchmark_prices.
+  interface RawBenchmarkRow {
+    ticker: string;
+    display_name: string;
+    inception_price: number | string;
+    latest_price: number | string | null;
+    latest_price_date: string | null;
+    notional_starting_cash: number | string;
+  }
+  interface RawPriceRow {
+    price_date: string;
+    close: number | string;
+  }
+  const benchmarkRows: LeaderboardBenchmarkRow[] = [];
+  try {
+    const { data: benchmarks, error: benchErr } = await supabase
+      .from("benchmarks")
+      .select(
+        "ticker, display_name, inception_price, latest_price, " +
+          "latest_price_date, notional_starting_cash",
+      );
+    if (benchErr) throw benchErr;
+
+    for (const b of (benchmarks ?? []) as unknown as RawBenchmarkRow[]) {
+      if (!b.latest_price || !b.latest_price_date) continue;
+      const latest = Number(b.latest_price);
+      const inception = Number(b.inception_price);
+      const notional = Number(b.notional_starting_cash);
+      if (!(latest > 0) || !(inception > 0)) continue;
+
+      const { data: priceData } = await supabase
+        .from("benchmark_prices")
+        .select("price_date, close")
+        .eq("ticker", b.ticker)
+        .order("price_date", { ascending: true });
+      const prices = ((priceData ?? []) as unknown as RawPriceRow[]).map(
+        (p) => ({ date: p.price_date, close: Number(p.close) }),
+      );
+
+      const latestDate = b.latest_price_date;
+      const dayAgo = shiftDays(latestDate, -1);
+      const thirtyAgo = shiftDays(latestDate, -30);
+      const yearAgo = shiftDays(latestDate, -365);
+      const yearStart = `${latestDate.slice(0, 4)}-01-01`;
+
+      const a1d = lastOnOrBefore(prices, dayAgo) ?? inception;
+      const a30d = lastOnOrBefore(prices, thirtyAgo) ?? inception;
+      const a1yr = lastOnOrBefore(prices, yearAgo) ?? inception;
+      const aYtd = firstOnOrAfter(prices, yearStart) ?? inception;
+
+      const totalValue = notional * (latest / inception);
+      const pnlUsd = totalValue - notional;
+
+      const benchSharpe = annualizedSharpe(prices);
+      benchmarkRows.push({
+        kind: "benchmark",
+        ticker: b.ticker,
+        display_name: b.display_name,
+        snapshot_date: latestDate,
+        total_value_usd: totalValue,
+        pnl_usd: pnlUsd,
+        returns: {
+          "1d": pctChange(a1d, latest),
+          "30d": pctChange(a30d, latest),
+          ytd: pctChange(aYtd, latest),
+          "1yr": pctChange(a1yr, latest),
+        },
+        sharpe: benchSharpe.sharpe,
+        sharpe_n_returns: benchSharpe.n,
+      });
+    }
+  } catch (err) {
+    console.error("Benchmarks fetch failed (non-fatal):", err);
+  }
+
+  const rows: LeaderboardRow[] = [...agentRows, ...benchmarkRows];
+
+  const latestDate = rows.reduce<string | null>(
+    (acc, r) =>
+      acc && (r.snapshot_date == null || acc > r.snapshot_date)
+        ? acc
+        : r.snapshot_date,
+    null,
+  );
+  return { rows, latestDate };
+}
+
+export const getLeaderboard = unstable_cache(
+  fetchLeaderboard,
+  ["leaderboard-v1"],
+  {
+    revalidate: 300,
+    tags: ["leaderboard"],
+  },
+);
+
+async function fetchTradeBuckets(
+  supabase: ReturnType<typeof getSupabase>,
+  rawAgents: { handle: string }[],
+): Promise<Map<string, TradeBuckets>> {
+  const out = new Map<string, TradeBuckets>();
+  if (rawAgents.length === 0) return out;
+
+  // Resolve handle → id so we can attribute trades back to the leaderboard row.
+  const { data: idRows, error: idErr } = await supabase
+    .from("agents")
+    .select("id, handle")
+    .in(
+      "handle",
+      rawAgents.map((a) => a.handle),
+    );
+  if (idErr || !idRows) {
+    if (idErr) console.error("Failed to resolve agent ids:", idErr);
+    return out;
+  }
+  const idToHandle = new Map<string, string>();
+  for (const row of idRows as { id: string; handle: string }[]) {
+    idToHandle.set(row.id, row.handle);
+  }
+
+  const now = new Date();
+  const yearAgoIso = new Date(
+    now.getTime() - 365 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const dayAgoMs = now.getTime() - 24 * 60 * 60 * 1000;
+  const thirtyDayMs = now.getTime() - 30 * 24 * 60 * 60 * 1000;
+  const yearStartMs = Date.UTC(now.getUTCFullYear(), 0, 1);
+  const yearAgoMs = new Date(yearAgoIso).getTime();
+
+  const agentIds = Array.from(idToHandle.keys());
+  if (agentIds.length === 0) return out;
+
+  const pageSize = 1000;
+  let from = 0;
+  type TradeTuple = { agent_id: string; executed_at: string };
+  const all: TradeTuple[] = [];
+  while (true) {
+    const { data, error } = await supabase
+      .from("agent_trades")
+      .select("agent_id, executed_at")
+      .in("agent_id", agentIds)
+      .gte("executed_at", yearAgoIso)
+      .range(from, from + pageSize - 1);
+    if (error) {
+      console.error("Failed to fetch agent_trades:", error);
+      break;
+    }
+    const batch = (data ?? []) as TradeTuple[];
+    all.push(...batch);
+    if (batch.length < pageSize) break;
+    from += pageSize;
+  }
+
+  for (const trade of all) {
+    const handle = idToHandle.get(trade.agent_id);
+    if (!handle) continue;
+    let bucket = out.get(handle);
+    if (!bucket) {
+      bucket = emptyBuckets();
+      out.set(handle, bucket);
+    }
+    const ts = new Date(trade.executed_at).getTime();
+    if (ts >= dayAgoMs) bucket["1d"] += 1;
+    if (ts >= thirtyDayMs) bucket["30d"] += 1;
+    if (ts >= yearStartMs) bucket.ytd += 1;
+    if (ts >= yearAgoMs) bucket["1yr"] += 1;
+  }
+  return out;
+}
+
+function toNum(v: number | string | null | undefined): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function pctChange(from: number, to: number): number | null {
+  if (!(from > 0)) return null;
+  return ((to - from) / from) * 100;
+}
+
+function shiftDays(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().split("T")[0];
+}
+
+function lastOnOrBefore(
+  series: { date: string; close: number }[],
+  cutoff: string,
+): number | null {
+  for (let i = series.length - 1; i >= 0; i--) {
+    if (series[i].date <= cutoff) return series[i].close;
+  }
+  return null;
+}
+
+function firstOnOrAfter(
+  series: { date: string; close: number }[],
+  cutoff: string,
+): number | null {
+  for (const p of series) {
+    if (p.date >= cutoff) return p.close;
+  }
+  return null;
+}
+
+// Mirrors the SQL Sharpe in agent_leaderboard: weekday-only daily returns
+// over the entire price history, (mean - rf_daily) / sample stdev * sqrt(252),
+// with rf = 5% annual. Min 30 returns to display.
+const SHARPE_RF_ANNUAL = 0.05;
+const SHARPE_RF_DAILY = SHARPE_RF_ANNUAL / 252;
+const SHARPE_MIN_RETURNS = 30;
+
+function annualizedSharpe(
+  series: { date: string; close: number }[],
+): { sharpe: number | null; n: number } {
+  const window = series.filter((p) => isWeekday(p.date));
+  const returns: number[] = [];
+  for (let i = 1; i < window.length; i++) {
+    const prev = window[i - 1].close;
+    const cur = window[i].close;
+    if (!(prev > 0)) continue;
+    returns.push((cur - prev) / prev);
+  }
+  if (returns.length < SHARPE_MIN_RETURNS) {
+    return { sharpe: null, n: returns.length };
+  }
+  const mean = returns.reduce((a, b) => a + b, 0) / returns.length;
+  const variance =
+    returns.reduce((a, b) => a + (b - mean) ** 2, 0) / (returns.length - 1);
+  const stdev = Math.sqrt(variance);
+  if (!(stdev > 0)) return { sharpe: null, n: returns.length };
+  return {
+    sharpe: ((mean - SHARPE_RF_DAILY) / stdev) * Math.sqrt(252),
+    n: returns.length,
+  };
+}
+
+function isWeekday(iso: string): boolean {
+  const dow = new Date(`${iso}T00:00:00Z`).getUTCDay();
+  return dow >= 1 && dow <= 5;
+}
+
+export function parseInitialPeriod(
+  raw: string | string[] | undefined,
+): Period {
+  const val = Array.isArray(raw) ? raw[0] : raw;
+  if (val && (PERIODS as readonly string[]).includes(val)) {
+    return val as Period;
+  }
+  return "30d";
+}


### PR DESCRIPTION
Mirrors the /consensus share infra: ShareRow on the page, dynamic OG image per-route, og:url omitted from metadata so X.com's per-URL og:image cache responds to ?v=N cache-busts.

Extracted the Supabase fetch + helpers from the page into lib/leaderboard-query.ts so the page and the OG renderer share a single unstable_cache hit per revalidation window. OG card lists the top 5 rows (agents + benchmarks) by 30d return with handle, Sharpe, and the period delta — same default the page opens to.

Share text quotes the current top-3 30d returns by display name so the preview reads as a punchy headline instead of a bare URL.