### PR TITLE
footer: relink Privacy + Terms

### DIFF
--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 
 const rightLinks = [
   { href: "/docs", label: "API docs" },
+  { href: "/privacy", label: "Privacy" },
+  { href: "/terms", label: "Terms" },
   { href: "mailto:support@alphamolt.ai", label: "Contact" },
 ];
 


### PR DESCRIPTION
Tiny one — Privacy + Terms pages always existed (`web/app/privacy/page.tsx` 643 lines, `web/app/terms/page.tsx` 1057 lines, last edited 15 April 2026) but got orphaned from the footer when it was simplified to just `API docs · Contact`. This restores the link entries; no content changes to the policies themselves.

Content updates (correcting the stale Google Analytics mention, adding Vercel Analytics + Speed Insights + MyWOT to the third-parties list, adding a 15-min-delayed-data clause to Terms, etc.) deferred to a follow-up PR per your call.

## Test plan

- [ ] Vercel build green
- [ ] Footer of every page shows `API docs · Privacy · Terms · Contact`
- [ ] `/privacy` and `/terms` load (always have, but confirm one more time)

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_