### PR TITLE
prices: 15-min delayed quotes via EODHD /real-time

### DIFF
--- a/.github/workflows/intraday-prices.yml
+++ b/.github/workflows/intraday-prices.yml
@@ -1,0 +1,48 @@
+name: Intraday 15-min prices
+
+on:
+  schedule:
+    # Every 15 min, 13:00–22:00 UTC, Mon–Fri.
+    # US market hours are 13:30–20:00 UTC during DST (14:30–21:00 UTC outside
+    # DST). We start at 13:00 to catch pre-open and run through 22:00 so the
+    # 21:30 UTC delayed quote settles into the day's final close. Weekends
+    # are skipped — markets are closed.
+    #
+    # GitHub Actions cron is best-effort, not exact — runs may drift by a
+    # few minutes. That's fine because the underlying data is itself 15-min
+    # delayed; a small extra wobble doesn't move the needle.
+    - cron: "*/15 13-22 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  intraday-prices:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Fetch intraday prices
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          EODHD_API_KEY: ${{ secrets.EODHD_API_KEY }}
+        run: python intraday_prices.py
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: intraday-prices-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ Weekly (Sunday UTC):
 Sun 07:00       agent_heartbeat.py        Rebalance every agent's portfolio via its strategy
 Sun 08:00       consensus_snapshot.py     Aggregate agent_holdings → consensus_snapshots (powers /consensus)
 
+Every 15 min (Mon–Fri, 13:00–22:00 UTC):
+                intraday_prices.py        Refresh companies.price + price_asof via EODHD /real-time (15-min delayed quotes)
+
 Every 4h:
                 moltbook_heartbeat.py     Reply to notifications + engage with finance submolts on Moltbook
                 bluesky_heartbeat.py      Reply to mentions + AI-in-finance posts + posts about top swarm-consensus tickers on Bluesky
@@ -70,6 +73,17 @@ Fetches revenue, margins, cash flow, EPS, R40 score from EODHD API.
 Updates `companies` table. Staleness threshold: 7 days. Rate limit: 1s between calls.
 Evaluates screening criteria and stores flag results in the `flags` JSONB column.
 Supports `--force`, `--ticker`, `--dry-run`, `--limit` flags.
+
+### intraday_prices.py (every 15 min, Mon–Fri, 13:00–22:00 UTC)
+Refreshes `companies.price` + `companies.price_asof` via EODHD's
+`/real-time` bulk endpoint — 15-minute-delayed quotes during US market
+hours. Only touches the price columns (uses `db.bulk_upsert_company_prices`
+which whitelists `ticker / price / price_asof`); fundamentals, R40, AI
+narrative, sort_order, flags etc. keep their daily/weekly cadence.
+Outside market hours `price_asof` rolls forward to the prior trading
+day's last intraday tick (~21:45 UTC) so `portfolio_valuation.py` at
+05:30 UTC still snapshots close-of-business prices into
+`agent_portfolio_history`. Supports `--dry-run` and `--tickers` flags.
 
 ### update_ai_narratives.py (04:00 UTC daily)
 Refreshes stale narratives (90+ days) using Gemini 2.5 Flash.
@@ -170,7 +184,7 @@ print(pm.get_portfolio(agent_id))    # MTM at latest companies.price
 ### companies (primary — replaces AI Analysis sheet)
 ```
 COMPANY:     ticker (PK), exchange, company_name, country, sector, description
-SCREENING:   status, composite_score, price, ps_now, price_pct_of_52w_high, perf_52w_vs_spy, rating, sort_order
+SCREENING:   status, composite_score, price, price_asof, ps_now, price_pct_of_52w_high, perf_52w_vs_spy, rating, sort_order
 OVERVIEW:    r40_score, fundamentals_snapshot, short_outlook
 REVENUE:     annual_revenue_5y, quarterly_revenue, rev_growth_ttm_pct, rev_growth_qoq_pct, rev_cagr_pct, rev_consistency_score
 MARGINS:     gross_margin_pct, gm_trend, operating_margin_pct, net_margin_pct, net_margin_yoy_pct, fcf_margin_pct
@@ -349,6 +363,9 @@ python update_ai_narratives.py             # refresh AI narratives
 python score_ai_analysis.py                # score + rank
 python price_sales_updater.py              # P/S update
 python price_sales_updater.py --tickers NVDA AAPL --force
+python intraday_prices.py                   # 15-min delayed prices via EODHD /real-time
+python intraday_prices.py --dry-run
+python intraday_prices.py --tickers NVDA AAPL META
 python build_universe_snapshot.py           # daily 3-tier JSON snapshot
 python build_universe_snapshot.py --tier compact --dry-run
 

--- a/db.py
+++ b/db.py
@@ -90,6 +90,29 @@ class SupabaseDB:
         if rows:
             self.client.table("companies").upsert(rows).execute()
 
+    def bulk_upsert_company_prices(self, rows: list[dict]) -> None:
+        """Write only the live price columns (price, price_asof) to many
+        company rows in a single batch.
+
+        Used by intraday_prices.py — the 15-min refresher must not touch
+        fundamentals / R40 / AI narrative / sort_order / flags or any other
+        column those daily jobs own. Each row must include `ticker`; any
+        keys outside the allowed set are filtered out defensively so an
+        accidental field can't blow away the daily-refreshed columns.
+        """
+        if not rows:
+            return
+        allowed = {"ticker", "price", "price_asof"}
+        cleaned: list[dict] = []
+        for row in rows:
+            slim = {k: row[k] for k in row.keys() & allowed}
+            if "ticker" not in slim or slim.get("price") is None:
+                continue
+            self._sanitize(slim)
+            cleaned.append(slim)
+        if cleaned:
+            self.client.table("companies").upsert(cleaned).execute()
+
     # ------------------------------------------------------------------
     # Price-Sales
     # ------------------------------------------------------------------

--- a/intraday_prices.py
+++ b/intraday_prices.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+Intraday 15-min delayed price refresher.
+
+Hits EODHD's /real-time bulk endpoint and writes (price, price_asof) back
+to `companies` for every ticker in the active TV screen. Scheduled every
+15 min during US market hours via .github/workflows/intraday-prices.yml.
+
+Only touches the price-related columns — fundamentals, R40, AI narrative,
+flags, sort_order etc. all keep their daily/weekly refresh cadence. The
+05:30 UTC portfolio_valuation.py snapshot still picks up close-of-business
+because the last intraday tick of the day runs around 21:45 UTC and
+markets have been closed since ~22:00 UTC by the time MTM runs.
+
+Usage:
+    python intraday_prices.py
+    python intraday_prices.py --dry-run
+    python intraday_prices.py --tickers NVDA AAPL META
+
+Env:
+    EODHD_API_KEY
+    SUPABASE_URL
+    SUPABASE_SERVICE_KEY
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+from db import SupabaseDB
+from exchanges import resolve_eodhd_exchange
+
+load_dotenv()
+
+EODHD_REALTIME_BASE = "https://eodhd.com/api/real-time"
+# EODHD's `s=` bulk param is documented as supporting "multiple tickers" without
+# a hard cap. 50 is conservative — keeps individual responses small and means
+# ~20 calls cover a ~1000-ticker universe in one tick.
+BATCH_SIZE = 50
+DELAY_BETWEEN_BATCHES = 0.3  # seconds; conservative — well under the per-minute limit
+TIMEOUT = 20
+
+
+def setup_logging() -> logging.Logger:
+    log_dir = Path(__file__).parent / "logs"
+    log_dir.mkdir(exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d")
+    log_file = log_dir / f"intraday_prices_{stamp}.txt"
+
+    logger = logging.getLogger("intraday_prices")
+    logger.setLevel(logging.INFO)
+    fmt = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+    )
+    fh = logging.FileHandler(log_file, encoding="utf-8")
+    fh.setFormatter(fmt)
+    logger.addHandler(fh)
+
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(fmt)
+    logger.addHandler(sh)
+    return logger
+
+
+def fetch_batch_prices(
+    symbols: list[str], api_key: str, logger: logging.Logger
+) -> dict[str, dict]:
+    """Fetch up to BATCH_SIZE symbols from EODHD's /real-time endpoint.
+
+    Symbols are full EODHD codes ("AAPL.US", "ARGX.NASDAQ"). The first
+    symbol goes in the URL path; the rest piggy-back via `?s=`. The
+    endpoint returns a dict for single-ticker calls and a list for bulk —
+    we normalise to a {SYMBOL_UPPER: row_dict} map.
+    """
+    if not symbols:
+        return {}
+    head, *rest = symbols
+    url = f"{EODHD_REALTIME_BASE}/{head}"
+    params: dict[str, str] = {"api_token": api_key, "fmt": "json"}
+    if rest:
+        params["s"] = ",".join(rest)
+
+    try:
+        resp = requests.get(url, params=params, timeout=TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        logger.warning(
+            "EODHD batch fetch failed (%d symbols, starting %s): %s",
+            len(symbols),
+            head,
+            exc,
+        )
+        return {}
+
+    rows = data if isinstance(data, list) else [data]
+    out: dict[str, dict] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        code = row.get("code")
+        if not isinstance(code, str) or not code:
+            continue
+        out[code.upper()] = row
+    return out
+
+
+def extract_price(row: dict) -> tuple[float, datetime] | None:
+    """Pull (price, asof_utc) out of an EODHD /real-time row, or None.
+
+    EODHD returns the string "NA" for tickers it can't price (delisted,
+    suspended, brand-new IPOs that aren't covered, etc.). We treat any
+    non-positive value as missing and let the caller skip.
+    """
+    close = row.get("close")
+    if close in (None, "NA", "-"):
+        return None
+    try:
+        price = float(close)
+    except (TypeError, ValueError):
+        return None
+    if not (price > 0):
+        return None
+
+    ts = row.get("timestamp")
+    if isinstance(ts, (int, float)) and ts > 0:
+        asof = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+    else:
+        # No timestamp from EODHD (rare) — stamp with our fetch time so
+        # the UI still has something fresh to display.
+        asof = datetime.now(timezone.utc)
+    return price, asof
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Intraday 15-min delayed price refresher (EODHD /real-time)"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="fetch + log, but skip the DB write",
+    )
+    parser.add_argument(
+        "--tickers",
+        nargs="+",
+        help="restrict to these tickers (still must be in_tv_screen)",
+    )
+    args = parser.parse_args()
+
+    logger = setup_logging()
+    logger.info("=" * 60)
+    logger.info(
+        "Intraday prices — %s UTC",
+        datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+    logger.info("=" * 60)
+
+    api_key = os.environ.get("EODHD_API_KEY")
+    if not api_key:
+        logger.error("EODHD_API_KEY env var is not set")
+        return 1
+
+    db = SupabaseDB()
+    companies = db.get_all_companies()
+    if not companies:
+        logger.warning("No companies — nothing to do")
+        return 0
+
+    eligible = [c for c in companies if c.get("in_tv_screen")]
+    if args.tickers:
+        wanted = {t.upper() for t in args.tickers}
+        eligible = [c for c in eligible if c["ticker"].upper() in wanted]
+    if not eligible:
+        logger.warning("No eligible tickers after filtering")
+        return 0
+
+    logger.info(
+        "Fetching prices for %d eligible tickers (batch=%d)",
+        len(eligible),
+        BATCH_SIZE,
+    )
+
+    # Build (alphamolt_ticker, eodhd_symbol) pairs so we can look up
+    # responses by EODHD code and route them back to the right row.
+    pairs: list[tuple[str, str]] = []
+    for c in eligible:
+        eodhd_ex = resolve_eodhd_exchange(c.get("exchange", "")) or "US"
+        pairs.append((c["ticker"], f"{c['ticker']}.{eodhd_ex}"))
+
+    updates: list[dict] = []
+    skipped: list[str] = []
+    fail_batches = 0
+
+    for i in range(0, len(pairs), BATCH_SIZE):
+        batch = pairs[i : i + BATCH_SIZE]
+        symbols = [sym for _, sym in batch]
+        rows = fetch_batch_prices(symbols, api_key, logger)
+        if not rows:
+            fail_batches += 1
+            for ticker, _ in batch:
+                skipped.append(ticker)
+        else:
+            for ticker, sym in batch:
+                row = rows.get(sym.upper())
+                if not row:
+                    skipped.append(ticker)
+                    continue
+                res = extract_price(row)
+                if not res:
+                    skipped.append(ticker)
+                    continue
+                price, asof = res
+                updates.append(
+                    {
+                        "ticker": ticker,
+                        "price": round(price, 4),
+                        "price_asof": asof.isoformat(),
+                    }
+                )
+        time.sleep(DELAY_BETWEEN_BATCHES)
+
+    logger.info(
+        "Fetched: %d updates / %d skipped / %d failed batches",
+        len(updates),
+        len(skipped),
+        fail_batches,
+    )
+    if skipped:
+        logger.info("Skipped tickers (first 20): %s", skipped[:20])
+
+    if args.dry_run:
+        logger.info("--dry-run — not writing. Sample updates:")
+        for row in updates[:10]:
+            logger.info(
+                "  %s  $%s  asof=%s",
+                row["ticker"],
+                row["price"],
+                row["price_asof"],
+            )
+        return 0
+
+    if not updates:
+        logger.warning("No updates to write")
+        return 0
+
+    db.bulk_upsert_company_prices(updates)
+    logger.info("Wrote %d price updates", len(updates))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migrations/015_companies_price_asof.sql
+++ b/migrations/015_companies_price_asof.sql
@@ -1,0 +1,15 @@
+-- Migration 015: add `price_asof` to companies for 15-min delayed quotes.
+--
+-- companies.price is now refreshed every 15 minutes during US market hours
+-- by intraday_prices.py (in addition to the daily score_ai_analysis.py /
+-- nightly_screen.py paths). price_asof records when the value last landed
+-- so the UI can show "15-min delayed · last refresh 14:32 UTC".
+--
+-- Outside market hours price_asof points at the prior trading day's last
+-- intraday tick (~21:45 UTC, which captures the close once delays settle).
+
+ALTER TABLE companies
+    ADD COLUMN IF NOT EXISTS price_asof TIMESTAMPTZ;
+
+COMMENT ON COLUMN companies.price_asof IS
+    'When companies.price was last refreshed. 15-min delayed intraday during US market hours via intraday_prices.py; close-of-business otherwise.';

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -28,6 +28,10 @@ CREATE TABLE companies (
     status                  TEXT NOT NULL DEFAULT '',
     composite_score         NUMERIC(5,1) DEFAULT 0,
     price                   NUMERIC(12,4),
+    -- When companies.price was last refreshed. 15-min delayed intraday
+    -- during US market hours via intraday_prices.py; close-of-business
+    -- otherwise.
+    price_asof              TIMESTAMPTZ,
     ps_now                  NUMERIC(8,2),
     price_pct_of_52w_high   NUMERIC(6,4),
     perf_52w_vs_spy         NUMERIC(8,4),

--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { getSupabase } from "@/lib/supabase";
 import { Company, PriceSales } from "@/lib/types";
 import {
+  formatAsof,
   formatPct,
   formatPrice,
   formatNumber,
@@ -35,7 +36,10 @@ import {
   type SwarmViewLine,
 } from "@/lib/company-agents-query";
 
-export const revalidate = 600;
+// 300s ISR matches the 15-min intraday cadence — readers see fresh
+// prices within 5 min of the next refresh, but we don't re-render
+// on every request.
+export const revalidate = 300;
 
 // ---------------------------------------------------------------------------
 // Data
@@ -304,10 +308,10 @@ export default async function CompanyPage({
   // ?v=… is a cache-bust for X.com's per-URL og:image cache — bump when
   // the OG design changes. Paired with og:url being omitted in the
   // generateMetadata above.
-  // ?v=4 bumped when the OG card redesigned (monogram POV cards, no
-  // brand logos) — forces X.com to re-fetch the new image for any
-  // previously-shared URL.
-  const shareUrl = `${absoluteUrl(`/company/${encodeURIComponent(decoded)}`)}?v=4`;
+  // ?v=5 bumped when the OG card freshness copy changed to
+  // "Quote 15-minute delayed" — forces X.com to re-fetch the new image
+  // for any previously-shared URL.
+  const shareUrl = `${absoluteUrl(`/company/${encodeURIComponent(decoded)}`)}?v=5`;
   const shareText =
     consensus.verdict === "bullish"
       ? `AI agents are bullish on $${decoded} — see who holds it, what they paid, and why on AlphaMolt.`
@@ -593,16 +597,14 @@ function HeroSection({
             {formatPrice(company.price)}
           </p>
           {/* Freshness sits directly under the price (not in a separate
-              tile) so readers know at a glance that this isn't a tick
-              quote. Phrasing is "latest daily refresh" — intentional,
-              not apologetic. */}
+              tile) so readers know at a glance that this is a delayed
+              quote, not a live tick. price_asof comes from EODHD's
+              /real-time endpoint via intraday_prices.py — 15-min delayed
+              during US market hours, prior-close otherwise. */}
           <p className="text-[10px] font-mono text-text-muted mt-1 leading-tight">
-            Latest daily refresh
-            {company.scored_at
-              ? ` · ${company.scored_at}`
-              : ""}
+            15-min delayed quote
             <br />
-            <span>Not a live quote</span>
+            <span>last refresh {formatAsof(company.price_asof)}</span>
           </p>
         </div>
         <HeroStat
@@ -631,7 +633,7 @@ function HeroSection({
           loudly that the price isn't tick-by-tick and the page is
           research, not advice. Increases trust by being explicit. */}
       <div className="mt-5 pt-4 border-t border-white/5 flex flex-wrap gap-2 text-[11px] font-mono text-text-muted">
-        <TrustPill>● Latest daily refresh, not live market data</TrustPill>
+        <TrustPill>● Quote 15-min delayed (EODHD)</TrustPill>
         <TrustPill>● Paper-trading only</TrustPill>
         <TrustPill>● Research aid, not financial advice</TrustPill>
       </div>
@@ -1468,10 +1470,11 @@ function ResearchContextSection() {
           recommendations, or an instruction to buy or sell any security.
         </p>
         <p className="mt-2">
-          Prices on this page reflect the latest daily market-data refresh
-          (typically within the last 24 hours), not live tick data. Holdings
-          and trade journals are paper-traded against $1M virtual accounts;
-          no real money changes hands.
+          Prices on this page are 15-minute-delayed quotes from EODHD,
+          refreshed every 15 minutes during US market hours and rolling
+          forward to the prior close overnight and on weekends. Holdings
+          and trade journals are paper-traded against $1M virtual
+          accounts; no real money changes hands.
         </p>
       </div>
     </section>

--- a/web/app/consensus/[date]/page.tsx
+++ b/web/app/consensus/[date]/page.tsx
@@ -141,7 +141,7 @@ function Methodology() {
         <em>Avg Entry</em> is the share-weighted average cost basis across
         every agent holding the ticker, and <em>Swarm P&amp;L</em> shows the
         implied unrealised return of the swarm against its blended entry. Data
-        is marked to market daily and the consensus snapshot itself refreshes
+        is marked to market with 15-minute-delayed prices, and the consensus snapshot itself refreshes
         once a week, every Monday morning UTC.
       </p>
     </section>

--- a/web/app/consensus/page.tsx
+++ b/web/app/consensus/page.tsx
@@ -100,7 +100,7 @@ export default async function ConsensusPage() {
             )}
             {formattedDate && rows.length > 0 && (
               <p className="mt-3 text-xs text-text-muted text-right font-mono">
-                Snapshot: {formattedDate} · marked to market daily
+                Snapshot: {formattedDate} · prices 15-minute delayed
               </p>
             )}
           </section>
@@ -210,7 +210,7 @@ function Methodology() {
         <em>Avg Entry</em> is the share-weighted average cost basis across
         every agent holding the ticker, and <em>Swarm P&amp;L</em> shows the
         implied unrealised return of the swarm against its blended entry. Data
-        is marked to market daily and the consensus snapshot itself refreshes
+        is marked to market with 15-minute-delayed prices, and the consensus snapshot itself refreshes
         once a week, every Monday morning UTC, after the weekly rebalance loop
         has settled.
       </p>

--- a/web/app/portfolio/page.tsx
+++ b/web/app/portfolio/page.tsx
@@ -5,7 +5,7 @@ import { deduplicateByCompany } from "@/lib/dedupe";
 import Nav from "@/components/nav";
 import DataTable from "@/components/data-table";
 
-export const revalidate = 600;
+export const revalidate = 300;
 
 export const metadata: Metadata = {
   title: "Example Agent Portfolio",

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -4,7 +4,9 @@ import { Company, SCREENER_COLUMNS } from "@/lib/types";
 import Nav from "@/components/nav";
 import DataTable from "@/components/data-table";
 
-export const revalidate = 600;
+// 300s matches the 15-min intraday price cadence so visitors see the
+// refreshed prices roughly within ¼ of a refresh window.
+export const revalidate = 300;
 
 export const metadata: Metadata = {
   title: "Stock Screener — US growth stocks ranked by AI agent score",
@@ -85,6 +87,10 @@ export default async function ScreenerPage({
             {heading}
           </h1>
           <p className="text-sm text-text-muted font-mono">{sub}</p>
+          <p className="text-xs text-text-muted font-mono mt-1">
+            Prices 15-minute delayed (EODHD) · refreshed every 15 min during
+            US market hours
+          </p>
         </div>
         <DataTable companies={companies} />
       </main>

--- a/web/lib/company-og.tsx
+++ b/web/lib/company-og.tsx
@@ -208,7 +208,7 @@ function LeftPanel({ args }: { args: CompanyOgArgs }) {
           color: TEXT_MUTED,
         }}
       >
-        Latest daily refresh · not a live quote
+        Quote 15-minute delayed · EODHD
       </div>
 
       {/* Stat cards row */}

--- a/web/lib/constants.ts
+++ b/web/lib/constants.ts
@@ -32,6 +32,43 @@ export function formatPrice(val: number | null | undefined): string {
   return formatNumber(val, { prefix: "$", decimals: 2 });
 }
 
+/**
+ * Compact "price as-of" formatter for the freshness pill.
+ *
+ *   same UTC day               → "14:32 UTC"
+ *   prior calendar UTC day     → "yesterday 21:30 UTC"
+ *   anything older (weekends,
+ *     holidays, stale data)    → "close of 2026-05-09"
+ *
+ * Returns "—" for null/undefined/invalid input so callers don't need to
+ * guard. Uses UTC (not the viewer's locale) so the value matches what
+ * the cron actually wrote — predictable across visitors.
+ */
+export function formatAsof(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const t = new Date(iso);
+  if (Number.isNaN(t.getTime())) return "—";
+
+  const now = new Date();
+  const tDay = Date.UTC(t.getUTCFullYear(), t.getUTCMonth(), t.getUTCDate());
+  const nowDay = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+  );
+  const dayDiff = Math.round((nowDay - tDay) / 86400000);
+
+  const hh = String(t.getUTCHours()).padStart(2, "0");
+  const mm = String(t.getUTCMinutes()).padStart(2, "0");
+
+  if (dayDiff === 0) return `${hh}:${mm} UTC`;
+  if (dayDiff === 1) return `yesterday ${hh}:${mm} UTC`;
+  const y = t.getUTCFullYear();
+  const m = String(t.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(t.getUTCDate()).padStart(2, "0");
+  return `close of ${y}-${m}-${d}`;
+}
+
 export function parseStatus(status: string | null | undefined): {
   label: string | null;
   color: string;

--- a/web/lib/openapi-spec.ts
+++ b/web/lib/openapi-spec.ts
@@ -11,7 +11,7 @@ export const OPENAPI_SPEC = {
     title: "AlphaMolt API",
     version: "1.0.0",
     description:
-      "Read-only access to the AlphaMolt equity screener. Data for hundreds of US-listed growth stocks (incl. ADRs), refreshed nightly, with fundamental metrics, AI narratives, and composite rankings. Designed for autonomous LLM agents competing in the AlphaMolt Arena.",
+      "Read-only access to the AlphaMolt equity screener. Hundreds of US-listed growth stocks (incl. ADRs) with 15-minute-delayed prices (refreshed every 15 min during US market hours), nightly-refreshed fundamentals + AI narratives, and composite rankings. Designed for autonomous LLM agents competing in the AlphaMolt Arena.",
     contact: {
       name: "AlphaMolt",
       url: "https://www.alphamolt.ai/docs",
@@ -414,7 +414,17 @@ export const OPENAPI_SPEC = {
           country: { type: "string" },
           status: { type: "string" },
           composite_score: { type: ["number", "null"] },
-          price: { type: ["number", "null"] },
+          price: {
+            type: ["number", "null"],
+            description:
+              "15-minute-delayed quote from EODHD, refreshed every 15 min during US market hours. Outside market hours, equals the prior trading day's last intraday tick (~21:45 UTC).",
+          },
+          price_asof: {
+            type: ["string", "null"],
+            format: "date-time",
+            description:
+              "ISO-8601 timestamp of the last price refresh. Pair with `price` to display freshness.",
+          },
           ps_now: { type: ["number", "null"] },
           rev_growth_ttm_pct: { type: ["number", "null"] },
           gross_margin_pct: { type: ["number", "null"] },
@@ -452,7 +462,16 @@ export const OPENAPI_SPEC = {
           description: { type: "string" },
           status: { type: "string" },
           composite_score: { type: ["number", "null"] },
-          price: { type: ["number", "null"] },
+          price: {
+            type: ["number", "null"],
+            description:
+              "15-minute-delayed quote from EODHD, refreshed every 15 min during US market hours.",
+          },
+          price_asof: {
+            type: ["string", "null"],
+            format: "date-time",
+            description: "ISO-8601 timestamp of the last price refresh.",
+          },
           ps_now: { type: ["number", "null"] },
           price_pct_of_52w_high: { type: ["number", "null"] },
           perf_52w_vs_spy: { type: ["number", "null"] },

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -11,6 +11,11 @@ export interface Company {
   status: string;
   composite_score: number | null;
   price: number | null;
+  // ISO-8601 timestamp. When companies.price was last refreshed —
+  // 15-min delayed during US market hours, close-of-business otherwise.
+  // Null only while migration 015 is rolling out or before the first
+  // intraday_prices.py run.
+  price_asof: string | null;
   ps_now: number | null;
   price_pct_of_52w_high: number | null;
   perf_52w_vs_spy: number | null;

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -213,8 +213,9 @@ Content-Type: application/json
 {"ticker": "NVDA", "quantity": 10}
 ```
 
-`/portfolio/sell` mirrors `/buy`. Fills at the latest `companies.price`,
-cash-settled, weighted-average cost basis.
+`/portfolio/sell` mirrors `/buy`. Fills at the latest `companies.price`
+(15-minute-delayed quote from EODHD, refreshed every 15 min during US
+market hours), cash-settled, weighted-average cost basis.
 
 ### Hard constraints (v1)
 

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -118,8 +118,10 @@ Authorization: Bearer $ALPHAMOLT_API_KEY
   cheaper than N `/equities` calls. Tiers: `compact` (small), `extended`
   (default, +4 quarters + monthly P/S), `full` (+all quarterly + weekly P/S).
 
-Fills execute at the latest `companies.price`, cash-settled, weighted-average
-cost basis. No fees, no slippage, no splits, no dividends in v1.
+Fills execute at the latest `companies.price` (15-minute-delayed quote from
+EODHD, refreshed every 15 min during US market hours), cash-settled,
+weighted-average cost basis. No fees, no slippage, no splits, no dividends
+in v1.
 
 ## Hard constraints — do not plan around capital you don't have
 


### PR DESCRIPTION
## Summary

Replaces the daily TradingView-screen-only price refresh with a 15-minute EODHD intraday refresher. Price columns update every 15 min during US market hours; everything else (fundamentals, R40, AI narrative, sort_order, flags, etc.) keeps its existing cadence. Daily MTM history is untouched — `portfolio_valuation.py` at 05:30 UTC still snapshots close-of-business prices into `agent_portfolio_history`.

## Data pipeline

- **`migrations/015_companies_price_asof.sql`** — adds `companies.price_asof TIMESTAMPTZ`. Mirrored in `supabase_schema.sql`.
- **`intraday_prices.py`** — bulk-fetches EODHD `/real-time` (50 tickers per call, ~20 calls for the whole screen). Skips `"NA"`/non-positive closes; stamps fetch time when EODHD doesn't return a timestamp. Args: `--dry-run`, `--tickers`.
- **`.github/workflows/intraday-prices.yml`** — cron `*/15 13-22 * * 1-5`. Pre-open warm-up at 13:00 UTC; tail at 22:00 UTC catches the close once delays settle.
- **`db.bulk_upsert_company_prices(rows)`** writes ONLY `(ticker, price, price_asof)`. Whitelists those keys defensively so an errant field in the row dict can't clobber daily-refreshed columns.

## Frontend

- Company hero freshness pill: `"Latest daily refresh, not live market data"` → `"Quote 15-min delayed (EODHD)"`. The caption under the price reads `"15-min delayed quote · last refresh 14:32 UTC"` via a new `formatAsof(price_asof)` helper.
- `formatAsof` in `web/lib/constants.ts` handles same-UTC-day / yesterday / older fallbacks (`"close of YYYY-MM-DD"`).
- `ResearchContextSection` copy explains the 15-min cadence + after-hours rollover.
- Screener subheading adds `"Prices 15-minute delayed (EODHD)"`.
- Consensus footnote tightened to `"prices 15-minute delayed"`.
- OG card caption: `"Latest daily refresh · not a live quote"` → `"Quote 15-minute delayed · EODHD"`. Share URL bumped `?v=4 → ?v=5` so X re-fetches.
- Page ISR tightened where prices appear: `/screener` 600 → 300, `/company/[ticker]` 600 → 300, `/portfolio` 600 → 300. `/leaderboard` and OG image revalidate windows unchanged.

## Docs

- `CLAUDE.md`: new schedule row, `intraday_prices.py` section, command examples.
- `web/lib/openapi-spec.ts`: `price` field annotated with the 15-min freshness framing; new `price_asof` field documented on both `EquitySummary` and `EquityFull` schemas.
- `web/public/skill.md` + `web/public/api-reference.md`: fill-price annotation updated.

## Pre-merge deployment step

**Run migration 015 against Supabase before merging** so the `price_asof` column exists when the new cron starts writing.

```sql
ALTER TABLE companies ADD COLUMN IF NOT EXISTS price_asof TIMESTAMPTZ;
```

## Test plan

- [ ] Migration runs cleanly (`SELECT price_asof FROM companies LIMIT 1` returns NULL until first refresh).
- [ ] `python intraday_prices.py --tickers NVDA AAPL META --dry-run` — confirm bulk fetch works, prices look right, `price_asof` parses on a 15-min boundary.
- [ ] `python intraday_prices.py --tickers NVDA AAPL META` — confirm DB rows update without touching unrelated columns.
- [ ] Trigger `intraday-prices.yml` manually during US market hours — confirm full ~1000-ticker run finishes inside the 10-min timeout.
- [ ] Visit `/company/NVDA` — confirm freshness pill reads `15-min delayed quote · last refresh HH:MM UTC`.
- [ ] Hit `/api/v1/equities/NVDA` — confirm `price` and `price_asof` are both populated.
- [ ] Tweet `https://www.alphamolt.ai/company/NVDA?v=5` — confirm new OG card shows `Quote 15-minute delayed · EODHD`.
- [ ] After 24h: `/leaderboard` rows still update once daily, no drift from intraday writes.

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_