### PR TITLE
company page: editorial pass — opinionated take, trust strip, debate

### DIFF
--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -17,18 +17,22 @@ import Nav from "@/components/nav";
 import PsChart from "@/components/ps-chart";
 import ShareRow from "@/components/share-row";
 import {
+  bucketAgentsByStance,
   buildAgentPovs,
   buildCompanyConsensus,
+  buildSwarmViewLine,
   countBuysSince,
   getCompanyHolders,
   getCompanySwarmSnapshot,
   getCompanyTradeTape,
   getHeartbeatRationales,
+  mostRecentExiter,
   type AgentPov,
   type AgentStance,
   type CompanyConsensus,
   type CompanySwarmSnapshot,
   type CompanyTrade,
+  type SwarmViewLine,
 } from "@/lib/company-agents-query";
 
 export const revalidate = 600;
@@ -195,6 +199,28 @@ export default async function CompanyPage({
     swarm.current_price ?? company.price ?? null,
   );
 
+  const buckets = bucketAgentsByStance(povs);
+  const featured = buckets.bullish[0] ?? null;
+  // Counterpoint = strongest bear; fall back to a neutral/cautious agent
+  // if nobody has actually exited so the section still has two voices.
+  const counterpoint = buckets.bearish[0] ?? buckets.neutral[0] ?? null;
+  // The "rest" grid excludes whoever's already shown as featured/
+  // counterpoint so there's no duplication.
+  const remainingPovs = povs.filter(
+    (p) => p.handle !== featured?.handle && p.handle !== counterpoint?.handle,
+  );
+
+  const swarmLine: SwarmViewLine = buildSwarmViewLine({
+    verdict: consensus.verdict,
+    bullPass: bull.passed,
+    bearPass: bear.passed,
+    bullRationale,
+    bearRationale,
+    psNow: company.ps_now ?? null,
+    psMedian: priceSales?.median_12m ?? null,
+    recentExitName: mostRecentExiter(povs),
+  });
+
   // Defensive: flags may be a dict OR a stringified JSON string (legacy data)
   let flags: Record<string, string> = {};
   const rawFlags = company.flags;
@@ -251,7 +277,7 @@ export default async function CompanyPage({
           company={company}
           status={status}
           swarm={swarm}
-          consensus={consensus}
+          swarmLine={swarmLine}
         />
 
         <ConsensusBriefSection
@@ -265,7 +291,26 @@ export default async function CompanyPage({
         />
 
         {povs.length > 0 && (
-          <AgentPovGrid povs={povs} ticker={company.ticker} />
+          <AgentSplitBlock
+            ticker={company.ticker}
+            buckets={buckets}
+          />
+        )}
+
+        {(featured || counterpoint) && (
+          <FeaturedDebate
+            ticker={company.ticker}
+            featured={featured}
+            counterpoint={counterpoint}
+          />
+        )}
+
+        {remainingPovs.length > 0 && (
+          <AgentPovGrid
+            povs={remainingPovs}
+            ticker={company.ticker}
+            heading={`Other agent views on ${company.ticker}`}
+          />
         )}
 
         <Fundamentals
@@ -301,6 +346,13 @@ export default async function CompanyPage({
           ticker={company.ticker}
           companyName={company.company_name}
         />
+
+        <RelatedLinksSection
+          ticker={company.ticker}
+          sector={company.sector}
+        />
+
+        <ResearchContextSection />
 
         <footer className="mt-10 pt-4 border-t border-border/40 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 text-xs font-mono text-text-muted">
           <div>
@@ -374,12 +426,12 @@ function HeroSection({
   company,
   status,
   swarm,
-  consensus,
+  swarmLine,
 }: {
   company: Company;
   status: ReturnType<typeof parseStatus>;
   swarm: CompanySwarmSnapshot;
-  consensus: CompanyConsensus;
+  swarmLine: SwarmViewLine;
 }) {
   const pnlColor =
     swarm.swarm_pnl_pct == null
@@ -387,6 +439,12 @@ function HeroSection({
       : swarm.swarm_pnl_pct >= 0
         ? "#00FF41"
         : "#FF3333";
+  const verdictColor =
+    swarmLine.verdict_word === "Bullish"
+      ? "#00FF41"
+      : swarmLine.verdict_word === "Bearish"
+        ? "#FF3333"
+        : "#FFD700";
 
   return (
     <section
@@ -417,8 +475,26 @@ function HeroSection({
           </span>
         )}
       </div>
-      <p className="text-text-muted text-xs mt-1.5 mb-5 font-mono">
+      <p className="text-text-muted text-xs mt-1.5 mb-4 font-mono">
         {company.exchange} · {company.country} · {company.sector}
+      </p>
+
+      {/* Opinionated swarm-view sentence — the page's "so what?". Sits
+          above the metrics row so a cold reader gets the conclusion
+          before the numbers. */}
+      <p className="text-base sm:text-lg leading-snug text-text mb-5">
+        <span
+          className="font-mono text-xs uppercase tracking-wider mr-2"
+          style={{ color: verdictColor }}
+        >
+          AI swarm view
+        </span>
+        <span className="font-bold" style={{ color: verdictColor }}>
+          {swarmLine.verdict_word}
+        </span>
+        <span className="text-text-dim">
+          {derivePostVerdictTail(swarmLine.headline, swarmLine.verdict_word)}
+        </span>
       </p>
 
       <div className="grid grid-cols-2 sm:grid-cols-5 gap-4 sm:gap-6">
@@ -426,11 +502,6 @@ function HeroSection({
           label="Current price"
           value={formatPrice(company.price)}
           accent="text"
-        />
-        <HeroStat
-          label="AI consensus"
-          value={renderConsensusPill(consensus.verdict)}
-          accent="muted"
         />
         <HeroStat
           label="Agents holding"
@@ -447,9 +518,51 @@ function HeroSection({
           value={company.sort_order != null ? `#${company.sort_order}` : "—"}
           accent="text"
         />
+        <HeroStat
+          label="Last updated"
+          value={company.scored_at ?? company.data_updated_at ?? "—"}
+          accent="muted"
+        />
+      </div>
+
+      {/* Trust strip — three short pills under the price block. Says
+          loudly that the price isn't tick-by-tick and the page is
+          research, not advice. Increases trust by being explicit. */}
+      <div className="mt-5 pt-4 border-t border-white/5 flex flex-wrap gap-2 text-[11px] font-mono text-text-muted">
+        <TrustPill>● Latest daily refresh, not live market data</TrustPill>
+        <TrustPill>● Paper-trading only</TrustPill>
+        <TrustPill>● Research aid, not financial advice</TrustPill>
       </div>
     </section>
   );
+}
+
+function TrustPill({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      className="inline-flex items-center px-2 py-0.5 rounded text-text-muted"
+      style={{
+        background: "rgba(255,255,255,0.03)",
+        border: "1px solid rgba(255,255,255,0.06)",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+// The full headline always starts with the verdict word followed by
+// punctuation (", but..." / " — agents..." / ": bulls cite..."). To
+// colour-style just the verdict, render it separately and use this
+// helper to peel off the part that comes after.
+function derivePostVerdictTail(
+  headline: string,
+  verdict: SwarmViewLine["verdict_word"],
+): string {
+  const word =
+    verdict === "Mixed" ? "Split" : verdict; // "Mixed" verdict still renders sentences starting with "Split"
+  if (headline.startsWith(word)) return headline.slice(word.length);
+  return ` ${headline}`;
 }
 
 function HeroStat({
@@ -479,27 +592,6 @@ function HeroStat({
         {value}
       </p>
     </div>
-  );
-}
-
-function renderConsensusPill(
-  verdict: CompanyConsensus["verdict"],
-): React.ReactNode {
-  const label =
-    verdict === "bullish" ? "Bullish" : verdict === "bearish" ? "Bearish" : "Mixed";
-  const color =
-    verdict === "bullish" ? "#00FF41" : verdict === "bearish" ? "#FF3333" : "#FFD700";
-  return (
-    <span
-      className="inline-flex items-center text-xs font-bold tracking-wider uppercase px-2 py-0.5 rounded"
-      style={{
-        color,
-        backgroundColor: color + "1f",
-        border: `1px solid ${color}40`,
-      }}
-    >
-      {label}
-    </span>
   );
 }
 
@@ -543,7 +635,7 @@ function ConsensusBriefSection({
   return (
     <section className="mb-6">
       <h2 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-2">
-        {ticker} AI Consensus
+        What AI Agents Think About {ticker}
       </h2>
       <div className="glass-card rounded-lg p-4 sm:p-5">
         <p className="text-sm sm:text-base text-text-dim leading-relaxed">
@@ -624,19 +716,271 @@ function BriefCard({
 function AgentPovGrid({
   povs,
   ticker,
+  heading,
 }: {
   povs: AgentPov[];
   ticker: string;
+  // Optional override — the page passes "Other agent views on TICKER"
+  // when this grid is rendered below FeaturedDebate so the cards aren't
+  // re-shown under the section heading they came from.
+  heading?: string;
 }) {
   return (
     <section className="mb-6">
       <h2 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-3">
-        What AI Agents Think About {ticker}
+        {heading ?? `What AI Agents Think About ${ticker}`}
       </h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
         {povs.map((p) => (
           <AgentPovCard key={p.handle} pov={p} />
         ))}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Agent Split — compact bucket list ("Bullish: A, B, C / Cautious: D / Bearish: E")
+// ---------------------------------------------------------------------------
+
+function AgentSplitBlock({
+  ticker,
+  buckets,
+}: {
+  ticker: string;
+  buckets: { bullish: AgentPov[]; neutral: AgentPov[]; bearish: AgentPov[] };
+}) {
+  // No useful split when literally every agent is on one side AND it's
+  // a small swarm — collapse the section so we don't render single-line
+  // noise. Three buckets with two+ entries between them = always show.
+  const total =
+    buckets.bullish.length + buckets.neutral.length + buckets.bearish.length;
+  if (total === 0) return null;
+
+  return (
+    <section className="mb-6">
+      <h2 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-2">
+        Where Agents Disagree on {ticker}
+      </h2>
+      <div className="glass-card rounded-lg p-4 space-y-2 text-sm">
+        <SplitRow label="Bullish" tone="green" povs={buckets.bullish} />
+        <SplitRow label="Cautious" tone="yellow" povs={buckets.neutral} />
+        <SplitRow label="Bearish / exited" tone="red" povs={buckets.bearish} />
+      </div>
+    </section>
+  );
+}
+
+function SplitRow({
+  label,
+  tone,
+  povs,
+}: {
+  label: string;
+  tone: "green" | "yellow" | "red";
+  povs: AgentPov[];
+}) {
+  const color =
+    tone === "green" ? "#00FF41" : tone === "yellow" ? "#FFD700" : "#FF3333";
+  if (povs.length === 0) {
+    return (
+      <p className="font-mono text-xs">
+        <span style={{ color }}>{label}:</span>{" "}
+        <span className="text-text-muted italic">none</span>
+      </p>
+    );
+  }
+  return (
+    <p className="font-mono text-xs">
+      <span style={{ color }} className="font-bold">
+        {label}:
+      </span>{" "}
+      {povs.map((p, i) => (
+        <span key={p.handle}>
+          <Link
+            href={`/u/${p.handle}`}
+            className="text-text-dim hover:text-text"
+          >
+            {p.display_name}
+          </Link>
+          {i < povs.length - 1 && (
+            <span className="text-text-muted">, </span>
+          )}
+        </span>
+      ))}
+    </p>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Featured Debate — Featured agent (top bull) + Counterpoint (top bear)
+// ---------------------------------------------------------------------------
+
+function FeaturedDebate({
+  ticker,
+  featured,
+  counterpoint,
+}: {
+  ticker: string;
+  featured: AgentPov | null;
+  counterpoint: AgentPov | null;
+}) {
+  return (
+    <section className="mb-6">
+      <h2 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-3">
+        Why Agents Are {featured ? "Bullish" : counterpoint?.stance === "bearish" ? "Bearish" : "Split"} on {ticker}
+      </h2>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {featured && <FeaturedCard pov={featured} kind="featured" />}
+        {counterpoint && counterpoint.handle !== featured?.handle && (
+          <FeaturedCard pov={counterpoint} kind="counterpoint" />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function FeaturedCard({
+  pov,
+  kind,
+}: {
+  pov: AgentPov;
+  kind: "featured" | "counterpoint";
+}) {
+  const accentColor = kind === "featured" ? "#00FF41" : "#FF4B4B";
+  const eyebrow = kind === "featured" ? "Featured agent view" : "Counterpoint";
+  return (
+    <Link
+      href={`/u/${pov.handle}`}
+      className="block rounded-xl p-5 border hover:border-border-light transition-colors"
+      style={{
+        background: `linear-gradient(180deg, ${accentColor}0a 0%, transparent 100%)`,
+        borderColor: `${accentColor}40`,
+      }}
+    >
+      <p
+        className="text-[10px] font-mono uppercase tracking-wider mb-3"
+        style={{ color: accentColor }}
+      >
+        {eyebrow}
+      </p>
+      <div className="flex items-center gap-3 mb-3">
+        <AgentMonogram seed={pov.display_name} />
+        <div className="flex-1 min-w-0">
+          <p className="font-bold text-text text-base truncate">
+            {pov.display_name}
+          </p>
+          <p className="text-xs text-text-muted font-mono truncate">
+            @{pov.handle}
+          </p>
+        </div>
+        <StancePill stance={pov.stance} />
+      </div>
+      {pov.rationale ? (
+        <p className="text-sm text-text-dim italic leading-relaxed">
+          &ldquo;{pov.rationale}&rdquo;
+        </p>
+      ) : (
+        <p className="text-xs text-text-muted italic">
+          No rationale recorded for this position yet.
+        </p>
+      )}
+      <p className="mt-3 text-[11px] font-mono text-text-muted">
+        {pov.position_qty > 0
+          ? `${pov.position_qty.toLocaleString("en-US")} sh @ ${formatPrice(pov.avg_entry)}`
+          : "No position"}
+        {" · "}
+        {pov.latest_action_label}
+      </p>
+    </Link>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Related links — internal CTAs near the bottom for crawl depth + UX
+// ---------------------------------------------------------------------------
+
+function RelatedLinksSection({
+  ticker,
+  sector,
+}: {
+  ticker: string;
+  sector: string | null;
+}) {
+  // All hrefs route to existing pages — nothing fictional. Sector-filtered
+  // screener URL works because the screener already reads ?sector=... query
+  // params. /consensus and /leaderboard are unconditional.
+  const links: Array<{ label: string; href: string }> = [
+    sector
+      ? {
+          label: `More ${sector} stocks`,
+          href: `/screener?sector=${encodeURIComponent(sector)}`,
+        }
+      : { label: "Browse the screener", href: "/screener" },
+    {
+      label: "AI agent leaderboard — who's compounding",
+      href: "/leaderboard",
+    },
+    {
+      label: "Stocks the swarm holds most — consensus",
+      href: "/consensus",
+    },
+    {
+      label: `Compare ${ticker} on the screener`,
+      href: "/screener",
+    },
+  ];
+
+  return (
+    <section className="mt-10">
+      <h2 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-3">
+        Related on AlphaMolt
+      </h2>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+        {links.map((link) => (
+          <li key={`${link.label}-${link.href}`}>
+            <Link
+              href={link.href}
+              className="block px-3 py-2 rounded-md border border-border/60 text-text-dim hover:text-green hover:border-green/40 transition-colors"
+            >
+              {link.label} <span aria-hidden>&rarr;</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Research context — fuller disclaimer block near the page footer
+// ---------------------------------------------------------------------------
+
+function ResearchContextSection() {
+  return (
+    <section className="mt-10">
+      <h2 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-3">
+        Research context
+      </h2>
+      <div
+        className="rounded-lg p-4 sm:p-5 text-sm text-text-muted leading-relaxed"
+        style={{
+          background: "rgba(255,255,255,0.02)",
+          border: "1px solid rgba(255,255,255,0.06)",
+        }}
+      >
+        <p>
+          AlphaMolt is for research and paper trading only. Agent views,
+          rankings and rationales are generated for analysis and comparison
+          across LLMs. They are not financial advice, investment
+          recommendations, or an instruction to buy or sell any security.
+        </p>
+        <p className="mt-2">
+          Prices on this page reflect the latest daily market-data refresh
+          (typically within the last 24 hours), not live tick data. Holdings
+          and trade journals are paper-traded against $1M virtual accounts;
+          no real money changes hands.
+        </p>
       </div>
     </section>
   );

--- a/web/lib/company-agents-query.ts
+++ b/web/lib/company-agents-query.ts
@@ -643,3 +643,137 @@ function formatRelativeShort(iso: string): string {
   const mins = Math.max(0, Math.floor(diffMs / (1000 * 60)));
   return `${mins}m ago`;
 }
+
+// ---------------------------------------------------------------------------
+// Editorial helpers — derive a "swarm view" sentence + bucket agents by
+// stance so the page reads like a research note, not a dashboard dump.
+// ---------------------------------------------------------------------------
+
+export interface SwarmViewLine {
+  // Full sentence rendered in the hero, e.g.
+  // "Bullish, but valuation risk is rising."
+  headline: string;
+  // Short verdict word for share-text and screen-reader summary.
+  verdict_word: "Bullish" | "Bearish" | "Mixed";
+}
+
+/**
+ * Compose the page's headline take. Output is intentionally a single
+ * sentence — the hero already shows the metrics; the sentence is for
+ * "so what?" framing.
+ *
+ * Picks the strongest opposing signal as the "but" clause:
+ *   - Bullish overall + bear FAIL          → "Bullish, but bears flag {risk}"
+ *   - Bullish + P/S > 1.2× 12-mo median   → "Bullish, but valuation is stretched vs its 12-mo median"
+ *   - Bullish + recent exit                → "Bullish, with {agent} as the notable exception"
+ *   - Bullish + no caveat                  → "Bullish — agent conviction is strong"
+ *   - Bearish + bull PASS                  → "Bearish, though the bull case still cites {edge}"
+ *   - Bearish + no rebuttal                → "Bearish — agents have walked away"
+ *   - Mixed + both rationales              → "Split: bulls cite {bull}, bears cite {bear}"
+ *   - Mixed + only bull or bear            → "Split — opinion divided on {whichever side has data}"
+ *   - Mixed + no rationales                → "Split — no clear thesis"
+ */
+export function buildSwarmViewLine({
+  verdict,
+  bullPass,
+  bearPass,
+  bullRationale,
+  bearRationale,
+  psNow,
+  psMedian,
+  recentExitName,
+}: {
+  verdict: CompanyConsensus["verdict"];
+  bullPass: boolean | null;
+  bearPass: boolean | null;
+  bullRationale: string | null;
+  bearRationale: string | null;
+  psNow: number | null;
+  psMedian: number | null;
+  recentExitName: string | null;
+}): SwarmViewLine {
+  const valuationStretched =
+    psNow != null && psMedian != null && psMedian > 0 && psNow / psMedian > 1.2;
+
+  if (verdict === "bullish") {
+    let headline: string;
+    if (bearPass === false && bearRationale) {
+      headline = `Bullish, but bears flag ${lowerFirstClause(bearRationale)}.`;
+    } else if (valuationStretched) {
+      headline = "Bullish, but valuation is stretched vs its 12-month median.";
+    } else if (recentExitName) {
+      headline = `Bullish, with ${recentExitName} as the notable exception.`;
+    } else {
+      headline = "Bullish — agent conviction is strong.";
+    }
+    return { headline, verdict_word: "Bullish" };
+  }
+
+  if (verdict === "bearish") {
+    let headline: string;
+    if (bullPass === true && bullRationale) {
+      headline = `Bearish, though the bull case still cites ${lowerFirstClause(bullRationale)}.`;
+    } else {
+      headline = "Bearish — agents have walked away.";
+    }
+    return { headline, verdict_word: "Bearish" };
+  }
+
+  // mixed
+  let headline: string;
+  if (bullRationale && bearRationale) {
+    headline = `Split: bulls cite ${lowerFirstClause(bullRationale)}, bears cite ${lowerFirstClause(bearRationale)}.`;
+  } else if (bullRationale) {
+    headline = `Split — bulls still see ${lowerFirstClause(bullRationale)}.`;
+  } else if (bearRationale) {
+    headline = `Split — bears flag ${lowerFirstClause(bearRationale)}.`;
+  } else {
+    headline = "Split — no clear thesis yet.";
+  }
+  return { headline, verdict_word: "Mixed" };
+}
+
+/**
+ * Bucket POVs into bull/cautious/bearish lists for the "Agent split"
+ * compact block. Pure regrouping of the input array — no sorting beyond
+ * what buildAgentPovs already did.
+ */
+export function bucketAgentsByStance(
+  povs: AgentPov[],
+): { bullish: AgentPov[]; neutral: AgentPov[]; bearish: AgentPov[] } {
+  const out = { bullish: [] as AgentPov[], neutral: [] as AgentPov[], bearish: [] as AgentPov[] };
+  for (const p of povs) {
+    if (p.stance === "bullish") out.bullish.push(p);
+    else if (p.stance === "bearish") out.bearish.push(p);
+    else out.neutral.push(p);
+  }
+  return out;
+}
+
+/**
+ * Find the most-recent exiter (bearish stance with a sell timestamp)
+ * for the optional "with X as the notable exception" hero line. Falls
+ * back to null when nobody exited recently.
+ */
+export function mostRecentExiter(povs: AgentPov[]): string | null {
+  let best: { name: string; ts: number } | null = null;
+  for (const p of povs) {
+    if (p.stance !== "bearish" || !p.latest_action_at) continue;
+    const ts = new Date(p.latest_action_at).getTime();
+    if (!Number.isFinite(ts)) continue;
+    if (Date.now() - ts > 30 * MS_PER_DAY) continue; // stale exits don't qualify
+    if (!best || ts > best.ts) best = { name: p.display_name, ts };
+  }
+  return best?.name ?? null;
+}
+
+/**
+ * Lowercase the first letter and trim trailing punctuation so a stored
+ * rationale ("Strong revenue growth and expanding TAM.") embeds cleanly
+ * mid-sentence ("...bulls cite strong revenue growth and expanding TAM,").
+ */
+function lowerFirstClause(s: string): string {
+  const trimmed = s.trim().replace(/[.;!?]+$/, "");
+  if (!trimmed) return "";
+  return trimmed[0].toLowerCase() + trimmed.slice(1);
+}


### PR DESCRIPTION
## Summary

Editorial pass on `/company/<ticker>` per the brief. Makes the page read like a research note instead of a dashboard dump.

### Hero changes

- **Opinionated swarm-view sentence** replaces the "AI Consensus: Bullish" pill in the metrics row:
  > **AI swarm view** **Bullish**, but valuation is stretched vs its 12-month median.

  Composed by `buildSwarmViewLine()` from real signals (verdict, bull/bear pass-fail, P/S vs median, recent exits). Every page is unique copy and the "but" clause picks the strongest opposing signal that's actually true. Falls back gracefully when signals are missing.
- **Trust strip** under the metrics row — three pills that say loudly that data is a daily refresh, paper-trading, research aid. Builds trust by being explicit.
- **AI Consensus tile dropped** from the metrics row (now in the headline sentence). Replaced with a **Last updated** tile showing `scored_at` so readers know when the data refreshed.

### New sections between AI Consensus Brief and Fundamentals

- **`AgentSplitBlock` — "Where Agents Disagree on TICKER"** — compact bucket list:
  > Bullish: Agent Zero, Claude Opus 4.7, Grok 4.3, Buffett Heir
  > Cautious: DeepSeek V4
  > Bearish / exited: OpenAI Codex 5.5
- **`FeaturedDebate` — "Why Agents Are Bullish on TICKER"** — two larger cards (Featured Agent + Counterpoint) with their rationale quotes. Pulls the most-bullish + most-bearish (or cautious if no bear) so the page reads as a debate, not a flat grid.
- **`AgentPovGrid` demoted to "Other agent views on TICKER"** — only renders agents not already in the debate, removing duplication.

### Footer

- **`RelatedLinksSection` — "Related on AlphaMolt"** — 4 internal CTAs: sector-filtered screener, leaderboard, consensus, full screener. Crawl depth + UX in one move. All hrefs route to existing pages.
- **`ResearchContextSection` — "Research context"** — fuller calm disclaimer block. Frames the data refresh as intentional ("latest daily market-data refresh, typically within the last 24 hours") rather than apologetic.

### Section heading rename

- `ConsensusBriefSection` h2: "ARGX AI Consensus" → **"What AI Agents Think About ARGX"** (matches brief voice + SEO target).

## Deferred from the brief

- **"Why this matters" interpretation box** — generating useful interpretive copy without an LLM call per page is hard. Easy follow-up if you want a templated version.
- **Top-right CTA in the nav** — site-wide nav change; out of scope for a company-page PR.

## Test plan

- [ ] `cd web && npm run build` passes
- [ ] Vercel deploy goes green
- [ ] Visit a populated ticker (`/company/ARGX` or whichever's currently top-scored) — sentence headline reads naturally and matches the data ("Bullish, but…" when bear flagged or P/S > 1.2× median; "Bullish — agent conviction is strong" otherwise)
- [ ] Trust strip pills render under the metrics row
- [ ] Featured + Counterpoint cards have monogram avatars, rationale quotes, and the "rest" grid below doesn't duplicate them
- [ ] Agent split block lists agents in the right buckets; clicking a name routes to `/u/<handle>`
- [ ] Related links route correctly (especially the sector-filtered screener URL)
- [ ] Research context block renders at the bottom; copy reads as calm/intentional
- [ ] Spot-check a thinly-evaluated ticker — empty rationales fall back to placeholder copy without exceptions

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_