### PR TITLE
screener: gate on US_EXCHANGES + broaden filters to ~1k+ universe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,13 @@ and score_ai_analysis.py to avoid duplicating the screening code.
 ## Scripts
 
 ### nightly_screen.py (03:00 UTC daily)
-TradingView screener over the US-listed universe (NYSE/NASDAQ/AMEX, incl. ADRs).
-Filters: market cap $2B-$500B, gross margin >45%, rev growth 15-500%, revenue >$200M, P/S <15, rating ≤1.8.
+TradingView screener over the US-listed universe (NYSE/NASDAQ/AMEX/NYSEARCA/
+BATS/ARCA, incl. ADRs that primary-list on a US exchange).
+Filters: market cap $2B-$500B, gross margin >25%, rev growth 10-500%, revenue >$100M, P/S <15, rating ≤2.5.
 Excludes: China, Hong Kong, Taiwan, Real Estate, REIT, Non-Energy Minerals, Finance, Utilities.
+Also drops rows whose `exchange` is not in `US_EXCHANGES` (OTC pink-sheet
+ADRs and primary foreign listings that TV's `america` market sometimes
+returns) — keeps Capcom/UCB/EssilorLuxottica from appearing as 2-3 dupes.
 Adds any new tickers to the `companies` table. Backfills country/sector for existing tickers.
 
 ### eodhd_updater.py (03:30 UTC daily)

--- a/delete_non_us_companies.py
+++ b/delete_non_us_companies.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+One-off cleanup: delete companies whose `exchange` is not in the
+canonical US set (NYSE/NASDAQ/AMEX/NYSEARCA/BATS/ARCA).
+
+Background: TradingView's `america` market sometimes returns OTC
+pink-sheet ADRs (e.g. UCBJY, CCOEF, RYKKY) and even primary foreign
+listings (9697 Tokyo, ADYEN Amsterdam). Until the post-filter in
+`tv_screen.py` was added, those rows were ingested by
+`nightly_screen.py` and now need cleaning out.
+
+Safety:
+- Skips any ticker referenced by `agent_holdings` or `agent_trades`
+  (FK ON DELETE RESTRICT / NO ACTION). `price_sales` and
+  `consensus_snapshots` cascade.
+- `--dry-run` just prints the deletion plan.
+
+Usage:
+    python delete_non_us_companies.py --dry-run
+    python delete_non_us_companies.py
+"""
+
+import argparse
+import logging
+import sys
+from datetime import date
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from db import SupabaseDB
+from tv_screen import US_EXCHANGES
+
+load_dotenv()
+
+
+def setup_logging() -> logging.Logger:
+    log_dir = Path(__file__).parent / "logs"
+    log_dir.mkdir(exist_ok=True)
+    log_file = log_dir / f"delete_non_us_companies_{date.today().isoformat()}.txt"
+
+    logger = logging.getLogger("delete_non_us_companies")
+    logger.setLevel(logging.INFO)
+    fmt = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+    )
+    fh = logging.FileHandler(log_file, encoding="utf-8")
+    fh.setFormatter(fmt)
+    logger.addHandler(fh)
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(fmt)
+    logger.addHandler(sh)
+    return logger
+
+
+def _referenced_tickers(db: SupabaseDB, table: str, candidates: set[str]) -> set[str]:
+    """Return the subset of `candidates` referenced by rows in `table`."""
+    if not candidates:
+        return set()
+    referenced = set()
+    # Supabase PostgREST `in` filter accepts a list — chunk to stay under URL limits.
+    chunk = 100
+    candidates_list = sorted(candidates)
+    for i in range(0, len(candidates_list), chunk):
+        batch = candidates_list[i:i + chunk]
+        resp = (
+            db.client.table(table)
+            .select("ticker")
+            .in_("ticker", batch)
+            .execute()
+        )
+        for row in resp.data or []:
+            referenced.add(row["ticker"])
+    return referenced
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print plan without deleting")
+    args = parser.parse_args()
+
+    logger = setup_logging()
+    logger.info("=" * 60)
+    logger.info("Delete non-US companies — %s", date.today().isoformat())
+    logger.info("US_EXCHANGES = %s", sorted(US_EXCHANGES))
+    logger.info("=" * 60)
+
+    db = SupabaseDB()
+
+    rows = db.get_all_companies(columns="ticker, exchange, country, company_name")
+    logger.info("Loaded %d companies", len(rows))
+
+    # Bucket: non-US (incl. blank exchange) candidates
+    non_us = []
+    for row in rows:
+        ex = str(row.get("exchange") or "").strip().upper()
+        if ex not in US_EXCHANGES:
+            non_us.append(row)
+
+    logger.info("Found %d rows with exchange ∉ US_EXCHANGES", len(non_us))
+    if not non_us:
+        logger.info("Nothing to delete.")
+        return
+
+    candidate_tickers = {r["ticker"] for r in non_us}
+
+    # FK guard: any ticker referenced by holdings or trades is preserved.
+    held = _referenced_tickers(db, "agent_holdings", candidate_tickers)
+    traded = _referenced_tickers(db, "agent_trades", candidate_tickers)
+    protected = held | traded
+
+    if protected:
+        logger.warning(
+            "%d tickers protected by FK references "
+            "(agent_holdings=%d, agent_trades=%d): %s",
+            len(protected), len(held), len(traded), sorted(protected),
+        )
+
+    deletable = [r for r in non_us if r["ticker"] not in protected]
+    logger.info("Deletable: %d / %d", len(deletable), len(non_us))
+
+    # Sample preview
+    for r in sorted(deletable, key=lambda x: x["ticker"])[:50]:
+        logger.info(
+            "  DELETE %s (%s, %s) — %s",
+            r["ticker"], r.get("exchange") or "—",
+            r.get("country") or "—", r.get("company_name") or "",
+        )
+    if len(deletable) > 50:
+        logger.info("  … and %d more", len(deletable) - 50)
+
+    if args.dry_run:
+        logger.info("Dry run — no changes written.")
+        return
+
+    if not deletable:
+        logger.info("Nothing deletable after FK guard.")
+        return
+
+    # Delete in chunks via PostgREST `in_` filter.
+    chunk = 100
+    deletable_tickers = sorted({r["ticker"] for r in deletable})
+    deleted = 0
+    for i in range(0, len(deletable_tickers), chunk):
+        batch = deletable_tickers[i:i + chunk]
+        db.client.table("companies").delete().in_("ticker", batch).execute()
+        deleted += len(batch)
+        logger.info("Deleted batch %d (%d rows)", i // chunk + 1, len(batch))
+
+    logger.info("Deleted %d non-US companies. Done.", deleted)
+
+
+if __name__ == "__main__":
+    main()

--- a/tv_screen.py
+++ b/tv_screen.py
@@ -31,13 +31,20 @@ EXCLUDED_SECTORS = {
     "Non-Energy Minerals", "Finance", "Utilities",
 }
 
-# Markets to screen. TradingView's "america" market covers NYSE/NASDAQ/
-# AMEX — the same set as agent_strategies.US_EXCHANGES — and includes
-# ADRs (foreign companies whose shares trade on US exchanges in USD).
-# Non-US markets are excluded because PortfolioManager treats every
+# Markets to screen. TradingView's "america" market nominally covers
+# NYSE/NASDAQ/AMEX but in practice also returns OTC pink-sheet ADRs and
+# some primary foreign listings. We post-filter on `exchange ∈
+# US_EXCHANGES` so only NYSE/NASDAQ/AMEX (incl. NYSEARCA/BATS/ARCA)
+# names — and US-listed ADRs of foreign companies — survive. Non-US
+# markets are excluded because PortfolioManager treats every
 # companies.price as USD; until we add FX, agents can only safely trade
 # US-listed names.
 MARKETS = ["america"]
+
+# US exchange codes accepted by the screener — same set as
+# agent_strategies.US_EXCHANGES (kept inline rather than imported to
+# keep tv_screen.py importable without the strategies module).
+US_EXCHANGES = {"NYSE", "NASDAQ", "AMEX", "NYSEARCA", "BATS", "ARCA"}
 
 
 def clean_ticker(raw_name: str) -> str:
@@ -85,11 +92,11 @@ def _screen_markets(markets: list[str], spy_perf_y: float, logger) -> list[dict]
             .select(*TV_SELECT_FIELDS)
             .where(
                 col("market_cap_basic").between(2_000_000_000, 500_000_000_000),
-                col("gross_profit_margin_fy") > 45,
-                col("total_revenue_yoy_growth_ttm").between(15, 500),
-                col("total_revenue_ttm") > 200_000_000,
+                col("gross_profit_margin_fy") > 25,
+                col("total_revenue_yoy_growth_ttm").between(10, 500),
+                col("total_revenue_ttm") > 100_000_000,
                 col("price_revenue_ttm") < 15,
-                col("recommendation_mark") <= 1.8,
+                col("recommendation_mark") <= 2.5,
                 col("sector").not_in(["Finance", "Utilities", "Non-Energy Minerals"]),
             )
             .limit(5000)
@@ -104,6 +111,7 @@ def _screen_markets(markets: list[str], spy_perf_y: float, logger) -> list[dict]
     logger.info("Unique sectors in results (%d): %s", len(unique_sectors), sorted(unique_sectors))
 
     equities = []
+    dropped_exchange_count = 0
     for _, row in df.iterrows():
         raw_name = str(row.get("name", ""))
         ticker = clean_ticker(raw_name)
@@ -112,13 +120,16 @@ def _screen_markets(markets: list[str], spy_perf_y: float, logger) -> list[dict]
 
         country = str(row.get("country", ""))
         sector = str(row.get("sector", ""))
+        exchange = str(row.get("exchange", "")).strip().upper()
 
         if country in EXCLUDED_COUNTRIES:
             continue
         if sector in EXCLUDED_SECTORS:
             continue
+        if exchange not in US_EXCHANGES:
+            dropped_exchange_count += 1
+            continue
 
-        exchange = str(row.get("exchange", ""))
         company_name = str(row.get("description", ""))
         price = row.get("close")
 
@@ -149,6 +160,12 @@ def _screen_markets(markets: list[str], spy_perf_y: float, logger) -> list[dict]
             "perf_52w_vs_spy": perf_52w_vs_spy,
             "rating": rating,
         })
+
+    if dropped_exchange_count:
+        logger.info(
+            "Dropped %d non-US-exchange rows (OTC pinks, foreign primaries)",
+            dropped_exchange_count,
+        )
 
     return equities
 


### PR DESCRIPTION
The TV `america` market was leaking OTC pink-sheet ADRs (UCBJY, CCOEF, RYKKY, ESLOF) and even some primary foreign listings (9697 Tokyo, ADYEN Amsterdam) past the screen, producing 2-3 dupes per company. Post-filter on `exchange ∈ US_EXCHANGES` (NYSE/NASDAQ/AMEX/NYSEARCA/ BATS/ARCA) — same set agent_strategies already uses — so US-listed ADRs of foreign companies still pass while OTC duplicates fall out.

Relax growth-tilted filters to broaden from "hundreds" toward 1k+ names:
- gross margin floor 45% → 25% (admits consumer/industrial/healthcare)
- revenue floor $200M → $100M
- rev growth floor 15% → 10%
- rating cap 1.8 → 2.5

Adds delete_non_us_companies.py for one-off DB cleanup of rows ingested before the gate existed. FK-safe: skips any ticker referenced by agent_holdings or agent_trades.