### PR TITLE
home: WOT trust badge low on the homepage

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import Nav from "@/components/nav";
 import HeroChart from "@/components/hero-chart";
 import HomeConsensus from "@/components/home-consensus";
+import WotBadge from "@/components/wot-badge";
 import HomePrompt from "@/components/home-prompt";
 import {
   getHomeLeaderboard,
@@ -120,6 +121,7 @@ export default async function HomePage() {
           </div>
           <Credibility />
           <EnterYourAgent />
+          <WotBadge />
         </div>
       </main>
     </>

--- a/web/components/wot-badge.tsx
+++ b/web/components/wot-badge.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * MyWOT (Web of Trust) trust-badge widget. WOT's loader inserts the
+ * badge HTML at the DOM position of its own `<script>` element, so we
+ * append the script into a placeholder div via useEffect — that's the
+ * only reliable way to anchor the badge to a specific spot in the page
+ * with Next.js's App Router (next/script always lands in <head>, and
+ * vanilla <script> tags in JSX don't execute).
+ *
+ * Idempotent: bails out if the script tag is already present (avoids
+ * a second badge being injected after a soft client-side nav back to
+ * the home page).
+ */
+export default function WotBadge() {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = ref.current;
+    if (!container) return;
+
+    const src =
+      "https://static.mywot.com/website_owners_badges/websiteOwnersBadge.js";
+    // Idempotency check — covers React strict-mode double mount in dev
+    // and client-side back-nav after the badge has already rendered.
+    if (
+      typeof document !== "undefined" &&
+      document.querySelector(`script[src="${src}"]`)
+    ) {
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = src;
+    container.appendChild(script);
+  }, []);
+
+  return (
+    <section
+      aria-label="Trust badge"
+      className="mt-16 mb-8 flex justify-center"
+    >
+      <div ref={ref} />
+    </section>
+  );
+}


### PR DESCRIPTION
Adds the MyWOT website-owners badge near the bottom of the homepage, after `EnterYourAgent` and before the layout footer. Pairs with the wot-verification meta tag from #783 so WOT can both verify the site *and* display its reputation badge to visitors.

## Why a client component?

WOT's loader injects the badge HTML at the DOM position of its own `<script>` tag. Three options considered:

- **Next.js's `<Script>` component** — always renders the script in `<head>`, so the badge would end up at the bottom of `<body>`, not where we want it. ❌
- **Plain `<script>` tag in JSX** — doesn't execute reliably in App Router. ❌
- **Client component with `useEffect`** — appends a `<script>` into a placeholder div, so the badge renders exactly at that DOM position. ✅

The component also has an idempotency check so React's strict-mode double-mount in dev (and client-side back-nav to `/` after the badge has already rendered) don't inject a second copy.

## Test plan

- [ ] Vercel build green
- [ ] Visit `/` → scroll to the bottom → confirm the MyWOT badge renders below `EnterYourAgent`, above the page footer
- [ ] Inspect element → confirm the WOT script is appended inside the placeholder div, not in `<head>`
- [ ] Soft-nav to another page and back → confirm exactly one badge renders (no duplicates)
- [ ] Click the badge → confirm it links to AlphaMolt's WOT profile

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_