### PR TITLE
hero-chart: fix Vercel build (Recharts v3 TooltipProps signature)

### DIFF
--- a/web/components/hero-chart.tsx
+++ b/web/components/hero-chart.tsx
@@ -24,9 +24,23 @@ import {
   Tooltip,
   XAxis,
   YAxis,
-  type TooltipProps,
 } from "recharts";
 import type { HeroChartData, HeroChartSeries } from "@/lib/hero-chart-query";
+
+// Recharts v3 omits `payload` from the public `TooltipProps` type (it's
+// read from an internal context and injected via cloneElement at render
+// time). We define a minimal local shape for the fields we actually
+// consume — keeps the build green regardless of upstream type changes.
+interface TooltipPayloadEntry {
+  dataKey?: string | number;
+  value?: number | string | Array<number | string>;
+  name?: string;
+}
+interface InjectedTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadEntry[];
+  label?: string | number;
+}
 
 // Spec colours from the brief, tuned for legibility against #0A0A0A.
 const HERO_CYAN = "#00F2FF";
@@ -386,7 +400,7 @@ function HeroTooltip({
   hero,
   series,
   startingValue,
-}: TooltipProps<number, string> & {
+}: InjectedTooltipProps & {
   hero: string | null;
   series: HeroChartSeries[];
   startingValue: number;


### PR DESCRIPTION
## Summary

Main is currently red on Vercel. The hero chart from #762 type-checks fine locally against Recharts v3 in some configurations, but the public `TooltipProps<TValue, TName>` type in v3 is actually `Omit<TProps<TValue, TName>, PropertiesReadFromContext> & { active?: boolean }` — `payload` and `label` got moved to an internal context and only land on the cloned element at runtime. Vercel's stricter checker caught it.

Fix: replace the `TooltipProps` inheritance with a local `InjectedTooltipProps` interface that describes just the `active` / `payload` / `label` shape we actually read. Runtime behaviour is unchanged (Recharts still clones the element with those props at render time); we just stop asking the upstream type for fields it no longer exposes.

## Test plan

- [ ] `cd web && npm run build` passes locally
- [ ] Vercel deployment goes green
- [ ] Visit `/` and confirm the hero-chart tooltip still appears on hover with the spotlit agent's value + delta vs day 1

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_