### PR TITLE
portfolios: revalue every 15 min during market hours

### DIFF
--- a/.github/workflows/portfolio-valuation.yml
+++ b/.github/workflows/portfolio-valuation.yml
@@ -1,11 +1,22 @@
-name: Daily portfolio valuation
+name: Portfolio valuation
 
 on:
   schedule:
-    # Runs at 5:30 AM UTC — 30 minutes after score_ai_analysis so
-    # companies.price is freshest before we snapshot agent portfolios.
+    # 1) Daily close-of-business snapshot at 05:30 UTC. Markets have
+    #    been closed since ~22:00 UTC the night before, so companies.price
+    #    is the prior trading day's close. This run guarantees every
+    #    weekday + weekend has a row, which keeps the agent_leaderboard
+    #    view's 1d / 1w / 30d window joins clean.
     - cron: "30 5 * * *"
-  workflow_dispatch: # Allow manual trigger from GitHub UI
+    # 2) Intraday revaluation every 15 min during US market hours,
+    #    Mon–Fri 13:00–22:00 UTC. Same upsert path overwrites the
+    #    (agent_id, snapshot_date) row repeatedly during the day —
+    #    end-of-day = close-of-business, intraday = live MTM. The
+    #    leaderboard's 1d return becomes "yesterday-close → today-
+    #    intraday-mid" instead of strict close-to-close, which makes
+    #    the page feel alive without changing how the view computes.
+    - cron: "*/15 13-22 * * 1-5"
+  workflow_dispatch:
 
 jobs:
   valuation:
@@ -36,5 +47,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: portfolio-valuation-logs-${{ github.run_id }}
+          # Intraday runs produce ~40 log files/day — drop retention from
+          # 30d to 7d to keep the artifact store from ballooning.
+          retention-days: 7
           path: logs/
-          retention-days: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Sun 08:00       consensus_snapshot.py     Aggregate agent_holdings → consensus
 
 Every 15 min (Mon–Fri, 13:00–22:00 UTC):
                 intraday_prices.py        Refresh companies.price + price_asof via EODHD /real-time (15-min delayed quotes)
+                portfolio_valuation.py    Re-mark every agent portfolio against the fresh price (overwrites today's row in agent_portfolio_history)
 
 Every 4h:
                 moltbook_heartbeat.py     Reply to notifications + engage with finance submolts on Moltbook
@@ -100,11 +101,24 @@ Reads `companies` + `price_sales` + TradingView market data.
 Computes status and composite_score for every ticker. Updates screening columns
 and assigns integer `sort_order` (1 = top ranked).
 
-### portfolio_valuation.py (05:30 UTC daily)
-Marks every agent portfolio to market using the latest `companies.price` and
+### portfolio_valuation.py (05:30 UTC daily + every 15 min during US market hours)
+Marks every agent portfolio to market against the latest `companies.price` and
 upserts a row into `agent_portfolio_history` (powering the `agent_leaderboard`
-view). Runs after `score_ai_analysis.py` so prices are freshest. Supports
-`--dry-run` and `--agent HANDLE` flags. See `portfolio.py` for the trading layer.
+view). Two cadences share the same script:
+
+- **Daily 05:30 UTC** — close-of-business snapshot. Markets have been closed
+  since ~22:00 UTC the previous evening so `companies.price` reflects the
+  previous trading day's close. Guarantees every weekday + weekend has a row,
+  which keeps the agent_leaderboard view's 1d / 1w / 30d window joins clean.
+- **Intraday every 15 min, Mon–Fri 13:00–22:00 UTC** — re-marks the same
+  `(agent_id, snapshot_date)` row using the freshly-refreshed delayed prices
+  from `intraday_prices.py`. End-of-day the row settles on the close;
+  during the day the leaderboard's 1d return becomes "yesterday-close →
+  today-intraday-mid" instead of strict close-to-close, which makes the
+  page feel alive without changing how `agent_leaderboard` computes.
+
+Supports `--dry-run` and `--agent HANDLE` flags. See `portfolio.py` for the
+trading layer.
 
 ### agent_heartbeat.py (Sundays 07:00 UTC)
 Weekly rebalance loop — the reason portfolios aren't frozen after the initial


### PR DESCRIPTION
## Summary

Now that `intraday_prices.py` keeps `companies.price` 15-min fresh, run `portfolio_valuation.py` on the same cadence so agent MTM tracks live through the trading day. The 05:30 UTC daily snapshot stays — it guarantees every weekday + weekend has a row so `agent_leaderboard`'s 1d / 1w / 30d window joins don't drift on Mondays.

**Implementation is trivial** because the existing path already upserts into `agent_portfolio_history` keyed on `(agent_id, snapshot_date)` — multiple runs the same day just overwrite. So this is a **workflow-only change**: one extra cron entry, zero script changes.

## Effect on the site

- **Hero chart's right edge becomes live** — the spotlit line's tip moves through the trading day.
- **Leaderboard's 1d column updates intra-day** instead of holding yesterday's close until tomorrow morning. Semantically becomes "yesterday-close → today-intraday-mid" while the market is open; settles to strict close-to-close after 22:00 UTC.
- **`agent_leaderboard` view code unchanged.** No migration. No new tables.

## Cost

- **GitHub Actions**: ~36 runs/day × 30s × 22 trading days = ~400 min/month. Well within free tier.
- **EODHD**: zero new calls. portfolio_valuation re-reads `companies.price` from Supabase.
- **Supabase**: ~324 writes/day across ~9 agents. Trivial.
- **Logs**: dropped retention 30d → 7d on this workflow since intraday produces ~40 logs/day.

## Test plan

- [ ] GHA build green (it's just a YAML edit)
- [ ] Trigger the workflow manually via `workflow_dispatch` during US market hours — confirm a run completes in < 1 min
- [ ] Visit `/leaderboard` → confirm 1d return moves intra-day for any active agent
- [ ] Visit `/` → confirm the hero chart's right edge updates as the day progresses
- [ ] After 24h: spot-check `agent_portfolio_history` rows for any one agent — `(agent_id, snapshot_date)` should still have exactly one row per day, last value reflecting the close

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_