### PR TITLE
Add GET /api/companies for the reply-writer Chrome extension

### DIFF
--- a/web/app/api/companies/route.ts
+++ b/web/app/api/companies/route.ts
@@ -1,0 +1,87 @@
+/**
+ * GET /api/companies
+ *
+ * Public, no-auth feed of every ticker AlphaMolt has a company page
+ * for — the superset that includes all consensus tickers + everything
+ * else in `companies`. Used by the reply-writer Chrome extension to
+ * verify a page exists before linking to /company/<TICKER>.
+ *
+ * Sibling of /api/consensus and /api/agents — same shape conventions
+ * (CORS-permissive, 1h CDN cache, daily client cache).
+ *
+ * Invariant: consensus_snapshots tickers are written by the heartbeat,
+ * which can only buy tickers present in `companies` (PortfolioManager
+ * validates via get_price()). So consensus is a strict subset of
+ * companies by construction — the extension can rely on it.
+ *
+ * Filter: any row with a non-null ticker, regardless of in_tv_screen.
+ * The /company/[ticker] page renders any ticker that exists in the
+ * table, so we shouldn't pre-filter to the active screen.
+ */
+
+import { errorResponse, jsonResponse, optionsResponse } from "@/lib/api-utils";
+import { getSupabase } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type CompanyRow = {
+  ticker: string;
+  company_name: string | null;
+  updated_at: string | null;
+};
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+export async function GET() {
+  try {
+    const supabase = getSupabase();
+
+    const { data, error } = await supabase
+      .from("companies")
+      .select("ticker, company_name, updated_at")
+      .not("ticker", "is", null)
+      .order("ticker", { ascending: true });
+    if (error) {
+      return errorResponse(error.message, 500);
+    }
+    const rows = (data ?? []) as unknown as CompanyRow[];
+
+    // Dedupe by ticker (first occurrence wins per the brief).
+    const seen = new Set<string>();
+    const entries: Array<{ ticker: string; name?: string }> = [];
+    let latestUpdate = 0;
+    for (const r of rows) {
+      const ticker = r.ticker?.trim().toUpperCase();
+      if (!ticker || seen.has(ticker)) continue;
+      seen.add(ticker);
+      const name = r.company_name?.trim();
+      entries.push(name ? { ticker, name } : { ticker });
+      if (r.updated_at) {
+        const t = Date.parse(r.updated_at);
+        if (!Number.isNaN(t) && t > latestUpdate) latestUpdate = t;
+      }
+    }
+
+    return jsonResponse(
+      {
+        version: 1,
+        updatedAt:
+          latestUpdate > 0 ? new Date(latestUpdate).toISOString() : null,
+        entries,
+      },
+      { headers: cacheHeaders() },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 500);
+  }
+}
+
+function cacheHeaders(): Record<string, string> {
+  return {
+    "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+  };
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/companies` — the third sibling of `/api/consensus` (#639) and `/api/agents` (#646). Public, no-auth, CORS-permissive, 1h CDN cache. Returns the superset of every ticker AlphaMolt has a `/company/<TICKER>` page for, so the reply-writer extension can verify a page exists before linking from a draft.

## Response shape

```json
{
  "version": 1,
  "updatedAt": "2026-05-04T12:34:00Z",
  "entries": [
    { "ticker": "SEZL", "name": "Sezzle Inc." },
    { "ticker": "RDDT", "name": "Reddit, Inc." }
  ]
}
```

## Implementation notes

- **Filter is "any row with a non-null ticker"** — no `in_tv_screen` gate, because `/company/[ticker]/page.tsx` renders any row that exists in the table (it only 404s when the row is absent). Pre-filtering would leave gaps the extension treats as missing pages.
- **Dedupe by uppercase-trimmed ticker**, first occurrence wins. The schema's UNIQUE constraint on `ticker` means this should be a no-op, but the brief calls it out as an invariant so we honor it.
- **`updatedAt` is the MAX of the included rows' `updated_at`**, computed from the same query result rather than a separate aggregate — cheaper, and the value naturally moves forward whenever `eodhd_updater` or `update_ai_narratives` writes.
- **Consensus-is-a-subset invariant** holds by construction: `consensus_snapshots` rows come from `agent_holdings` → PortfolioManager buys → validated against `companies`. No code-level assertion needed.

## Test plan

- [ ] `curl https://www.alphamolt.ai/api/companies` returns the JSON above
- [ ] CORS check from a non-AlphaMolt origin succeeds
- [ ] Spot-check 5 random entries — each `https://www.alphamolt.ai/company/<TICKER>` returns 200
- [ ] Set-difference check: every `ticker` in `/api/consensus` also appears in `/api/companies`

https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ)_