### PR TITLE
Agent-focused redesign of /company/[ticker] + dynamic OG card

### DIFF
--- a/web/app/company/[ticker]/opengraph-image.tsx
+++ b/web/app/company/[ticker]/opengraph-image.tsx
@@ -1,0 +1,107 @@
+/**
+ * Dynamic OG card for /company/[ticker]. Renders the agent verdict +
+ * top-3 holders + a single trade-tape line per the locked mockup.
+ *
+ * Falls back to a clean empty-state card when:
+ *   - the ticker isn't in the companies table (treats it as 404 → returns
+ *     a generic "AlphaMolt" card to avoid breaking link previews)
+ *   - the ticker has no agent holders yet (right column hidden, hero
+ *     shows "No AI agents hold this yet")
+ */
+
+import { ImageResponse } from "next/og";
+import { getSupabase } from "@/lib/supabase";
+import {
+  getCompanySwarmSnapshot,
+  getCompanyTradeTape,
+  type CompanyTrade,
+} from "@/lib/company-agents-query";
+import {
+  OG_ALT,
+  OG_SIZE,
+  renderCompanyOg,
+} from "@/lib/company-og";
+
+export const runtime = "nodejs";
+export const revalidate = 3600;
+export const alt = OG_ALT;
+export const size = OG_SIZE;
+export const contentType = "image/png";
+
+const TRADE_TAPE_MAX_CHARS = 90;
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ ticker: string }>;
+}) {
+  const { ticker: rawTicker } = await params;
+  const ticker = decodeURIComponent(rawTicker).toUpperCase();
+
+  let company_name: string | null = null;
+  let snapshot: Awaited<
+    ReturnType<typeof getCompanySwarmSnapshot>
+  > | null = null;
+  let latestTrade: CompanyTrade | null = null;
+
+  try {
+    const supabase = getSupabase();
+    const [companyRes, snap, trades] = await Promise.all([
+      supabase
+        .from("companies")
+        .select("company_name")
+        .eq("ticker", ticker)
+        .maybeSingle(),
+      getCompanySwarmSnapshot(ticker),
+      getCompanyTradeTape(ticker, 1),
+    ]);
+    company_name =
+      (companyRes.data as { company_name: string | null } | null)
+        ?.company_name ?? null;
+    snapshot = snap;
+    latestTrade = trades[0] ?? null;
+  } catch (err) {
+    // Don't break social previews on a Supabase blip — fall through to
+    // an empty card.
+    console.error(`og /company/${ticker} fetch failed:`, err);
+  }
+
+  const numAgents = snapshot?.num_agents ?? 0;
+  const totalAgents = snapshot?.total_agents ?? 0;
+  const pctAgents = snapshot?.pct_agents ?? 0;
+  const swarmPnlPct = snapshot?.swarm_pnl_pct ?? null;
+  const snapshotDate = snapshot?.snapshot_date ?? null;
+  const topHolders = snapshot?.top_holders ?? [];
+
+  return new ImageResponse(
+    renderCompanyOg({
+      ticker,
+      company_name,
+      num_agents: numAgents,
+      total_agents: totalAgents,
+      pct_agents: pctAgents,
+      swarm_pnl_pct: swarmPnlPct,
+      snapshot_date: snapshotDate,
+      top_holders: topHolders,
+      latest_trade_text: latestTrade
+        ? formatTradeTapeLine(latestTrade)
+        : null,
+    }),
+    {
+      ...size,
+      headers: {
+        "Cache-Control":
+          "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800",
+      },
+    },
+  );
+}
+
+function formatTradeTapeLine(t: CompanyTrade): string {
+  const head = `@${t.handle} ${t.side === "buy" ? "bought" : "sold"} ${t.quantity} @ $${t.price_usd.toFixed(2)}`;
+  if (!t.note) return head;
+  const tail = ` — "${t.note}"`;
+  const line = `${head}${tail}`;
+  if (line.length <= TRADE_TAPE_MAX_CHARS) return line;
+  return `${line.slice(0, TRADE_TAPE_MAX_CHARS - 1)}…`;
+}

--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -15,26 +15,46 @@ import {
 import { absoluteUrl } from "@/lib/site";
 import Nav from "@/components/nav";
 import PsChart from "@/components/ps-chart";
+import ShareRow from "@/components/share-row";
+import {
+  countBuysSince,
+  getCompanyHolders,
+  getCompanySwarmSnapshot,
+  getCompanyTradeTape,
+  getHeartbeatRationales,
+  type CompanyHolder,
+  type CompanySwarmSnapshot,
+  type CompanyTrade,
+  type HeartbeatRationale,
+} from "@/lib/company-agents-query";
 
 export const revalidate = 600;
 
 async function getData(ticker: string) {
   const supabase = getSupabase();
-  const [companyRes, psRes] = await Promise.all([
-    supabase.from("companies").select("*").eq("ticker", ticker).single(),
-    supabase.from("price_sales").select("*").eq("ticker", ticker).single(),
-  ]);
+  const [companyRes, psRes, swarm, holders, trades, rationales] =
+    await Promise.all([
+      supabase.from("companies").select("*").eq("ticker", ticker).single(),
+      supabase.from("price_sales").select("*").eq("ticker", ticker).single(),
+      getCompanySwarmSnapshot(ticker),
+      getCompanyHolders(ticker),
+      getCompanyTradeTape(ticker, 25),
+      getHeartbeatRationales(ticker, 4),
+    ]);
 
   return {
     company: companyRes.data as Company | null,
     priceSales: psRes.data as PriceSales | null,
+    swarm,
+    holders,
+    trades,
+    rationales,
   };
 }
 
-// SEO metadata. Next.js runs this for every request alongside the page, so
-// we fetch only the 5 columns we need for title/description to keep it cheap.
-// Falls back to generic "ticker not found" metadata for missing companies
-// rather than crashing, since the page itself handles 404 via notFound().
+// SEO metadata. Locked title format pairs with the new opengraph-image so
+// X / Bluesky / Slack previews share a consistent "Agent Verdict & Trade
+// Journal" framing.
 export async function generateMetadata({
   params,
 }: {
@@ -59,16 +79,8 @@ export async function generateMetadata({
     }
 
     const name = (data.company_name as string | null) ?? ticker;
-    const sector = (data.sector as string | null) ?? "equity";
-    // Prefer the short outlook (1–2 sentences, written for humans) over the
-    // fundamentals description. Trim to ~155 chars for SERP width.
-    const raw =
-      (data.short_outlook as string | null) ??
-      (data.description as string | null) ??
-      `${name} (${ticker}) — ${sector} equity tracked by AlphaMolt with AI narrative, fundamentals, and P/S history.`;
-    const description = raw.length > 155 ? `${raw.slice(0, 152)}...` : raw;
-
-    const title = `${name} (${ticker}) — ${sector} stock analysis`;
+    const description = `AI agent verdict on ${name} (${ticker}): who holds it, what they paid, and the live trade tape with per-pick rationales.`;
+    const title = `AlphaMolt — ${ticker} Agent Verdict & Trade Journal`;
     const canonical = `/company/${encodeURIComponent(ticker)}`;
 
     return {
@@ -93,8 +105,7 @@ export async function generateMetadata({
   }
 }
 
-// Breadcrumb JSON-LD helper. Rendered as a <script> inside the page body so
-// Google can build rich-result breadcrumbs above the SERP snippet.
+// Breadcrumb JSON-LD helper.
 function breadcrumbJsonLd(ticker: string, name: string | null) {
   const display = name ?? ticker;
   return {
@@ -129,7 +140,9 @@ export default async function CompanyPage({
   params: Promise<{ ticker: string }>;
 }) {
   const { ticker } = await params;
-  const { company, priceSales } = await getData(decodeURIComponent(ticker));
+  const decoded = decodeURIComponent(ticker);
+  const { company, priceSales, swarm, holders, trades, rationales } =
+    await getData(decoded);
 
   if (!company) notFound();
 
@@ -138,6 +151,7 @@ export default async function CompanyPage({
   const bull = parseEval(company.bull_eval);
   const bearRationale = extractEvalRationale(company.bear_eval);
   const bullRationale = extractEvalRationale(company.bull_eval);
+
   // Defensive: flags may be a dict OR a stringified JSON string (legacy data)
   let flags: Record<string, string> = {};
   const rawFlags = company.flags;
@@ -153,7 +167,19 @@ export default async function CompanyPage({
     }
   }
 
+  // "Bulls won this week" — count buys since last bull_eval refresh.
+  // Falls back to past 7 days when bull_eval_at is null.
+  const bullSince =
+    company.bull_eval_at ??
+    new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const buysSinceEval = await countBuysSince(decoded, bullSince);
+
   const breadcrumb = breadcrumbJsonLd(company.ticker, company.company_name);
+  const shareUrl = absoluteUrl(`/company/${encodeURIComponent(decoded)}`);
+  const shareText =
+    swarm.num_agents > 0
+      ? `${swarm.num_agents} of ${swarm.total_agents} AI agents hold $${decoded} on AlphaMolt — see who, when, and why.`
+      : `AlphaMolt's agent verdict on $${decoded} — fundamentals, AI narrative, and the live trade tape.`;
 
   return (
     <>
@@ -171,178 +197,499 @@ export default async function CompanyPage({
           &larr; Back to Screener
         </Link>
 
-        {/* Header */}
-        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
-          <div>
-            <div className="flex items-center gap-3 mb-1">
-              <h1 className="font-mono text-2xl font-bold text-green">
-                {company.ticker}
-              </h1>
-              <span
-                className="text-xs px-2 py-0.5 rounded font-mono"
-                title={status.detail ?? status.label}
-                style={{
-                  color: status.color,
-                  backgroundColor: status.color + "15",
-                }}
-              >
-                {status.label}
-              </span>
+        {/* 1. Hero — Agent Verdict */}
+        <HeroSection
+          company={company}
+          status={status}
+          swarm={swarm}
+        />
+
+        {/* 2. Holders Strip */}
+        <HoldersStrip holders={holders} />
+
+        {/* 3. Trade Tape */}
+        <TradeTape trades={trades} />
+
+        {/* 4. House Bull vs Bear */}
+        <HouseBullBear
+          bullColor={bull.color}
+          bullLabel={bull.label}
+          bullRationale={bullRationale}
+          bearColor={bear.color}
+          bearLabel={bear.label}
+          bearRationale={bearRationale}
+          buysSinceEval={buysSinceEval}
+          totalAgents={swarm.total_agents}
+        />
+
+        {/* 5. Live LLM rationales — only when data exists */}
+        {rationales.length > 0 && <LiveRationales rationales={rationales} />}
+
+        {/* 6. AI Outlook (collapsed) */}
+        <AiOutlook company={company} />
+
+        {/* 7. By the Numbers + Show all metrics */}
+        <ByTheNumbers company={company} priceSales={priceSales} flags={flags} />
+
+        {/* 8. P/S History Chart */}
+        {priceSales && (
+          <section className="mt-6">
+            <SectionHeader>P/S History</SectionHeader>
+            <div className="glass-card rounded-lg p-4">
+              <div className="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-4">
+                <Metric
+                  label="Current"
+                  value={formatNumber(priceSales.ps_now, { decimals: 1 })}
+                />
+                <Metric
+                  label="52w High"
+                  value={formatNumber(priceSales.high_52w, { decimals: 1 })}
+                />
+                <Metric
+                  label="52w Low"
+                  value={formatNumber(priceSales.low_52w, { decimals: 1 })}
+                />
+                <Metric
+                  label="12m Median"
+                  value={formatNumber(priceSales.median_12m, { decimals: 1 })}
+                />
+                <Metric
+                  label="ATH"
+                  value={formatNumber(priceSales.ath, { decimals: 1 })}
+                />
+              </div>
+              {priceSales.history_json &&
+                priceSales.history_json.length > 0 && (
+                  <PsChart data={priceSales.history_json} />
+                )}
             </div>
-            {status.detail && (
-              <p className="text-xs font-mono mt-1" style={{ color: status.color }}>
-                {status.detail}
-              </p>
-            )}
-            <p className="text-text-dim text-sm">
-              {company.company_name} &middot; {company.exchange} &middot;{" "}
-              {company.country}
-            </p>
-            <p className="text-text-dim text-xs mt-1">{company.sector}</p>
-            {company.description && (
-              <p className="text-text-muted text-sm mt-2 max-w-xl">
-                {company.description}
-              </p>
+          </section>
+        )}
+
+        {/* 9. Footer — data freshness + share */}
+        <footer className="mt-10 pt-4 border-t border-border/40 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 text-xs font-mono text-text-muted">
+          <div>
+            <span className="mr-3">
+              AI analyzed:{" "}
+              <span className="text-text-dim">
+                {company.ai_analyzed_at ?? "—"}
+              </span>
+            </span>
+            <span className="mr-3">
+              Data updated:{" "}
+              <span className="text-text-dim">
+                {company.data_updated_at ?? "—"}
+              </span>
+            </span>
+            {swarm.snapshot_date && (
+              <span>
+                Swarm snapshot:{" "}
+                <span className="text-text-dim">{swarm.snapshot_date}</span>
+              </span>
             )}
           </div>
-          <div className="text-right font-mono">
-            <p className="text-2xl font-bold">{formatPrice(company.price)}</p>
-            <p className="text-xs text-text-muted">
-              Rank #{company.sort_order ?? "--"} &middot; Score{" "}
-              {formatNumber(company.composite_score, { decimals: 1 })}
-            </p>
-          </div>
+          <ShareRow url={shareUrl} text={shareText} />
+        </footer>
+      </main>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
+
+function HeroSection({
+  company,
+  status,
+  swarm,
+}: {
+  company: Company;
+  status: ReturnType<typeof parseStatus>;
+  swarm: CompanySwarmSnapshot;
+}) {
+  const hasAgents = swarm.num_agents > 0;
+  const pnlColor =
+    swarm.swarm_pnl_pct == null
+      ? COLORS.textMuted
+      : swarm.swarm_pnl_pct >= 0
+      ? "var(--tw-color-green, #00FF41)"
+      : "#FF3333";
+
+  return (
+    <section
+      className="rounded-xl p-6 mb-6 relative overflow-hidden"
+      style={{
+        background:
+          "linear-gradient(140deg, rgba(0,255,65,0.08) 0%, rgba(0,40,20,0.18) 30%, rgba(10,10,10,0.9) 100%)",
+        border: "1px solid rgba(0,255,65,0.18)",
+      }}
+    >
+      <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+        {/* Ticker + name */}
+        <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+          <h1 className="font-mono text-5xl font-bold text-green leading-none">
+            {company.ticker}
+          </h1>
+          <p className="text-text-dim text-2xl leading-tight">
+            {company.company_name}
+          </p>
+          <span
+            className="text-[11px] px-2 py-0.5 rounded font-mono uppercase tracking-wider"
+            title={status.detail ?? status.label}
+            style={{
+              color: status.color,
+              backgroundColor: status.color + "1f",
+            }}
+          >
+            {status.label}
+          </span>
         </div>
 
-        {/* Bento grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {/* Screening */}
-          <Card title="Screening Metrics">
-            <Metric label="P/S Ratio" value={formatNumber(company.ps_now, { decimals: 1 })} flag={flags.ps_now} />
-            <Metric label="52w High %" value={formatPct(company.price_pct_of_52w_high ? company.price_pct_of_52w_high * 100 : null)} />
-            <Metric label="52w vs SPY" value={formatPct(company.perf_52w_vs_spy ? company.perf_52w_vs_spy * 100 : null)} />
-            <Metric label="Rating" value={formatNumber(company.rating, { decimals: 1 })} />
-            <Metric label="R40 Score" value={company.r40_score || "--"} />
-          </Card>
-
-          {/* Revenue */}
-          <Card title="Revenue">
-            <Metric label="Rev Growth TTM" value={formatPct(company.rev_growth_ttm_pct)} flag={flags.rev_growth_ttm_pct} />
-            <Metric label="Rev Growth QoQ" value={formatPct(company.rev_growth_qoq_pct)} />
-            <Metric label="Rev CAGR 3Y" value={formatPct(company.rev_cagr_pct)} />
-            <Metric label="Consistency" value={company.rev_consistency_score || "--"} />
-            {company.quarterly_revenue && (
-              <div className="mt-2 pt-2 border-t border-border/50">
-                <p className="text-xs text-text-muted mb-1">Quarterly</p>
-                <p className="text-xs text-text-dim break-words">{company.quarterly_revenue}</p>
-              </div>
-            )}
-          </Card>
-
-          {/* Margins */}
-          <Card title="Margins">
-            <Metric label="Gross Margin" value={formatPct(company.gross_margin_pct)} flag={flags.gross_margin_pct} />
-            <Metric label="GM Trend" value={company.gm_trend || "--"} />
-            <Metric label="Operating Margin" value={formatPct(company.operating_margin_pct)} />
-            <Metric label="Net Margin" value={formatPct(company.net_margin_pct)} flag={flags.net_margin_pct} />
-            <Metric label="Net Margin YoY" value={formatPct(company.net_margin_yoy_pct)} />
-            <Metric label="FCF Margin" value={formatPct(company.fcf_margin_pct)} flag={flags.fcf_margin_pct} />
-          </Card>
-
-          {/* Efficiency */}
-          <Card title="Efficiency">
-            <Metric label="OpEx/Revenue" value={formatPct(company.opex_pct_revenue)} />
-            <Metric label="S&M+R&D/Revenue" value={formatPct(company.sm_rd_pct_revenue)} />
-            <Metric label="Rule of 40" value={formatNumber(company.rule_of_40, { decimals: 1 })} flag={flags.rule_of_40} />
-            <Metric label="Qtrs to Profit" value={company.qrtrs_to_profitability || "--"} />
-          </Card>
-
-          {/* Earnings */}
-          <Card title="Earnings">
-            <Metric label="EPS" value={formatNumber(company.eps_only, { prefix: "$", decimals: 2 })} />
-            <Metric label="EPS YoY" value={formatPct(company.eps_yoy_pct)} />
-          </Card>
-
-          {/* Evaluations — full width so rationale text has room */}
-          <div className="md:col-span-2 lg:col-span-3">
-            <Card title="Example Agent Evaluations">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {/* Bear */}
-                <div className="border-l-2 pl-3" style={{ borderColor: bear.color }}>
-                  <div className="flex items-baseline gap-2 mb-2">
-                    <span
-                      className="font-mono text-xs uppercase tracking-wider"
-                      style={{ color: COLORS.textMuted }}
-                    >
-                      Bear (Fundamental Sentinel)
-                    </span>
-                    <span
-                      className="font-mono text-sm font-bold"
-                      style={{ color: bear.color }}
-                    >
-                      {bear.label}
-                    </span>
-                  </div>
-                  {bearRationale ? (
-                    <p className="text-sm text-text-dim leading-relaxed">
-                      {bearRationale}
-                    </p>
-                  ) : (
-                    <p className="text-xs text-text-muted italic">
-                      No rationale provided
-                    </p>
-                  )}
-                </div>
-
-                {/* Bull */}
-                <div className="border-l-2 pl-3" style={{ borderColor: bull.color }}>
-                  <div className="flex items-baseline gap-2 mb-2">
-                    <span
-                      className="font-mono text-xs uppercase tracking-wider"
-                      style={{ color: COLORS.textMuted }}
-                    >
-                      Bull (Smash-Hit Scout)
-                    </span>
-                    <span
-                      className="font-mono text-sm font-bold"
-                      style={{ color: bull.color }}
-                    >
-                      {bull.label}
-                    </span>
-                  </div>
-                  {bullRationale ? (
-                    <p className="text-sm text-text-dim leading-relaxed">
-                      {bullRationale}
-                    </p>
-                  ) : (
-                    <p className="text-xs text-text-muted italic">
-                      No rationale provided
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              {company.in_portfolio && (
-                <div className="mt-4 pt-3 border-t border-border/50">
-                  <span className="text-xs font-mono text-green">
-                    ✓ Selected by example agent (portfolio rank #{company.portfolio_sort_order ?? "--"})
+        {/* Right-aligned agent verdict line */}
+        <div className="flex flex-col items-start lg:items-end font-mono">
+          {hasAgents ? (
+            <p className="text-xl text-text">
+              <span className="font-bold text-green">{swarm.num_agents}</span>
+              <span className="text-text-muted"> / </span>
+              <span className="font-bold">{swarm.total_agents}</span>{" "}
+              <span className="text-text-dim">agents hold this</span>
+              {swarm.earliest_held_since && (
+                <span className="text-text-muted">
+                  {" "}
+                  · since {swarm.earliest_held_since}
+                </span>
+              )}
+            </p>
+          ) : (
+            <p className="text-xl text-text-dim">No agents hold this yet</p>
+          )}
+          {hasAgents && (
+            <p className="text-xs text-text-muted mt-1">
+              swarm avg entry{" "}
+              <span className="text-text-dim">
+                {formatPrice(swarm.swarm_avg_entry)}
+              </span>{" "}
+              · current{" "}
+              <span className="text-text-dim">
+                {formatPrice(swarm.current_price ?? company.price)}
+              </span>
+              {swarm.swarm_pnl_pct != null && (
+                <>
+                  {" "}
+                  · swarm P&amp;L{" "}
+                  <span style={{ color: pnlColor }} className="font-bold">
+                    {swarm.swarm_pnl_pct >= 0 ? "+" : ""}
+                    {swarm.swarm_pnl_pct.toFixed(1)}%
                   </span>
-                </div>
+                </>
               )}
-            </Card>
-          </div>
+            </p>
+          )}
+        </div>
+      </div>
 
-          {/* AI Narrative — full width */}
-          <div className="md:col-span-2 lg:col-span-3">
-            <Card title="AI Narrative">
-              {company.short_outlook && (
-                <div className="mb-4">
-                  <p className="text-xs text-text-muted mb-1">Outlook</p>
-                  <p className="text-sm text-text">{company.short_outlook}</p>
-                </div>
-              )}
+      {/* Subline: exchange · country · sector */}
+      <p className="text-text-muted text-xs mt-3 font-mono">
+        {company.exchange} · {company.country} · {company.sector}
+      </p>
+    </section>
+  );
+}
+
+function HoldersStrip({ holders }: { holders: CompanyHolder[] }) {
+  if (holders.length === 0) {
+    return (
+      <section className="mb-6">
+        <SectionHeader>Holders</SectionHeader>
+        <div className="glass-card rounded-lg p-4 text-sm text-text-muted">
+          No agents currently hold this.
+        </div>
+      </section>
+    );
+  }
+
+  const visible = holders.slice(0, 6);
+  const overflow = holders.length - visible.length;
+
+  return (
+    <section className="mb-6">
+      <SectionHeader>Holders</SectionHeader>
+      <div className="flex gap-3 overflow-x-auto pb-2 -mx-1 px-1">
+        {visible.map((h) => (
+          <HolderCard key={h.handle} holder={h} />
+        ))}
+        {overflow > 0 && (
+          <div
+            className="shrink-0 self-stretch min-w-[90px] flex items-center justify-center rounded-lg border border-border/60 text-text-muted text-xs font-mono"
+            style={{ background: "rgba(255,255,255,0.02)" }}
+          >
+            +{overflow} more
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function HolderCard({ holder }: { holder: CompanyHolder }) {
+  const positive = holder.pnl_pct != null && holder.pnl_pct >= 0;
+  const pnlBg = positive ? "rgba(0,255,65,0.10)" : "rgba(255,51,51,0.10)";
+  const pnlColor = positive ? "#00FF41" : "#FF3333";
+
+  return (
+    <Link
+      href={`/u/${holder.handle}`}
+      className="shrink-0 w-[200px] glass-card rounded-lg p-3 hover:border-green/40 border border-border/60 transition-colors"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-sm font-bold text-text truncate flex-1">
+          {holder.display_name}
+        </span>
+        {holder.is_house_agent && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-text-muted/15 text-text-muted font-mono uppercase tracking-wider">
+            House
+          </span>
+        )}
+      </div>
+      <div className="flex items-baseline gap-2 text-xs font-mono text-text-dim">
+        <span>{formatNumber(holder.quantity, { decimals: 0 })} qty</span>
+        <span className="text-text-muted">·</span>
+        <span>${holder.avg_cost_usd.toFixed(2)}</span>
+      </div>
+      <div className="flex items-center justify-between mt-2">
+        {holder.pnl_pct != null ? (
+          <span
+            className="text-xs font-mono font-bold px-1.5 py-0.5 rounded"
+            style={{ background: pnlBg, color: pnlColor }}
+          >
+            {positive ? "+" : ""}
+            {holder.pnl_pct.toFixed(1)}%
+          </span>
+        ) : (
+          <span className="text-xs text-text-muted">—</span>
+        )}
+        {holder.days_held != null && (
+          <span className="text-xs font-mono text-text-muted">
+            {holder.days_held}d
+          </span>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+function TradeTape({ trades }: { trades: CompanyTrade[] }) {
+  if (trades.length === 0) {
+    return (
+      <section className="mb-6">
+        <SectionHeader>Trade Tape — agent journal</SectionHeader>
+        <div className="glass-card rounded-lg p-4 text-sm text-text-muted">
+          No trades recorded yet.
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mb-6">
+      <SectionHeader>Trade Tape — agent journal</SectionHeader>
+      <div className="glass-card rounded-lg overflow-hidden">
+        <ul className="divide-y divide-border/40">
+          {trades.map((t) => (
+            <TradeRow key={t.id} trade={t} />
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function TradeRow({ trade }: { trade: CompanyTrade }) {
+  const isBuy = trade.side === "buy";
+  const stripeColor = isBuy ? "#00FF41" : "#FF3333";
+  const sideLabel = isBuy ? "BOUGHT" : "SOLD";
+  const ago = formatRelative(trade.executed_at);
+
+  return (
+    <li
+      className="pl-3 pr-4 py-3 flex flex-col gap-1"
+      style={{ borderLeft: `3px solid ${stripeColor}` }}
+    >
+      <div className="flex flex-wrap items-baseline gap-2 text-sm font-mono">
+        <Link
+          href={`/u/${trade.handle}`}
+          className="text-text font-bold hover:text-green"
+        >
+          [{trade.display_name}]
+        </Link>
+        <span className="font-bold" style={{ color: stripeColor }}>
+          {sideLabel}
+        </span>
+        <span className="text-text-dim">
+          {formatNumber(trade.quantity, { decimals: 0 })} @ $
+          {trade.price_usd.toFixed(2)}
+        </span>
+        <span className="text-text-muted text-xs">· {ago}</span>
+      </div>
+      {trade.note && (
+        <p className="text-xs text-text-muted italic pl-1 leading-relaxed">
+          {trade.note}
+        </p>
+      )}
+    </li>
+  );
+}
+
+function HouseBullBear({
+  bullColor,
+  bullLabel,
+  bullRationale,
+  bearColor,
+  bearLabel,
+  bearRationale,
+  buysSinceEval,
+  totalAgents,
+}: {
+  bullColor: string;
+  bullLabel: string;
+  bullRationale: string | null;
+  bearColor: string;
+  bearLabel: string;
+  bearRationale: string | null;
+  buysSinceEval: number;
+  totalAgents: number;
+}) {
+  return (
+    <section className="mb-6">
+      <SectionHeader>House Bull vs Bear</SectionHeader>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div
+          className="rounded-lg p-4 border"
+          style={{
+            background: "rgba(0,255,65,0.04)",
+            borderColor: "rgba(0,255,65,0.18)",
+          }}
+        >
+          <div className="flex items-baseline gap-2 mb-2">
+            <span className="font-mono text-xs uppercase tracking-wider text-text-muted">
+              Smash-Hit Scout (Bull)
+            </span>
+            <span
+              className="font-mono text-sm font-bold"
+              style={{ color: bullColor }}
+            >
+              {bullLabel}
+            </span>
+          </div>
+          {bullRationale ? (
+            <p className="text-sm text-text-dim leading-relaxed">
+              {bullRationale}
+            </p>
+          ) : (
+            <p className="text-xs text-text-muted italic">Not yet evaluated</p>
+          )}
+        </div>
+        <div
+          className="rounded-lg p-4 border"
+          style={{
+            background: "rgba(255,51,51,0.04)",
+            borderColor: "rgba(255,51,51,0.18)",
+          }}
+        >
+          <div className="flex items-baseline gap-2 mb-2">
+            <span className="font-mono text-xs uppercase tracking-wider text-text-muted">
+              Fundamental Sentinel (Bear)
+            </span>
+            <span
+              className="font-mono text-sm font-bold"
+              style={{ color: bearColor }}
+            >
+              {bearLabel}
+            </span>
+          </div>
+          {bearRationale ? (
+            <p className="text-sm text-text-dim leading-relaxed">
+              {bearRationale}
+            </p>
+          ) : (
+            <p className="text-xs text-text-muted italic">Not yet evaluated</p>
+          )}
+        </div>
+      </div>
+      {totalAgents > 0 && (
+        <p className="text-xs text-text-muted mt-3 font-mono">
+          {buysSinceEval > 0
+            ? `Bulls won this week — ${buysSinceEval} ${
+                buysSinceEval === 1 ? "agent" : "agents"
+              } bought after last Sunday's eval.`
+            : `No buys recorded since the last Sunday eval.`}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function LiveRationales({
+  rationales,
+}: {
+  rationales: HeartbeatRationale[];
+}) {
+  return (
+    <section className="mb-6">
+      <SectionHeader>Live LLM rationales</SectionHeader>
+      <div className="glass-card rounded-lg p-4 space-y-3">
+        {rationales.map((r, i) => (
+          <div
+            key={`${r.handle}-${r.started_at}-${i}`}
+            className="flex flex-col gap-1"
+          >
+            <p className="text-sm text-text-dim italic leading-relaxed">
+              &ldquo;{r.rationale}&rdquo;
+            </p>
+            <p className="text-xs font-mono text-text-muted text-right">
+              — {r.model_label}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AiOutlook({ company }: { company: Company }) {
+  const hasMore =
+    !!(
+      company.full_outlook ||
+      company.key_risks ||
+      company.fundamentals_snapshot ||
+      company.event_impact
+    );
+
+  return (
+    <section className="mb-6">
+      <SectionHeader>AI Outlook</SectionHeader>
+      <div className="glass-card rounded-lg p-4">
+        {company.short_outlook ? (
+          <p className="text-sm text-text leading-relaxed">
+            {company.short_outlook}
+          </p>
+        ) : (
+          <p className="text-sm text-text-muted italic">
+            No outlook recorded yet.
+          </p>
+        )}
+        {hasMore && (
+          <details className="mt-3 group">
+            <summary className="text-xs font-mono text-text-muted hover:text-green cursor-pointer select-none">
+              <span className="group-open:hidden">Show full narrative ▼</span>
+              <span className="hidden group-open:inline">
+                Hide full narrative ▲
+              </span>
+            </summary>
+            <div className="mt-3 space-y-3 pt-3 border-t border-border/40">
               {company.full_outlook && (
-                <div className="mb-4">
+                <div>
                   <p className="text-xs text-text-muted mb-1">Full Outlook</p>
                   <p className="text-sm text-text-dim leading-relaxed whitespace-pre-wrap">
                     {company.full_outlook}
@@ -350,53 +697,249 @@ export default async function CompanyPage({
                 </div>
               )}
               {company.key_risks && (
-                <div className="mb-4">
+                <div>
                   <p className="text-xs text-text-muted mb-1">Key Risks</p>
-                  <p className="text-sm text-orange">{company.key_risks}</p>
+                  <p className="text-sm text-orange leading-relaxed">
+                    {company.key_risks}
+                  </p>
                 </div>
               )}
               {company.fundamentals_snapshot && (
-                <div className="mb-4">
-                  <p className="text-xs text-text-muted mb-1">Fundamentals Snapshot</p>
-                  <p className="text-sm text-text-dim">{company.fundamentals_snapshot}</p>
+                <div>
+                  <p className="text-xs text-text-muted mb-1">
+                    Fundamentals Snapshot
+                  </p>
+                  <p className="text-sm text-text-dim leading-relaxed">
+                    {company.fundamentals_snapshot}
+                  </p>
                 </div>
               )}
               {company.event_impact && (
                 <div>
                   <p className="text-xs text-text-muted mb-1">Event Impact</p>
-                  <p className="text-sm text-text-dim">{company.event_impact}</p>
+                  <p className="text-sm text-text-dim leading-relaxed">
+                    {company.event_impact}
+                  </p>
+                </div>
+              )}
+            </div>
+          </details>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ByTheNumbers({
+  company,
+  priceSales,
+  flags,
+}: {
+  company: Company;
+  priceSales: PriceSales | null;
+  flags: Record<string, string>;
+}) {
+  // Score arrow mirrors the up/down indicator in the mockup. We don't
+  // have a delta, so we just use score >=50 as "up" / else "down" — a
+  // visual flourish, not a metric.
+  const score = company.composite_score;
+  const scoreArrow =
+    score == null ? "" : score >= 50 ? "▲" : "▼";
+  const scoreColor =
+    score == null
+      ? COLORS.textMuted
+      : score >= 50
+      ? "#00FF41"
+      : "#FFD700";
+
+  return (
+    <section className="mb-6">
+      <SectionHeader>By the Numbers</SectionHeader>
+      <div className="glass-card rounded-lg p-4">
+        <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-4">
+          <CompactStat
+            label="Price"
+            value={formatPrice(company.price)}
+          />
+          <CompactStat
+            label="P/S"
+            value={formatNumber(company.ps_now, { decimals: 2 })}
+          />
+          <CompactStat
+            label="P/S median"
+            value={formatNumber(priceSales?.median_12m, { decimals: 2 })}
+          />
+          <CompactStat
+            label="Rev TTM growth"
+            value={formatPct(company.rev_growth_ttm_pct)}
+          />
+          <CompactStat
+            label="Gross margin"
+            value={formatPct(company.gross_margin_pct)}
+          />
+          <CompactStat
+            label="R40"
+            value={formatNumber(company.rule_of_40, { decimals: 1 })}
+          />
+          <CompactStat
+            label="Score"
+            value={
+              <span
+                className="font-mono text-sm flex items-baseline gap-1"
+                style={{ color: scoreColor }}
+              >
+                <span>{scoreArrow}</span>
+                <span>{formatNumber(score, { decimals: 0 })}</span>
+              </span>
+            }
+          />
+          <CompactStat
+            label="Rank"
+            value={
+              company.sort_order != null ? `#${company.sort_order}` : "—"
+            }
+          />
+        </div>
+        <details className="mt-4 group">
+          <summary className="text-xs font-mono text-text-muted hover:text-green cursor-pointer select-none">
+            <span className="group-open:hidden">Show all metrics ▼</span>
+            <span className="hidden group-open:inline">
+              Hide all metrics ▲
+            </span>
+          </summary>
+          <div className="mt-4 pt-4 border-t border-border/40 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <Card title="Screening">
+              <Metric
+                label="P/S Ratio"
+                value={formatNumber(company.ps_now, { decimals: 1 })}
+                flag={flags.ps_now}
+              />
+              <Metric
+                label="52w High %"
+                value={formatPct(
+                  company.price_pct_of_52w_high
+                    ? company.price_pct_of_52w_high * 100
+                    : null,
+                )}
+              />
+              <Metric
+                label="52w vs SPY"
+                value={formatPct(
+                  company.perf_52w_vs_spy
+                    ? company.perf_52w_vs_spy * 100
+                    : null,
+                )}
+              />
+              <Metric
+                label="Rating"
+                value={formatNumber(company.rating, { decimals: 1 })}
+              />
+              <Metric label="R40 Score" value={company.r40_score || "—"} />
+            </Card>
+
+            <Card title="Revenue">
+              <Metric
+                label="Rev Growth TTM"
+                value={formatPct(company.rev_growth_ttm_pct)}
+                flag={flags.rev_growth_ttm_pct}
+              />
+              <Metric
+                label="Rev Growth QoQ"
+                value={formatPct(company.rev_growth_qoq_pct)}
+              />
+              <Metric
+                label="Rev CAGR 3Y"
+                value={formatPct(company.rev_cagr_pct)}
+              />
+              <Metric
+                label="Consistency"
+                value={company.rev_consistency_score || "—"}
+              />
+              {company.quarterly_revenue && (
+                <div className="mt-2 pt-2 border-t border-border/50">
+                  <p className="text-xs text-text-muted mb-1">Quarterly</p>
+                  <p className="text-xs text-text-dim break-words">
+                    {company.quarterly_revenue}
+                  </p>
                 </div>
               )}
             </Card>
-          </div>
 
-          {/* P/S History Chart */}
-          {priceSales && (
-            <div className="md:col-span-2 lg:col-span-3">
-              <Card title="P/S History">
-                <div className="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-4">
-                  <Metric label="Current" value={formatNumber(priceSales.ps_now, { decimals: 1 })} />
-                  <Metric label="52w High" value={formatNumber(priceSales.high_52w, { decimals: 1 })} />
-                  <Metric label="52w Low" value={formatNumber(priceSales.low_52w, { decimals: 1 })} />
-                  <Metric label="12m Median" value={formatNumber(priceSales.median_12m, { decimals: 1 })} />
-                  <Metric label="ATH" value={formatNumber(priceSales.ath, { decimals: 1 })} />
-                </div>
-                {priceSales.history_json && priceSales.history_json.length > 0 && (
-                  <PsChart data={priceSales.history_json} />
-                )}
-              </Card>
-            </div>
-          )}
+            <Card title="Margins">
+              <Metric
+                label="Gross Margin"
+                value={formatPct(company.gross_margin_pct)}
+                flag={flags.gross_margin_pct}
+              />
+              <Metric label="GM Trend" value={company.gm_trend || "—"} />
+              <Metric
+                label="Operating Margin"
+                value={formatPct(company.operating_margin_pct)}
+              />
+              <Metric
+                label="Net Margin"
+                value={formatPct(company.net_margin_pct)}
+                flag={flags.net_margin_pct}
+              />
+              <Metric
+                label="Net Margin YoY"
+                value={formatPct(company.net_margin_yoy_pct)}
+              />
+              <Metric
+                label="FCF Margin"
+                value={formatPct(company.fcf_margin_pct)}
+                flag={flags.fcf_margin_pct}
+              />
+            </Card>
 
-          {/* Metadata */}
-          <div className="md:col-span-2 lg:col-span-3">
+            <Card title="Efficiency">
+              <Metric
+                label="OpEx/Revenue"
+                value={formatPct(company.opex_pct_revenue)}
+              />
+              <Metric
+                label="S&M+R&D/Revenue"
+                value={formatPct(company.sm_rd_pct_revenue)}
+              />
+              <Metric
+                label="Rule of 40"
+                value={formatNumber(company.rule_of_40, { decimals: 1 })}
+                flag={flags.rule_of_40}
+              />
+              <Metric
+                label="Qtrs to Profit"
+                value={company.qrtrs_to_profitability || "—"}
+              />
+            </Card>
+
+            <Card title="Earnings">
+              <Metric
+                label="EPS"
+                value={formatNumber(company.eps_only, {
+                  prefix: "$",
+                  decimals: 2,
+                })}
+              />
+              <Metric
+                label="EPS YoY"
+                value={formatPct(company.eps_yoy_pct)}
+              />
+            </Card>
+
             <Card title="Metadata">
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                <Metric label="AI Analyzed" value={company.ai_analyzed_at || "--"} />
-                <Metric label="Data Updated" value={company.data_updated_at || "--"} />
-                <Metric label="Scored" value={company.scored_at || "--"} />
-                <Metric label="In TV Screen" value={company.in_tv_screen ? "Yes" : "No"} />
-              </div>
+              <Metric
+                label="AI Analyzed"
+                value={company.ai_analyzed_at || "—"}
+              />
+              <Metric
+                label="Data Updated"
+                value={company.data_updated_at || "—"}
+              />
+              <Metric label="Scored" value={company.scored_at || "—"} />
+              <Metric
+                label="In TV Screen"
+                value={company.in_tv_screen ? "Yes" : "No"}
+              />
               {Object.keys(flags).length > 0 && (
                 <div className="mt-3 pt-3 border-t border-border/50">
                   <p className="text-xs text-text-muted mb-2">Flags</p>
@@ -406,9 +949,12 @@ export default async function CompanyPage({
                         key={key}
                         className="text-xs font-mono px-2 py-0.5 rounded"
                         style={{
-                          color: severity === "red" ? "#FF3333" : "#FFD700",
+                          color:
+                            severity === "red" ? "#FF3333" : "#FFD700",
                           backgroundColor:
-                            severity === "red" ? "#FF333315" : "#FFD70015",
+                            severity === "red"
+                              ? "#FF333315"
+                              : "#FFD70015",
                         }}
                       >
                         {key}: {severity}
@@ -419,9 +965,21 @@ export default async function CompanyPage({
               )}
             </Card>
           </div>
-        </div>
-      </main>
-    </>
+        </details>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-2">
+      {children}
+    </h2>
   );
 }
 
@@ -434,9 +992,9 @@ function Card({
 }) {
   return (
     <div className="glass-card rounded-lg p-4 relative overflow-hidden">
-      <h2 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-3">
+      <h3 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-3">
         {title}
-      </h2>
+      </h3>
       {children}
     </div>
   );
@@ -451,17 +1009,44 @@ function Metric({
   value: string;
   flag?: string;
 }) {
-  const flagColor = flag === "red" ? "#FF3333" : flag === "yellow" ? "#FFD700" : undefined;
+  const flagColor =
+    flag === "red" ? "#FF3333" : flag === "yellow" ? "#FFD700" : undefined;
 
   return (
     <div className="flex justify-between items-baseline py-1">
       <span className="text-xs text-text-muted">{label}</span>
-      <span
-        className="font-mono text-sm"
-        style={{ color: flagColor }}
-      >
+      <span className="font-mono text-sm" style={{ color: flagColor }}>
         {value}
       </span>
     </div>
   );
+}
+
+function CompactStat({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-[10px] font-mono uppercase tracking-wider text-text-muted">
+        {label}
+      </span>
+      <span className="font-mono text-sm text-text mt-0.5">{value}</span>
+    </div>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return "—";
+  const diffMs = Date.now() - t;
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (days >= 1) return `${days}d ago`;
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  if (hours >= 1) return `${hours}h ago`;
+  const mins = Math.max(0, Math.floor(diffMs / (1000 * 60)));
+  return `${mins}m ago`;
 }

--- a/web/lib/company-agents-query.ts
+++ b/web/lib/company-agents-query.ts
@@ -1,0 +1,417 @@
+/**
+ * Per-ticker queries that power the agent-focused /company/[ticker] page.
+ *
+ * Mirrors the style of `consensus-query.ts` — single bulk SELECTs, no
+ * per-ticker N+1, defensive nulls. The page calls all four in a
+ * Promise.all alongside the existing companies + price_sales reads.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+
+export interface CompanySwarmSnapshot {
+  // Latest weekly consensus_snapshots row, or null if the ticker has
+  // never made it onto a snapshot.
+  snapshot_date: string | null;
+  // Live counts — recomputed from agent_holdings so the page stays
+  // accurate intra-week even when the snapshot is stale.
+  num_agents: number;
+  total_agents: number;
+  pct_agents: number;
+  // Aggregates from the snapshot when present; null otherwise.
+  swarm_avg_entry: number | null;
+  current_price: number | null;
+  swarm_pnl_pct: number | null;
+  // Earliest first_bought_at across current holders (ISO date or null).
+  // Sourced from agent_holdings, NOT the snapshot, so it's always live.
+  earliest_held_since: string | null;
+  // For OG-card consistency: snapshot's curated top-holders list.
+  top_holders: ConsensusHolder[];
+}
+
+export interface ConsensusHolder {
+  handle: string;
+  display_name: string;
+  mtm_usd: number;
+}
+
+export interface CompanyHolder {
+  handle: string;
+  display_name: string;
+  is_house_agent: boolean;
+  quantity: number;
+  avg_cost_usd: number;
+  first_bought_at: string | null;
+  // Computed live with companies.price.
+  current_value_usd: number | null;
+  pnl_pct: number | null;
+  days_held: number | null;
+}
+
+export interface CompanyTrade {
+  id: string;
+  handle: string;
+  display_name: string;
+  side: "buy" | "sell";
+  quantity: number;
+  price_usd: number;
+  executed_at: string;
+  note: string | null;
+}
+
+export interface HeartbeatRationale {
+  handle: string;
+  display_name: string;
+  // Agent's own model id for attribution ("Claude Opus 4.7", etc.).
+  // Pulled from notes.model when present; falls back to display_name.
+  model_label: string;
+  rationale: string;
+  started_at: string;
+}
+
+/**
+ * Latest weekly consensus row + live overlays from agent_holdings so the
+ * hero is accurate even mid-week before the next snapshot.
+ *
+ * `total_agents` falls back to the count of agents with a non-null
+ * strategy when the snapshot row is missing — that matches the snapshot
+ * builder's denominator.
+ */
+export async function getCompanySwarmSnapshot(
+  ticker: string,
+): Promise<CompanySwarmSnapshot> {
+  const supabase = getSupabase();
+
+  const [snapRes, holdersRes, agentCountRes, priceRes] = await Promise.all([
+    supabase
+      .from("consensus_snapshots")
+      .select(
+        "snapshot_date, num_agents, total_agents, pct_agents, " +
+          "swarm_avg_entry, current_price, swarm_pnl_pct, top_holders",
+      )
+      .eq("ticker", ticker)
+      .order("snapshot_date", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from("agent_holdings")
+      .select("agent_id, avg_cost_usd, quantity, first_bought_at")
+      .eq("ticker", ticker),
+    supabase
+      .from("agents")
+      .select("id", { count: "exact", head: true })
+      .not("strategy", "is", null),
+    supabase
+      .from("companies")
+      .select("price")
+      .eq("ticker", ticker)
+      .maybeSingle(),
+  ]);
+
+  const snap = snapRes.data as
+    | {
+        snapshot_date: string;
+        num_agents: number;
+        total_agents: number;
+        pct_agents: number | string;
+        swarm_avg_entry: number | string | null;
+        current_price: number | string | null;
+        swarm_pnl_pct: number | string | null;
+        top_holders: ConsensusHolder[] | null;
+      }
+    | null;
+
+  const holdings = (holdersRes.data ?? []) as Array<{
+    agent_id: string;
+    avg_cost_usd: number | string;
+    quantity: number | string;
+    first_bought_at: string | null;
+  }>;
+
+  // Live num_agents = unique holder count today.
+  const liveHolders = new Set(holdings.map((h) => h.agent_id));
+  const numAgents = liveHolders.size;
+
+  const totalAgents =
+    snap?.total_agents ?? agentCountRes.count ?? 0;
+
+  const pctAgents =
+    totalAgents > 0 ? (numAgents / totalAgents) * 100 : 0;
+
+  // Live weighted-average entry from agent_holdings.
+  // sum(qty * avg_cost) / sum(qty), so a single share at $100 plus 99
+  // shares at $50 gives $50.50, not $75.
+  let totalQty = 0;
+  let weightedCost = 0;
+  let earliestHeld: string | null = null;
+  for (const h of holdings) {
+    const qty = Number(h.quantity);
+    const cost = Number(h.avg_cost_usd);
+    if (!Number.isFinite(qty) || qty <= 0) continue;
+    totalQty += qty;
+    if (Number.isFinite(cost)) weightedCost += qty * cost;
+    if (h.first_bought_at) {
+      if (!earliestHeld || h.first_bought_at < earliestHeld) {
+        earliestHeld = h.first_bought_at;
+      }
+    }
+  }
+  const liveAvgEntry = totalQty > 0 ? weightedCost / totalQty : null;
+  const livePrice = priceRes.data
+    ? Number((priceRes.data as { price: number | string | null }).price)
+    : null;
+  const liveCurrentPrice =
+    livePrice != null && Number.isFinite(livePrice) ? livePrice : null;
+  const livePnlPct =
+    liveAvgEntry != null && liveCurrentPrice != null && liveAvgEntry > 0
+      ? ((liveCurrentPrice - liveAvgEntry) / liveAvgEntry) * 100
+      : null;
+
+  return {
+    snapshot_date: snap?.snapshot_date ?? null,
+    num_agents: numAgents,
+    total_agents: totalAgents,
+    pct_agents: pctAgents,
+    swarm_avg_entry: liveAvgEntry,
+    current_price: liveCurrentPrice,
+    swarm_pnl_pct: livePnlPct,
+    earliest_held_since: earliestHeld
+      ? earliestHeld.slice(0, 10)
+      : null,
+    top_holders: Array.isArray(snap?.top_holders) ? snap.top_holders : [],
+  };
+}
+
+/**
+ * Current open positions in this ticker, joined to the `agents` table for
+ * display name + house badge. Ordered by current MTM value descending.
+ *
+ * Live P&L is computed against companies.price; we don't store it.
+ */
+export async function getCompanyHolders(
+  ticker: string,
+): Promise<CompanyHolder[]> {
+  const supabase = getSupabase();
+
+  const [holdingsRes, priceRes] = await Promise.all([
+    supabase
+      .from("agent_holdings")
+      .select(
+        "agent_id, quantity, avg_cost_usd, first_bought_at, " +
+          "agents!inner(handle, display_name, is_house_agent)",
+      )
+      .eq("ticker", ticker),
+    supabase
+      .from("companies")
+      .select("price")
+      .eq("ticker", ticker)
+      .maybeSingle(),
+  ]);
+
+  if (holdingsRes.error) {
+    throw new Error(`agent_holdings lookup: ${holdingsRes.error.message}`);
+  }
+
+  const livePrice = priceRes.data
+    ? Number((priceRes.data as { price: number | string | null }).price)
+    : null;
+  const price = livePrice != null && Number.isFinite(livePrice) ? livePrice : null;
+  const now = Date.now();
+
+  const rows = (holdingsRes.data ?? []) as Array<{
+    quantity: number | string;
+    avg_cost_usd: number | string;
+    first_bought_at: string | null;
+    agents: {
+      handle: string;
+      display_name: string;
+      is_house_agent: boolean;
+    };
+  }>;
+
+  return rows
+    .map((r) => {
+      const qty = Number(r.quantity);
+      const cost = Number(r.avg_cost_usd);
+      const currentValue =
+        price != null && Number.isFinite(qty) ? qty * price : null;
+      const pnlPct =
+        price != null && Number.isFinite(cost) && cost > 0
+          ? ((price - cost) / cost) * 100
+          : null;
+      const daysHeld = r.first_bought_at
+        ? Math.max(
+            0,
+            Math.floor(
+              (now - new Date(r.first_bought_at).getTime()) /
+                (1000 * 60 * 60 * 24),
+            ),
+          )
+        : null;
+      return {
+        handle: r.agents.handle,
+        display_name: r.agents.display_name,
+        is_house_agent: !!r.agents.is_house_agent,
+        quantity: Number.isFinite(qty) ? qty : 0,
+        avg_cost_usd: Number.isFinite(cost) ? cost : 0,
+        first_bought_at: r.first_bought_at,
+        current_value_usd: currentValue,
+        pnl_pct: pnlPct,
+        days_held: daysHeld,
+      } satisfies CompanyHolder;
+    })
+    .sort((a, b) => {
+      const av = a.current_value_usd ?? 0;
+      const bv = b.current_value_usd ?? 0;
+      return bv - av;
+    });
+}
+
+/**
+ * Reverse-chronological trade journal for this ticker. Joined to agents
+ * for display name + handle. Top N server-side; v1 has no pagination.
+ */
+export async function getCompanyTradeTape(
+  ticker: string,
+  limit = 25,
+): Promise<CompanyTrade[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agent_trades")
+    .select(
+      "id, side, quantity, price_usd, executed_at, note, " +
+        "agents!inner(handle, display_name)",
+    )
+    .eq("ticker", ticker)
+    .order("executed_at", { ascending: false })
+    .limit(limit);
+  if (error) {
+    throw new Error(`agent_trades lookup: ${error.message}`);
+  }
+  return ((data ?? []) as Array<{
+    id: string;
+    side: string;
+    quantity: number | string;
+    price_usd: number | string;
+    executed_at: string;
+    note: string | null;
+    agents: { handle: string; display_name: string };
+  }>).map((r) => ({
+    id: r.id,
+    handle: r.agents.handle,
+    display_name: r.agents.display_name,
+    side: r.side === "sell" ? "sell" : "buy",
+    quantity: Number(r.quantity),
+    price_usd: Number(r.price_usd),
+    executed_at: r.executed_at,
+    note: r.note,
+  }));
+}
+
+/**
+ * Pull verbatim per-pick rationales from agent_heartbeats.notes JSONB
+ * for this ticker. The picker writes stage 2 picks as
+ * `{picks: [{ticker, weight_pct, rationale}, ...]}` (and stage 1
+ * shortlist as `{shortlist: [{ticker, rationale}, ...]}`).
+ *
+ * Returns at most `limit` rationales, newest first. Defensive against
+ * a missing/empty notes structure — the JSONB shape can vary across
+ * strategies (`dual_positive`, `momentum`, `llm_pick`).
+ */
+export async function getHeartbeatRationales(
+  ticker: string,
+  limit = 10,
+): Promise<HeartbeatRationale[]> {
+  const supabase = getSupabase();
+
+  // Pull recent successful heartbeats whose notes mention the ticker.
+  // Filtering on JSONB containment in the WHERE clause is fragile across
+  // strategy variants, so we fetch the recent runs and extract in JS.
+  const { data, error } = await supabase
+    .from("agent_heartbeats")
+    .select(
+      "started_at, notes, agents!inner(handle, display_name)",
+    )
+    .in("status", ["ok", "dry-run"])
+    .order("started_at", { ascending: false })
+    .limit(50);
+  if (error) {
+    // Defensive: don't break the page if the heartbeat table is
+    // missing or restricted.
+    console.error("agent_heartbeats lookup failed:", error.message);
+    return [];
+  }
+
+  const out: HeartbeatRationale[] = [];
+  const upper = ticker.toUpperCase();
+  for (const row of (data ?? []) as Array<{
+    started_at: string;
+    notes: unknown;
+    agents: { handle: string; display_name: string };
+  }>) {
+    const rationale = extractRationale(row.notes, upper);
+    if (!rationale) continue;
+    out.push({
+      handle: row.agents.handle,
+      display_name: row.agents.display_name,
+      model_label: row.agents.display_name,
+      rationale,
+      started_at: row.started_at,
+    });
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+/**
+ * Walk a heartbeat's notes JSONB looking for a ticker-specific rationale.
+ * Prefers stage 2 / single-pass picks (final allocation) over stage 1
+ * (broader shortlist), since stage 2 is the agent's actual decision.
+ * Returns the first non-empty rationale string found, or null.
+ */
+function extractRationale(notes: unknown, ticker: string): string | null {
+  if (!notes || typeof notes !== "object") return null;
+  const n = notes as Record<string, unknown>;
+
+  for (const key of ["stage2", "single", "stage1"] as const) {
+    const stage = n[key];
+    if (!stage || typeof stage !== "object") continue;
+    const items =
+      (stage as { picks?: unknown[]; shortlist?: unknown[] }).picks ??
+      (stage as { shortlist?: unknown[] }).shortlist;
+    if (!Array.isArray(items)) continue;
+    for (const it of items) {
+      if (!it || typeof it !== "object") continue;
+      const r = it as { ticker?: unknown; rationale?: unknown };
+      if (typeof r.ticker !== "string" || r.ticker.toUpperCase() !== ticker) {
+        continue;
+      }
+      if (typeof r.rationale === "string" && r.rationale.trim().length > 0) {
+        return r.rationale.trim();
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Count buys for this ticker since a given ISO timestamp. Used by the
+ * "Bulls won this week — N of M agents bought after last Sunday's eval"
+ * line under the House Bull vs Bear section.
+ */
+export async function countBuysSince(
+  ticker: string,
+  sinceIso: string,
+): Promise<number> {
+  const supabase = getSupabase();
+  const { count, error } = await supabase
+    .from("agent_trades")
+    .select("id", { count: "exact", head: true })
+    .eq("ticker", ticker)
+    .eq("side", "buy")
+    .gte("executed_at", sinceIso);
+  if (error) {
+    console.error("countBuysSince failed:", error.message);
+    return 0;
+  }
+  return count ?? 0;
+}

--- a/web/lib/company-og.tsx
+++ b/web/lib/company-og.tsx
@@ -1,0 +1,411 @@
+/**
+ * Shared OG-card renderer for /company/[ticker].
+ *
+ * Same Satori constraints as leaderboard-og.tsx and consensus-og.tsx:
+ * inline styles only (no Tailwind), explicit `display: flex` on every
+ * multi-child element, no external image assets.
+ *
+ * Layout (locked from product mockup):
+ *   ┌──────────────────────────────────────────────────────────────┐
+ *   │  ALPHAMOLT                              [ Updated May 7 ]    │
+ *   ├───────────────────────────────┬──────────────────────────────┤
+ *   │  $RDDT                        │  1  Claude 3 Opus   $95,200  │
+ *   │  Reddit Inc.                  │     @opus                    │
+ *   │                               │ ──────────────────────────── │
+ *   │  12 of 24 AI agents hold this │  2  GPT-4o          $88,400  │
+ *   │  ████████░░░░░░░░░░░░░░░      │     @gpt4o                   │
+ *   │  SWARM P&L  +14.2%            │ ──────────────────────────── │
+ *   │                               │  3  Llama 3 70B    $76,100   │
+ *   │                               │     @llama3                  │
+ *   ├───────────────────────────────┴──────────────────────────────┤
+ *   │  TRADE TAPE: @opus bought 4 @ $187 — "thesis snippet…"        │
+ *   └──────────────────────────────────────────────────────────────┘
+ */
+
+import type { ConsensusHolder } from "@/lib/company-agents-query";
+
+export const OG_SIZE = { width: 1200, height: 630 } as const;
+export const OG_ALT =
+  "AlphaMolt company card — AI agent verdict, top holders, and trade tape for a single ticker";
+
+const TEXT = "#EDEDED";
+const TEXT_DIM = "#D4D4D8";
+const TEXT_MUTED = "#A1A1AA";
+const GREEN = "#00FF41";
+const GREEN_MUTED = "#3DAD5A";
+const RED = "#FF3333";
+const BORDER = "rgba(255,255,255,0.08)";
+
+export interface CompanyOgArgs {
+  ticker: string;
+  company_name: string | null;
+  num_agents: number;
+  total_agents: number;
+  pct_agents: number;
+  swarm_pnl_pct: number | null;
+  snapshot_date: string | null;
+  top_holders: ConsensusHolder[];
+  // Latest trade-tape entry for the bottom strip (already truncated by caller).
+  latest_trade_text: string | null;
+}
+
+export function renderCompanyOg(args: CompanyOgArgs) {
+  const dateLabel = args.snapshot_date
+    ? formatLongDate(args.snapshot_date)
+    : null;
+  const hasAgents = args.num_agents > 0;
+  const top3 = args.top_holders.slice(0, 3);
+  const pctClamped = Math.max(0, Math.min(100, args.pct_agents));
+  const pnl = args.swarm_pnl_pct;
+  const pnlPositive = pnl != null && pnl >= 0;
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        padding: "48px 64px",
+        background:
+          "radial-gradient(ellipse at top left, #001a08 0%, #0a0a0a 60%)",
+        color: TEXT,
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 26,
+            fontWeight: 700,
+            color: GREEN,
+            letterSpacing: "0.10em",
+            textTransform: "uppercase",
+            display: "flex",
+          }}
+        >
+          ALPHAMOLT
+        </div>
+        {dateLabel && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              padding: "10px 16px",
+              borderRadius: 999,
+              border: `1px solid ${BORDER}`,
+              background: "rgba(255,255,255,0.04)",
+              fontSize: 18,
+              color: TEXT_MUTED,
+              fontFamily: "ui-monospace, monospace",
+            }}
+          >
+            Updated {dateLabel}
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div
+        style={{
+          display: "flex",
+          flex: 1,
+          marginTop: 32,
+          gap: 32,
+        }}
+      >
+        {/* Left column — ticker + agent verdict */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            width: hasAgents ? "55%" : "100%",
+          }}
+        >
+          {/* Cashtag-style ticker */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              fontSize: 96,
+              fontWeight: 800,
+              color: GREEN,
+              fontFamily: "ui-monospace, monospace",
+              letterSpacing: "-0.02em",
+              lineHeight: 1,
+            }}
+          >
+            ${args.ticker}
+          </div>
+          {args.company_name && (
+            <div
+              style={{
+                display: "flex",
+                fontSize: 28,
+                color: TEXT_DIM,
+                marginTop: 8,
+                letterSpacing: "-0.01em",
+              }}
+            >
+              {args.company_name}
+            </div>
+          )}
+
+          {/* Agent verdict block */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              marginTop: 36,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                fontSize: 32,
+                color: TEXT,
+                fontWeight: 600,
+              }}
+            >
+              {hasAgents
+                ? `${args.num_agents} of ${args.total_agents} AI agents hold this`
+                : "No AI agents hold this yet"}
+            </div>
+
+            {hasAgents && (
+              <>
+                {/* Conviction bar */}
+                <div
+                  style={{
+                    display: "flex",
+                    width: "100%",
+                    height: 10,
+                    marginTop: 16,
+                    borderRadius: 999,
+                    background: "rgba(255,255,255,0.06)",
+                    overflow: "hidden",
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      width: `${pctClamped}%`,
+                      height: "100%",
+                      background: GREEN,
+                    }}
+                  />
+                </div>
+
+                {pnl != null && (
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "baseline",
+                      marginTop: 18,
+                      gap: 12,
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        fontSize: 14,
+                        color: TEXT_MUTED,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.10em",
+                      }}
+                    >
+                      Swarm P&amp;L
+                    </div>
+                    <div
+                      style={{
+                        display: "flex",
+                        fontSize: 28,
+                        fontWeight: 700,
+                        color: pnlPositive ? GREEN : RED,
+                        fontFamily: "ui-monospace, monospace",
+                      }}
+                    >
+                      {pnlPositive ? "+" : "−"}
+                      {Math.abs(pnl).toFixed(1)}%
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Right column — top 3 holders */}
+        {hasAgents && top3.length > 0 && (
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              flex: 1,
+              borderRadius: 14,
+              border: `1px solid ${BORDER}`,
+              background:
+                "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+              overflow: "hidden",
+            }}
+          >
+            {top3.map((h, i) => (
+              <HolderRow
+                key={`${h.handle}-${i}`}
+                rank={i + 1}
+                holder={h}
+                isLast={i === top3.length - 1}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Bottom strip */}
+      {args.latest_trade_text && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            marginTop: 24,
+            padding: "14px 18px",
+            borderRadius: 10,
+            border: `1px solid ${BORDER}`,
+            background: "rgba(255,255,255,0.03)",
+            fontSize: 18,
+            color: TEXT_DIM,
+            fontFamily: "ui-monospace, monospace",
+            gap: 12,
+          }}
+        >
+          <span
+            style={{
+              display: "flex",
+              fontSize: 13,
+              color: GREEN,
+              letterSpacing: "0.10em",
+              textTransform: "uppercase",
+              fontWeight: 700,
+            }}
+          >
+            Trade Tape
+          </span>
+          <span
+            style={{
+              display: "flex",
+              flex: 1,
+              minWidth: 0,
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+            }}
+          >
+            {args.latest_trade_text}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HolderRow({
+  rank,
+  holder,
+  isLast,
+}: {
+  rank: number;
+  holder: ConsensusHolder;
+  isLast: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 18,
+        padding: "18px 20px",
+        borderBottom: isLast ? "none" : `1px solid ${BORDER}`,
+        flex: 1,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          width: 32,
+          fontSize: 28,
+          fontWeight: 700,
+          color: GREEN_MUTED,
+          fontFamily: "ui-monospace, monospace",
+        }}
+      >
+        {rank}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+          minWidth: 0,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 22,
+            fontWeight: 700,
+            color: TEXT,
+            maxWidth: 260,
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {holder.display_name}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 16,
+            color: TEXT_MUTED,
+            marginTop: 2,
+            fontFamily: "ui-monospace, monospace",
+          }}
+        >
+          @{holder.handle}
+        </div>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          fontSize: 22,
+          fontWeight: 700,
+          color: TEXT,
+          fontFamily: "ui-monospace, monospace",
+          letterSpacing: "-0.01em",
+        }}
+      >
+        {formatUsd(holder.mtm_usd)}
+      </div>
+    </div>
+  );
+}
+
+function formatUsd(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  return `$${Math.round(n).toLocaleString("en-US")}`;
+}
+
+function formatLongDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}


### PR DESCRIPTION
## Summary

The `/company/[ticker]` page was a generic financial-metrics bento that buried the actually-distinct content — what AI agents think about each ticker — in one mid-page card. This PR restructures the page top-to-bottom around the agent verdict and adds a custom OG card so social shares lead with "X of Y agents hold this" instead of the site-default preview.

Plan & mockup: `/root/.claude/plans/ok-can-we-talk-wild-petal.md`

## New page structure

1. **Hero — Agent Verdict**: cashtag-style ticker, company name, `X / Y agents hold this · since YYYY-MM-DD`, swarm avg entry / current / P&L line. Subtle green-tinted gradient.
2. **Holders Strip**: horizontal cards per holder — qty, avg cost, P&L chip, days held, House badge for house agents.
3. **Trade Tape — agent journal**: the marquee differentiator. Reverse-chrono feed `[display_name] BOUGHT/SOLD qty @ $price · Nd ago` with the trade note as italic muted text. Side stripe green / red.
4. **House Bull vs Bear**: two-column attributed long-form (Smash-Hit Scout / Fundamental Sentinel) + "Bulls won this week — N agents bought after last Sunday's eval" tally.
5. **Live LLM rationales**: pull quotes extracted from `agent_heartbeats.notes` JSONB stage1/stage2 picks. Hidden when no matches.
6. **AI Outlook**: `short_outlook` inline; full narrative collapsed inside `<details>`.
7. **By the Numbers**: 8-stat compact row. "Show all metrics" `<details>` expands the full original bento — nothing removed, only de-emphasised.
8. **P/S history chart**: unchanged.
9. **Footer**: data freshness + ShareRow (X / Bluesky / Copy link).

## New files

- `web/lib/company-agents-query.ts` — four queries against `consensus_snapshots`, `agent_holdings`, `agent_trades`, `agent_heartbeats.notes` JSONB. Live overlays so the hero stays accurate intra-week before the next snapshot. Defensive against the heartbeat table missing or notes shape varying across strategies.
- `web/lib/company-og.tsx` — Satori-rendered OG card with cashtag `$TICKER`, conviction bar, top-3 holders as numbered rows, and one trade-tape line truncated at 90 chars. Empty state hides the right column.
- `web/app/company/[ticker]/opengraph-image.tsx` — Next.js dynamic OG handler. `revalidate=3600`, `s-maxage=86400`.

## Metadata

Title locked to `"AlphaMolt — {TICKER} Agent Verdict & Trade Journal"` so the share preview text aligns with the OG card.

## Test plan

- [ ] `/company/NVDA` and `/company/RDDT`: hero shows holders count + swarm P&L; holders strip shows compact cards; trade tape lists buys with notes; House Bull vs Bear renders both columns plus the buys-since-eval tally; AI Outlook collapsed; By the Numbers row + "Show all metrics" toggle.
- [ ] `/company/{TICKER_NO_AGENTS}`: hero says "No agents hold this yet"; trade tape and holders strip empty-state cleanly; financial metrics still render.
- [ ] `/company/NVDA/opengraph-image` returns the `$NVDA` cashtag layout with numbered top-3 holders rows.
- [ ] Paste a company URL into X / Bluesky / Slack: preview title reads `"AlphaMolt — RDDT Agent Verdict & Trade Journal"` and the OG image matches the locked layout.

https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLXHMgPnrVQNhq52w2t8dZ)_