### PR TITLE
leaderboard: add 1W tab between 1D and 30D

### DIFF
--- a/migrations/014_pnl_pct_1w.sql
+++ b/migrations/014_pnl_pct_1w.sql
@@ -1,0 +1,136 @@
+-- Migration 014: add `pnl_pct_1w` to agent_leaderboard.
+--
+-- The leaderboard tab strip already exposes 1D / 30D / YTD / 1YR. A 1-week
+-- window fills the gap between "today's noise" and "month-over-month" — it
+-- sees one weekly rebalance cycle but still resets fast enough to surface
+-- agents that just shifted strategy. Same NULL-on-insufficient-history
+-- discipline as the other windows (migration 012): a 5-day-old agent's
+-- "1w" cell stays NULL so the frontend renders "calculating".
+
+DROP VIEW IF EXISTS agent_leaderboard;
+
+CREATE VIEW agent_leaderboard AS
+WITH latest AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        snapshot_date,
+        cash_usd,
+        holdings_value_usd,
+        total_value_usd,
+        pnl_usd,
+        pnl_pct,
+        num_positions
+    FROM agent_portfolio_history
+    ORDER BY agent_id, snapshot_date DESC
+),
+one_day_ago AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '1 day'
+    ORDER BY agent_id, snapshot_date DESC
+),
+one_week_ago AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '7 days'
+    ORDER BY agent_id, snapshot_date DESC
+),
+thirty_days_ago AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '30 days'
+    ORDER BY agent_id, snapshot_date DESC
+),
+year_start AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date < DATE_TRUNC('year', CURRENT_DATE)::DATE
+    ORDER BY agent_id, snapshot_date DESC
+),
+one_year_ago AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '1 year'
+    ORDER BY agent_id, snapshot_date DESC
+),
+sharpe_returns AS (
+    SELECT
+        agent_id,
+        (total_value_usd - LAG(total_value_usd) OVER w)
+            / NULLIF(LAG(total_value_usd) OVER w, 0) AS daily_return
+    FROM agent_portfolio_history
+    WHERE EXTRACT(DOW FROM snapshot_date) BETWEEN 1 AND 5
+    WINDOW w AS (PARTITION BY agent_id ORDER BY snapshot_date)
+),
+sharpe AS (
+    SELECT
+        agent_id,
+        AVG(daily_return)         AS mean_return,
+        STDDEV_SAMP(daily_return) AS stdev_return,
+        COUNT(daily_return)       AS n_returns
+    FROM sharpe_returns
+    WHERE daily_return IS NOT NULL
+    GROUP BY agent_id
+)
+SELECT
+    a.handle,
+    a.display_name,
+    a.is_house_agent,
+    l.snapshot_date,
+    l.cash_usd,
+    l.holdings_value_usd,
+    l.total_value_usd,
+    l.pnl_usd,
+    l.pnl_pct,
+    l.num_positions,
+    CASE
+        WHEN t1d.value_anchor IS NULL OR t1d.value_anchor = 0 THEN NULL
+        ELSE ROUND(((l.total_value_usd - t1d.value_anchor)
+                    / t1d.value_anchor) * 100, 4)
+    END AS pnl_pct_1d,
+    CASE
+        WHEN t1w.value_anchor IS NULL OR t1w.value_anchor = 0 THEN NULL
+        ELSE ROUND(((l.total_value_usd - t1w.value_anchor)
+                    / t1w.value_anchor) * 100, 4)
+    END AS pnl_pct_1w,
+    CASE
+        WHEN t30.value_anchor IS NULL OR t30.value_anchor = 0 THEN NULL
+        ELSE ROUND(((l.total_value_usd - t30.value_anchor)
+                    / t30.value_anchor) * 100, 4)
+    END AS pnl_pct_30d,
+    CASE
+        WHEN tytd.value_anchor IS NULL OR tytd.value_anchor = 0 THEN NULL
+        ELSE ROUND(((l.total_value_usd - tytd.value_anchor)
+                    / tytd.value_anchor) * 100, 4)
+    END AS pnl_pct_ytd,
+    CASE
+        WHEN t1y.value_anchor IS NULL OR t1y.value_anchor = 0 THEN NULL
+        ELSE ROUND(((l.total_value_usd - t1y.value_anchor)
+                    / t1y.value_anchor) * 100, 4)
+    END AS pnl_pct_1yr,
+    CASE
+        WHEN s.n_returns < 30
+          OR s.stdev_return IS NULL
+          OR s.stdev_return = 0 THEN NULL
+        ELSE ROUND((((s.mean_return - 0.05 / 252.0) / s.stdev_return) * SQRT(252))::numeric, 4)
+    END AS sharpe,
+    COALESCE(s.n_returns, 0)::int AS sharpe_n_returns
+FROM latest l
+JOIN agents a ON a.id = l.agent_id
+LEFT JOIN one_day_ago     t1d  ON t1d.agent_id  = l.agent_id
+LEFT JOIN one_week_ago    t1w  ON t1w.agent_id  = l.agent_id
+LEFT JOIN thirty_days_ago t30  ON t30.agent_id  = l.agent_id
+LEFT JOIN year_start      tytd ON tytd.agent_id = l.agent_id
+LEFT JOIN one_year_ago    t1y  ON t1y.agent_id  = l.agent_id
+LEFT JOIN sharpe          s    ON s.agent_id    = l.agent_id
+ORDER BY l.pnl_pct DESC;

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -452,15 +452,16 @@ CREATE INDEX IF NOT EXISTS idx_bench_prices_date ON benchmark_prices (price_date
 
 
 -- ============================================================
--- agent_leaderboard view — four rolling return windows
+-- agent_leaderboard view — five rolling return windows
 --
 -- Supersedes the earlier definition above. Exposes pnl_pct_1d /
--- pnl_pct_30d / pnl_pct_ytd / pnl_pct_1yr, each computed with a
--- since-inception fallback when the agent has less history than the
--- window. Keeps pnl_pct (all-time) on the view so the homepage
--- rankings card still reads it. Default sort stays `pnl_pct DESC`
--- for backwards-compat; the leaderboard page re-sorts by
--- pnl_pct_30d DESC NULLS LAST.
+-- pnl_pct_1w / pnl_pct_30d / pnl_pct_ytd / pnl_pct_1yr. Each window
+-- is NULL when the agent has no snapshot at-or-before its cutoff
+-- (migration 012 dropped the since-inception fallback so windows
+-- stay comparable across agents of different ages). Keeps pnl_pct
+-- (all-time) so the homepage rankings card still reads it. Default
+-- sort stays `pnl_pct DESC` for backwards-compat; the leaderboard
+-- page re-sorts by the user-selected period.
 -- ============================================================
 
 -- DROP first because we're recreating with renamed/extra columns
@@ -487,6 +488,14 @@ one_day_ago AS (
         total_value_usd AS value_anchor
     FROM agent_portfolio_history
     WHERE snapshot_date <= CURRENT_DATE - INTERVAL '1 day'
+    ORDER BY agent_id, snapshot_date DESC
+),
+one_week_ago AS (
+    SELECT DISTINCT ON (agent_id)
+        agent_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '7 days'
     ORDER BY agent_id, snapshot_date DESC
 ),
 thirty_days_ago AS (
@@ -559,6 +568,11 @@ SELECT
                     / t1d.value_anchor) * 100, 4)
     END AS pnl_pct_1d,
     CASE
+        WHEN t1w.value_anchor IS NULL OR t1w.value_anchor = 0 THEN NULL
+        ELSE ROUND(((l.total_value_usd - t1w.value_anchor)
+                    / t1w.value_anchor) * 100, 4)
+    END AS pnl_pct_1w,
+    CASE
         WHEN t30.value_anchor IS NULL OR t30.value_anchor = 0 THEN NULL
         ELSE ROUND(((l.total_value_usd - t30.value_anchor)
                     / t30.value_anchor) * 100, 4)
@@ -584,6 +598,7 @@ SELECT
 FROM latest l
 JOIN agents a ON a.id = l.agent_id
 LEFT JOIN one_day_ago     t1d    ON t1d.agent_id    = l.agent_id
+LEFT JOIN one_week_ago    t1w    ON t1w.agent_id    = l.agent_id
 LEFT JOIN thirty_days_ago t30    ON t30.agent_id    = l.agent_id
 LEFT JOIN year_start      tytd   ON tytd.agent_id   = l.agent_id
 LEFT JOIN one_year_ago    t1y    ON t1y.agent_id    = l.agent_id

--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -132,7 +132,7 @@ export default async function LeaderboardPage({
 
 function topByPeriod(
   rows: Awaited<ReturnType<typeof getLeaderboard>>["rows"],
-  period: "1d" | "30d" | "ytd" | "1yr",
+  period: "1d" | "1w" | "30d" | "ytd" | "1yr",
   n: number,
 ) {
   return [...rows]

--- a/web/components/home-leaderboard.tsx
+++ b/web/components/home-leaderboard.tsx
@@ -22,6 +22,7 @@ interface Props {
 
 const PERIOD_LABELS: Record<Period, string> = {
   "1d": "1D",
+  "1w": "1W",
   "30d": "30D",
   ytd: "YTD",
   "1yr": "1Y",

--- a/web/components/leaderboard-table.tsx
+++ b/web/components/leaderboard-table.tsx
@@ -5,11 +5,12 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useTransition } from "react";
 
 // Shared window keys. Order of `PERIODS` is the toggle render order.
-const PERIODS = ["1d", "30d", "ytd", "1yr"] as const;
+const PERIODS = ["1d", "1w", "30d", "ytd", "1yr"] as const;
 export type Period = (typeof PERIODS)[number];
 
 const PERIOD_LABELS: Record<Period, string> = {
   "1d": "1d",
+  "1w": "1w",
   "30d": "30d",
   ytd: "YTD",
   "1yr": "1Yr",

--- a/web/lib/home-leaderboard-query.ts
+++ b/web/lib/home-leaderboard-query.ts
@@ -7,12 +7,13 @@
 
 import { getSupabase } from "@/lib/supabase";
 
-export type Period = "1d" | "30d" | "ytd" | "1yr";
-export const PERIODS: readonly Period[] = ["1d", "30d", "ytd", "1yr"];
+export type Period = "1d" | "1w" | "30d" | "ytd" | "1yr";
+export const PERIODS: readonly Period[] = ["1d", "1w", "30d", "ytd", "1yr"];
 export const DEFAULT_PERIOD: Period = "30d";
 
 export interface Returns {
   "1d": number | null;
+  "1w": number | null;
   "30d": number | null;
   ytd: number | null;
   "1yr": number | null;
@@ -50,6 +51,7 @@ export async function getHomeLeaderboard(): Promise<HomeLeaderboardResult> {
     display_name: string;
     is_house_agent: boolean;
     pnl_pct_1d: number | string | null;
+    pnl_pct_1w: number | string | null;
     pnl_pct_30d: number | string | null;
     pnl_pct_ytd: number | string | null;
     pnl_pct_1yr: number | string | null;
@@ -57,7 +59,7 @@ export async function getHomeLeaderboard(): Promise<HomeLeaderboardResult> {
   const { data: viewRows, error: viewErr } = await supabase
     .from("agent_leaderboard")
     .select(
-      "handle, display_name, is_house_agent, pnl_pct_1d, pnl_pct_30d, pnl_pct_ytd, pnl_pct_1yr",
+      "handle, display_name, is_house_agent, pnl_pct_1d, pnl_pct_1w, pnl_pct_30d, pnl_pct_ytd, pnl_pct_1yr",
     )
     .eq("is_house_agent", false);
   if (viewErr) {
@@ -75,6 +77,7 @@ export async function getHomeLeaderboard(): Promise<HomeLeaderboardResult> {
     display_name: r.display_name,
     returns: {
       "1d": toNum(r.pnl_pct_1d),
+      "1w": toNum(r.pnl_pct_1w),
       "30d": toNum(r.pnl_pct_30d),
       ytd: toNum(r.pnl_pct_ytd),
       "1yr": toNum(r.pnl_pct_1yr),

--- a/web/lib/leaderboard-og.tsx
+++ b/web/lib/leaderboard-og.tsx
@@ -24,6 +24,7 @@ const BORDER = "rgba(255,255,255,0.08)";
 
 const PERIOD_LABELS: Record<Period, string> = {
   "1d": "1-day",
+  "1w": "1-week",
   "30d": "30-day",
   ytd: "YTD",
   "1yr": "1-year",

--- a/web/lib/leaderboard-query.ts
+++ b/web/lib/leaderboard-query.ts
@@ -16,12 +16,12 @@ import type {
   Period,
 } from "@/components/leaderboard-table";
 
-const PERIODS: readonly Period[] = ["1d", "30d", "ytd", "1yr"];
+const PERIODS: readonly Period[] = ["1d", "1w", "30d", "ytd", "1yr"];
 
 type TradeBuckets = Record<Period, number>;
 
 function emptyBuckets(): TradeBuckets {
-  return { "1d": 0, "30d": 0, ytd: 0, "1yr": 0 };
+  return { "1d": 0, "1w": 0, "30d": 0, ytd: 0, "1yr": 0 };
 }
 
 export interface LeaderboardResult {
@@ -43,6 +43,7 @@ async function fetchLeaderboard(): Promise<LeaderboardResult> {
     total_value_usd: number | string;
     pnl_usd: number | string;
     pnl_pct_1d: number | string | null;
+    pnl_pct_1w: number | string | null;
     pnl_pct_30d: number | string | null;
     pnl_pct_ytd: number | string | null;
     pnl_pct_1yr: number | string | null;
@@ -55,7 +56,7 @@ async function fetchLeaderboard(): Promise<LeaderboardResult> {
     .select(
       "handle, display_name, is_house_agent, snapshot_date, cash_usd, " +
         "holdings_value_usd, total_value_usd, pnl_usd, " +
-        "pnl_pct_1d, pnl_pct_30d, pnl_pct_ytd, pnl_pct_1yr, " +
+        "pnl_pct_1d, pnl_pct_1w, pnl_pct_30d, pnl_pct_ytd, pnl_pct_1yr, " +
         "sharpe, sharpe_n_returns, num_positions",
     );
   if (agentErr) console.error("Failed to fetch agent leaderboard:", agentErr);
@@ -82,6 +83,7 @@ async function fetchLeaderboard(): Promise<LeaderboardResult> {
       returns: applyInceptionFloors(
         {
           "1d": toNum(r.pnl_pct_1d),
+          "1w": toNum(r.pnl_pct_1w),
           "30d": toNum(r.pnl_pct_30d),
           ytd: toNum(r.pnl_pct_ytd),
           "1yr": toNum(r.pnl_pct_1yr),
@@ -136,11 +138,13 @@ async function fetchLeaderboard(): Promise<LeaderboardResult> {
 
       const latestDate = b.latest_price_date;
       const dayAgo = shiftDays(latestDate, -1);
+      const weekAgo = shiftDays(latestDate, -7);
       const thirtyAgo = shiftDays(latestDate, -30);
       const yearAgo = shiftDays(latestDate, -365);
       const yearStart = `${latestDate.slice(0, 4)}-01-01`;
 
       const a1d = lastOnOrBefore(prices, dayAgo) ?? inception;
+      const a1w = lastOnOrBefore(prices, weekAgo) ?? inception;
       const a30d = lastOnOrBefore(prices, thirtyAgo) ?? inception;
       const a1yr = lastOnOrBefore(prices, yearAgo) ?? inception;
       const aYtd = firstOnOrAfter(prices, yearStart) ?? inception;
@@ -158,6 +162,7 @@ async function fetchLeaderboard(): Promise<LeaderboardResult> {
         pnl_usd: pnlUsd,
         returns: {
           "1d": pctChange(a1d, latest),
+          "1w": pctChange(a1w, latest),
           "30d": pctChange(a30d, latest),
           ytd: pctChange(aYtd, latest),
           "1yr": pctChange(a1yr, latest),
@@ -220,6 +225,7 @@ async function fetchTradeBuckets(
     now.getTime() - 365 * 24 * 60 * 60 * 1000,
   ).toISOString();
   const dayAgoMs = now.getTime() - 24 * 60 * 60 * 1000;
+  const weekAgoMs = now.getTime() - 7 * 24 * 60 * 60 * 1000;
   const thirtyDayMs = now.getTime() - 30 * 24 * 60 * 60 * 1000;
   const yearStartMs = Date.UTC(now.getUTCFullYear(), 0, 1);
   const yearAgoMs = new Date(yearAgoIso).getTime();
@@ -258,6 +264,7 @@ async function fetchTradeBuckets(
     }
     const ts = new Date(trade.executed_at).getTime();
     if (ts >= dayAgoMs) bucket["1d"] += 1;
+    if (ts >= weekAgoMs) bucket["1w"] += 1;
     if (ts >= thirtyDayMs) bucket["30d"] += 1;
     if (ts >= yearStartMs) bucket.ytd += 1;
     if (ts >= yearAgoMs) bucket["1yr"] += 1;
@@ -320,6 +327,7 @@ function applyInceptionFloors(
   const now = new Date();
   const ageDays = (now.getTime() - inception.getTime()) / 86400000;
   const out = { ...returns };
+  if (ageDays < 7) out["1w"] = null;
   if (ageDays < 30) out["30d"] = null;
   if (ageDays < 365) out["1yr"] = null;
   if (inception.getUTCFullYear() >= now.getUTCFullYear()) out.ytd = null;


### PR DESCRIPTION
A one-week window fills the gap between today's noise and month-over- month: it captures one rebalance cycle but resets fast enough to surface agents that just shifted strategy.

- Migration 014 adds `pnl_pct_1w` to the agent_leaderboard view (mirrors the existing 1d/30d/ytd/1yr CTEs + CASE blocks; same NULL-on- insufficient-history discipline as migration 012).
- supabase_schema.sql updated to reflect the new view shape.
- Plumb the new period through leaderboard-query (select column, trade bucket counter, benchmark return computation, inception floor) and home-leaderboard-query (select + Returns type).
- PERIODS / PERIOD_LABELS extended in both leaderboard-table.tsx and home-leaderboard.tsx so the tab strip and the home-page period toggle pick up the new entry. Same for the OG card.

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi