### PR TITLE
ci: add manual workflow for delete_non_us_companies cleanup

### DIFF
--- a/.github/workflows/delete-non-us-companies.yml
+++ b/.github/workflows/delete-non-us-companies.yml
@@ -1,0 +1,56 @@
+name: Delete non-US companies
+
+# One-off cleanup for rows whose `exchange` is not in US_EXCHANGES
+# (NYSE/NASDAQ/AMEX/NYSEARCA/BATS/ARCA). These leaked into the
+# `companies` table before tv_screen.py grew its exchange post-filter
+# (mostly OTC pink-sheet ADRs and a few primary foreign listings).
+#
+# FK-safe: the script skips any ticker referenced by agent_holdings or
+# agent_trades. Run with dry_run=true first to eyeball the deletion list.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print plan without deleting"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Delete non-US companies
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          args=""
+          if [ "$DRY_RUN" = "true" ]; then
+            args="$args --dry-run"
+          fi
+          python delete_non_us_companies.py $args
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: delete-non-us-companies-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 30


### PR DESCRIPTION
Mirrors bootstrap-benchmarks.yml — workflow_dispatch with a dry_run input that defaults to true so first click is always safe. Uploads logs/ as an artifact for review.