### PR TITLE
screener: surface picker-agent signals + bull/bear verdict tags in compact tier

### DIFF
--- a/build_universe_snapshot.py
+++ b/build_universe_snapshot.py
@@ -58,7 +58,7 @@ TIERS = ("compact", "extended", "full")
 # Compact: just the decision-relevant scan fields. No history, no long
 # narratives. Designed to fit in any model's context for stage 1.
 COMPACT_FUNDAMENTAL_FIELDS = (
-    "rating", "r40_score",
+    "rating", "rule_of_40",
     "rev_growth_ttm_pct",
     "gross_margin_pct", "fcf_margin_pct",
 )

--- a/build_universe_snapshot.py
+++ b/build_universe_snapshot.py
@@ -93,6 +93,23 @@ def _safe(v: Any) -> Any:
     return v
 
 
+def _eval_verdict(raw: Any) -> str | None:
+    """Strip the rationale from a bull_eval / bear_eval value.
+
+    Stored verdicts look like "✅ (rare disease pharma...)" or
+    "❌ Net margin declined". Compact picker prompts only need the
+    pass/fail tag — return "✅" or "❌" or None if no verdict yet.
+    """
+    if not raw:
+        return None
+    s = str(raw)
+    if "✅" in s:
+        return "✅"
+    if "❌" in s:
+        return "❌"
+    return None
+
+
 def _round(v: Any, places: int = 2) -> Any:
     if v is None:
         return None
@@ -237,6 +254,14 @@ def _build_ticker_entry(
         company,
         COMPACT_NARRATIVE_FIELDS if is_compact else EXTENDED_NARRATIVE_FIELDS,
     )
+    # Bull/bear verdicts as bare tags so picker agents can see who passed
+    # our two AI auditors at a glance. Extended tier already has the full
+    # rationale strings in the narrative block, so only add tags to compact.
+    if is_compact:
+        entry["verdicts"] = {
+            "bull": _eval_verdict(company.get("bull_eval")),
+            "bear": _eval_verdict(company.get("bear_eval")),
+        }
     return entry
 
 

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -22,17 +22,29 @@ export const metadata: Metadata = {
 
 async function getCompanies(): Promise<Company[]> {
   const supabase = getSupabase();
-  const { data, error } = await supabase
-    .from("companies")
-    .select(SCREENER_COLUMNS)
-    .order("sort_order", { ascending: true, nullsFirst: false });
+  const [companiesRes, psRes] = await Promise.all([
+    supabase
+      .from("companies")
+      .select(SCREENER_COLUMNS)
+      .order("sort_order", { ascending: true, nullsFirst: false }),
+    supabase.from("price_sales").select("ticker, median_12m"),
+  ]);
 
-  if (error) {
-    console.error("Failed to fetch companies:", error);
+  if (companiesRes.error) {
+    console.error("Failed to fetch companies:", companiesRes.error);
     return [];
   }
+  if (psRes.error) {
+    console.error("Failed to fetch price_sales:", psRes.error);
+  }
 
-  return (data ?? []) as unknown as Company[];
+  const psMap = new Map<string, number | null>(
+    ((psRes.data ?? []) as Array<{ ticker: string; median_12m: number | null }>)
+      .map((r) => [r.ticker, r.median_12m]),
+  );
+
+  const rows = (companiesRes.data ?? []) as unknown as Company[];
+  return rows.map((c) => ({ ...c, ps_median_12m: psMap.get(c.ticker) ?? null }));
 }
 
 export default async function ScreenerPage() {

--- a/web/components/data-table.tsx
+++ b/web/components/data-table.tsx
@@ -96,22 +96,26 @@ export default function DataTable({ companies }: { companies: Company[] }) {
 
       {/* Table */}
       <div className="overflow-x-auto rounded-lg border border-border">
-        <table className="w-full text-sm font-mono table-fixed min-w-[1200px]">
+        <table className="w-full text-sm font-mono table-fixed min-w-[1650px]">
           <colgroup>
-            <col className="w-[50px]" />
-            <col className="w-[90px]" />
-            <col className="w-[90px]" />
-            <col className="w-[220px]" />
-            <col className="w-[70px]" />
-            <col className="w-[160px]" />
-            <col className="w-[120px]" />
-            <col className="w-[90px]" />
-            <col className="w-[70px]" />
-            <col className="w-[85px]" />
-            <col className="w-[70px]" />
-            <col className="w-[70px]" />
-            <col className="w-[70px]" />
-            <col className="w-[70px]" />
+            <col className="w-[50px]" />   {/* # */}
+            <col className="w-[90px]" />   {/* Status */}
+            <col className="w-[90px]" />   {/* Ticker */}
+            <col className="w-[220px]" />  {/* Company */}
+            <col className="w-[70px]" />   {/* Score */}
+            <col className="w-[160px]" />  {/* Sector */}
+            <col className="w-[120px]" />  {/* Country */}
+            <col className="w-[90px]" />   {/* Price */}
+            <col className="w-[70px]" />   {/* P/S */}
+            <col className="w-[80px]" />   {/* P/S Med */}
+            <col className="w-[85px]" />   {/* Rev Gr% */}
+            <col className="w-[70px]" />   {/* GM% */}
+            <col className="w-[75px]" />   {/* FCF M% */}
+            <col className="w-[70px]" />   {/* R40 */}
+            <col className="w-[90px]" />   {/* 52w vs SPY */}
+            <col className="w-[70px]" />   {/* Rating */}
+            <col className="w-[70px]" />   {/* Bear */}
+            <col className="w-[70px]" />   {/* Bull */}
           </colgroup>
           <thead>
             <tr className="border-b border-border bg-bg-card">
@@ -124,8 +128,12 @@ export default function DataTable({ companies }: { companies: Company[] }) {
               <Th onClick={() => handleSort("country")} active={sortKey === "country"} dir={sortDir} tooltip="Country of incorporation / primary listing.">Country</Th>
               <Th onClick={() => handleSort("price")} active={sortKey === "price"} dir={sortDir} tooltip="Latest TradingView close price (USD for US listings; native currency otherwise).">Price</Th>
               <Th onClick={() => handleSort("ps_now")} active={sortKey === "ps_now"} dir={sortDir} tooltip="Trailing-twelve-month price-to-sales ratio.">P/S</Th>
+              <Th onClick={() => handleSort("ps_median_12m")} active={sortKey === "ps_median_12m"} dir={sortDir} tooltip="12-month median P/S — anchor for 'is this expensive?'. The Discount badge fires when current P/S is >20% below this.">P/S Med</Th>
               <Th onClick={() => handleSort("rev_growth_ttm_pct")} active={sortKey === "rev_growth_ttm_pct"} dir={sortDir} tooltip="TTM revenue growth — year-over-year percent change.">Rev Gr%</Th>
               <Th onClick={() => handleSort("gross_margin_pct")} active={sortKey === "gross_margin_pct"} dir={sortDir} tooltip="Gross margin (TTM). Screen requires >25%.">GM%</Th>
+              <Th onClick={() => handleSort("fcf_margin_pct")} active={sortKey === "fcf_margin_pct"} dir={sortDir} tooltip="Free cash flow margin (TTM). Positive means the business funds itself from operations.">FCF M%</Th>
+              <Th onClick={() => handleSort("rule_of_40")} active={sortKey === "rule_of_40"} dir={sortDir} tooltip="Rule of 40: revenue growth + operating margin. Above 40 is the canonical SaaS/growth quality bar.">R40</Th>
+              <Th onClick={() => handleSort("perf_52w_vs_spy")} active={sortKey === "perf_52w_vs_spy"} dir={sortDir} tooltip="52-week relative performance vs S&P 500. Capped at +40% in the score (blow-off-top guard); below -50% disqualifies (falling-knife guard).">52w vs SPY</Th>
               <Th onClick={() => handleSort("rating")} active={sortKey === "rating"} dir={sortDir} tooltip="TradingView technical/analyst rating. 1.0 = strong buy, 5.0 = strong sell. Score multiplier tapers from 1.21 and disqualifies above 1.6.">Rating</Th>
               <Th onClick={() => handleSort("bear_eval")} active={sortKey === "bear_eval"} dir={sortDir} tooltip="Forensic fundamental-health audit by Gemini 2.5 Flash. ✅ pass / ❌ fail. Hover a row's badge for the rationale. Refreshed daily on a ~5-day rotation.">Bear</Th>
               <Th onClick={() => handleSort("bull_eval")} active={sortKey === "bull_eval"} dir={sortDir} tooltip="Growth/venture equity audit by Claude Opus 4.6 — looks for 'smash hits' in expanding verticals. ✅ pass / ❌ fail. Hover a row's badge for the rationale. Refreshed daily on a ~5-day rotation.">Bull</Th>
@@ -168,7 +176,7 @@ export default function DataTable({ companies }: { companies: Company[] }) {
                   </td>
                   <td
                     className="px-3 py-2 truncate"
-                    title={c.company_name || ""}
+                    title={c.short_outlook || c.company_name || ""}
                   >
                     <Link
                       href={`/company/${c.ticker}`}
@@ -198,6 +206,9 @@ export default function DataTable({ companies }: { companies: Company[] }) {
                   <td className="px-3 py-2 text-right whitespace-nowrap">
                     {formatNumber(c.ps_now, { decimals: 1 })}
                   </td>
+                  <td className="px-3 py-2 text-right text-text-dim whitespace-nowrap">
+                    {formatNumber(c.ps_median_12m, { decimals: 1 })}
+                  </td>
                   <td className="px-3 py-2 text-right whitespace-nowrap">
                     <span
                       className={
@@ -218,6 +229,43 @@ export default function DataTable({ companies }: { companies: Company[] }) {
                       }
                     >
                       {formatPct(c.gross_margin_pct)}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-right whitespace-nowrap">
+                    <span
+                      className={
+                        (c.fcf_margin_pct ?? 0) > 0
+                          ? "text-green"
+                          : "text-text-dim"
+                      }
+                    >
+                      {formatPct(c.fcf_margin_pct)}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-right whitespace-nowrap">
+                    <span
+                      className={
+                        (c.rule_of_40 ?? 0) >= 40
+                          ? "text-green"
+                          : "text-text-dim"
+                      }
+                    >
+                      {formatNumber(c.rule_of_40, { decimals: 1 })}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-right whitespace-nowrap">
+                    <span
+                      className={
+                        (c.perf_52w_vs_spy ?? 0) >= 0
+                          ? "text-green"
+                          : "text-text-dim"
+                      }
+                    >
+                      {formatPct(
+                        c.perf_52w_vs_spy != null
+                          ? c.perf_52w_vs_spy * 100
+                          : null,
+                      )}
                     </span>
                   </td>
                   <td className="px-3 py-2 text-right text-text-dim whitespace-nowrap">

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -62,6 +62,9 @@ export interface Company {
   bull_eval: string | null;
   bull_eval_at: string | null;
 
+  // Joined client-side from price_sales
+  ps_median_12m: number | null;
+
   // Portfolio
   in_portfolio: boolean | null;
   portfolio_sort_order: number | null;
@@ -103,6 +106,8 @@ export const SCREENER_COLUMNS = [
   "ps_now",
   "rev_growth_ttm_pct",
   "gross_margin_pct",
+  "fcf_margin_pct",
+  "rule_of_40",
   "rating",
   "sort_order",
   "bear_eval",


### PR DESCRIPTION
Aligns the human-facing screener with what picker agents read in the compact universe tier — "what humans see should match what agents see."

## Screener (4 new columns + outlook tooltip)

Surfaces fields that drive composite_score / agent picks but were previously invisible:

| Column | Source | Green threshold |
|---|---|---|
| **P/S Med** | `price_sales.median_12m` (joined client-side) | — |
| **FCF M%** | `companies.fcf_margin_pct` | > 0 |
| **R40** | `companies.rule_of_40` | ≥ 40 |
| **52w vs SPY** | `companies.perf_52w_vs_spy × 100` | ≥ 0 |

`short_outlook` now shows as a hover tooltip on the company-name cell (already fetched, just wasn't rendered). Each new header has its own tooltip explaining the metric. Table min-width grew 1200 → 1650; existing horizontal-scroll wrapper handles narrow viewports.

## Compact universe tier — two changes

1. **Bull/bear verdict tags** (eabb058): each compact entry gets a `verdicts: { bull, bear }` block with bare `"✅"` / `"❌"` / `null` — picker agents see at a glance who passed our two AI auditors without inflating the prompt with rationale strings. Extended/full tiers already have full bull_eval/bear_eval; this only fires on compact. Cost: ~5 chars per row.
2. **`r40_score` → `rule_of_40`** in `COMPACT_FUNDAMENTAL_FIELDS` (0901054): swap the diamond-emoji text format for the numeric value, matching the screener's R40 column. Token-cheaper, sortable, same signal.

Coverage caveat: bull/bear rotation just switched to daily 100/day on this branch, so on day-1 most rows have `verdicts: { bull: null, bear: null }`. Fills in over ~5 days as the rotation cycles through the universe.

## Files

- `web/lib/types.ts` — `SCREENER_COLUMNS` gains `rule_of_40` + `fcf_margin_pct`; `Company` gains `ps_median_12m`
- `web/app/screener/page.tsx` — parallel-fetches `price_sales` and merges `median_12m` by ticker
- `web/components/data-table.tsx` — 4 new headers/cells + per-column tooltips + outlook tooltip on company name
- `build_universe_snapshot.py` — verdict tags helper + `COMPACT_FUNDAMENTAL_FIELDS` swap

## Test plan

- [ ] Frontend redeploy on Vercel; confirm `/screener` renders 18 columns with values
- [ ] Hover company name → `short_outlook` shows
- [ ] Hover each new column header → tooltip shows
- [ ] Sort each new column ascending + descending; NULLs stay at the bottom
- [ ] Spot-check P/S Med vs `/company/[ticker]` "12m Median" — should match
- [ ] Trigger Universe Snapshot workflow; inspect today's compact JSON for `verdicts` block + numeric `rule_of_40`
- [ ] Hit `GET /api/v1/universe?detail=compact` and confirm shape matches

https://claude.ai/code/session_015iqfCbtXgumZdDvDcbxyCH

---
_Generated by [Claude Code](https://claude.ai/code/session_015iqfCbtXgumZdDvDcbxyCH)_