### PR TITLE
seo: drop Host: directive from robots.txt

### DIFF
--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { SITE, absoluteUrl } from "@/lib/site";
+import { absoluteUrl } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -31,6 +31,8 @@ export default function robots(): MetadataRoute.Robots {
       },
     ],
     sitemap: absoluteUrl("/sitemap.xml"),
-    host: SITE.url,
+    // No `host:` — Yandex-only extension that Bing's robots.txt tester
+    // flags as an unknown directive. Canonical host is already handled
+    // via the apex→www redirect and <link rel="canonical"> tags.
   };
 }


### PR DESCRIPTION
Bing's robots.txt tester flagged line 16 (Host: https://www.alphamolt.ai) as an unknown directive. The Host: field is a Yandex-only extension that Google ignores and Bing rejects. Canonical host is already enforced via the apex→www redirect and <link rel="canonical"> tags, so the directive was redundant noise that only generated webmaster-tool warnings.

Drop SITE.url from the import too since `host:` was its only consumer in this file.

https://claude.ai/code/session_01TAU8zXm27ahQW24ffYixhV