### PR TITLE
seo: on-page audit + OG card redesign (monogram avatars, no brand logos)

### DIFF
--- a/web/app/company/[ticker]/opengraph-image.tsx
+++ b/web/app/company/[ticker]/opengraph-image.tsx
@@ -1,25 +1,31 @@
 /**
  * Dynamic OG card for /company/[ticker]. Renders the agent verdict +
- * top-3 holders + a single trade-tape line per the locked mockup.
+ * top 3 POVs (2 bullish + 1 bearish where available) per the locked
+ * mockup — with monogram avatars instead of brand logos so the card
+ * doesn't read as an endorsement.
  *
  * Falls back to a clean empty-state card when:
- *   - the ticker isn't in the companies table (treats it as 404 → returns
- *     a generic "AlphaMolt" card to avoid breaking link previews)
- *   - the ticker has no agent holders yet (right column hidden, hero
- *     shows "No AI agents hold this yet")
+ *   - the ticker isn't in the companies table → returns a generic
+ *     AlphaMolt card to avoid breaking link previews
+ *   - the ticker has no agent rationales yet → right column shows
+ *     "No agent rationales recorded yet."
  */
 
 import { ImageResponse } from "next/og";
 import { getSupabase } from "@/lib/supabase";
 import {
+  buildAgentPovs,
+  buildCompanyConsensus,
+  getCompanyHolders,
   getCompanySwarmSnapshot,
   getCompanyTradeTape,
-  type CompanyTrade,
+  getHeartbeatRationales,
 } from "@/lib/company-agents-query";
 import {
   OG_ALT,
   OG_SIZE,
   renderCompanyOg,
+  type OgPov,
 } from "@/lib/company-og";
 
 export const runtime = "nodejs";
@@ -28,7 +34,7 @@ export const alt = OG_ALT;
 export const size = OG_SIZE;
 export const contentType = "image/png";
 
-const TRADE_TAPE_MAX_CHARS = 90;
+const RATIONALE_MAX_CHARS = 90;
 
 export default async function Image({
   params,
@@ -38,54 +44,104 @@ export default async function Image({
   const { ticker: rawTicker } = await params;
   const ticker = decodeURIComponent(rawTicker).toUpperCase();
 
-  let company_name: string | null = null;
-  let snapshot: Awaited<
-    ReturnType<typeof getCompanySwarmSnapshot>
-  > | null = null;
-  let latestTrade: CompanyTrade | null = null;
+  let company: {
+    company_name: string | null;
+    exchange: string | null;
+    country: string | null;
+    sector: string | null;
+    price: number | null;
+    sort_order: number | null;
+  } | null = null;
+  let snapshot: Awaited<ReturnType<typeof getCompanySwarmSnapshot>> | null =
+    null;
+  let holders: Awaited<ReturnType<typeof getCompanyHolders>> = [];
+  let trades: Awaited<ReturnType<typeof getCompanyTradeTape>> = [];
+  let rationales: Awaited<ReturnType<typeof getHeartbeatRationales>> = [];
+  let totalScreened: number | null = null;
 
   try {
     const supabase = getSupabase();
-    const [companyRes, snap, trades] = await Promise.all([
+    const [companyRes, snap, hldrs, trds, rats, countRes] = await Promise.all([
       supabase
         .from("companies")
-        .select("company_name")
+        .select("company_name, exchange, country, sector, price, sort_order")
         .eq("ticker", ticker)
         .maybeSingle(),
       getCompanySwarmSnapshot(ticker),
-      getCompanyTradeTape(ticker, 1),
+      getCompanyHolders(ticker),
+      // Wide window so the POV derivation can find each agent's latest
+      // action even for stocks with thousands of historical trades.
+      getCompanyTradeTape(ticker, 200),
+      getHeartbeatRationales(ticker, 12),
+      // Total screened-universe count → "Rank #N of M+" label.
+      supabase
+        .from("companies")
+        .select("ticker", { count: "exact", head: true })
+        .eq("in_tv_screen", true),
     ]);
-    company_name =
-      (companyRes.data as { company_name: string | null } | null)
-        ?.company_name ?? null;
+    company =
+      (companyRes.data as typeof company | null) ?? null;
     snapshot = snap;
-    latestTrade = trades[0] ?? null;
+    holders = hldrs;
+    trades = trds;
+    rationales = rats;
+    totalScreened = countRes.count ?? null;
   } catch (err) {
     // Don't break social previews on a Supabase blip — fall through to
     // an empty card.
     console.error(`og /company/${ticker} fetch failed:`, err);
   }
 
-  const numAgents = snapshot?.num_agents ?? 0;
-  const totalAgents = snapshot?.total_agents ?? 0;
-  const pctAgents = snapshot?.pct_agents ?? 0;
-  const swarmPnlPct = snapshot?.swarm_pnl_pct ?? null;
-  const snapshotDate = snapshot?.snapshot_date ?? null;
-  const topHolders = snapshot?.top_holders ?? [];
+  const consensus = buildCompanyConsensus(
+    snapshot?.num_agents ?? 0,
+    snapshot?.total_agents ?? 0,
+    trades,
+    holders,
+  );
+  const allPovs = buildAgentPovs(
+    holders,
+    trades,
+    rationales,
+    snapshot?.current_price ?? company?.price ?? null,
+  );
+
+  // Pick the three voices that tell the most interesting story:
+  // top 2 bullish + 1 bearish (or counterpoint), where each one has a
+  // non-empty rationale. We only show agents with something to say —
+  // skip "Bought 12d ago" with no quote.
+  const withRationale = allPovs.filter(
+    (p) => p.rationale && p.rationale.trim().length > 0,
+  );
+  const bulls = withRationale.filter((p) => p.stance === "bullish");
+  const bears = withRationale.filter((p) => p.stance === "bearish");
+  const neutrals = withRationale.filter((p) => p.stance === "neutral");
+  const picked = [
+    bulls[0],
+    bulls[1] ?? neutrals[0],
+    bears[0] ?? neutrals[bulls[1] ? 1 : 0],
+  ].filter((p): p is NonNullable<typeof p> => !!p);
+
+  const povs: OgPov[] = picked.map((p) => ({
+    display_name: p.display_name,
+    stance: p.stance,
+    rationale: truncate(p.rationale ?? "", RATIONALE_MAX_CHARS),
+  }));
 
   return new ImageResponse(
     renderCompanyOg({
       ticker,
-      company_name,
-      num_agents: numAgents,
-      total_agents: totalAgents,
-      pct_agents: pctAgents,
-      swarm_pnl_pct: swarmPnlPct,
-      snapshot_date: snapshotDate,
-      top_holders: topHolders,
-      latest_trade_text: latestTrade
-        ? formatTradeTapeLine(latestTrade)
-        : null,
+      company_name: company?.company_name ?? null,
+      exchange: company?.exchange ?? null,
+      country: company?.country ?? null,
+      sector: company?.sector ?? null,
+      price: company?.price ?? null,
+      rank: company?.sort_order ?? null,
+      total_screened: totalScreened,
+      num_agents: snapshot?.num_agents ?? 0,
+      total_agents: snapshot?.total_agents ?? 0,
+      swarm_pnl_pct: snapshot?.swarm_pnl_pct ?? null,
+      verdict: consensus.verdict,
+      povs,
     }),
     {
       ...size,
@@ -97,11 +153,7 @@ export default async function Image({
   );
 }
 
-function formatTradeTapeLine(t: CompanyTrade): string {
-  const head = `@${t.handle} ${t.side === "buy" ? "bought" : "sold"} ${t.quantity} @ $${t.price_usd.toFixed(2)}`;
-  if (!t.note) return head;
-  const tail = ` — "${t.note}"`;
-  const line = `${head}${tail}`;
-  if (line.length <= TRADE_TAPE_MAX_CHARS) return line;
-  return `${line.slice(0, TRADE_TAPE_MAX_CHARS - 1)}…`;
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1)}…`;
 }

--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -98,9 +98,10 @@ export async function generateMetadata({
     // SEO framing: lead with the ticker + "Stock AI Analysis" so the
     // result is clickable for queries like "ARGX stock AI analysis"
     // rather than competing head-on with Google Finance / Yahoo on
-    // raw quote intent. " | AlphaMolt" is appended by the layout
-    // template, so we don't repeat the brand here.
-    const title = `${ticker} Stock AI Analysis: What Agents Think About ${name}`;
+    // raw quote intent. Kept short so " | AlphaMolt" (12 chars,
+    // appended by the layout template) doesn't push us past Google's
+    // ~60-char truncation point on long company names.
+    const title = `${ticker} Stock AI Analysis · ${name}`;
     const description = `What ${name} (${ticker}) looks like to AI agents — live consensus, holdings, bull/bear rationales, and recent paper-traded moves.`;
     const canonical = `/company/${encodeURIComponent(ticker)}`;
 
@@ -128,6 +129,49 @@ export async function generateMetadata({
     console.error(`generateMetadata: failed for ${ticker}:`, err);
     return { title: `${ticker} — AlphaMolt` };
   }
+}
+
+// Article JSON-LD signals "this is editorial content about a corporation"
+// (not a generic data table). Google then has a stronger basis to display
+// it for queries like "ARGX stock analysis" alongside the news/article
+// vertical, instead of bucketing it with the raw-quote pages it has
+// already crowned (Yahoo, Google Finance). datePublished / dateModified
+// come from the scoring + AI-analysis timestamps we already store.
+function articleJsonLd({
+  ticker,
+  name,
+  description,
+  datePublished,
+  dateModified,
+}: {
+  ticker: string;
+  name: string | null;
+  description: string;
+  datePublished: string | null;
+  dateModified: string | null;
+}) {
+  const display = name ?? ticker;
+  return {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: `${ticker} Stock AI Analysis — What AI Agents Think About ${display}`,
+    description,
+    url: absoluteUrl(`/company/${encodeURIComponent(ticker)}`),
+    image: absoluteUrl(`/company/${encodeURIComponent(ticker)}/opengraph-image`),
+    author: { "@type": "Organization", name: "AlphaMolt" },
+    publisher: {
+      "@type": "Organization",
+      name: "AlphaMolt",
+      logo: { "@type": "ImageObject", url: absoluteUrl("/opengraph-image") },
+    },
+    datePublished: datePublished ?? dateModified ?? undefined,
+    dateModified: dateModified ?? datePublished ?? undefined,
+    about: {
+      "@type": "Corporation",
+      name: display,
+      tickerSymbol: ticker,
+    },
+  };
 }
 
 function breadcrumbJsonLd(
@@ -248,11 +292,22 @@ export default async function CompanyPage({
     company.company_name,
     company.sector,
   );
+  const article = articleJsonLd({
+    ticker: company.ticker,
+    name: company.company_name,
+    description: `What ${company.company_name ?? company.ticker} (${company.ticker}) looks like to AI agents — live consensus, holdings, bull/bear rationales, and recent paper-traded moves.`,
+    datePublished: company.ai_analyzed_at ?? null,
+    dateModified:
+      company.scored_at ?? company.data_updated_at ?? company.ai_analyzed_at ?? null,
+  });
 
   // ?v=… is a cache-bust for X.com's per-URL og:image cache — bump when
   // the OG design changes. Paired with og:url being omitted in the
   // generateMetadata above.
-  const shareUrl = `${absoluteUrl(`/company/${encodeURIComponent(decoded)}`)}?v=3`;
+  // ?v=4 bumped when the OG card redesigned (monogram POV cards, no
+  // brand logos) — forces X.com to re-fetch the new image for any
+  // previously-shared URL.
+  const shareUrl = `${absoluteUrl(`/company/${encodeURIComponent(decoded)}`)}?v=4`;
   const shareText =
     consensus.verdict === "bullish"
       ? `AI agents are bullish on $${decoded} — see who holds it, what they paid, and why on AlphaMolt.`
@@ -265,6 +320,10 @@ export default async function CompanyPage({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(article) }}
       />
       <Nav />
       <main className="flex-1 max-w-[1200px] mx-auto w-full px-4 py-6">
@@ -467,12 +526,21 @@ function HeroSection({
       }}
     >
       <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
-        <h1 className="font-mono text-4xl sm:text-5xl font-bold text-green leading-none">
-          {company.ticker}
+        {/* Single H1 contains the SEO-rich phrase. The ticker is visually
+            dominant; the rest is small but lives in the same <h1>
+            element so crawlers see "ARGX Stock AI Analysis — argenx SE"
+            as the page headline instead of just "ARGX". */}
+        <h1 className="flex flex-wrap items-baseline gap-x-3 gap-y-1 leading-none">
+          <span className="font-mono text-4xl sm:text-5xl font-bold text-green">
+            {company.ticker}
+          </span>
+          <span className="text-text-dim text-xl sm:text-2xl leading-tight font-sans font-normal">
+            {company.company_name}
+          </span>
+          <span className="sr-only">
+            {" "}Stock AI Analysis
+          </span>
         </h1>
-        <p className="text-text-dim text-xl sm:text-2xl leading-tight">
-          {company.company_name}
-        </p>
         {status.label && (
           <span
             className="text-[11px] px-2 py-0.5 rounded font-mono uppercase tracking-wider"

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -7,26 +7,33 @@ import DataTable from "@/components/data-table";
 export const revalidate = 600;
 
 export const metadata: Metadata = {
-  title: "Screener — US-listed growth stocks",
+  title: "Stock Screener — US growth stocks ranked by AI agent score",
   description:
-    "Hundreds of US-listed growth stocks (incl. ADRs) ranked by composite score. Nightly screen on market cap, gross margin, revenue growth, and Rule of 40.",
+    "Hundreds of US-listed growth stocks (incl. ADRs) ranked by AlphaMolt's AI agent composite score. Filter by sector, sort by R40, P/S, gross margin, FCF margin.",
   alternates: { canonical: "/screener" },
   openGraph: {
-    title: "AlphaMolt Screener — US-listed growth stocks",
+    title: "AlphaMolt Stock Screener — US growth stocks",
     description:
-      "Browse hundreds of US-listed growth stocks (incl. ADRs) ranked by composite score. Nightly screen, fundamentals, and AI narratives refreshed daily.",
+      "Browse hundreds of US-listed growth stocks ranked by composite score from AlphaMolt's AI agents. Fundamentals and AI narratives refreshed daily.",
     url: "/screener",
     type: "website",
   },
 };
 
-async function getCompanies(): Promise<Company[]> {
+async function getCompanies(sector: string | null): Promise<Company[]> {
   const supabase = getSupabase();
+  // Sector filter is server-side so /screener?sector=Health+Technology
+  // is a real URL — same hit as if it were a static page. Makes the
+  // breadcrumb link from /company/[ticker] actually work, and gives
+  // crawlers per-sector pages without us needing to mint slug routes.
+  let query = supabase
+    .from("companies")
+    .select(SCREENER_COLUMNS)
+    .order("sort_order", { ascending: true, nullsFirst: false });
+  if (sector) query = query.eq("sector", sector);
+
   const [companiesRes, psRes] = await Promise.all([
-    supabase
-      .from("companies")
-      .select(SCREENER_COLUMNS)
-      .order("sort_order", { ascending: true, nullsFirst: false }),
+    query,
     supabase.from("price_sales").select("ticker, median_12m"),
   ]);
 
@@ -47,8 +54,27 @@ async function getCompanies(): Promise<Company[]> {
   return rows.map((c) => ({ ...c, ps_median_12m: psMap.get(c.ticker) ?? null }));
 }
 
-export default async function ScreenerPage() {
-  const companies = await getCompanies();
+function parseSector(raw: string | string[] | undefined): string | null {
+  if (Array.isArray(raw)) return raw[0] ?? null;
+  return raw ?? null;
+}
+
+export default async function ScreenerPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ sector?: string | string[] }>;
+}) {
+  const sector = parseSector((await searchParams).sector);
+  const companies = await getCompanies(sector);
+
+  const heading = sector
+    ? `${sector} Stock Screener`
+    : "Stock Screener";
+  const sub = sector
+    ? `${companies.length} ${sector} ${
+        companies.length === 1 ? "equity" : "equities"
+      } ranked by AI agent composite score`
+    : `${companies.length} US-listed equities (incl. ADRs) ranked by AI agent composite score`;
 
   return (
     <>
@@ -56,11 +82,9 @@ export default async function ScreenerPage() {
       <main className="flex-1 max-w-[1600px] mx-auto w-full px-4 py-6">
         <div className="mb-6">
           <h1 className="font-mono text-xl font-bold text-text mb-1">
-            Screener
+            {heading}
           </h1>
-          <p className="text-sm text-text-muted font-mono">
-            {companies.length} US-listed equities tracked (incl. ADRs)
-          </p>
+          <p className="text-sm text-text-muted font-mono">{sub}</p>
         </div>
         <DataTable companies={companies} />
       </main>

--- a/web/lib/company-og.tsx
+++ b/web/lib/company-og.tsx
@@ -1,64 +1,81 @@
 /**
  * Shared OG-card renderer for /company/[ticker].
  *
- * Same Satori constraints as leaderboard-og.tsx and consensus-og.tsx:
- * inline styles only (no Tailwind), explicit `display: flex` on every
- * multi-child element, no external image assets.
+ * Layout matches the locked product mockup but with monogram avatars
+ * instead of brand logos — every agent (Claude, GPT, user-registered)
+ * gets the same treatment so the card doesn't read as an endorsement.
  *
- * Layout (locked from product mockup):
- *   ┌──────────────────────────────────────────────────────────────┐
- *   │  ALPHAMOLT                              [ Updated May 7 ]    │
- *   ├───────────────────────────────┬──────────────────────────────┤
- *   │  $RDDT                        │  1  Claude 3 Opus   $95,200  │
- *   │  Reddit Inc.                  │     @opus                    │
- *   │                               │ ──────────────────────────── │
- *   │  12 of 24 AI agents hold this │  2  GPT-4o          $88,400  │
- *   │  ████████░░░░░░░░░░░░░░░      │     @gpt4o                   │
- *   │  SWARM P&L  +14.2%            │ ──────────────────────────── │
- *   │                               │  3  Llama 3 70B    $76,100   │
- *   │                               │     @llama3                  │
- *   ├───────────────────────────────┴──────────────────────────────┤
- *   │  TRADE TAPE: @opus bought 4 @ $187 — "thesis snippet…"        │
- *   └──────────────────────────────────────────────────────────────┘
+ * Satori constraints (same as leaderboard-og.tsx / consensus-og.tsx):
+ *   - inline styles only (no Tailwind classes)
+ *   - `display: flex` REQUIRED on every multi-child element
+ *   - no `gap` — use margin instead
+ *   - no external image assets — everything is text or coloured boxes
+ *
+ *   ┌───────────────────────────────────┬─────────────────────────────┐
+ *   │ ● alphamolt                       │ ✦ What AI Agents Think      │
+ *   │                                   │                             │
+ *   │  ARGX                             │ ┌───────────────────────┐  │
+ *   │  argenx SE                        │ │ C  Claude Opus 4.7    │  │
+ *   │  NASDAQ · NL · Health Technology  │ │    Bullish            │  │
+ *   │                                   │ │    "VYVGART franchise.."│  │
+ *   │  $822.67                          │ └───────────────────────┘  │
+ *   │                                   │ ┌───────────────────────┐  │
+ *   │  ┌───────┐ ┌───────┐ ┌───┐ ┌───┐ │ │ G  Grok 4.3           │  │
+ *   │  │AI Cons│ │4/9 ag │ │P&L│ │#1 │ │ │    Bullish            │  │
+ *   │  │Bullish│ │       │ │+2%│ │/450│ │ │    "High R40.."       │  │
+ *   │  └───────┘ └───────┘ └───┘ └───┘ │ └───────────────────────┘  │
+ *   │                                   │ ┌───────────────────────┐  │
+ *   │                                   │ │ O  OpenAI Codex 5.5   │  │
+ *   │                                   │ │    Bearish            │  │
+ *   │                                   │ │    "Valuation stretched."│  │
+ *   │                                   │ └───────────────────────┘  │
+ *   ├───────────────────────────────────┴─────────────────────────────┤
+ *   │ ~ Live AI stock analysis from multiple agents.   alphamolt.ai   │
+ *   └─────────────────────────────────────────────────────────────────┘
  */
 
-import type { ConsensusHolder } from "@/lib/company-agents-query";
+import type { AgentPov, CompanyConsensus } from "@/lib/company-agents-query";
 
 export const OG_SIZE = { width: 1200, height: 630 } as const;
 export const OG_ALT =
-  "AlphaMolt company card — AI agent verdict, top holders, and trade tape for a single ticker";
+  "AlphaMolt company card — AI agent verdict, swarm holdings, and top bull/bear rationales for a single ticker";
 
+const BG = "#050505";
 const TEXT = "#EDEDED";
 const TEXT_DIM = "#D4D4D8";
 const TEXT_MUTED = "#A1A1AA";
 const GREEN = "#00FF41";
-const GREEN_MUTED = "#3DAD5A";
 const RED = "#FF3333";
+const YELLOW = "#FFD700";
 const BORDER = "rgba(255,255,255,0.08)";
+const CARD_BG = "rgba(255,255,255,0.025)";
 
 export interface CompanyOgArgs {
   ticker: string;
   company_name: string | null;
+  exchange: string | null;
+  country: string | null;
+  sector: string | null;
+  price: number | null;
+  rank: number | null;
+  total_screened: number | null;
   num_agents: number;
   total_agents: number;
-  pct_agents: number;
   swarm_pnl_pct: number | null;
-  snapshot_date: string | null;
-  top_holders: ConsensusHolder[];
-  // Latest trade-tape entry for the bottom strip (already truncated by caller).
-  latest_trade_text: string | null;
+  verdict: CompanyConsensus["verdict"];
+  // Three pre-picked POVs for the right column — typically 2 bullish + 1
+  // bearish so the card reads as a debate. Caller (opengraph-image.tsx)
+  // does the picking + rationale truncation.
+  povs: OgPov[];
+}
+
+export interface OgPov {
+  display_name: string;
+  stance: "bullish" | "bearish" | "neutral";
+  rationale: string; // already truncated to ~80 chars
 }
 
 export function renderCompanyOg(args: CompanyOgArgs) {
-  const dateLabel = args.snapshot_date
-    ? formatLongDate(args.snapshot_date)
-    : null;
-  const hasAgents = args.num_agents > 0;
-  const top3 = args.top_holders.slice(0, 3);
-  const pctClamped = Math.max(0, Math.min(100, args.pct_agents));
-  const pnl = args.swarm_pnl_pct;
-  const pnlPositive = pnl != null && pnl >= 0;
-
   return (
     <div
       style={{
@@ -66,346 +83,493 @@ export function renderCompanyOg(args: CompanyOgArgs) {
         height: "100%",
         display: "flex",
         flexDirection: "column",
-        padding: "48px 64px",
-        background:
-          "radial-gradient(ellipse at top left, #001a08 0%, #0a0a0a 60%)",
+        background: BG,
         color: TEXT,
         fontFamily: "system-ui, -apple-system, sans-serif",
+        // Subtle radial glow top-left to match the rest of the brand
+        backgroundImage:
+          "radial-gradient(ellipse 80% 60% at 0% 0%, rgba(0,255,65,0.06) 0%, rgba(5,5,5,0) 60%)",
       }}
     >
-      {/* Header */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-        }}
-      >
-        <div
-          style={{
-            fontSize: 26,
-            fontWeight: 700,
-            color: GREEN,
-            letterSpacing: "0.10em",
-            textTransform: "uppercase",
-            display: "flex",
-          }}
-        >
-          ALPHAMOLT
-        </div>
-        {dateLabel && (
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              padding: "10px 16px",
-              borderRadius: 999,
-              border: `1px solid ${BORDER}`,
-              background: "rgba(255,255,255,0.04)",
-              fontSize: 18,
-              color: TEXT_MUTED,
-              fontFamily: "ui-monospace, monospace",
-            }}
-          >
-            Updated {dateLabel}
-          </div>
-        )}
-      </div>
-
-      {/* Body */}
       <div
         style={{
           display: "flex",
           flex: 1,
-          marginTop: 32,
-          gap: 32,
+          paddingTop: 40,
+          paddingBottom: 28,
+          paddingLeft: 56,
+          paddingRight: 56,
         }}
       >
-        {/* Left column — ticker + agent verdict */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            width: hasAgents ? "55%" : "100%",
-          }}
-        >
-          {/* Cashtag-style ticker */}
-          <div
-            style={{
-              display: "flex",
-              alignItems: "baseline",
-              fontSize: 96,
-              fontWeight: 800,
-              color: GREEN,
-              fontFamily: "ui-monospace, monospace",
-              letterSpacing: "-0.02em",
-              lineHeight: 1,
-            }}
-          >
-            ${args.ticker}
-          </div>
-          {args.company_name && (
-            <div
-              style={{
-                display: "flex",
-                fontSize: 28,
-                color: TEXT_DIM,
-                marginTop: 8,
-                letterSpacing: "-0.01em",
-              }}
-            >
-              {args.company_name}
-            </div>
-          )}
-
-          {/* Agent verdict block */}
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              marginTop: 36,
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                fontSize: 32,
-                color: TEXT,
-                fontWeight: 600,
-              }}
-            >
-              {hasAgents
-                ? `${args.num_agents} of ${args.total_agents} AI agents hold this`
-                : "No AI agents hold this yet"}
-            </div>
-
-            {hasAgents && (
-              <>
-                {/* Conviction bar */}
-                <div
-                  style={{
-                    display: "flex",
-                    width: "100%",
-                    height: 10,
-                    marginTop: 16,
-                    borderRadius: 999,
-                    background: "rgba(255,255,255,0.06)",
-                    overflow: "hidden",
-                  }}
-                >
-                  <div
-                    style={{
-                      display: "flex",
-                      width: `${pctClamped}%`,
-                      height: "100%",
-                      background: GREEN,
-                    }}
-                  />
-                </div>
-
-                {pnl != null && (
-                  <div
-                    style={{
-                      display: "flex",
-                      alignItems: "baseline",
-                      marginTop: 18,
-                      gap: 12,
-                    }}
-                  >
-                    <div
-                      style={{
-                        display: "flex",
-                        fontSize: 14,
-                        color: TEXT_MUTED,
-                        textTransform: "uppercase",
-                        letterSpacing: "0.10em",
-                      }}
-                    >
-                      Swarm P&amp;L
-                    </div>
-                    <div
-                      style={{
-                        display: "flex",
-                        fontSize: 28,
-                        fontWeight: 700,
-                        color: pnlPositive ? GREEN : RED,
-                        fontFamily: "ui-monospace, monospace",
-                      }}
-                    >
-                      {pnlPositive ? "+" : "−"}
-                      {Math.abs(pnl).toFixed(1)}%
-                    </div>
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        </div>
-
-        {/* Right column — top 3 holders */}
-        {hasAgents && top3.length > 0 && (
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              flex: 1,
-              borderRadius: 14,
-              border: `1px solid ${BORDER}`,
-              background:
-                "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
-              overflow: "hidden",
-            }}
-          >
-            {top3.map((h, i) => (
-              <HolderRow
-                key={`${h.handle}-${i}`}
-                rank={i + 1}
-                holder={h}
-                isLast={i === top3.length - 1}
-              />
-            ))}
-          </div>
-        )}
+        <LeftPanel args={args} />
+        <RightPanel povs={args.povs} />
       </div>
-
-      {/* Bottom strip */}
-      {args.latest_trade_text && (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            marginTop: 24,
-            padding: "14px 18px",
-            borderRadius: 10,
-            border: `1px solid ${BORDER}`,
-            background: "rgba(255,255,255,0.03)",
-            fontSize: 18,
-            color: TEXT_DIM,
-            fontFamily: "ui-monospace, monospace",
-            gap: 12,
-          }}
-        >
-          <span
-            style={{
-              display: "flex",
-              fontSize: 13,
-              color: GREEN,
-              letterSpacing: "0.10em",
-              textTransform: "uppercase",
-              fontWeight: 700,
-            }}
-          >
-            Trade Tape
-          </span>
-          <span
-            style={{
-              display: "flex",
-              flex: 1,
-              minWidth: 0,
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-            }}
-          >
-            {args.latest_trade_text}
-          </span>
-        </div>
-      )}
+      <FooterStrip />
     </div>
   );
 }
 
-function HolderRow({
-  rank,
-  holder,
-  isLast,
-}: {
-  rank: number;
-  holder: ConsensusHolder;
-  isLast: boolean;
-}) {
+// ---------------------------------------------------------------------------
+// Left panel — brand mark, ticker, price, stat cards
+// ---------------------------------------------------------------------------
+
+function LeftPanel({ args }: { args: CompanyOgArgs }) {
+  const verdictLabel =
+    args.verdict === "bullish"
+      ? "Bullish"
+      : args.verdict === "bearish"
+        ? "Bearish"
+        : "Mixed";
+  const verdictColor =
+    args.verdict === "bullish"
+      ? GREEN
+      : args.verdict === "bearish"
+        ? RED
+        : YELLOW;
+  const pnl = args.swarm_pnl_pct;
+  const pnlSign = pnl == null ? "—" : pnl >= 0 ? "+" : "−";
+  const pnlAbs = pnl == null ? "" : `${Math.abs(pnl).toFixed(1)}%`;
+  const pnlColor = pnl == null ? TEXT_MUTED : pnl >= 0 ? GREEN : RED;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: 590,
+        marginRight: 24,
+      }}
+    >
+      <BrandMark />
+
+      {/* Big green ticker */}
+      <div
+        style={{
+          display: "flex",
+          marginTop: 12,
+          fontSize: 132,
+          lineHeight: 1,
+          fontWeight: 800,
+          letterSpacing: "-0.04em",
+          color: GREEN,
+        }}
+      >
+        {args.ticker}
+      </div>
+
+      {/* Company name */}
+      <div
+        style={{
+          display: "flex",
+          marginTop: 6,
+          fontSize: 44,
+          lineHeight: 1.1,
+          fontWeight: 500,
+          color: TEXT,
+        }}
+      >
+        {truncate(args.company_name ?? args.ticker, 22)}
+      </div>
+
+      {/* Sector subline */}
+      <div
+        style={{
+          display: "flex",
+          marginTop: 14,
+          fontSize: 18,
+          color: TEXT_MUTED,
+          letterSpacing: "0.01em",
+        }}
+      >
+        {[args.exchange, args.country, args.sector]
+          .filter((s): s is string => !!s && s.length > 0)
+          .join("  ·  ")}
+      </div>
+
+      {/* Price */}
+      <div
+        style={{
+          display: "flex",
+          marginTop: 26,
+          fontSize: 72,
+          lineHeight: 1,
+          fontWeight: 700,
+          color: TEXT,
+          letterSpacing: "-0.02em",
+        }}
+      >
+        {args.price != null ? formatPrice(args.price) : "—"}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          marginTop: 8,
+          fontSize: 16,
+          color: TEXT_MUTED,
+        }}
+      >
+        Latest daily refresh · not a live quote
+      </div>
+
+      {/* Stat cards row */}
+      <div
+        style={{
+          display: "flex",
+          marginTop: 22,
+        }}
+      >
+        <StatCard
+          label="AI Consensus"
+          value={verdictLabel}
+          valueColor={verdictColor}
+        />
+        <StatCard
+          label="Agents hold"
+          value={`${args.num_agents} / ${args.total_agents}`}
+        />
+        <StatCard
+          label="Swarm P&L"
+          value={pnl == null ? "—" : `${pnlSign}${pnlAbs}`}
+          valueColor={pnlColor}
+        />
+        <StatCard
+          label="Rank"
+          value={args.rank != null ? `#${args.rank}` : "—"}
+          valueSub={
+            args.total_screened ? `of ${args.total_screened}+` : undefined
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+function BrandMark() {
+  // Tiny "● alphamolt" wordmark. Avoids needing an external image.
   return (
     <div
       style={{
         display: "flex",
         alignItems: "center",
-        gap: 18,
-        padding: "18px 20px",
-        borderBottom: isLast ? "none" : `1px solid ${BORDER}`,
-        flex: 1,
+        height: 32,
       }}
     >
       <div
         style={{
           display: "flex",
-          width: 32,
-          fontSize: 28,
-          fontWeight: 700,
-          color: GREEN_MUTED,
-          fontFamily: "ui-monospace, monospace",
+          width: 14,
+          height: 14,
+          borderRadius: 7,
+          background: GREEN,
+          boxShadow: `0 0 12px ${GREEN}`,
+          marginRight: 10,
         }}
-      >
-        {rank}
-      </div>
+      />
       <div
         style={{
           display: "flex",
-          flexDirection: "column",
-          flex: 1,
-          minWidth: 0,
+          fontSize: 22,
+          fontWeight: 600,
+          color: TEXT,
+          letterSpacing: "0.01em",
         }}
       >
-        <div
-          style={{
-            display: "flex",
-            fontSize: 22,
-            fontWeight: 700,
-            color: TEXT,
-            maxWidth: 260,
-            overflow: "hidden",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {holder.display_name}
-        </div>
-        <div
-          style={{
-            display: "flex",
-            fontSize: 16,
-            color: TEXT_MUTED,
-            marginTop: 2,
-            fontFamily: "ui-monospace, monospace",
-          }}
-        >
-          @{holder.handle}
-        </div>
+        alphamolt
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  valueColor,
+  valueSub,
+}: {
+  label: string;
+  value: string;
+  valueColor?: string;
+  valueSub?: string;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        padding: "12px 14px",
+        marginRight: 10,
+        borderRadius: 10,
+        background: CARD_BG,
+        border: `1px solid ${BORDER}`,
+        minWidth: 110,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          fontSize: 10,
+          textTransform: "uppercase",
+          letterSpacing: "0.12em",
+          color: TEXT_MUTED,
+          marginBottom: 6,
+          fontWeight: 600,
+        }}
+      >
+        {label}
       </div>
       <div
         style={{
           display: "flex",
           fontSize: 22,
           fontWeight: 700,
-          color: TEXT,
-          fontFamily: "ui-monospace, monospace",
-          letterSpacing: "-0.01em",
+          color: valueColor ?? TEXT,
+          lineHeight: 1,
         }}
       >
-        {formatUsd(holder.mtm_usd)}
+        {value}
+      </div>
+      {valueSub && (
+        <div
+          style={{
+            display: "flex",
+            fontSize: 11,
+            color: TEXT_MUTED,
+            marginTop: 4,
+          }}
+        >
+          {valueSub}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Right panel — three agent POV cards
+// ---------------------------------------------------------------------------
+
+function RightPanel({ povs }: { povs: OgPov[] }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        padding: "16px 18px",
+        borderRadius: 14,
+        background: "rgba(255,255,255,0.015)",
+        border: `1px solid ${BORDER}`,
+      }}
+    >
+      {/* Section header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          marginBottom: 14,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 18,
+            color: GREEN,
+            marginRight: 8,
+          }}
+        >
+          ✦
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 22,
+            fontWeight: 700,
+            color: TEXT,
+            letterSpacing: "-0.01em",
+          }}
+        >
+          What AI Agents Think
+        </div>
+      </div>
+
+      {/* POV cards */}
+      {povs.length > 0 ? (
+        povs.slice(0, 3).map((p, i) => (
+          <PovCard
+            key={`${p.display_name}-${i}`}
+            pov={p}
+            last={i === Math.min(2, povs.length - 1)}
+          />
+        ))
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            flex: 1,
+            alignItems: "center",
+            justifyContent: "center",
+            color: TEXT_MUTED,
+            fontSize: 16,
+          }}
+        >
+          No agent rationales recorded yet.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PovCard({ pov, last }: { pov: OgPov; last: boolean }) {
+  const accent =
+    pov.stance === "bullish"
+      ? GREEN
+      : pov.stance === "bearish"
+        ? RED
+        : YELLOW;
+  const stanceLabel =
+    pov.stance === "bullish"
+      ? "Bullish"
+      : pov.stance === "bearish"
+        ? "Bearish"
+        : "Cautious";
+  return (
+    <div
+      style={{
+        display: "flex",
+        padding: "12px 14px",
+        marginBottom: last ? 0 : 10,
+        borderRadius: 10,
+        background: "rgba(255,255,255,0.025)",
+        border: `1px solid ${accent}40`,
+      }}
+    >
+      <AgentMonogram seed={pov.display_name} accent={accent} />
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          marginLeft: 14,
+          flex: 1,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "baseline" }}>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 20,
+              fontWeight: 700,
+              color: TEXT,
+              marginRight: 10,
+            }}
+          >
+            {truncate(pov.display_name, 22)}
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 14,
+              fontWeight: 700,
+              color: accent,
+              letterSpacing: "0.04em",
+            }}
+          >
+            {stanceLabel}
+          </div>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            marginTop: 6,
+            fontSize: 15,
+            lineHeight: 1.35,
+            color: TEXT_DIM,
+            fontStyle: "italic",
+          }}
+        >
+          &ldquo;{pov.rationale}&rdquo;
+        </div>
       </div>
     </div>
   );
 }
 
-function formatUsd(n: number): string {
-  if (!Number.isFinite(n)) return "—";
-  return `$${Math.round(n).toLocaleString("en-US")}`;
+// Monogram avatar — first letter of the agent's display name on a
+// tinted disk coloured by stance. Deliberately *not* a brand logo so
+// every model family (and user-registered agents) gets the same
+// treatment.
+function AgentMonogram({ seed, accent }: { seed: string; accent: string }) {
+  const initial = (seed?.[0] ?? "?").toUpperCase();
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 44,
+        height: 44,
+        borderRadius: 22,
+        background: `${accent}1f`,
+        border: `1px solid ${accent}50`,
+        color: accent,
+        fontSize: 22,
+        fontWeight: 700,
+      }}
+    >
+      {initial}
+    </div>
+  );
 }
 
-function formatLongDate(iso: string): string {
-  const d = new Date(`${iso}T00:00:00Z`);
-  return d.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    timeZone: "UTC",
-  });
+// ---------------------------------------------------------------------------
+// Footer strip — brand line + tagline
+// ---------------------------------------------------------------------------
+
+function FooterStrip() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "14px 56px 22px",
+        borderTop: `1px solid ${BORDER}`,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          fontSize: 14,
+          color: TEXT_MUTED,
+        }}
+      >
+        Live AI stock analysis from multiple agents · paper-trading research, not financial advice.
+      </div>
+      <div
+        style={{
+          display: "flex",
+          fontSize: 14,
+          fontWeight: 600,
+          color: TEXT,
+        }}
+      >
+        alphamolt.ai
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1)}…`;
+}
+
+function formatPrice(n: number): string {
+  return `$${n.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 }


### PR DESCRIPTION
## Summary

Two halves, one PR: the on-page SEO fixes that came out of an audit of `/company/[ticker]` and `/screener` post-#777, plus the OG card redesign — matching the locked product mockup but with monogram avatars instead of brand logos.

## On-page SEO (`/company/[ticker]`)

- **Title template shortened**
  - Before: `{TICKER} Stock AI Analysis: What Agents Think About {Company Name}` + ` | AlphaMolt` ran 65–80 chars (truncated in Google SERPs)
  - After: `{TICKER} Stock AI Analysis · {Company Name}` lands under 60 chars once the brand suffix is appended
- **Article JSON-LD added** alongside the existing BreadcrumbList. `headline` / `datePublished` (= `ai_analyzed_at`) / `dateModified` (= `scored_at`) / `about.Corporation.tickerSymbol` = ticker. Signals "editorial content about a corporation" so we can sit alongside the news vertical rather than fight Yahoo/Google Finance on raw quote intent.
- **H1 keyword-enriched** without changing the visual. The H1 was `<h1>ARGX</h1>` + a separate `<p>` for the company name — crawlers only saw "ARGX". Now the H1 contains the ticker + company name + a visually-hidden "Stock AI Analysis" tail, all in one element. Visual output identical.

## Screener (`/screener`)

- **Title** bumped to "Stock Screener — US growth stocks ranked by AI agent score"
- **`?sector=` filter** now works server-side. Makes the breadcrumb link from `/company/[ticker]` actually filter (was previously a dead URL parameter). H1 switches to "{Sector} Stock Screener" when filtered. Gives crawlers per-sector entry points without minting slug routes.

## OG card redesign (`web/lib/company-og.tsx`)

Drops the previous "top holders + trade-tape strip" layout for the product-mockup one:

- **Left column**: big green ticker, company name, sector subline (NASDAQ · Netherlands · Health Technology), price + "Latest daily refresh · not a live quote" caption, four stat cards (AI Consensus, Agents hold, Swarm P&L, Rank).
- **Right column**: "✦ What AI Agents Think" header + three agent POV cards. Each card has a stance pill in its accent colour, the agent's display name, and a (truncated) rationale quote.
- **POV picking** = top 2 bullish + 1 bearish, all with non-empty rationales. Agents who have nothing to say are skipped.
- **Monogram avatars** = first letter on a tinted disk coloured by stance (green/red/yellow). No brand logos. Every agent — including user-registered ones — gets the same treatment. No implicit endorsement of model providers.

Share-URL cache buster bumped `?v=3 → ?v=4` so X.com re-fetches the redesigned image for already-tweeted company URLs.

## Test plan

- [ ] Vercel build green
- [ ] `view-source` on `/company/ARGX` shows:
  - `<title>ARGX Stock AI Analysis · argenx SE | AlphaMolt</title>` (or whichever ticker)
  - BreadcrumbList JSON-LD (existing) + Article JSON-LD (new)
  - H1 contains "Stock AI Analysis" (in `sr-only` span)
- [ ] Visit `/company/ARGX/opengraph-image` directly — image renders with monogram avatars (no brand logos), the three POV cards have stance pills, the stat cards in the lower-left read correctly
- [ ] Visit `/screener?sector=Health Technology` — only Health Tech rows render, H1 reads "Health Technology Stock Screener"
- [ ] Click the sector node in the breadcrumb on `/company/ARGX` — lands on a filtered screener
- [ ] Validate JSON-LD via Google's Rich Results test (paste a /company URL)
- [ ] Tweet a `/company/ARGX?v=4` URL — confirm X serves the new OG image

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_