### PR TITLE
hero-chart: fall back to all-time rank when 30d returns aren't populated

### DIFF
--- a/web/lib/hero-chart-query.ts
+++ b/web/lib/hero-chart-query.ts
@@ -45,11 +45,17 @@ const BENCHMARK_LABELS: Record<string, string> = {
 async function fetchHeroChart(): Promise<HeroChartData> {
   const supabase = getSupabase();
 
+  // Rank by 30d return when it's populated (migration 012 returns NULL
+  // for agents younger than 30 days). When the arena is fresh and no
+  // agent has 30 days of history yet, all rows have pnl_pct_30d = NULL
+  // and `nullsFirst: false` sinks them — without the tiebreaker we'd
+  // pick four arbitrary agents. `pnl_pct` (all-time) is always
+  // populated so it picks up the slack cleanly.
   const { data: lbData } = await supabase
     .from("agent_leaderboard")
-    .select("handle, display_name, pnl_pct_30d")
-    .not("pnl_pct_30d", "is", null)
+    .select("handle, display_name, pnl_pct_30d, pnl_pct")
     .order("pnl_pct_30d", { ascending: false, nullsFirst: false })
+    .order("pnl_pct", { ascending: false, nullsFirst: false })
     .limit(TOP_N);
   const topRows = (lbData ?? []) as Array<{
     handle: string;


### PR DESCRIPTION
## Symptom

The Alpha-Pulse hero shows the empty placeholder ("Waiting on the first portfolio snapshot…") even though the leaderboard right below it renders 9 healthy agents with sparklines.

## Root cause

The arena is younger than 30 days. Migration 012 (`drop_period_return_fallback`) made `pnl_pct_30d` strictly NULL when the agent has no snapshot at-or-before today − 30 days, instead of falling back to since-inception. Every agent's "30D" column is `—` in the leaderboard table for that reason — and my hero-chart query had `.not("pnl_pct_30d", "is", null)` which then filtered every row out.

## Fix

Drop the IS NOT NULL filter, add `pnl_pct` (all-time) as a secondary order. Supabase chains the two orders, so when `pnl_pct_30d` is populated for everyone the behaviour is identical to before; when nobody has 30 days yet, `pnl_pct` picks up the slack and the chart shows the four best-performing agents by total return.

## Test plan

- [ ] Deploy lands green
- [ ] Visit `/` — the hero chart renders four agent lines instead of the placeholder
- [ ] Confirm the spotlit line + cyan glow looks right; click each model chip to confirm spotlight rotates
- [ ] Once the arena hits 30+ days of history, confirm ranking still goes by 30d return (the new tiebreaker only kicks in when 30d is NULL)

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_