### PR TITLE
home: drop HomeLeaderboard render + rename consensus to &quot;AI stock-picker favourites&quot;

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import Nav from "@/components/nav";
 import HeroChart from "@/components/hero-chart";
 import HomeConsensus from "@/components/home-consensus";
-import HomeLeaderboard from "@/components/home-leaderboard";
 import HomePrompt from "@/components/home-prompt";
 import {
   getHomeLeaderboard,
@@ -109,13 +108,11 @@ export default async function HomePage() {
         />
         <div className="max-w-[1120px] mx-auto w-full px-4 sm:px-6">
           <Hero chart={chart} />
-          <div className="mt-2 sm:mt-4 mb-16 sm:mb-20">
-            <HomeLeaderboard
-              agents={board.agents}
-              error={fetchError}
-            />
-          </div>
-          <div className="mb-20 sm:mb-28">
+          {/* HomeLeaderboard removed for now — the hero chart already
+              covers the agent-performance angle. board.agents is still
+              fetched above so the ItemList JSON-LD below has something
+              to expose for SEO. */}
+          <div className="mt-2 sm:mt-4 mb-20 sm:mb-28">
             <HomeConsensus
               rows={consensus.rows}
               snapshotDate={consensus.snapshot_date}
@@ -174,8 +171,8 @@ function Hero({ chart }: { chart: HeroChartData }) {
       </p>
 
       <div className="mt-6 flex flex-wrap items-center gap-3">
-        <a
-          href="#leaderboard"
+        <Link
+          href="/leaderboard"
           className="inline-flex items-center px-5 py-2.5 rounded-lg bg-text text-bg text-sm font-semibold tracking-tight hover:bg-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
           style={{
             boxShadow:
@@ -183,7 +180,7 @@ function Hero({ chart }: { chart: HeroChartData }) {
           }}
         >
           See the leaderboard &rarr;
-        </a>
+        </Link>
         <a
           href="#enter-agent"
           className="inline-flex items-center px-5 py-2.5 rounded-lg text-text text-sm font-semibold tracking-tight transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"

--- a/web/components/home-consensus.tsx
+++ b/web/components/home-consensus.tsx
@@ -22,7 +22,7 @@ export default function HomeConsensus({ rows, snapshotDate, topN = 5 }: Props) {
       <header className="flex items-start justify-between gap-4 mb-5 flex-wrap">
         <div>
           <h2 className="text-2xl sm:text-[28px] font-bold tracking-tight text-text leading-tight">
-            What the swarm is buying
+            AI stock-picker favourites
           </h2>
           <p className="mt-1.5 text-sm text-text-muted">
             Most-held equities across the arena&rsquo;s {totalAgents || ""}{" "}


### PR DESCRIPTION
## Summary

Two small homepage tweaks:

- **Drop the `HomeLeaderboard` render** — the Alpha-Pulse hero chart already covers the agent-performance angle visually, so the full table below it was duplicative. Component file (`home-leaderboard.tsx`) and query (`home-leaderboard-query.ts`) stay in the tree so re-adding is a one-line change. The `getHomeLeaderboard()` call + `ItemList` JSON-LD in `page.tsx` is kept intact so SEO structured data still exposes the agent set.
- **Rename the consensus widget header**: "What the swarm is buying" → "AI stock-picker favourites". Reads better for cold readers (no insider framing).
- **CTA reroute**: the hero's "See the leaderboard →" button now points to `/leaderboard` via Next `<Link>` instead of the `#leaderboard` anchor (which would dead-end now that the section is gone).

## Test plan

- [ ] Vercel build goes green
- [ ] Visit `/` — confirm flow is: Hero (chart + caption + CTAs) → AI stock-picker favourites → Credibility → Enter Your Agent
- [ ] "See the leaderboard" CTA navigates to `/leaderboard`
- [ ] `view-source:/` still contains the `ItemList` JSON-LD with the top 5 agents

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_