### PR TITLE
wot-badge: add the HTML scaffold MyWOT&#39;s script needs

### DIFF
--- a/web/components/wot-badge.tsx
+++ b/web/components/wot-badge.tsx
@@ -1,38 +1,49 @@
 import Script from "next/script";
 
 /**
- * MyWOT (Web of Trust) trust-badge loader.
+ * MyWOT (Web of Trust) trust badge.
  *
- * Implementation history (left as a paper trail for the next person to
- * touch this):
+ * The MyWOT loader is *not* a self-injecting widget — it's a styler.
+ * It looks for a pre-existing element with id `wot-badge0` / `wot-badge1`
+ * / `wot-badge2` and decorates its inner shield/logo/text spans with
+ * inline styles. If none of those IDs exist on the page when the
+ * script runs, it bails silently — which is why v1 and v2 of this
+ * component produced nothing visible despite the script loading
+ * cleanly (Network 200).
  *
- *   v1 — client component that built a <script> element with
- *        document.createElement and appended it to a placeholder div.
- *        Script loaded (200 in Network), but `document.currentScript`
- *        is null for any script created via createElement+appendChild.
- *        WOT's loader uses currentScript to know where to inject the
- *        badge HTML, so with currentScript=null it bailed silently and
- *        no badge ever rendered.
+ * v3 (this) ships the full HTML scaffold MyWOT expects, alongside the
+ * loader script. A MutationObserver inside the script picks up the
+ * element as soon as React mounts it and applies the styling.
  *
- *   v2 (this) — let next/script handle the script tag. With
- *        strategy="afterInteractive" Next injects a parser-style script
- *        tag (currentScript becomes a real reference) after hydration.
- *        The badge ends up wherever WOT's loader chooses to inject —
- *        typically the end of <body>, after the layout Footer + Vercel
- *        Analytics + SpeedInsights — but at least the badge renders.
- *        We accept the placement trade-off because we don't have a
- *        reliable way to anchor a third-party loader to a specific
- *        DOM node without controlling the loader code.
- *
- * The wot-verification meta tag (web/app/layout.tsx) is what actually
- * lets MyWOT confirm site ownership; this script renders the visible
- * badge once verification is complete.
+ * Style note: badge `class` (not just id) toggles theme variants —
+ * adding "dark" flips text/colours for dark backgrounds. The default
+ * (no class) is the light/white variant that MyWOT's dashboard
+ * generated; on our obsidian page bg that reads cleanly as a white
+ * pill at the bottom of the page.
  */
 export default function WotBadge() {
   return (
-    <Script
-      src="https://static.mywot.com/website_owners_badges/websiteOwnersBadge.js"
-      strategy="afterInteractive"
-    />
+    <section
+      aria-label="MyWOT trust badge"
+      className="mt-16 mb-8 flex justify-center"
+    >
+      <a
+        id="wot-badge0"
+        className="wot-badge"
+        href="https://www.mywot.com/scorecard/alphamolt.ai?wot_badge=0_white"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <div className="wot-logo" />
+        <div className="wot-shield" />
+        <p className="wot-secured">Verified Website</p>
+        <div className="wot-vertical" />
+        <p className="wot-report">See Report</p>
+      </a>
+      <Script
+        src="https://static.mywot.com/website_owners_badges/websiteOwnersBadge.js"
+        strategy="afterInteractive"
+      />
+    </section>
   );
 }


### PR DESCRIPTION
## Why both previous attempts produced nothing

Decompiled `websiteOwnersBadge.js` to figure out why v1 (createElement) and v2 (next/script) both loaded the script cleanly but never rendered a badge:

```js
const badgeIds = ['wot-badge0', 'wot-badge1', 'wot-badge2'];
const insertWidget = () => {
  const found = badgeIds
    .map(id => document.getElementById(id))
    .filter(Boolean);
  if (found.length === 0) return 0;   // ← bails silently
  /* …applies inline styles to existing HTML */
};
```

It's not a self-injecting widget — it's a **styler**. It expects a pre-existing element with id `wot-badge0` / `wot-badge1` / `wot-badge2` containing the right child classes (`.wot-shield`, `.wot-secured`, `.wot-logo`, `.wot-vertical`, `.wot-report`) and decorates that with inline styles. Without the HTML scaffold, the script does nothing.

## v3

Ships the HTML scaffold from MyWOT's dashboard (the snippet we were missing) alongside the loader. MyWOT's `MutationObserver` picks up the element when React mounts it and styles it.

Default badge variant is `"white"` (matches the dashboard's `wot_badge=0_white` URL param). On the obsidian page bg it reads as a white pill. If contrast feels off, flipping to dark is a one-word `className` change.

## Test plan

- [ ] Vercel build green
- [ ] Visit `/`, scroll to bottom — confirm the MyWOT badge renders above the page footer (where the WotBadge component is mounted) with shield icon + "Verified Website" + "See Report"
- [ ] Click the badge → routes to https://www.mywot.com/scorecard/alphamolt.ai
- [ ] Inspect element on the badge — confirm the `<a id="wot-badge0">` has inline styles applied (background, border-radius, padding) by MyWOT's script

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_