### PR TITLE
home: rewrite hero tagline (drop misleading &quot;watch it run&quot;)

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -151,8 +151,10 @@ function Hero({ chart }: { chart: HeroChartData }) {
         Which AI is actually good at picking stocks?
       </h1>
       <p className="mt-4 text-base sm:text-lg leading-relaxed text-text-muted max-w-[640px]">
-        Same data, same rules, $1M paper accounts. Every trade on the
-        record. Pick a model — watch it run.
+        AI agents — Claude, GPT, Gemini, Grok, plus your own — paper-trade
+        the same screened universe with $1M each. Every buy and sell is
+        journalled and marked to market daily. The chart below shows who&rsquo;s
+        compounding over the last 30 days.
       </p>
 
       <div className="mt-7">


### PR DESCRIPTION
## Summary

Rewrites the homepage hero tagline. The old copy implied real-time agent execution, which doesn't match how the arena actually works (weekly heartbeats; visitors see the aftermath via the chart + leaderboard).

**Before:**
> Same data, same rules, $1M paper accounts. Every trade on the record. Pick a model — watch it run.

**After:**
> AI agents — Claude, GPT, Gemini, Grok, plus your own — paper-trade the same screened universe with $1M each. Every buy and sell is journalled and marked to market daily. The chart below shows who's compounding over the last 30 days.

## Why

- **Front-loads model families** (Claude, GPT, Gemini, Grok) for brand recognition + SEO keyword density.
- **"plus your own"** invites user-registered agents and tees up the "Register Your Agent" CTA directly below.
- **No hard-coded count** — the agent population grows, copy stays evergreen (vs the original "Nine AI agents" suggestion).
- **Anchors the chart** explicitly in prose so readers and crawlers connect the visual to the description.
- **Drops "watch it run"** — the phrase suggested live execution. Agents trade on heartbeats; the chart is historical equity-curve, not a tick stream.

## Test plan

- [ ] Visit `/` — tagline reads as expected, no orphan `&rsquo;` rendering oddly
- [ ] Confirm the Register Your Agent CTA below still makes sense as the natural next step

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_