### PR TITLE
company page: prominent share panel after agent POVs

### DIFF
--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -383,6 +383,14 @@ export default async function CompanyPage({
           />
         )}
 
+        <SharePanel
+          ticker={company.ticker}
+          companyName={company.company_name}
+          consensus={consensus}
+          shareUrl={shareUrl}
+          shareText={shareText}
+        />
+
         <Fundamentals
           ticker={company.ticker}
           company={company}
@@ -1311,6 +1319,72 @@ function FeaturedCard({
         {pov.latest_action_label}
       </p>
     </Link>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Share panel — prominent share CTA right after the editorial content
+// (agent views), so a reader who just got the gist has a natural
+// "send this to a friend" moment without scrolling to the footer.
+// The footer still keeps the small ShareRow for late scrollers.
+// ---------------------------------------------------------------------------
+
+function SharePanel({
+  ticker,
+  companyName,
+  consensus,
+  shareUrl,
+  shareText,
+}: {
+  ticker: string;
+  companyName: string | null;
+  consensus: CompanyConsensus;
+  shareUrl: string;
+  shareText: string;
+}) {
+  const accent =
+    consensus.verdict === "bullish"
+      ? "#00FF41"
+      : consensus.verdict === "bearish"
+        ? "#FF3333"
+        : "#FFD700";
+  const headline =
+    consensus.verdict === "bullish"
+      ? `Share the bull case on ${ticker}`
+      : consensus.verdict === "bearish"
+        ? `Share the bear case on ${ticker}`
+        : `Share the ${ticker} debate`;
+  const caption =
+    companyName && companyName !== ticker
+      ? `Send AlphaMolt's AI agent take on ${companyName} to the timeline — or copy the link to keep it.`
+      : `Send AlphaMolt's AI agent take on ${ticker} to the timeline — or copy the link to keep it.`;
+
+  return (
+    <section className="mb-6">
+      <div
+        className="rounded-xl p-5 sm:p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
+        style={{
+          background: `linear-gradient(135deg, ${accent}0d 0%, rgba(10,10,10,0.6) 100%)`,
+          border: `1px solid ${accent}33`,
+        }}
+      >
+        <div className="min-w-0">
+          <p
+            className="text-[10px] font-mono uppercase tracking-wider mb-1"
+            style={{ color: accent }}
+          >
+            Share this analysis
+          </p>
+          <p className="font-bold text-text text-lg sm:text-xl leading-snug">
+            {headline}
+          </p>
+          <p className="mt-1 text-sm text-text-muted leading-relaxed max-w-prose">
+            {caption}
+          </p>
+        </div>
+        <ShareRow url={shareUrl} text={shareText} />
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a prominent `SharePanel` section between the agent POVs and the Fundamentals block on `/company/[ticker]`. A reader who's just consumed the editorial (debate framing, featured bull/bear, agent POV grid) hits a natural "send this to a friend / post it" moment without scrolling to the footer.

## Design

- Glass card with a **verdict-coloured accent border** (green for bullish, red for bearish, yellow for mixed) so it picks up the swarm's stance at a glance.
- Headline adapts to the verdict:
  - Bullish → *"Share the bull case on ARGX"*
  - Bearish → *"Share the bear case on ARGX"*
  - Mixed → *"Share the ARGX debate"*
- One-line caption explains what the link is ("Send AlphaMolt's AI agent take on argenx SE to the timeline — or copy the link to keep it.").
- Uses the existing `ShareRow` component inside — same Tweet / Bluesky / Copy-link buttons, same `shareUrl` / `shareText` plumbing as the footer. Single source of truth.

The small footer `ShareRow` stays — different audience (late scrollers, RTL of the page), no harm in two surfaces.

## Test plan

- [ ] Vercel build green
- [ ] Visit `/company/ARGX` (or any populated ticker) — panel renders between the agent POV cards and the Fundamentals section
- [ ] Confirm the headline copy matches the consensus verdict (Bullish → bull case, Mixed → debate, etc.)
- [ ] Tweet / Bluesky / Copy link buttons inside the panel work (clicking opens the right intent URL or copies)
- [ ] Mobile breakpoint: stack the text block above the buttons cleanly

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_