### PR TITLE
og: unblock main — typeof company → CompanyShape alias

### DIFF
--- a/web/app/company/[ticker]/opengraph-image.tsx
+++ b/web/app/company/[ticker]/opengraph-image.tsx
@@ -44,14 +44,15 @@ export default async function Image({
   const { ticker: rawTicker } = await params;
   const ticker = decodeURIComponent(rawTicker).toUpperCase();
 
-  let company: {
+  type CompanyShape = {
     company_name: string | null;
     exchange: string | null;
     country: string | null;
     sector: string | null;
     price: number | null;
     sort_order: number | null;
-  } | null = null;
+  };
+  let company: CompanyShape | null = null;
   let snapshot: Awaited<ReturnType<typeof getCompanySwarmSnapshot>> | null =
     null;
   let holders: Awaited<ReturnType<typeof getCompanyHolders>> = [];
@@ -80,7 +81,7 @@ export default async function Image({
         .eq("in_tv_screen", true),
     ]);
     company =
-      (companyRes.data as typeof company | null) ?? null;
+      (companyRes.data as CompanyShape | null) ?? null;
     snapshot = snap;
     holders = hldrs;
     trades = trds;


### PR DESCRIPTION
## Why this exists

PR #778 was merged at commit `9c582e0` — that's *before* my type-fix commit on the same branch. So the broken `typeof company` cast landed on main, and every Vercel build since has been failing with:

> Type error: Property 'price' does not exist on type 'never'.

Result: **nothing has shipped since 15:57 UTC**, including the share panel from #779 (which merged on top but can't deploy until the build is green).

## The fix

Same one-line move from the original #778 follow-up commit: hoist the inline `{ ... } | null` shape into a named `CompanyShape` type alias and cast against that explicitly. TS otherwise walks `typeof <let-bound-null>` to `null` and downstream `company?.price` ends up on `never`.

## After merge

- Vercel build goes green
- New OG card (monogram avatars + agent POV cards) starts being served from `/company/[ticker]/opengraph-image`
- Share panel from #779 finally renders on `/company/[ticker]`
- X.com may still serve a stale cached OG image — `shareUrl` already includes `?v=4` to force re-fetch on freshly tweeted links

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_