### PR TITLE
wot-badge: dark variant + tighter spacing

### DIFF
--- a/web/components/wot-badge.tsx
+++ b/web/components/wot-badge.tsx
@@ -15,22 +15,21 @@ import Script from "next/script";
  * loader script. A MutationObserver inside the script picks up the
  * element as soon as React mounts it and applies the styling.
  *
- * Style note: badge `class` (not just id) toggles theme variants —
- * adding "dark" flips text/colours for dark backgrounds. The default
- * (no class) is the light/white variant that MyWOT's dashboard
- * generated; on our obsidian page bg that reads cleanly as a white
- * pill at the bottom of the page.
+ * Style note: badge `className` (not just id) toggles theme variants —
+ * adding "dark" flips text/colours so the pill reads dark-on-dark
+ * rather than bright-white-on-obsidian (which looked garish against
+ * the rest of the page).
  */
 export default function WotBadge() {
   return (
     <section
       aria-label="MyWOT trust badge"
-      className="mt-16 mb-8 flex justify-center"
+      className="mt-12 mb-6 flex justify-center"
     >
       <a
         id="wot-badge0"
-        className="wot-badge"
-        href="https://www.mywot.com/scorecard/alphamolt.ai?wot_badge=0_white"
+        className="wot-badge dark"
+        href="https://www.mywot.com/scorecard/alphamolt.ai?wot_badge=0_dark"
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
## Summary

The white WOT pill clashed hard with the obsidian page background. Decompiled `websiteOwnersBadge.js` reads `className.includes("dark")` to flip its colour scheme — so a one-word className change gets us the dark variant for free, no forking of MyWOT's loader.

Also trimmed the vertical breathing room (`mt-16/mb-8` → `mt-12/mb-6`) so the badge sits as a quieter foot-of-page mark rather than its own hero block.

URL param bumped `wot_badge=0_white → 0_dark` to match the variant — that's just MyWOT's analytics tracking, doesn't affect rendering.

## Test plan

- [ ] Vercel build green
- [ ] Visit `/` and scroll to the badge — confirm it's now dark-on-dark (white text + green shield on a dark pill) instead of white-on-dark
- [ ] Click → still routes to https://www.mywot.com/scorecard/alphamolt.ai

If the dark variant still feels too prominent, easy next move is to demote it from a centered standalone section into a small chip in the layout `<Footer />` next to the existing `paper trading only · not financial advice` line.

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_