### PR TITLE
agent-heartbeat workflow: debug logging + safer empty-array expansion

### DIFF
--- a/.github/workflows/agent-heartbeat.yml
+++ b/.github/workflows/agent-heartbeat.yml
@@ -74,20 +74,25 @@ jobs:
           HEARTBEAT_DRY_RUN: ${{ inputs.dry_run }}
           HEARTBEAT_FORCE: ${{ inputs.force }}
         run: |
+          set -u
+          echo "DEBUG: raw HEARTBEAT_HANDLE='${HEARTBEAT_HANDLE}' (length=${#HEARTBEAT_HANDLE})"
+          echo "DEBUG: raw HEARTBEAT_DRY_RUN='${HEARTBEAT_DRY_RUN}'"
+          echo "DEBUG: raw HEARTBEAT_FORCE='${HEARTBEAT_FORCE}'"
           ARGS=()
           # Trim whitespace so a stray space-only value doesn't add an
           # empty --handle arg.
-          HANDLE="$(printf '%s' "$HEARTBEAT_HANDLE" | tr -d '[:space:]')"
-          if [ -n "$HANDLE" ]; then
-            ARGS+=(--handle "$HANDLE")
+          HANDLE="$(printf '%s' "${HEARTBEAT_HANDLE}" | tr -d '[:space:]')"
+          if [ -n "${HANDLE}" ]; then
+            ARGS+=(--handle "${HANDLE}")
           fi
-          if [ "$HEARTBEAT_DRY_RUN" = "true" ]; then
+          if [ "${HEARTBEAT_DRY_RUN}" = "true" ]; then
             ARGS+=(--dry-run)
           fi
-          if [ "$HEARTBEAT_FORCE" = "true" ]; then
+          if [ "${HEARTBEAT_FORCE}" = "true" ]; then
             ARGS+=(--force)
           fi
-          python agent_heartbeat.py "${ARGS[@]}"
+          echo "DEBUG: argv = python agent_heartbeat.py ${ARGS[@]+"${ARGS[@]}"}"
+          python agent_heartbeat.py ${ARGS[@]+"${ARGS[@]}"}
 
       - name: Upload logs
         if: always()


### PR DESCRIPTION
PR #468's earlier fix still produces "argument --handle: expected one argument" when the handle field is left blank. Adding three echoes to surface what HEARTBEAT_HANDLE / HEARTBEAT_DRY_RUN / HEARTBEAT_FORCE actually look like at runtime, plus the final argv before python is invoked. Once the next run shows the values, we can pinpoint and revert the debug.

Also switching the array expansion from "${ARGS[@]}" to ${ARGS[@]+"${ARGS[@]}"} — the bash idiom for "expand the array elements if any exist, otherwise expand to literally nothing." Plain "${ARGS[@]}" on an empty array combined with `set -u` can produce an unbound-variable error in some bashes; this guard avoids that path.

https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ