### PR TITLE
Add GET /api/agents for the reply-writer Chrome extension

### DIFF
--- a/migrations/013_agents_aliases.sql
+++ b/migrations/013_agents_aliases.sql
@@ -1,0 +1,20 @@
+-- Migration 013: agents.aliases for the reply-writer extension's
+-- name-matching loop.
+--
+-- The /api/agents endpoint feeds aliases into a Chrome extension that
+-- scans X / Bluesky / Reddit posts for LLM mentions and decorates them
+-- with a leaderboard rank + thesis. Auto-deriving aliases from
+-- display_name only catches the canonical form ("Claude Opus 4.7") —
+-- people actually type "Opus 4.7", "Claude 4.7", "claude-opus-4.7", etc.
+-- These are editorial choices that benefit from per-agent curation.
+--
+-- Nullable + no default — empty / NULL means "no curated aliases yet,
+-- detection falls back to display_name exact-match", which is what the
+-- extension already does. Populate per agent with SQL like:
+--
+--   UPDATE agents
+--      SET aliases = ARRAY['Opus 4.7', 'Claude 4.7', 'claude-opus-4-7']
+--    WHERE handle = 'smoke-test-claude';
+
+ALTER TABLE agents
+  ADD COLUMN IF NOT EXISTS aliases TEXT[];

--- a/web/app/api/agents/route.ts
+++ b/web/app/api/agents/route.ts
@@ -1,0 +1,136 @@
+/**
+ * GET /api/agents
+ *
+ * Public, no-auth feed of LLM agents on the leaderboard, shaped for the
+ * AlphaMolt reply-writer Chrome extension (repo tobyrowland/x_replies).
+ *
+ * The extension fetches once per user per day. It uses the response to:
+ *   1. Detect LLM mentions in social posts via the `aliases` array
+ *      (whole-word, case-insensitive).
+ *   2. Inject the matched agent's rank + thesis into the system prompt
+ *      so Opus drafts a brief, sometimes-enigmatic reply that links to
+ *      https://www.alphamolt.ai/agent/<slug>.
+ *
+ * Shape:
+ *   {
+ *     "version": 1,
+ *     "updatedAt": "<ISO 8601>",
+ *     "entries": [
+ *       { "slug": "smoke-test-claude",
+ *         "name": "Claude Opus 4.7",
+ *         "aliases": ["Opus 4.7", ...],
+ *         "rank": 1,
+ *         "thesis": "<agents.description>" }
+ *     ]
+ *   }
+ *
+ * Filter: only agents that appear on the leaderboard view (i.e. have at
+ * least one portfolio_history snapshot). Pure-evaluation house agents
+ * with no portfolio fall out automatically.
+ *
+ * Rank: row position when sorted by pnl_pct DESC — matches the view's
+ * default ORDER BY and the homepage rankings card. The leaderboard
+ * /page/ may re-sort by 30d/YTD/etc., but rank-as-context for an LLM
+ * prompt is a single integer; all-time return is the canonical pick.
+ */
+
+import { errorResponse, jsonResponse, optionsResponse } from "@/lib/api-utils";
+import { getSupabase } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type LeaderboardRow = {
+  handle: string;
+  display_name: string;
+  pnl_pct: number | string | null;
+  snapshot_date: string | null;
+};
+
+type AgentRow = {
+  handle: string;
+  description: string | null;
+  aliases: string[] | null;
+};
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+export async function GET() {
+  try {
+    const supabase = getSupabase();
+
+    // 1. Pull leaderboard rows in canonical (pnl_pct DESC) order.
+    const { data: lbData, error: lbErr } = await supabase
+      .from("agent_leaderboard")
+      .select("handle, display_name, pnl_pct, snapshot_date")
+      .order("pnl_pct", { ascending: false });
+    if (lbErr) {
+      return errorResponse(lbErr.message, 500);
+    }
+    const rows = (lbData ?? []) as unknown as LeaderboardRow[];
+    if (rows.length === 0) {
+      return jsonResponse(
+        { version: 1, updatedAt: null, entries: [] },
+        { headers: cacheHeaders() },
+      );
+    }
+
+    // 2. Bulk-fetch description + aliases for those handles.
+    const handles = rows.map((r) => r.handle);
+    const { data: aData, error: aErr } = await supabase
+      .from("agents")
+      .select("handle, description, aliases")
+      .in("handle", handles);
+    if (aErr) {
+      return errorResponse(aErr.message, 500);
+    }
+    const meta = new Map<string, AgentRow>();
+    for (const a of (aData ?? []) as unknown as AgentRow[]) {
+      meta.set(a.handle, a);
+    }
+
+    // 3. Top-level updatedAt = latest snapshot_date across the rows
+    //    (anchored to midnight UTC for ISO 8601 cleanliness, mirroring
+    //    /api/consensus). Falls back to null if no rows have a date.
+    const latestDate = rows
+      .map((r) => r.snapshot_date)
+      .filter((d): d is string => Boolean(d))
+      .sort()
+      .pop();
+    const updatedAt = latestDate
+      ? new Date(`${latestDate}T00:00:00Z`).toISOString()
+      : null;
+
+    // 4. Shape entries; rank is the row index + 1.
+    const entries = rows.map((r, idx) => {
+      const m = meta.get(r.handle);
+      return {
+        slug: r.handle,
+        name: r.display_name,
+        aliases: m?.aliases ?? [],
+        rank: idx + 1,
+        ...(m?.description?.trim()
+          ? { thesis: m.description.trim() }
+          : {}),
+      };
+    });
+
+    return jsonResponse(
+      { version: 1, updatedAt, entries },
+      { headers: cacheHeaders() },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 500);
+  }
+}
+
+function cacheHeaders(): Record<string, string> {
+  // Daily client-side cache + once-per-day fetch cadence. CDN cache
+  // protects the origin from extension-install bursts.
+  return {
+    "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+  };
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/agents` — public, no-auth feed of LLM agents on the leaderboard, shaped for the reply-writer Chrome extension (repo `tobyrowland/x_replies`). Mirrors the design of `/api/consensus`: sidecar feed for one consumer, outside the public `/api/v1` surface, no OpenAPI entry, CORS-permissive, 1h CDN cache.

## Response shape

```json
{
  "version": 1,
  "updatedAt": "2026-05-04T00:00:00Z",
  "entries": [
    { "slug": "smoke-test-claude",
      "name": "Claude Opus 4.7",
      "aliases": ["Opus 4.7", "Claude 4.7"],
      "rank": 1,
      "thesis": "<agents.description>" }
  ]
}
```

## Field mapping decisions

- **`thesis` → `agents.description`** — existing public tagline (≤500 chars). Same pattern as `/api/consensus` mapping thesis → `companies.short_outlook`. Refresh in one place, no separate editorial step.
- **`aliases` → new `agents.aliases TEXT[]` column** (migration 013). Nullable; empty / NULL means no curated aliases yet, extension falls back to `display_name` exact-match. Auto-derivation only catches the canonical form; people actually type "Opus 4.7", "Claude 4.7", etc., and those are editorial choices that benefit from per-agent curation.
- **`rank` → row position in `agent_leaderboard`** sorted by `pnl_pct DESC`. All-time return is the canonical rank; the leaderboard page may re-sort but rank-as-prompt-context is a single integer.
- **Filter**: only agents that appear on the leaderboard view (i.e. have ≥ 1 portfolio_history snapshot). Pure-evaluation house agents with no portfolio fall out automatically.

## After merge

1. Run migration 013 in Supabase
2. Populate aliases per agent, e.g.:
   ```sql
   UPDATE agents SET aliases = ARRAY['Opus 4.7', 'Claude 4.7', 'claude-opus-4-7']
   WHERE handle = 'smoke-test-claude';

   UPDATE agents SET aliases = ARRAY['Gemini 3.1', 'Gemini 3.1 Pro', 'gemini-3.1-pro', 'Gemini Pro 3.1']
   WHERE handle = 'gemini-3-1-pro';

   UPDATE agents SET aliases = ARRAY['Grok 4.3', 'grok-4.3', 'Grok 4-3']
   WHERE handle = 'grok-4-3';
   ```

## Test plan

- [ ] `curl https://www.alphamolt.ai/api/agents` returns the JSON above
- [ ] `fetch('https://www.alphamolt.ai/api/agents').then(r => r.json()).then(console.log)` from any other origin's DevTools succeeds
- [ ] Each entry's derived URL `https://www.alphamolt.ai/agent/<slug>` returns 200
- [ ] At least one entry has populated `aliases` and `thesis`

https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ)_