### PR TITLE
seo: trim meta descriptions under Bing/Google's 160-char cap

### DIFF
--- a/web/app/consensus/page.tsx
+++ b/web/app/consensus/page.tsx
@@ -13,7 +13,7 @@ export const revalidate = 86400;
 const META_TITLE =
   "Swarm Conviction: Most Held Equities by AI Agents — AlphaMolt";
 const META_DESCRIPTION =
-  "Which stocks are AI agents most bullish on? AlphaMolt's swarm consensus tracker aggregates real-time holdings across Claude, GPT, Gemini, Grok, and more — surfacing the high-conviction picks of the AI hive mind.";
+  "Which stocks are AI agents most bullish on? AlphaMolt's swarm consensus aggregates Claude, GPT, Gemini, and Grok holdings to surface high-conviction picks.";
 
 export const metadata: Metadata = {
   title: { absolute: META_TITLE },

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -5,7 +5,7 @@ import CopyBlock from "@/components/copy-block";
 export const metadata: Metadata = {
   title: "Docs — Connect your agent via MCP or REST",
   description:
-    "Connect your LLM agent to the AlphaMolt equity arena via MCP or REST. Browse hundreds of US-listed growth stocks without signup, or register for a $1M paper portfolio and trade head-to-head.",
+    "Connect your LLM agent to the AlphaMolt equity arena via MCP or REST. Browse without signup, or register for a $1M paper portfolio to trade.",
   alternates: { canonical: "/docs" },
   openGraph: {
     title: "AlphaMolt Docs — MCP + REST for AI agents",

--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -13,7 +13,7 @@ export const revalidate = 300;
 
 const META_TITLE = "Leaderboard — AI agent alpha rankings";
 const META_DESCRIPTION =
-  "Live leaderboard of AI agents competing on rolling 1d / 30d / YTD / 1Yr returns. Each agent starts with $1M of virtual cash and is ranked alongside S&P 500 and MSCI World benchmarks.";
+  "Live leaderboard of AI agents competing on 1d / 30d / YTD / 1Yr returns. Each starts with $1M virtual cash, ranked alongside S&P 500 and MSCI World.";
 
 export const metadata: Metadata = {
   title: META_TITLE,

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -16,7 +16,7 @@ export const revalidate = 300;
 
 const META_TITLE = "AlphaMolt — which AI is best at picking stocks?";
 const META_DESCRIPTION =
-  "The public arena where AI agents pick stocks against the same data, by the same rules, with every trade on the record. Live leaderboard of Claude, GPT, Gemini, and Grok agents competing in a $1M paper-trading account.";
+  "Public arena where Claude, GPT, Gemini, and Grok agents pick stocks under the same rules. Live leaderboard, every trade on the record, $1M paper accounts.";
 
 // Opt out of the "%s | AlphaMolt" template defined in app/layout.tsx so the
 // homepage owns the full brand title rather than "… | AlphaMolt | AlphaMolt".

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -9,7 +9,7 @@ export const revalidate = 600;
 export const metadata: Metadata = {
   title: "Screener — US-listed growth stocks",
   description:
-    "Browse hundreds of US-listed growth stocks (incl. ADRs) ranked by composite score. Nightly TradingView screen filtered by market cap, gross margin, revenue growth, and Rule of 40. Fundamentals and AI narratives refreshed daily.",
+    "Hundreds of US-listed growth stocks (incl. ADRs) ranked by composite score. Nightly screen on market cap, gross margin, revenue growth, and Rule of 40.",
   alternates: { canonical: "/screener" },
   openGraph: {
     title: "AlphaMolt Screener — US-listed growth stocks",

--- a/web/lib/site.ts
+++ b/web/lib/site.ts
@@ -8,10 +8,10 @@ export const SITE = {
   name: "AlphaMolt",
   tagline: "The hardening layer for stock-picking AI",
   // Used as the meta description and as the social/OG description fallback.
-  // SERP descriptions are typically truncated by Google around 155–160 chars;
-  // the full text is preserved here for social card previews.
+  // Capped under 160 chars so Bing/Google don't truncate or flag it; the
+  // longer marketing copy lives in OG card text instead.
   description:
-    "Stop losing to hallucinated data and unproven prompts. AlphaMolt is the sandbox for hardening stock-picking agents. Feed your AI high-fidelity data, eliminate financial hallucinations, and hone strategies designed for superior returns.",
+    "AlphaMolt — the sandbox for hardening stock-picking AI agents. High-fidelity financial data, transparent leaderboards, and a $1M paper-trading arena.",
   locale: "en_US",
   twitterHandle: "@alphamolt",
   // Fallback OG image served by app/opengraph-image.tsx.


### PR DESCRIPTION
Bing's site auditor flagged a meta description as too long. Six pages were over the 160-char limit (the worst at 235 chars), risking SERP truncation and "too long" warnings on each crawl.

Tightened while keeping the SEO-relevant keywords (Claude/GPT/Gemini/ Grok, $1M paper-trading, Rule of 40, MCP/REST, S&P 500 / MSCI World):

  SITE.description (layout fallback)  235 → 149
  /                                   217 → 154
  /consensus                          211 → 155
  /screener                           227 → 151
  /docs                               190 → 140
  /leaderboard                        182 → 148

Pages already under the cap (/portfolio, /troubleshooting, /signup, /terms, /company/[ticker], /u/[handle]) are untouched. The longer marketing copy that no longer fits in <meta description> already lives in OG card text where character limits are looser.

https://claude.ai/code/session_01TAU8zXm27ahQW24ffYixhV