### PR TITLE
screener: broaden to ~1k+ via market cap floor $500M and growth floor 0%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ and score_ai_analysis.py to avoid duplicating the screening code.
 ### nightly_screen.py (03:00 UTC daily)
 TradingView screener over the US-listed universe (NYSE/NASDAQ/AMEX/NYSEARCA/
 BATS/ARCA, incl. ADRs that primary-list on a US exchange).
-Filters: market cap $2B-$500B, gross margin >25%, rev growth 10-500%, revenue >$100M, P/S <15, rating ≤2.5.
+Filters: market cap $500M-$500B, gross margin >25%, rev growth 0-500%, revenue >$100M, P/S <15, rating ≤2.5.
 Excludes: China, Hong Kong, Taiwan, Real Estate, REIT, Non-Energy Minerals, Finance, Utilities.
 Also drops rows whose `exchange` is not in `US_EXCHANGES` (OTC pink-sheet
 ADRs and primary foreign listings that TV's `america` market sometimes

--- a/tv_screen.py
+++ b/tv_screen.py
@@ -91,9 +91,9 @@ def _screen_markets(markets: list[str], spy_perf_y: float, logger) -> list[dict]
             .set_markets(*markets)
             .select(*TV_SELECT_FIELDS)
             .where(
-                col("market_cap_basic").between(2_000_000_000, 500_000_000_000),
+                col("market_cap_basic").between(500_000_000, 500_000_000_000),
                 col("gross_profit_margin_fy") > 25,
-                col("total_revenue_yoy_growth_ttm").between(10, 500),
+                col("total_revenue_yoy_growth_ttm").between(0, 500),
                 col("total_revenue_ttm") > 100_000_000,
                 col("price_revenue_ttm") < 15,
                 col("recommendation_mark") <= 2.5,


### PR DESCRIPTION
Last run landed at 358 names (633 raw, 236 dropped by US_EXCHANGES gate). The binding constraint was rev growth >=10%, which prices out mature compounders, plus the $2B market cap floor cutting small caps.

- market cap floor $2B → $500M (admits small caps)
- rev growth floor 10% → 0% (admits non-shrinking compounders)

Other gates kept as-is — gross margin >25%, revenue >$100M, P/S <15, rating <=2.5, sector exclusions, US_EXCHANGES post-filter.