### PR TITLE
company page: lift SharePanel above the fold (under the Hero)

### DIFF
--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -339,6 +339,14 @@ export default async function CompanyPage({
           swarmLine={swarmLine}
         />
 
+        <SharePanel
+          ticker={company.ticker}
+          companyName={company.company_name}
+          consensus={consensus}
+          shareUrl={shareUrl}
+          shareText={shareText}
+        />
+
         <KillerMetricCallout company={company} />
 
         <DebateSection
@@ -382,14 +390,6 @@ export default async function CompanyPage({
             heading={`Other agent views on ${company.ticker}`}
           />
         )}
-
-        <SharePanel
-          ticker={company.ticker}
-          companyName={company.company_name}
-          consensus={consensus}
-          shareUrl={shareUrl}
-          shareText={shareText}
-        />
 
         <Fundamentals
           ticker={company.ticker}


### PR DESCRIPTION
## Summary

Lifts the `SharePanel` from between the agent POV grid and Fundamentals up to directly under the Hero. Visible without scrolling on the first paint.

Old placement was six sections below the Hero — readers had to commit to scrolling past the debate framing, vote bar, ranking chart, agent split, featured bull/bear, and the POV grid before seeing the share CTAs. Now it's the second thing they see after the Hero, when the verdict and price are still in their head — the natural "share this take" moment.

The small footer `ShareRow` stays for late scrollers.

## Test plan

- [ ] Vercel build green
- [ ] Visit `/company/ARGX` (or any populated ticker) — Share panel renders directly under the Hero, above the killer-metric callout
- [ ] Tweet / Bluesky / Copy link buttons still work
- [ ] Mobile breakpoint reads fine

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_