### PR TITLE
agent-heartbeat workflow: handle whitespace / empty handle input

### DIFF
--- a/.github/workflows/agent-heartbeat.yml
+++ b/.github/workflows/agent-heartbeat.yml
@@ -67,18 +67,27 @@ jobs:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          # Workflow-dispatch inputs piped via env so values with
+          # whitespace / shell metacharacters can't break the arg list.
+          # On scheduled runs these are empty strings — flags below skip.
+          HEARTBEAT_HANDLE: ${{ inputs.handle }}
+          HEARTBEAT_DRY_RUN: ${{ inputs.dry_run }}
+          HEARTBEAT_FORCE: ${{ inputs.force }}
         run: |
-          ARGS=""
-          if [ -n "${{ inputs.handle }}" ]; then
-            ARGS="$ARGS --handle ${{ inputs.handle }}"
+          ARGS=()
+          # Trim whitespace so a stray space-only value doesn't add an
+          # empty --handle arg.
+          HANDLE="$(printf '%s' "$HEARTBEAT_HANDLE" | tr -d '[:space:]')"
+          if [ -n "$HANDLE" ]; then
+            ARGS+=(--handle "$HANDLE")
           fi
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            ARGS="$ARGS --dry-run"
+          if [ "$HEARTBEAT_DRY_RUN" = "true" ]; then
+            ARGS+=(--dry-run)
           fi
-          if [ "${{ inputs.force }}" = "true" ]; then
-            ARGS="$ARGS --force"
+          if [ "$HEARTBEAT_FORCE" = "true" ]; then
+            ARGS+=(--force)
           fi
-          python agent_heartbeat.py $ARGS
+          python agent_heartbeat.py "${ARGS[@]}"
 
       - name: Upload logs
         if: always()


### PR DESCRIPTION
A workflow_dispatch run with the handle field left blank (or containing only whitespace) was producing 'python agent_heartbeat.py --handle ' with no following value, which argparse rejects with "argument --handle: expected one argument".

Two fixes layered:

1. Pipe inputs through `env:` rather than substituting into bash directly. GitHub-Actions templating is text replacement — values with spaces, quotes, or shell metacharacters can split the command line in surprising ways. Env vars give shell quoting a fair chance.

2. Build the python args as a bash array and expand with "${ARGS[@]}". A single string concatenation and unquoted $ARGS word-splits at every space and drops empty trailing tokens — the exact failure mode here.

Also strip whitespace from HANDLE before the [ -n ] check, so a space-only paste doesn't slip through and produce --handle with nothing after it.

https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ