### PR TITLE
score: new composite formula — quality blend + P/S vs median + AI verdict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,10 +293,21 @@ and `bootstrap_benchmarks.py`.
 
 **Flags JSONB:** `{"gross_margin_pct": "red", "fcf_margin_pct": "yellow"}` — replaces inline emoji markers
 
-**Composite score base weights:** R40 47%, P/S 29% (inverted), 52w vs SPY 24%
+**Composite score base (0–90):**
+- *Quality* (45) — 0.60·pct(R40) + 0.25·pct(FCF margin) + 0.15·pct(gross margin)
+- *Value* (25) — inverse percentile of P/S ÷ 12-mo P/S median (relative to own history, not absolute)
+- *Momentum* (20) — percentile of perf_52w_vs_spy (collared)
+
+**AI verdict multiplier (bull × bear, applied to base):**
+- bull ✅ bear ✅ → ×1.30 (dual-positive — real opportunity)
+- bull ❌ bear ✅ → ×1.00 (sound but no edge)
+- bull ✅ bear ❌ → ×0.70 (story but red flags)
+- bull ❌ bear ❌ → ×0.40 (avoid)
+- either eval missing → ×1.00 (no penalty for stale rows)
+
 **Momentum collar (perf_52w_vs_spy):** < -0.5 → score=0 (falling knife), > 0.4 → capped at 0.4 (blow-off top)
 **Rating multiplier:** 1.0–1.2 → ×1.0, 1.21–1.6 → linear taper ×1.0→×0.01, >1.6 → ×0.01 (disqualify)
-**Penalties:** 🔴 outlook ×0.25, 🟡 outlook ×0.50, 🟡 flags on any column ×0.50
+**Post-score penalties (stack with AI multiplier):** 🔴 outlook ×0.25, 🟡 outlook ×0.50, 🟡 flags on any column ×0.50
 
 ## Key Constants
 

--- a/score_ai_analysis.py
+++ b/score_ai_analysis.py
@@ -92,6 +92,24 @@ def parse_rating_numeric(rating_str):
     return None
 
 
+def parse_eval_pass(eval_str):
+    """Return True if the eval verdict is a Green Tick, False for a Red X.
+
+    Cells are written by bull_evaluation.py / bear_evaluation.py as
+    "✅ (rationale)" or "❌ rationale" (Unicode U+2705 / U+274C).
+    Empty / unrecognised cells return None — treated by the scoring
+    function as "no signal" (multiplier=1.0), not "fail".
+    """
+    if not eval_str:
+        return None
+    s = str(eval_str).strip()
+    if s.startswith("✅"):
+        return True
+    if s.startswith("❌"):
+        return False
+    return None
+
+
 def _status_base(status_str):
     """Extract the emoji prefix from a status string."""
     if not status_str:
@@ -121,7 +139,10 @@ def compute_status(entry, ps_data, screened_tickers):
 
     ps_row = ps_data.get(ticker, {})
     ps_now = ps_row.get("ps_now")
-    median = ps_row.get("12m_median") if isinstance(ps_row.get("12m_median"), (int, float)) else None
+    # Column is `median_12m` in price_sales (not `12m_median` — that earlier
+    # spelling silently suppressed every Discount badge because the lookup
+    # always returned None).
+    median = ps_row.get("median_12m") if isinstance(ps_row.get("median_12m"), (int, float)) else None
     if ps_now is not None and median is not None and median > 0 and ps_now / median < 0.80:
         pct = round((1 - ps_now / median) * 100)
         return f"🏷️ -{pct}% vs. 52w p/s"
@@ -160,13 +181,45 @@ def _collar_perf(perf):
     return min(perf, 0.4)
 
 
+def _ai_multiplier(bull_pass, bear_pass):
+    """4-way AI verdict multiplier (bull × bear treated as one 2-bit signal).
+
+    bull=PASS bear=PASS  → 1.30  (dual-positive — real opportunity)
+    bull=FAIL bear=PASS  → 1.00  (sound but no edge — default for screen)
+    bull=PASS bear=FAIL  → 0.70  (good story, red flags)
+    bull=FAIL bear=FAIL  → 0.40  (avoid)
+    either eval missing  → 1.00  (no penalty for stale / unevaluated rows)
+    """
+    if bull_pass is None or bear_pass is None:
+        return 1.0
+    if bull_pass and bear_pass:
+        return 1.30
+    if bull_pass and not bear_pass:
+        return 0.70
+    if not bull_pass and bear_pass:
+        return 1.00
+    return 0.40
+
+
 def compute_composite_score(row_data, all_rows):
     """Calculate composite score using percentile-based weighting.
 
-    Base score (0–100) from three factors, then multiplied by a rating gate.
-    Performance is collared: < -0.5 disqualifies, > 0.4 capped.
-    Percentile ranking uses the collared values so scaling is linear
-    within the -0.5 to 0.4 band.
+    Base score (0–90) is the weighted sum of three percentile factors:
+
+      Quality  (45) = 0.60·pct(R40) + 0.25·pct(FCF_margin) + 0.15·pct(GM)
+      Value    (25) = inverse pct of P/S ÷ 12-mo P/S median
+                      (relative to own history beats absolute cross-sector P/S)
+      Momentum (20) = pct of perf_52w_vs_spy, collared at [-0.5, +0.4]
+
+    Then multiplied by two independent gates:
+
+      AI verdict (bull × bear)  → 0.40 to 1.30
+      Rating multiplier         → 0.01 to 1.00
+
+    Performance < -0.5 still hard-disqualifies (returns 0). Yellow-flag
+    and outlook penalties are applied OUTSIDE this function (see the
+    main loop) so they stack with the AI multiplier rather than baking
+    into it.
     """
     def pct(values, v, invert=False):
         if v is None or not values:
@@ -179,19 +232,27 @@ def compute_composite_score(row_data, all_rows):
     if row_data.get("_perf_f") is not None and collared_perf is None:
         return 0
 
-    all_ps = [r["_ps_now_f"] for r in all_rows if r.get("_ps_now_f") is not None]
     all_r40 = [r["_r40_f"] for r in all_rows if r.get("_r40_f") is not None]
-    # Collar all perf values so percentile ranking scales within the band
+    all_fcf = [r["_fcf_f"] for r in all_rows if r.get("_fcf_f") is not None]
+    all_gm = [r["_gm_f"] for r in all_rows if r.get("_gm_f") is not None]
+    all_ps_ratio = [r["_ps_ratio_f"] for r in all_rows if r.get("_ps_ratio_f") is not None]
     all_perf = [_collar_perf(r["_perf_f"]) for r in all_rows
                 if r.get("_perf_f") is not None and _collar_perf(r["_perf_f"]) is not None]
 
-    base = (
-        pct(all_r40, row_data.get("_r40_f")) * 47
-        + pct(all_ps, row_data.get("_ps_now_f"), invert=True) * 29
-        + pct(all_perf, collared_perf) * 24
+    quality = (
+        pct(all_r40, row_data.get("_r40_f")) * 0.60
+        + pct(all_fcf, row_data.get("_fcf_f")) * 0.25
+        + pct(all_gm, row_data.get("_gm_f")) * 0.15
     )
+    value = pct(all_ps_ratio, row_data.get("_ps_ratio_f"), invert=True)
+    momentum = pct(all_perf, collared_perf)
 
-    return base * _rating_multiplier(row_data.get("_rating_f"))
+    base = quality * 45 + value * 25 + momentum * 20  # 0–90
+
+    ai_mult = _ai_multiplier(row_data.get("_bull_pass"), row_data.get("_bear_pass"))
+    rating_mult = _rating_multiplier(row_data.get("_rating_f"))
+
+    return base * ai_mult * rating_mult
 
 
 # ---------------------------------------------------------------------------
@@ -324,6 +385,38 @@ def main():
             entry["_rating_f"] = rating_raw
         else:
             entry["_rating_f"] = parse_rating_numeric(rating_raw)
+
+        # Quality sub-factors (FCF margin and gross margin layer on top of
+        # R40, which only captures revenue growth + operating margin).
+        gm_raw = entry.get("gross_margin_pct")
+        entry["_gm_f"] = (
+            float(gm_raw) if isinstance(gm_raw, (int, float)) else db.safe_float(gm_raw)
+        )
+        fcf_raw = entry.get("fcf_margin_pct")
+        entry["_fcf_f"] = (
+            float(fcf_raw) if isinstance(fcf_raw, (int, float)) else db.safe_float(fcf_raw)
+        )
+
+        # Value factor: P/S today ÷ trailing-12mo P/S median. Comparing a
+        # name to its own history beats an absolute P/S percentile across
+        # sectors (a 5× P/S means very different things for a SaaS name
+        # vs an industrial). Falls back to None when the median is
+        # missing/zero — the percentile helper then treats it as p=0.5.
+        ps_median = ps.get("median_12m")
+        if (
+            isinstance(ps_median, (int, float))
+            and ps_median > 0
+            and entry["ps_now"] is not None
+        ):
+            entry["_ps_ratio_f"] = entry["ps_now"] / ps_median
+        else:
+            entry["_ps_ratio_f"] = None
+
+        # AI verdicts — bull_eval / bear_eval start with ✅ or ❌. Missing
+        # or unrecognised cells stay None and short-circuit the AI
+        # multiplier to 1.0.
+        entry["_bull_pass"] = parse_eval_pass(entry.get("bull_eval"))
+        entry["_bear_pass"] = parse_eval_pass(entry.get("bear_eval"))
 
         entries.append(entry)
 


### PR DESCRIPTION
## Summary

Reshape `compute_composite_score` so AI-blessed quality names rise to the top of the screener instead of fundamentals-only names with no bull thesis.

### Old vs new

**Old** (sums to 100, then × rating gate):
```
R40 47%  +  P/S(inv) 29%  +  perf_52w_vs_spy 24%
× rating_mult
```

**New** (sums to 90, then two independent multipliers):
```
Quality  45 = 0.60·pct(R40) + 0.25·pct(FCF margin) + 0.15·pct(gross margin)
Value    25 = inverse pct of P/S ÷ 12-mo P/S median   (not absolute P/S)
Momentum 20 = pct(perf_52w_vs_spy)                    (same collar as before)

× AI verdict multiplier (bull × bear, 0.40 / 0.70 / 1.00 / 1.30)
× rating_mult                                          (unchanged)
```

### Why each piece

- **Quality blend** — R40 alone captures revenue growth + operating margin. Layering FCF margin and gross margin makes "quality" reflect cash conversion + pricing power too. R40 still dominates at 60% within the blend, so existing R40 leaders don't get displaced unless their margins are objectively poor.
- **Value vs own median** — a 5× P/S is dirt-cheap for a SaaS name and bubble-priced for an industrial. Anchoring the value factor on the ticker's own trailing-12-month median is sector-agnostic and surfaces real-discount setups (the same data already powers the 🏷️ Discount badge).
- **AI verdict as 4-way multiplier** — treats bull and bear as one coherent 2-bit signal. Dual-positive gets +30%, dual-fail gets cut to 40%, mixed cases sit between. Missing evals stay neutral so stale rotation rows don't sink.

### What stays

- Falling-knife collar (`perf < -0.5` → score=0)
- Rating gate (1.0–1.2 → ×1.0, taper to ×0.01 at 1.6, ×0.01 above)
- Post-score penalties (🔴 outlook ×0.25, 🟡 outlook ×0.50, 🟡 flags ×0.50) — orthogonal signals, they stack with the AI multiplier

### Side fix

`compute_status` was reading `ps_row.get("12m_median")` but the actual column is `median_12m` — that's why **every "🏷️ Discount" badge was silently suppressed**. Fixed while I was here (the value factor needed the same field).

### Expected ranking shift on your current top 10

Eyeballing your screener snapshot (rough — actual numbers depend on the new quality blend too):

| Now | Ticker | Score | AI verdict | New (est) |
|---|---|---|---|---|
| 1 | BWMX | 95.7 | Bear ✅ Bull ❌ | ~96 (flat) |
| 7 | ANIP | 72.8 | Bear ✅ Bull ✅ | ~95 (↑↑↑) |
| 3 | TCOM | 75.9 | Bear ❌ Bull ✅ | ~53 (↓↓) |
| 10 | AROC | 70.3 | Bear ❌ Bull ❌ | ~28 (↓↓↓) |

ANIP rockets toward the leader, dual-fail names sink, boring-but-clean BWMX keeps its spot.

## Test plan

- [ ] `python score_ai_analysis.py` runs locally without errors and writes new sort_order
- [ ] Eyeball the new screener top 10 — dual-positive names like ANIP should be near the top; AROC and TCOM should drop noticeably
- [ ] At least one row now shows a 🏷️ Discount status badge (the column-name typo fix unblocks this)
- [ ] Spot-check a few rows: ANAB / older agents with missing bull_eval still get rated normally (multiplier=1.0, not 0.40)

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_