### PR TITLE
seo: add MyWOT site-verification meta tag

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -88,6 +88,16 @@ export const metadata: Metadata = {
     },
   },
   category: "finance",
+  // Third-party site-verification tokens. `other` is the right slot for
+  // anything Next doesn't have a first-class field for (google/yandex/
+  // yahoo/me get their own keys on `verification`). Tokens are public
+  // by design — they show up in the HTML head regardless — so it's fine
+  // to commit them straight into the repo.
+  verification: {
+    other: {
+      "wot-verification": "835a07d9db47a82cd345",
+    },
+  },
 };
 
 // JSON-LD for Organization + WebSite. Rendered once in the root layout so


### PR DESCRIPTION
Adds the MyWOT (Web of Trust) site-verification meta tag site-wide so WOT can crawl + index the site and we get a reputation badge in their browser extension / search overlay.

Token is public by design (lives in the HTML head regardless), so committed straight rather than env-var routed. Lives in `web/app/layout.tsx`'s root metadata block, under `verification.other` — the same place future Bing/Yandex/Pinterest tokens would slot in.

Renders site-wide as:

```html
<meta name="wot-verification" content="835a07d9db47a82cd345"/>
```

## Test plan

- [ ] Vercel build green
- [ ] `view-source` on `https://www.alphamolt.ai/` shows the meta tag inside `<head>`
- [ ] Click "Verify" in the MyWOT dashboard and confirm verification succeeds

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_