### PR TITLE
Fix Vercel deploy + X.com OG cache for /company/[ticker]

### DIFF
--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -90,7 +90,11 @@ export async function generateMetadata({
       openGraph: {
         title,
         description,
-        url: canonical,
+        // Deliberately no `url` — X uses og:url as a cache key, and pinning
+        // it to the bare path makes share-URL cache-bust (?v=N) a no-op
+        // because X resolves back to whatever it cached for the canonical
+        // URL. Letting X use the actually-fetched URL means each ?v= bump
+        // forces a fresh fetch. Canonical above still covers SEO.
         type: "article",
       },
       twitter: {
@@ -175,7 +179,12 @@ export default async function CompanyPage({
   const buysSinceEval = await countBuysSince(decoded, bullSince);
 
   const breadcrumb = breadcrumbJsonLd(company.ticker, company.company_name);
-  const shareUrl = absoluteUrl(`/company/${encodeURIComponent(decoded)}`);
+  // ?v=… is a cache-bust for X.com's per-URL og:image cache — bump it any
+  // time a previously-shared company URL is rendering with the stale
+  // pre-redesign card (X holds the image for hours-to-days regardless of
+  // what we serve). Paired with `og:url` being deliberately omitted in
+  // generateMetadata above so X keys cache off the actually-fetched URL.
+  const shareUrl = `${absoluteUrl(`/company/${encodeURIComponent(decoded)}`)}?v=2`;
   const shareText =
     swarm.num_agents > 0
       ? `${swarm.num_agents} of ${swarm.total_agents} AI agents hold $${decoded} on AlphaMolt — see who, when, and why.`


### PR DESCRIPTION
## Summary

Two follow-ups to the company-page redesign in #652:

1. **Unblock the Vercel deploy.** `next build` was failing TypeScript at `web/lib/company-agents-query.ts:220`. Supabase's PostgREST type inference falls back to `GenericStringError[]` for queries with `!inner` joins, which TS refuses to direct-cast to a row shape. Cast through `unknown` first on the three joined queries (lines 220, 290, 346). Line 123 has no join and was already fine.

2. **Fix the stale X.com share preview.** Tweets linking to `/company/<TICKER>` are showing the pre-redesign card (the `short_outlook` snippet) because X.com keyed its og:image cache on the bare URL before the new agent-focused OG card shipped. Mirroring the prior `/consensus` fix (a2463f6, 90cdc5b):
   - Append `?v=2` to the in-page share URL so freshly tweeted links are cache keys X hasn't seen.
   - Drop `url: canonical` from `openGraph` so X keys cache off the actually-fetched URL instead of resolving share URLs back to the cached entry. `alternates.canonical` still covers SEO.
   - Bump `?v=` on any future redesign regression.

Existing tweets with bare `/company/<TICKER>` URLs will keep showing the stale card (X already keyed them); new shares after this deploys will render the new card.

## Test plan

- [ ] Vercel build succeeds on this branch
- [ ] `/company/RDDT` renders the new agent-focused page (not 404, not the old bento)
- [ ] Click the Tweet button on `/company/RDDT` → the URL X.com receives ends in `?v=2`
- [ ] Pasting `https://www.alphamolt.ai/company/RDDT?v=2` into X.com's share composer shows the new OG card (12 of 24 AI agents hold this / top 3 holders / trade-tape line)
- [ ] Page source for `/company/<TICKER>` no longer contains `<meta property="og:url" ...>`

https://claude.ai/code/session_01TAU8zXm27ahQW24ffYixhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAU8zXm27ahQW24ffYixhV)_