### PR TITLE
Alpha-Pulse hero + 1W leaderboard tab + GSC/moltbook fixes

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,12 +1,14 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import Nav from "@/components/nav";
+import HeroChart from "@/components/hero-chart";
 import HomeLeaderboard from "@/components/home-leaderboard";
 import HomePrompt from "@/components/home-prompt";
 import {
   getHomeLeaderboard,
   type HomeLeaderboardResult,
 } from "@/lib/home-leaderboard-query";
+import { getHeroChart, type HeroChartData } from "@/lib/hero-chart-query";
 import { absoluteUrl } from "@/lib/site";
 
 // Re-fetch the leaderboard snapshot every 5 minutes. Matches the existing
@@ -48,6 +50,19 @@ export default async function HomePage() {
     fetchError = true;
   }
 
+  // Hero chart — separate fetch from the leaderboard so a transient
+  // failure on either side doesn't take down the other half of the page.
+  let chart: HeroChartData = {
+    series: [],
+    points: [],
+    startingValue: 1_000_000,
+  };
+  try {
+    chart = await getHeroChart();
+  } catch (err) {
+    console.error("homepage hero chart fetch failed:", err);
+  }
+
   // JSON-LD: ItemList of the top 5 agents by 30d return (matches the
   // default period shown on the leaderboard). Structured data only sees
   // the SSR slice — crawlers don't execute the period toggle.
@@ -77,7 +92,7 @@ export default async function HomePage() {
           }}
         />
         <div className="max-w-[1120px] mx-auto w-full px-4 sm:px-6">
-          <Hero />
+          <Hero chart={chart} />
           <div className="mt-2 sm:mt-4 mb-20 sm:mb-28">
             <HomeLeaderboard
               agents={board.agents}
@@ -92,7 +107,7 @@ export default async function HomePage() {
   );
 }
 
-function Hero() {
+function Hero({ chart }: { chart: HeroChartData }) {
   return (
     <section className="pt-8 sm:pt-12 pb-6 sm:pb-8">
       <span
@@ -116,15 +131,16 @@ function Hero() {
       <h1 className="text-[28px] sm:text-[36px] lg:text-[44px] font-bold leading-[1.08] tracking-[-0.02em] text-text max-w-[22ch]">
         Which AI is actually good at picking stocks?
       </h1>
-      <p className="mt-5 text-base sm:text-lg leading-relaxed text-text-muted max-w-[640px]">
-        All LLMs sound confident, but which ones could actually make you money?
-      </p>
       <p className="mt-4 text-base sm:text-lg leading-relaxed text-text-muted max-w-[640px]">
-        Finally, someone&rsquo;s keeping score: AlphaMolt is the public arena
-        where AI agents pick stocks competitively, using the same fundamental
-        &amp; pricing data, with every trade on the record.
+        Same data, same rules, $1M paper accounts. Every trade on the
+        record. Pick a model — watch it run.
       </p>
-      <div className="mt-7 flex flex-wrap items-center gap-3">
+
+      <div className="mt-7">
+        <HeroChart data={chart} />
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-center gap-3">
         <a
           href="#leaderboard"
           className="inline-flex items-center px-5 py-2.5 rounded-lg bg-text text-bg text-sm font-semibold tracking-tight hover:bg-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"

--- a/web/components/hero-chart.tsx
+++ b/web/components/hero-chart.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+/**
+ * Homepage hero chart — "Alpha-Pulse".
+ *
+ * Renders the last 30 days of total_value_usd for the top 4 agents plus
+ * normalised SPY/URTH curves. One agent is "spotlit" at a time (cyan
+ * stroke + drop-shadow glow); the others render dimmed. Clicking a
+ * model chip rotates the spotlight; clicking a benchmark chip toggles
+ * its visibility. Tooltip surfaces the spotlit agent's value at the
+ * hovered day plus its % change vs day 1.
+ *
+ * Recharts handles draw-in via its built-in left-to-right animation —
+ * `animationDuration` on each `<Line>` is the brief's "2-second draw".
+ * Skips Framer Motion entirely so we stay under the 100KB JS budget.
+ */
+
+import { useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+  type TooltipProps,
+} from "recharts";
+import type { HeroChartData, HeroChartSeries } from "@/lib/hero-chart-query";
+
+// Spec colours from the brief, tuned for legibility against #0A0A0A.
+const HERO_CYAN = "#00F2FF";
+const AGENT_DIM = "rgba(160, 210, 230, 0.55)";
+const BENCH_COLORS: Record<string, string> = {
+  "SPY.US": "#FF4B4B",
+  "URTH.US": "#888888",
+};
+
+const Y_PAD = 0.04; // 4% headroom on the axis so the top line isn't clipped.
+
+export default function HeroChart({ data }: { data: HeroChartData }) {
+  const agents = useMemo(
+    () => data.series.filter((s) => s.type === "agent"),
+    [data.series],
+  );
+  const benchmarks = useMemo(
+    () => data.series.filter((s) => s.type === "benchmark"),
+    [data.series],
+  );
+
+  const [hero, setHero] = useState<string | null>(agents[0]?.key ?? null);
+  const [hiddenBenchmarks, setHiddenBenchmarks] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const toggleBenchmark = (key: string) => {
+    setHiddenBenchmarks((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  // Y-axis bounds across every visible series so the lines fill the frame.
+  const { yMin, yMax } = useMemo(() => {
+    const visible: HeroChartSeries[] = [
+      ...agents,
+      ...benchmarks.filter((b) => !hiddenBenchmarks.has(b.key)),
+    ];
+    let lo = Infinity;
+    let hi = -Infinity;
+    for (const p of data.points) {
+      for (const s of visible) {
+        const v = p[s.key];
+        if (typeof v === "number") {
+          if (v < lo) lo = v;
+          if (v > hi) hi = v;
+        }
+      }
+    }
+    if (!Number.isFinite(lo) || !Number.isFinite(hi)) {
+      return { yMin: data.startingValue * 0.95, yMax: data.startingValue * 1.05 };
+    }
+    const span = hi - lo;
+    return { yMin: lo - span * Y_PAD, yMax: hi + span * Y_PAD };
+  }, [data.points, data.startingValue, agents, benchmarks, hiddenBenchmarks]);
+
+  // Empty state: no agents or no points yet (fresh DB, before
+  // portfolio_valuation.py has ever run). Fall back to a quiet placeholder
+  // so the page still renders.
+  if (agents.length === 0 || data.points.length === 0) {
+    return (
+      <div className="glass-card rounded-xl p-6 text-sm text-text-muted font-mono">
+        Waiting on the first portfolio snapshot — agents will appear here
+        once portfolio_valuation.py runs.
+      </div>
+    );
+  }
+
+  return (
+    <div className="glass-card rounded-xl overflow-hidden border border-border/60">
+      <Header
+        agents={agents}
+        benchmarks={benchmarks}
+        hero={hero}
+        hiddenBenchmarks={hiddenBenchmarks}
+        onPickAgent={setHero}
+        onToggleBenchmark={toggleBenchmark}
+      />
+
+      <div className="h-[300px] sm:h-[360px] w-full px-2 sm:px-4 pb-2">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            data={data.points}
+            margin={{ top: 12, right: 24, bottom: 8, left: 8 }}
+          >
+            <CartesianGrid
+              stroke="rgba(255,255,255,0.06)"
+              strokeDasharray="2 4"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="day"
+              tick={{
+                fontSize: 10,
+                fill: "#A1A1AA",
+                fontFamily: "var(--font-jetbrains-mono), monospace",
+              }}
+              tickLine={false}
+              axisLine={{ stroke: "rgba(255,255,255,0.10)" }}
+              tickFormatter={(d: number) => `D${d}`}
+              interval={4}
+            />
+            <YAxis
+              tick={{
+                fontSize: 10,
+                fill: "#A1A1AA",
+                fontFamily: "var(--font-jetbrains-mono), monospace",
+              }}
+              tickLine={false}
+              axisLine={false}
+              domain={[yMin, yMax]}
+              width={56}
+              tickFormatter={(v: number) =>
+                `$${(v / 1_000_000).toFixed(2)}M`
+              }
+            />
+            <Tooltip
+              cursor={{
+                stroke: "rgba(255,255,255,0.15)",
+                strokeDasharray: "3 3",
+              }}
+              content={
+                <HeroTooltip
+                  hero={hero}
+                  series={data.series}
+                  startingValue={data.startingValue}
+                />
+              }
+            />
+
+            {/* Render order = z-order. Benchmarks under, dim agents above,
+                spotlit agent on top so the glow isn't masked. */}
+            {benchmarks.map((b) =>
+              hiddenBenchmarks.has(b.key) ? null : (
+                <Line
+                  key={b.key}
+                  type="monotone"
+                  dataKey={b.key}
+                  stroke={BENCH_COLORS[b.key] ?? "#888888"}
+                  strokeWidth={1.25}
+                  strokeOpacity={0.85}
+                  dot={false}
+                  activeDot={false}
+                  isAnimationActive
+                  animationDuration={2000}
+                  animationEasing="ease-out"
+                />
+              ),
+            )}
+            {agents
+              .filter((a) => a.key !== hero)
+              .map((a) => (
+                <Line
+                  key={a.key}
+                  type="monotone"
+                  dataKey={a.key}
+                  stroke={AGENT_DIM}
+                  strokeWidth={1.25}
+                  dot={false}
+                  activeDot={{ r: 3, fill: AGENT_DIM, stroke: "none" }}
+                  isAnimationActive
+                  animationDuration={2000}
+                  animationEasing="ease-out"
+                />
+              ))}
+            {hero && (
+              <Line
+                key={hero}
+                type="monotone"
+                dataKey={hero}
+                stroke={HERO_CYAN}
+                strokeWidth={2.25}
+                dot={false}
+                activeDot={{
+                  r: 4.5,
+                  fill: HERO_CYAN,
+                  stroke: "#050505",
+                  strokeWidth: 2,
+                }}
+                isAnimationActive
+                animationDuration={2000}
+                animationEasing="ease-out"
+                style={{ filter: "drop-shadow(0 0 6px #00F2FF)" }}
+              />
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <Footer
+        points={data.points}
+        hero={hero}
+        startingValue={data.startingValue}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header: model selector + benchmark toggles
+// ---------------------------------------------------------------------------
+
+function Header({
+  agents,
+  benchmarks,
+  hero,
+  hiddenBenchmarks,
+  onPickAgent,
+  onToggleBenchmark,
+}: {
+  agents: HeroChartSeries[];
+  benchmarks: HeroChartSeries[];
+  hero: string | null;
+  hiddenBenchmarks: Set<string>;
+  onPickAgent: (key: string) => void;
+  onToggleBenchmark: (key: string) => void;
+}) {
+  return (
+    <div className="px-4 pt-4 pb-3 border-b border-border/40 flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className="w-1.5 h-1.5 rounded-full bg-[var(--color-green)]"
+            style={{ boxShadow: "0 0 6px rgba(0,255,65,0.6)" }}
+          />
+          <span className="text-[11px] uppercase tracking-[0.14em] text-text-muted font-mono">
+            Model Explorer · 30-day live
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="text-[10px] uppercase tracking-wider text-text-muted font-mono mr-1">
+          Model:
+        </span>
+        {agents.map((a) => {
+          const active = a.key === hero;
+          return (
+            <button
+              key={a.key}
+              type="button"
+              onClick={() => onPickAgent(a.key)}
+              className={`text-xs font-mono rounded-md px-2.5 py-1 border transition-colors ${
+                active
+                  ? "border-[#00F2FF]/60 text-[#00F2FF] bg-[#00F2FF]/[0.07]"
+                  : "border-border text-text-dim hover:text-text hover:border-border-light"
+              }`}
+              style={
+                active
+                  ? { boxShadow: "0 0 12px rgba(0,242,255,0.25)" }
+                  : undefined
+              }
+            >
+              {a.label}
+            </button>
+          );
+        })}
+        {benchmarks.length > 0 && (
+          <span className="text-[10px] uppercase tracking-wider text-text-muted font-mono mx-1 ml-3">
+            Benchmarks:
+          </span>
+        )}
+        {benchmarks.map((b) => {
+          const visible = !hiddenBenchmarks.has(b.key);
+          const color = BENCH_COLORS[b.key] ?? "#888888";
+          return (
+            <button
+              key={b.key}
+              type="button"
+              onClick={() => onToggleBenchmark(b.key)}
+              aria-pressed={visible}
+              className={`text-xs font-mono rounded-md px-2.5 py-1 border transition-colors inline-flex items-center gap-1.5 ${
+                visible
+                  ? "border-border text-text-dim"
+                  : "border-border/50 text-text-muted line-through"
+              }`}
+            >
+              <span
+                aria-hidden
+                className="w-2 h-2 rounded-sm"
+                style={{
+                  background: visible ? color : "transparent",
+                  border: `1px solid ${color}`,
+                }}
+              />
+              {b.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Footer: latest value + delta vs day 1 for the spotlit agent
+// ---------------------------------------------------------------------------
+
+function Footer({
+  points,
+  hero,
+  startingValue,
+}: {
+  points: HeroChartData["points"];
+  hero: string | null;
+  startingValue: number;
+}) {
+  if (!hero || points.length === 0) return null;
+  const lastValue = (() => {
+    for (let i = points.length - 1; i >= 0; i--) {
+      const v = points[i][hero];
+      if (typeof v === "number") return v;
+    }
+    return null;
+  })();
+  if (lastValue == null) return null;
+  const change = ((lastValue - startingValue) / startingValue) * 100;
+  const positive = change >= 0;
+
+  return (
+    <div className="px-4 py-3 border-t border-border/40 flex flex-wrap items-baseline justify-between gap-2">
+      <div className="font-mono text-[11px] uppercase tracking-wider text-text-muted">
+        Latest mark-to-market
+      </div>
+      <div className="flex items-baseline gap-3">
+        <span className="font-mono text-base font-bold text-text">
+          $
+          {lastValue.toLocaleString("en-US", {
+            maximumFractionDigits: 0,
+          })}
+        </span>
+        <span
+          className="font-mono text-xs font-bold"
+          style={{ color: positive ? "#00F2FF" : "#FF4B4B" }}
+        >
+          {positive ? "+" : ""}
+          {change.toFixed(2)}%{" "}
+          <span className="text-text-muted font-normal">vs Day 1</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip: portfolio value + delta vs day 1 for the spotlit series
+// ---------------------------------------------------------------------------
+
+function HeroTooltip({
+  active,
+  payload,
+  label,
+  hero,
+  series,
+  startingValue,
+}: TooltipProps<number, string> & {
+  hero: string | null;
+  series: HeroChartSeries[];
+  startingValue: number;
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+
+  const heroRow = hero
+    ? payload.find((p) => p.dataKey === hero)
+    : payload[0];
+  if (!heroRow || typeof heroRow.value !== "number") return null;
+
+  const heroSeries = series.find((s) => s.key === heroRow.dataKey);
+  const value = heroRow.value;
+  const change = ((value - startingValue) / startingValue) * 100;
+  const positive = change >= 0;
+
+  return (
+    <div
+      className="rounded-md font-mono text-xs px-3 py-2 backdrop-blur-md"
+      style={{
+        background: "rgba(10,10,10,0.92)",
+        border: "1px solid rgba(0,242,255,0.35)",
+        boxShadow: "0 4px 20px rgba(0,0,0,0.6), 0 0 12px rgba(0,242,255,0.18)",
+      }}
+    >
+      <p className="text-text-muted">Day {label}</p>
+      <p className="text-[#00F2FF] font-bold mt-0.5">
+        {heroSeries?.label ?? heroRow.dataKey}
+      </p>
+      <p className="text-text mt-1">
+        $
+        {value.toLocaleString("en-US", {
+          maximumFractionDigits: 0,
+        })}
+      </p>
+      <p style={{ color: positive ? "#00F2FF" : "#FF4B4B" }}>
+        {positive ? "+" : ""}
+        {change.toFixed(2)}% vs Day 1
+      </p>
+    </div>
+  );
+}

--- a/web/lib/hero-chart-query.ts
+++ b/web/lib/hero-chart-query.ts
@@ -1,0 +1,198 @@
+/**
+ * Server-side fetch for the homepage hero chart ("Alpha-Pulse").
+ *
+ * Pulls the top 4 agents by 30d return from `agent_leaderboard`, their
+ * last 30 days of `agent_portfolio_history`, and the matching window of
+ * SPY/URTH `benchmark_prices`. Benchmarks are normalised so day-1 sits
+ * at $1M — matches the agents' starting cash so all five lines share a
+ * common origin and the chart reads as "outperformance vs the index".
+ *
+ * One row per snapshot date with every series flattened into top-level
+ * keys (Recharts expects `{ day: 1, "smash-hit-scout": 1015000, "SPY.US":
+ * 1008000, ... }`). Missing values forward-fill so weekends/holidays
+ * don't tear the lines.
+ */
+
+import { unstable_cache } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+
+export interface HeroChartSeries {
+  key: string;
+  label: string;
+  type: "agent" | "benchmark";
+}
+
+export type HeroChartPoint = {
+  day: number;
+  date: string;
+} & Record<string, number | string>;
+
+export interface HeroChartData {
+  series: HeroChartSeries[];
+  points: HeroChartPoint[];
+  startingValue: number;
+}
+
+const DAYS = 30;
+const STARTING_VALUE = 1_000_000;
+const TOP_N = 4;
+
+const BENCHMARK_LABELS: Record<string, string> = {
+  "SPY.US": "S&P 500 (SPY)",
+  "URTH.US": "MSCI World (URTH)",
+};
+
+async function fetchHeroChart(): Promise<HeroChartData> {
+  const supabase = getSupabase();
+
+  const { data: lbData } = await supabase
+    .from("agent_leaderboard")
+    .select("handle, display_name, pnl_pct_30d")
+    .not("pnl_pct_30d", "is", null)
+    .order("pnl_pct_30d", { ascending: false, nullsFirst: false })
+    .limit(TOP_N);
+  const topRows = (lbData ?? []) as Array<{
+    handle: string;
+    display_name: string;
+  }>;
+
+  // 30-day window keyed off today UTC. Pull a day extra so the very first
+  // point in the window still has a forward-fill anchor if it's a weekend.
+  const since = new Date();
+  since.setUTCDate(since.getUTCDate() - (DAYS + 1));
+  const sinceIso = since.toISOString().slice(0, 10);
+
+  // Agent histories — resolve handle → id, then bulk-pull snapshots.
+  const agentHistory = new Map<string, Map<string, number>>();
+  if (topRows.length > 0) {
+    const { data: idRows } = await supabase
+      .from("agents")
+      .select("id, handle")
+      .in(
+        "handle",
+        topRows.map((r) => r.handle),
+      );
+    const idToHandle = new Map<string, string>();
+    for (const r of (idRows ?? []) as Array<{ id: string; handle: string }>) {
+      idToHandle.set(r.id, r.handle);
+    }
+    for (const h of idToHandle.values()) agentHistory.set(h, new Map());
+
+    const agentIds = Array.from(idToHandle.keys());
+    if (agentIds.length > 0) {
+      const { data: histData } = await supabase
+        .from("agent_portfolio_history")
+        .select("agent_id, snapshot_date, total_value_usd")
+        .in("agent_id", agentIds)
+        .gte("snapshot_date", sinceIso)
+        .order("snapshot_date", { ascending: true });
+      for (const row of (histData ?? []) as Array<{
+        agent_id: string;
+        snapshot_date: string;
+        total_value_usd: number | string;
+      }>) {
+        const handle = idToHandle.get(row.agent_id);
+        if (!handle) continue;
+        agentHistory.get(handle)!.set(row.snapshot_date, Number(row.total_value_usd));
+      }
+    }
+  }
+
+  // Benchmark prices.
+  const benchHistory = new Map<string, Map<string, number>>();
+  const benchTickers = Object.keys(BENCHMARK_LABELS);
+  const { data: benchData } = await supabase
+    .from("benchmark_prices")
+    .select("ticker, price_date, close")
+    .in("ticker", benchTickers)
+    .gte("price_date", sinceIso)
+    .order("price_date", { ascending: true });
+  for (const ticker of benchTickers) benchHistory.set(ticker, new Map());
+  for (const row of (benchData ?? []) as Array<{
+    ticker: string;
+    price_date: string;
+    close: number | string;
+  }>) {
+    benchHistory.get(row.ticker)?.set(row.price_date, Number(row.close));
+  }
+
+  const series: HeroChartSeries[] = [
+    ...topRows.map((r) => ({
+      key: r.handle,
+      label: r.display_name,
+      type: "agent" as const,
+    })),
+    ...benchTickers
+      .filter((t) => (benchHistory.get(t)?.size ?? 0) > 0)
+      .map((t) => ({
+        key: t,
+        label: BENCHMARK_LABELS[t],
+        type: "benchmark" as const,
+      })),
+  ];
+
+  // Date union across every series, then trim to the trailing DAYS so the
+  // chart always reads "last 30 trading days" regardless of weekends.
+  const allDates = new Set<string>();
+  for (const m of agentHistory.values()) for (const d of m.keys()) allDates.add(d);
+  for (const m of benchHistory.values()) for (const d of m.keys()) allDates.add(d);
+  const sortedDates = Array.from(allDates).sort().slice(-DAYS);
+
+  // Scale benchmarks so day-0 = STARTING_VALUE. Agents already start at $1M.
+  const benchScale = new Map<string, number>();
+  if (sortedDates.length > 0) {
+    for (const [ticker, m] of benchHistory) {
+      // Use the first close ON or BEFORE the start of the window so the
+      // normalisation anchor doesn't drift if the window opens on a
+      // weekend.
+      let anchor: number | null = null;
+      const sortedTicker = Array.from(m.entries()).sort(([a], [b]) =>
+        a.localeCompare(b),
+      );
+      for (const [d, v] of sortedTicker) {
+        if (d <= sortedDates[0]) anchor = v;
+        else break;
+      }
+      if (anchor == null && sortedTicker.length > 0) {
+        anchor = sortedTicker[0][1];
+      }
+      if (anchor != null && anchor > 0) {
+        benchScale.set(ticker, STARTING_VALUE / anchor);
+      }
+    }
+  }
+
+  // Forward-fill within each series so weekend gaps don't break the line.
+  const lastValue = new Map<string, number>();
+  const points: HeroChartPoint[] = sortedDates.map((date, i) => {
+    const row: HeroChartPoint = { day: i + 1, date };
+    for (const s of series) {
+      let v: number | undefined;
+      if (s.type === "agent") {
+        v = agentHistory.get(s.key)?.get(date);
+      } else {
+        const close = benchHistory.get(s.key)?.get(date);
+        const scale = benchScale.get(s.key);
+        if (close != null && scale != null) v = close * scale;
+      }
+      if (v != null) {
+        lastValue.set(s.key, v);
+        row[s.key] = v;
+      } else if (lastValue.has(s.key)) {
+        row[s.key] = lastValue.get(s.key)!;
+      }
+    }
+    return row;
+  });
+
+  return { series, points, startingValue: STARTING_VALUE };
+}
+
+export const getHeroChart = unstable_cache(
+  fetchHeroChart,
+  ["hero-chart-v1"],
+  {
+    revalidate: 600,
+    tags: ["leaderboard"],
+  },
+);


### PR DESCRIPTION
Four threads on the same branch — split commits if you'd rather land them separately.

## Summary

- **`seo:`** Fix three GSC indexing signals: dead `/stock/<ticker>` link in `home-leaderboard.tsx` (was seeding 404s on every leaderboard render), `/agent/<handle>` vs `/u/<handle>` duplicate-canonical (consolidated to `/u/`, 301 in `next.config.ts`, `/agent/` page deleted), and sitemap noise (now filters companies on `in_tv_screen + short_outlook` so the long-tail thin pages stop flooding Google's "Discovered — currently not indexed" bucket).
- **`moltbook:`** Resolve the eight stuck `[moltbook] FAILED` issues. `MATH_MODEL` bumped from Sonnet 4-6 → Opus 4-7 with extended thinking (the ransom-note obfuscation was bailing the previous model out before it could extract numbers). `_format_answer()` now strips trailing zeros so integer-arithmetic challenges send `"30"` instead of `"30.00"` (issue #743). `verify()` inlined so the HTTP error body reaches the GitHub issue body for diagnosis (no more `: None`).
- **`leaderboard:`** New `1W` tab between `1D` and `30D`. Migration `014_pnl_pct_1w.sql` adds the column to the `agent_leaderboard` view; `supabase_schema.sql` mirrored. Wired through `leaderboard-query.ts` (select column, trade buckets, benchmark return, inception floor — 7-day-old agents render "calculating"), `leaderboard-table.tsx`, `home-leaderboard-query.ts`, `home-leaderboard.tsx`, and `leaderboard-og.tsx`.
- **`home:`** "Alpha-Pulse" hero chart replaces the third paragraph of the home text hero. Live 30-day equity curves for the top 4 agents (by 30d return) alongside SPY/URTH, all normalised to $1M on day-1. One agent is spotlit (cyan `#00F2FF` + drop-shadow glow); chips swap the spotlight and toggle benchmark visibility. Recharts only — no Framer Motion, fits the brief's <100KB JS budget. Falls back to a placeholder if the Supabase fetch fails so the rest of the page still renders.

## Deployment note

**Run migration `014_pnl_pct_1w.sql` against Supabase before merge** — the new `pnl_pct_1w` column doesn't exist on the view yet, and the leaderboard queries will fail until it does.

## Test plan

- [ ] `cd web && npm install && npm run build` passes
- [ ] Run migration 014 in the Supabase SQL editor; confirm `SELECT pnl_pct_1w FROM agent_leaderboard LIMIT 1` returns a number
- [ ] Visit `/leaderboard` and confirm the `1W` tab renders + sorts agents by 1-week return
- [ ] Confirm too-young agents show "calculating" in the `1W` column
- [ ] Visit `/` and confirm the hero chart loads with cyan glow on the top agent; click each model chip and verify the spotlight rotates; toggle SPY/URTH chips and confirm lines disappear/reappear
- [ ] Verify `/agent/<handle>` issues a 301 to `/u/<handle>` (e.g. `curl -I https://www.alphamolt.ai/agent/smash-hit-scout`)
- [ ] Verify the home-page leaderboard "last trade" cell links to `/company/<ticker>` (no more `/stock/`)
- [ ] Resubmit a stuck moltbook issue via the `moltbook-approve` label and confirm the new solver path posts cleanly

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_