### PR TITLE
hero-chart: SEO caption + aria-label + faster draw-in

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -140,6 +140,17 @@ function Hero({ chart }: { chart: HeroChartData }) {
         <HeroChart data={chart} />
       </div>
 
+      {/* Static caption sits in the SSR HTML so search crawlers (who
+          can't read the chart's SVG) still get keyword-rich context
+          for what's being shown. Doubles as a screen-reader-friendly
+          description below the chart. */}
+      <p className="mt-3 text-sm text-text-muted max-w-[720px] leading-relaxed">
+        Each line is one AI agent paper-trading $1M against the S&amp;P 500
+        and MSCI World over the last 30 days. The brightest line is the
+        currently spotlit agent — click another model above to compare.
+        Marked to market daily; every trade journalled.
+      </p>
+
       <div className="mt-6 flex flex-wrap items-center gap-3">
         <a
           href="#leaderboard"

--- a/web/components/hero-chart.tsx
+++ b/web/components/hero-chart.tsx
@@ -11,7 +11,8 @@
  * hovered day plus its % change vs day 1.
  *
  * Recharts handles draw-in via its built-in left-to-right animation —
- * `animationDuration` on each `<Line>` is the brief's "2-second draw".
+ * `animationDuration` on each `<Line>` is tuned (see DRAW_MS below) to
+ * read as "drawing in" without delaying perceived page completion.
  * Skips Framer Motion entirely so we stay under the 100KB JS budget.
  */
 
@@ -49,6 +50,11 @@ const BENCH_COLORS: Record<string, string> = {
   "SPY.US": "#FF4B4B",
   "URTH.US": "#888888",
 };
+
+// Draw-in animation. The brief asked for 2s but real-user feedback was
+// that the long sweep delayed perceived page completion; 600ms still
+// reads as "drawing in" without holding the eye hostage.
+const DRAW_MS = 600;
 
 const Y_PAD = 0.04; // 4% headroom on the axis so the top line isn't clipped.
 
@@ -105,15 +111,29 @@ export default function HeroChart({ data }: { data: HeroChartData }) {
   // so the page still renders.
   if (agents.length === 0 || data.points.length === 0) {
     return (
-      <div className="glass-card rounded-xl p-6 text-sm text-text-muted font-mono">
+      <div
+        role="status"
+        aria-live="polite"
+        className="glass-card rounded-xl p-6 text-sm text-text-muted font-mono"
+      >
         Waiting on the first portfolio snapshot — agents will appear here
         once portfolio_valuation.py runs.
       </div>
     );
   }
 
+  const ariaLabel = `30-day equity curves for ${agents.length} AI agents (${agents
+    .map((a) => a.label)
+    .join(", ")}) compared with ${benchmarks
+    .map((b) => b.label)
+    .join(" and ")} benchmarks. All start at $1,000,000.`;
+
   return (
-    <div className="glass-card rounded-xl overflow-hidden border border-border/60">
+    <div
+      role="img"
+      aria-label={ariaLabel}
+      className="glass-card rounded-xl overflow-hidden border border-border/60"
+    >
       <Header
         agents={agents}
         benchmarks={benchmarks}
@@ -188,7 +208,7 @@ export default function HeroChart({ data }: { data: HeroChartData }) {
                   dot={false}
                   activeDot={false}
                   isAnimationActive
-                  animationDuration={2000}
+                  animationDuration={DRAW_MS}
                   animationEasing="ease-out"
                 />
               ),
@@ -205,7 +225,7 @@ export default function HeroChart({ data }: { data: HeroChartData }) {
                   dot={false}
                   activeDot={{ r: 3, fill: AGENT_DIM, stroke: "none" }}
                   isAnimationActive
-                  animationDuration={2000}
+                  animationDuration={DRAW_MS}
                   animationEasing="ease-out"
                 />
               ))}
@@ -224,7 +244,7 @@ export default function HeroChart({ data }: { data: HeroChartData }) {
                   strokeWidth: 2,
                 }}
                 isAnimationActive
-                animationDuration={2000}
+                animationDuration={DRAW_MS}
                 animationEasing="ease-out"
                 style={{ filter: "drop-shadow(0 0 6px #00F2FF)" }}
               />


### PR DESCRIPTION
## Summary

Three SEO + perceived-perf follow-ups to the Alpha-Pulse hero:

- **Static caption** below the chart, sitting in the SSR HTML (`page.tsx`) so crawlers — who can't read SVG — still get keyword-dense context for what's plotted. Compensates for the ~120 words of body copy trimmed from the hero when the chart replaced the old text paragraphs.
- **`role="img"` + `aria-label`** on the chart container listing the plotted agents and benchmarks. Screen readers + Google's accessibility-as-SEO signal now have something to chew on. Empty-state placeholder gets `role="status"` / `aria-live="polite"` so it's announced when it swaps in.
- **Trimmed draw-in animation** from 2000ms → 600ms via a `DRAW_MS` constant. The brief originally asked for a 2s sweep, but real-world feedback was that it held the eye hostage past page completion. 600ms still reads as "drawing in" without delaying perception of the page being done.

## What I didn't do

The third item from my offer was "check the actual Vercel Web Vitals data" — I can't reach Vercel's dashboard from this sandbox, only GitHub. Worth eyeballing https://vercel.com/<your-team>/v0-alphamolt/analytics once this lands to see if LCP/CLS actually shifted.

## Test plan

- [ ] Vercel build goes green
- [ ] View source on `/` — confirm the caption text is in the SSR HTML (not lazy-loaded)
- [ ] Inspect the chart card with a screen-reader extension (or `axe` devtools) — confirm aria-label is announced
- [ ] Visit `/` and confirm the chart draw-in completes in ~0.6s instead of ~2s
- [ ] After a few days, check Vercel Web Vitals for any LCP/CLS movement

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_