### PR TITLE
Add trading_agents strategy with three Tauric Trader house agents

### DIFF
--- a/.github/workflows/trading-agents-heartbeat.yml
+++ b/.github/workflows/trading-agents-heartbeat.yml
@@ -1,0 +1,137 @@
+name: Tauric Trader Heartbeat
+
+# Weekly rebalance for the three Tauric Trader house agents
+# (tauric-opus-4-7, tauric-gemini-3, tauric-qwen). Runs each variant as a
+# separate matrix job so the framework's heavy LLM-debate workload (~300
+# LLM calls per variant per run) parallelises and a single bad-LLM
+# variant can't block the others.
+#
+# Monday 21:30 UTC — runs the day after the Sunday 07:00 UTC weekly
+# `agent_heartbeat` swarm rebalance has settled, and well after Monday's
+# 06:00 UTC `universe-snapshot` has refreshed the screener JSON that
+# the stage-1 shortlist reads.
+
+on:
+  schedule:
+    - cron: "30 21 * * 1"
+  workflow_dispatch:
+    inputs:
+      handle:
+        description: "Run only this Tauric Trader handle (optional)"
+        required: false
+        type: choice
+        default: "all"
+        options:
+          - all
+          - tauric-opus-4-7
+          - tauric-gemini-3
+          - tauric-qwen
+      dry_run:
+        description: "Plan trades but execute none"
+        required: false
+        type: boolean
+        default: false
+      force:
+        description: "Ignore heartbeat_interval_hours and run now"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    # 30 tickers × ~30s/propagate ≈ 15 min typical, 45 min worst case.
+    # Bump to 120 min for slow LLMs (Opus) and any framework warm-up.
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false  # one bad variant must not block the others
+      matrix:
+        handle:
+          - tauric-opus-4-7
+          - tauric-gemini-3
+          - tauric-qwen
+
+    steps:
+      - name: Skip variant if a specific handle was requested
+        id: filter
+        env:
+          REQUESTED: ${{ inputs.handle }}
+          MATRIX_HANDLE: ${{ matrix.handle }}
+        run: |
+          set -u
+          REQ="$(printf '%s' "${REQUESTED:-}" | tr -d '[:space:]')"
+          if [ -z "${REQ}" ] || [ "${REQ}" = "all" ] || [ "${REQ}" = "${MATRIX_HANDLE}" ]; then
+            echo "should_run=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "should_run=false" >> "${GITHUB_OUTPUT}"
+            echo "Skipping ${MATRIX_HANDLE} — only running ${REQ}"
+          fi
+
+      - name: Checkout repository
+        if: steps.filter.outputs.should_run == 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        if: steps.filter.outputs.should_run == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Restore TradingAgents memory cache
+        if: steps.filter.outputs.should_run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.tradingagents
+            ~/.cache/tradingagents
+          # Per-variant memory — each variant evolves its own reflection
+          # history from past trade outcomes. ``restore-keys`` lets older
+          # caches seed newer runs while still writing a fresh entry.
+          key: tradingagents-memory-${{ matrix.handle }}-${{ github.run_id }}
+          restore-keys: |
+            tradingagents-memory-${{ matrix.handle }}-
+
+      - name: Install dependencies
+        if: steps.filter.outputs.should_run == 'true'
+        run: pip install -r requirements.txt
+
+      - name: Run Tauric Trader heartbeat
+        if: steps.filter.outputs.should_run == 'true'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          # Provider keys. Only the variant's own brain reads its key;
+          # the rest stay unused per job. Missing keys raise
+          # LLMProviderError on that variant only.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # TradingAgents' Google adapter reads GOOGLE_API_KEY — mirror
+          # the Gemini key into it so the same secret powers both stages.
+          GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          # Pipe workflow_dispatch inputs via env so values with whitespace
+          # / shell metacharacters can't break the arg list. On scheduled
+          # runs these are empty strings — flags below skip.
+          HEARTBEAT_DRY_RUN: ${{ inputs.dry_run }}
+          HEARTBEAT_FORCE: ${{ inputs.force }}
+          MATRIX_HANDLE: ${{ matrix.handle }}
+        run: |
+          set -u
+          ARGS=(--handle "${MATRIX_HANDLE}")
+          if [ "${HEARTBEAT_DRY_RUN}" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          if [ "${HEARTBEAT_FORCE}" = "true" ]; then
+            ARGS+=(--force)
+          fi
+          echo "DEBUG: argv = python agent_heartbeat.py ${ARGS[@]+"${ARGS[@]}"}"
+          python agent_heartbeat.py ${ARGS[@]+"${ARGS[@]}"}
+
+      - name: Upload logs
+        if: always() && steps.filter.outputs.should_run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tauric-trader-${{ matrix.handle }}-${{ github.run_id }}
+          path: logs/
+          retention-days: 30

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,35 @@
+alphamolt — equity screening & agent arena
+Copyright (c) 2025-2026 Toby Rowland.
+
+This product includes software developed by third parties:
+
+================================================================
+TauricResearch/TradingAgents
+================================================================
+
+The `trading_agents` strategy and the three "Tauric Trader" house agents
+(tauric-opus-4-7, tauric-gemini-3, tauric-qwen) run unmodified instances
+of the TauricResearch/TradingAgents multi-agent trading framework as a
+runtime dependency.
+
+  Project: https://github.com/TauricResearch/TradingAgents
+  License: Apache License, Version 2.0
+
+  Copyright (c) TauricResearch
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+The three Tauric Trader agents on the alphamolt leaderboard credit this
+framework explicitly in their on-leaderboard `description` fields and
+on their public agent profile pages — visit
+https://github.com/TauricResearch/TradingAgents for the upstream project.

--- a/agent_strategies.py
+++ b/agent_strategies.py
@@ -767,10 +767,19 @@ def _llm_pick_lazy(ctx: RebalanceContext) -> RebalanceResult:
     return rebalance_llm_pick(ctx)
 
 
+def _trading_agents_lazy(ctx: RebalanceContext) -> RebalanceResult:
+    # Lazy-imported so the upstream TauricResearch/TradingAgents
+    # framework (and its heavy LangChain dependency tree) doesn't load
+    # for unrelated heartbeats.
+    from trading_agents_strategy import rebalance_trading_agents
+    return rebalance_trading_agents(ctx)
+
+
 STRATEGIES: dict[str, Strategy] = {
     "dual_positive": rebalance_dual_positive,
     "momentum": rebalance_momentum,
     "llm_pick": _llm_pick_lazy,
+    "trading_agents": _trading_agents_lazy,
 }
 
 

--- a/bootstrap_trading_agents.py
+++ b/bootstrap_trading_agents.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Bootstrap the three Tauric Trader house agents.
+
+Inserts (or updates, idempotently) three rows in `agents`:
+
+    tauric-opus-4-7    Tauric Trader (Claude Opus 4.7)
+    tauric-gemini-3    Tauric Trader (Gemini 3 Pro)
+    tauric-qwen        Tauric Trader (Qwen 3)
+
+Each row is wired to the `trading_agents` strategy with a `config` JSONB
+specifying its LLM brain. After insertion, every variant gets a $1M
+paper-money account opened via `PortfolioManager.open_account`.
+
+Existing rows are detected by handle and left untouched — re-running is
+safe. No existing agents are modified by this script.
+
+Usage:
+    python bootstrap_trading_agents.py             # insert + open accounts
+    python bootstrap_trading_agents.py --dry-run   # print what would change
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from dotenv import load_dotenv
+
+from db import SupabaseDB
+from portfolio import DEFAULT_STARTING_CASH, PortfolioManager
+
+UPSTREAM_REPO_URL = "https://github.com/TauricResearch/TradingAgents"
+
+# Short chip rendered on the leaderboard. The `{brain}` placeholder is
+# substituted per-variant below. Keep under ~500 chars to stay within the
+# createAgent validator's existing cap (see migration 010).
+DESCRIPTION_TEMPLATE = (
+    "Tauric Trader is a reference implementation of the open-source "
+    "TauricResearch/TradingAgents multi-agent framework (Apache 2.0, "
+    f"{UPSTREAM_REPO_URL}). Brain: {{brain}}."
+)
+
+# Longer narrative for the agent profile page. Markdown-friendly.
+LONG_DESCRIPTION_TEMPLATE = (
+    "Built on the **TauricResearch/TradingAgents** framework — a multi-agent "
+    "debate system pairing fundamental, sentiment, news and technical analysts "
+    "with bull/bear researchers, a trader and a risk manager. This variant "
+    "runs the framework unchanged with **{brain}** as its deep-think model.\n\n"
+    "Each week it picks ~30 candidates from the alphamolt screener, then runs "
+    "the full multi-analyst debate per ticker to derive BUY/SELL/HOLD "
+    f"decisions.\n\nFramework: {UPSTREAM_REPO_URL}"
+)
+
+
+# (handle, display_name, brain_label, config)
+VARIANTS: list[tuple[str, str, str, dict]] = [
+    (
+        "tauric-opus-4-7",
+        "Tauric Trader (Claude Opus 4.7)",
+        "Claude Opus 4.7",
+        {
+            "llm_provider": "anthropic",
+            "deep_think_llm": "claude-opus-4-7",
+            "quick_think_llm": "claude-haiku-4-5-20251001",
+            "max_debate_rounds": 2,
+            "max_candidates": 30,
+            "max_positions": 20,
+            "cash_reserve_pct": 0.02,
+            "online_tools": True,
+        },
+    ),
+    (
+        "tauric-gemini-3",
+        "Tauric Trader (Gemini 3 Pro)",
+        "Gemini 3 Pro",
+        {
+            "llm_provider": "google",
+            "deep_think_llm": "gemini-3-pro",
+            "quick_think_llm": "gemini-3-flash",
+            "max_debate_rounds": 2,
+            "max_candidates": 30,
+            "max_positions": 20,
+            "cash_reserve_pct": 0.02,
+            "online_tools": True,
+        },
+    ),
+    (
+        "tauric-qwen",
+        "Tauric Trader (Qwen 3)",
+        "Qwen 3",
+        {
+            "llm_provider": "qwen",
+            "deep_think_llm": "qwen3-max",
+            "quick_think_llm": "qwen3-turbo",
+            "backend_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+            "max_debate_rounds": 2,
+            "max_candidates": 30,
+            "max_positions": 20,
+            "cash_reserve_pct": 0.02,
+            "online_tools": True,
+        },
+    ),
+]
+
+
+def main() -> int:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print rows that would be inserted, without writing.",
+    )
+    parser.add_argument(
+        "--starting-cash",
+        type=float,
+        default=DEFAULT_STARTING_CASH,
+        help=f"Starting cash per agent (default ${DEFAULT_STARTING_CASH:,.0f})",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    logger = logging.getLogger("bootstrap_trading_agents")
+
+    db = SupabaseDB()
+    pm = PortfolioManager(db)
+
+    inserted = 0
+    existed = 0
+    opened_accounts = 0
+
+    for handle, display_name, brain, config in VARIANTS:
+        description = DESCRIPTION_TEMPLATE.format(brain=brain)
+        long_description = LONG_DESCRIPTION_TEMPLATE.format(brain=brain)
+
+        existing = db.get_agent_by_handle(handle)
+        if existing:
+            existed += 1
+            logger.info(
+                "  %-20s  (already exists, id=%s — leaving row untouched)",
+                handle,
+                existing["id"][:8],
+            )
+            agent_id = existing["id"]
+        else:
+            row = {
+                "handle": handle,
+                "display_name": display_name,
+                "description": description,
+                "long_description": long_description,
+                "is_house_agent": True,
+                "api_key_hash": "house-agent",
+                "api_key_prefix": f"ak_house_{handle.split('-')[0][:8]}",
+                "strategy": "trading_agents",
+                "heartbeat_interval_hours": 168,
+                "config": config,
+            }
+            if args.dry_run:
+                logger.info("  %-20s  [dry-run] would insert: %s", handle, row)
+                inserted += 1
+                continue
+            resp = db.client.table("agents").insert(row).execute()
+            if not resp.data:
+                logger.error("  %-20s  insert returned no row", handle)
+                continue
+            agent_id = resp.data[0]["id"]
+            inserted += 1
+            logger.info(
+                "  %-20s  ✓ inserted (id=%s, brain=%s)",
+                handle,
+                agent_id[:8],
+                brain,
+            )
+
+        # Open paper-money account (idempotent — open_account no-ops if a
+        # row already exists for this agent_id).
+        if args.dry_run:
+            continue
+        before = db.get_agent_account(agent_id)
+        pm.open_account(agent_id, starting_cash=args.starting_cash)
+        if not before:
+            opened_accounts += 1
+            logger.info(
+                "  %-20s  ✓ opened paper account with $%.2f",
+                handle,
+                args.starting_cash,
+            )
+
+    logger.info(
+        "Bootstrap complete: %d inserted, %d already existed, %d new paper accounts opened",
+        inserted,
+        existed,
+        opened_accounts,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/llm_picker.py
+++ b/llm_picker.py
@@ -544,6 +544,60 @@ def rebalance_llm_pick(ctx: RebalanceContext) -> RebalanceResult:
 # ---------------------------------------------------------------------------
 
 
+def pick_shortlist_via_llm(
+    *,
+    provider: str,
+    model: str,
+    snapshot: dict,
+    snapshot_date: str,
+    portfolio: dict,
+    universe_tickers: set[str],
+    system_prompt: str,
+    user_template: str,
+    shortlist_max: int,
+    max_tokens: int = 16384,
+    temperature: float = 0.2,
+) -> tuple[str, list[dict], list[str], tuple[int | None, int | None], str | None]:
+    """Reusable shortlist call — shared by llm_pick stage 1 and trading_agents.
+
+    ``user_template`` must accept the keyword args ``snapshot_date``,
+    ``universe_json``, ``portfolio_json``, ``shortlist_max`` via str.format.
+    Validation: keeps only tickers in ``universe_tickers``, dedupes, caps
+    at ``shortlist_max``, drops entries with missing/blank tickers.
+
+    Returns (raw_text, shortlist, dropped, (input_tokens, output_tokens),
+    retry_text). ``retry_text`` is None when the first parse succeeded;
+    otherwise it's the second LLM call's response text (useful for journals).
+    """
+    user = user_template.format(
+        snapshot_date=snapshot_date,
+        universe_json=json.dumps(snapshot, separators=(",", ":")),
+        portfolio_json=json.dumps(portfolio, separators=(",", ":")),
+        shortlist_max=shortlist_max,
+    )
+    resp = call_llm(
+        provider=provider,
+        model=model,
+        system=system_prompt,
+        user=user,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+    parsed, retry_resp = _parse_with_retry(
+        provider, model, resp.text, system=system_prompt,
+    )
+    shortlist, dropped = _validate_shortlist(
+        parsed, universe_tickers, cap=shortlist_max,
+    )
+    return (
+        resp.text,
+        shortlist,
+        dropped,
+        (resp.input_tokens, resp.output_tokens),
+        retry_resp.text if retry_resp else None,
+    )
+
+
 def _run_stage1(
     *,
     provider: str,
@@ -554,32 +608,18 @@ def _run_stage1(
     universe_tickers: set[str],
     params: dict,
 ) -> tuple[str, list[dict], list[str], tuple[int | None, int | None], str | None]:
-    user = STAGE1_USER_TEMPLATE.format(
-        snapshot_date=snapshot_date,
-        universe_json=json.dumps(snapshot, separators=(",", ":")),
-        portfolio_json=json.dumps(portfolio, separators=(",", ":")),
-        shortlist_max=int(params["shortlist_max"]),
-    )
-    resp = call_llm(
+    return pick_shortlist_via_llm(
         provider=provider,
         model=model,
-        system=STAGE1_SYSTEM_PROMPT,
-        user=user,
+        snapshot=snapshot,
+        snapshot_date=snapshot_date,
+        portfolio=portfolio,
+        universe_tickers=universe_tickers,
+        system_prompt=STAGE1_SYSTEM_PROMPT,
+        user_template=STAGE1_USER_TEMPLATE,
+        shortlist_max=int(params["shortlist_max"]),
         max_tokens=int(params["stage1_max_tokens"]),
         temperature=float(params["temperature"]),
-    )
-    parsed, retry_resp = _parse_with_retry(
-        provider, model, resp.text, system=STAGE1_SYSTEM_PROMPT,
-    )
-    shortlist, dropped = _validate_shortlist(
-        parsed, universe_tickers, cap=int(params["shortlist_max"]),
-    )
-    return (
-        resp.text,
-        shortlist,
-        dropped,
-        (resp.input_tokens, resp.output_tokens),
-        retry_resp.text if retry_resp else None,
     )
 
 

--- a/llm_providers.py
+++ b/llm_providers.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 logger = logging.getLogger("llm_providers")
 
 
-PROVIDERS = ("anthropic", "openai", "deepseek", "google", "xai")
+PROVIDERS = ("anthropic", "openai", "deepseek", "google", "xai", "qwen")
 
 # Per-provider env var holding the API key. Centralised so the heartbeat
 # workflow's env stanza and the agents.config docs can stay in sync.
@@ -35,10 +35,14 @@ ENV_VAR_FOR_PROVIDER = {
     "deepseek": "DEEPSEEK_API_KEY",
     "google": "GEMINI_API_KEY",
     "xai": "GROK_API_KEY",
+    "qwen": "DASHSCOPE_API_KEY",
 }
 
 DEEPSEEK_BASE_URL = "https://api.deepseek.com"
 XAI_BASE_URL = "https://api.x.ai/v1"
+# Alibaba's DashScope exposes an OpenAI-compatible endpoint that serves
+# the Qwen model family. We dispatch via _call_openai_compatible.
+QWEN_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 
 
 class LLMProviderError(RuntimeError):
@@ -92,6 +96,13 @@ def call_llm(
             api_key_env="GROK_API_KEY",
             base_url=XAI_BASE_URL,
             provider_label="xai",
+        )
+    if provider == "qwen":
+        return _call_openai_compatible(
+            model, system, user, max_tokens, temperature,
+            api_key_env="DASHSCOPE_API_KEY",
+            base_url=QWEN_BASE_URL,
+            provider_label="qwen",
         )
     # Unreachable — guarded by PROVIDERS check above, but keeps type-checkers happy.
     raise LLMProviderError(f"unhandled provider: {provider}")

--- a/migrations/016_agent_methodology.sql
+++ b/migrations/016_agent_methodology.sql
@@ -1,0 +1,131 @@
+-- Migration 016: Standardise methodology text across every portfolio agent.
+--
+-- Each portfolio agent (i.e. agents.strategy IS NOT NULL) gets:
+--   * a one-line `description` rendered as the leaderboard chip
+--   * a multi-paragraph `long_description` rendered on the agent profile
+--     page, written in Markdown
+--
+-- Updates are scoped per-strategy:
+--   * dual_positive  / momentum     — fixed text (same algorithm for all
+--                                     agents using that strategy)
+--   * llm_pick / trading_agents     — template strings with the variant's
+--                                     LLM brain interpolated from
+--                                     agents.config JSONB, so the same
+--                                     UPDATE works across every brain
+--                                     variant (existing + future)
+--
+-- Analyst agents (smash-hit-scout, fundamental-sentinel — both have
+-- strategy=NULL) are intentionally NOT touched. They're evaluators, not
+-- traders; their existing schema-seeded descriptions stay as-is.
+--
+-- Idempotent — re-running on the same agents produces identical text.
+-- Safe to apply multiple times.
+--
+-- This migration is description-only. It NEVER modifies:
+--   * agents.strategy   — agent's portfolio behaviour is unchanged
+--   * agents.config     — per-agent params untouched
+--   * agents.handle     — leaderboard identity preserved
+--   * any other column  — explicit allow-list below
+
+
+-- ============================================================
+-- dual_positive
+-- ============================================================
+UPDATE agents
+   SET description = 'Equal-weights the top 20 names where both bear and bull AI analysts say ✅, deduped by company. Rebalances weekly Sundays 07:00 UTC: sells anything that drops off the dual-positive set first to free cash, then equal-weights the new additions with a 2% cash reserve.',
+       long_description = $md$# Strategy: dual_positive
+
+From the screener universe (~400 vetted US-listed growth names), filters for tickers where both `bear_eval` and `bull_eval` contain ✅ — meaning both AI analysts independently approve. Dedupes by company (favouring US listings when an ADR and primary listing both appear), sorts by `composite_score` descending, and equal-weights the top 20.
+
+**Refresh cadence:** Sundays 07:00 UTC via `agent_heartbeat.py`.
+
+**Trade discipline:**
+- Sells positions that have fallen out of the top 20 first, to free cash for new additions
+- Trims overweight positions back to equal weight
+- Trades smaller than $500 notional are skipped as noise (preserves idempotence on small price drift)
+
+**Idempotence:** running twice back-to-back on an unchanged universe is a no-op.
+
+**Source code:** `agent_strategies.rebalance_dual_positive` in the [update_ai_analysis](https://github.com/tobyrowland/update_ai_analysis) repo.
+$md$
+ WHERE strategy = 'dual_positive';
+
+
+-- ============================================================
+-- momentum
+-- ============================================================
+UPDATE agents
+   SET description = 'Low-churn momentum. Holds names with 52w returns vs SPY in the [-15%, +40%] band, rating ≤ 1.6, and ✅ bull+bear verdicts. Max 2 sells + 2 buys per heartbeat to avoid churn; weekly Sundays 07:00 UTC.',
+       long_description = $md$# Strategy: momentum
+
+Tracks the top of the screener's eligible universe by `perf_52w_vs_spy`, after filtering for:
+- `bear_eval` and `bull_eval` both ✅ (both AI analysts approve)
+- `rating` ≤ 1.6 (sound fundamentals)
+- US-listed (NYSE / NASDAQ / AMEX / NYSEARCA / BATS / ARCA)
+- `perf_52w_vs_spy` in `[-15%, +40%]` (momentum band — outside is falling-knife or blow-off-top)
+
+**Sell triggers (any of):**
+- Rating climbs above 1.6
+- Bear flips ❌
+- Position drops out of the eligible set AND `perf_52w_vs_spy` falls below the floor (becalmed)
+
+**Buy logic:** Top of the eligible set by `perf_52w_vs_spy` desc, must beat the entry floor (≥ 0% vs SPY). Equal-weighted with a 2% cash reserve. Ramps aggressively to a 15-position floor when below it; otherwise capped at 2 buys per heartbeat to avoid churn.
+
+**Cadence:** weekly Sundays 07:00 UTC.
+
+**Source code:** `agent_strategies.rebalance_momentum`.
+$md$
+ WHERE strategy = 'momentum';
+
+
+-- ============================================================
+-- llm_pick
+-- ============================================================
+-- Per-agent brain name is interpolated from agents.config JSONB. The
+-- llm_pick strategy stores ("provider","model") in config; we surface
+-- both in the description so the leaderboard chip stays informative.
+UPDATE agents
+   SET description = 'Two-stage LLM portfolio picker. Stage 1: reads the compact ~400-ticker screener and shortlists 50 names. Stage 2: reads deeper data on those 50 and picks 15–25 with weights. Brain: ' || COALESCE(config->>'model', 'unset') || ' (' || COALESCE(config->>'provider', 'unset') || '). Cadence: weekly Sundays 07:00 UTC.',
+       long_description = $md$# Strategy: llm_pick
+
+Two-stage LLM-driven portfolio constructor. Both stages run on the same brain — **$md$ || COALESCE(config->>'model', 'unset') || $md$** (via $md$ || COALESCE(config->>'provider', 'unset') || $md$).
+
+**Stage 1 (shortlist):** receives the compact `universe_snapshots` JSON for that day — every ticker's fundamentals, P/S history, R40 score, momentum, narrative, and bull/bear AI verdicts. The model picks up to 50 tickers it wants to research further.
+
+**Stage 2 (final picks):** receives the *full* tier of the same snapshot sliced to those 50 names (with all annual + quarterly history and weekly P/S series), picks 15–25 names with portfolio weights summing to 95–100% (residual = cash reserve).
+
+**Cadence:** weekly Sundays 07:00 UTC via `agent_heartbeat.py`, after that morning's `score_ai_analysis` + `universe_snapshot` runs have settled.
+
+**Determinism:** both stages run at temperature 0.2 — mildly stochastic but broadly repeatable. Each variant's brain is fixed per `agents.config`, so divergence between variants reflects model taste, not random seed.
+
+**Source code:** `llm_picker.rebalance_llm_pick`.
+$md$
+ WHERE strategy = 'llm_pick';
+
+
+-- ============================================================
+-- trading_agents (Tauric Trader)
+-- ============================================================
+-- Per-agent brain interpolated from agents.config — `deep_think_llm` is
+-- the model that drives every analyst, researcher and the trader/risk
+-- pipeline inside TradingAgents.
+UPDATE agents
+   SET description = 'Tauric Trader is a reference implementation of the open-source TauricResearch/TradingAgents multi-agent framework (Apache 2.0, https://github.com/TauricResearch/TradingAgents). Brain: ' || COALESCE(config->>'deep_think_llm', 'unset') || '. Cadence: weekly Mondays 21:30 UTC.',
+       long_description = $md$Built on the **TauricResearch/TradingAgents** framework — a multi-agent debate system pairing fundamental, sentiment, news and technical analysts with bull/bear researchers, a trader and a risk manager. This variant runs the framework **unchanged** with **$md$ || COALESCE(config->>'deep_think_llm', 'unset') || $md$** as its deep-think model.
+
+**Weekly methodology:**
+
+1. **Stage 1 — Shortlist.** The variant's own deep-think LLM reads the alphamolt compact universe snapshot (~400 vetted US-listed growth names with our fundamentals, P/S history, R40 scores, and bull/bear AI verdicts) and picks ~30 tickers worth a deep multi-analyst dive.
+
+2. **Stage 2 — Deep dive.** For each shortlisted ticker, `TradingAgentsGraph.propagate(ticker, today)` runs the full analyst-debate-trader-risk pipeline inside the framework. The framework fetches its **own** price history, news, sentiment and fundamentals data; the alphamolt screener data is NOT injected into the debate, so TradingAgents reasons independently from our screener's view. After the debate, the risk team emits a `BUY` / `SELL` / `HOLD` verdict per ticker.
+
+3. **Stage 3 — Reconcile.** Equal-weights the BUY verdicts across up to 20 positions with a 2% cash reserve, exits SELLs, leaves HOLDs untouched. Trades smaller than $500 notional are skipped as noise.
+
+**Cadence:** Mondays 21:30 UTC via `.github/workflows/trading-agents-heartbeat.yml` — runs ~30h after the rest of the swarm's Sunday rebalance has settled, so this agent's positions don't drag against fresh consensus picks.
+
+**Reflection memory:** TradingAgents persists per-ticker memory between runs (its own append-only file). Last week's bet on a name and how that bet actually played out feeds back into next week's analyst debate, so the variant evolves over time rather than re-reasoning from scratch.
+
+**Attribution:** [TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents) (Apache 2.0).
+**Source code wiring:** `trading_agents_strategy.rebalance_trading_agents`.
+$md$
+ WHERE strategy = 'trading_agents';

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ anthropic>=0.40.0
 openai>=1.50.0
 google-generativeai>=0.8.0
 atproto>=0.0.55
+# Tauric Trader (trading_agents strategy) — pulls TauricResearch/TradingAgents
+# directly from GitHub. Pin to a specific commit SHA before the first live
+# heartbeat so cache hits stay deterministic across CI runs.
+tradingagents @ git+https://github.com/TauricResearch/TradingAgents.git@main

--- a/test_trading_agents_strategy.py
+++ b/test_trading_agents_strategy.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Smoke test for the trading_agents strategy reconciler.
+
+Verifies the offline pieces — decision parsing + trade planning — without
+hitting Supabase, the LLM providers, or the upstream TradingAgents
+framework. Run directly:
+
+    python test_trading_agents_strategy.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from types import SimpleNamespace
+
+from trading_agents_strategy import (
+    _equal_weight_targets,
+    _extract_decision,
+    _plan_trades,
+)
+
+
+class _StubPM:
+    """Minimal PortfolioManager stand-in — only `get_price` is exercised here."""
+
+    def __init__(self, prices: dict[str, float]):
+        self._prices = prices
+
+    def get_price(self, ticker: str) -> float:
+        if ticker not in self._prices:
+            from portfolio import PortfolioError
+            raise PortfolioError(f"no price for {ticker}")
+        return self._prices[ticker]
+
+
+def _ctx(prices: dict[str, float]):
+    return SimpleNamespace(pm=_StubPM(prices))
+
+
+class DecisionParserTests(unittest.TestCase):
+    def test_final_proposal_buy(self):
+        text = (
+            "Risk team reviewed. Position sizing looks reasonable.\n"
+            "FINAL TRANSACTION PROPOSAL: **BUY**"
+        )
+        self.assertEqual(_extract_decision(text), "BUY")
+
+    def test_final_proposal_sell(self):
+        text = "After debate: FINAL TRANSACTION PROPOSAL: SELL — exit fully."
+        self.assertEqual(_extract_decision(text), "SELL")
+
+    def test_final_proposal_hold(self):
+        text = "Bull case unchanged but momentum stalled.\nFINAL TRANSACTION PROPOSAL: HOLD"
+        self.assertEqual(_extract_decision(text), "HOLD")
+
+    def test_fallback_to_last_token(self):
+        # No explicit "FINAL TRANSACTION PROPOSAL" header — the parser
+        # should fall back to the last verdict token in the text.
+        text = (
+            "Earlier draft considered HOLD given valuation. Trader pushed back. "
+            "Final verdict: Buy."
+        )
+        self.assertEqual(_extract_decision(text), "BUY")
+
+    def test_empty_text_defaults_hold(self):
+        self.assertEqual(_extract_decision(""), "HOLD")
+        self.assertEqual(_extract_decision("   \n"), "HOLD")
+
+
+class EqualWeightTargetsTests(unittest.TestCase):
+    def test_equal_weight_two_priced(self):
+        ctx = _ctx({"NVDA": 1000.0, "AAPL": 200.0})
+        target_qty, meta, unpriced = _equal_weight_targets(
+            ctx=ctx,
+            buy_tickers=["NVDA", "AAPL"],
+            total_value=200_000.0,
+            cash_reserve_pct=0.02,
+            max_positions=20,
+        )
+        # investable = 196,000; per_target = 98,000.
+        # NVDA qty = floor(98000 / 1000) = 98
+        # AAPL qty = floor(98000 / 200) = 490
+        self.assertEqual(target_qty["NVDA"], 98)
+        self.assertEqual(target_qty["AAPL"], 490)
+        self.assertEqual(unpriced, [])
+
+    def test_unpriced_ticker_dropped(self):
+        ctx = _ctx({"NVDA": 1000.0})
+        target_qty, _meta, unpriced = _equal_weight_targets(
+            ctx=ctx,
+            buy_tickers=["NVDA", "MISSING"],
+            total_value=100_000.0,
+            cash_reserve_pct=0.02,
+            max_positions=20,
+        )
+        self.assertIn("NVDA", target_qty)
+        self.assertNotIn("MISSING", target_qty)
+        self.assertEqual(unpriced, ["MISSING"])
+
+    def test_max_positions_caps_list(self):
+        ctx = _ctx({f"T{i}": 100.0 for i in range(10)})
+        target_qty, _meta, _unpriced = _equal_weight_targets(
+            ctx=ctx,
+            buy_tickers=[f"T{i}" for i in range(10)],
+            total_value=100_000.0,
+            cash_reserve_pct=0.0,
+            max_positions=3,
+        )
+        self.assertEqual(len(target_qty), 3)
+
+
+class PlanTradesTests(unittest.TestCase):
+    def test_buy_new_position(self):
+        ctx = _ctx({"NVDA": 100.0})
+        plan = _plan_trades(
+            ctx=ctx,
+            portfolio={"holdings": []},
+            target_qty={"NVDA": 50},
+            sells_tickers=set(),
+            target_meta={"NVDA": {"price": 100.0}},
+            min_trade_usd=500.0,
+        )
+        self.assertEqual(len(plan["buys"]), 1)
+        self.assertEqual(plan["buys"][0][0], "NVDA")
+        self.assertEqual(plan["buys"][0][1], 50)
+        self.assertEqual(plan["sells"], [])
+
+    def test_sell_explicit_sell_verdict(self):
+        ctx = _ctx({"INTC": 30.0})
+        plan = _plan_trades(
+            ctx=ctx,
+            portfolio={"holdings": [{"ticker": "INTC", "quantity": 100.0}]},
+            target_qty={},  # not a BUY
+            sells_tickers={"INTC"},
+            target_meta={},
+            min_trade_usd=500.0,
+        )
+        self.assertEqual(len(plan["sells"]), 1)
+        self.assertEqual(plan["sells"][0][0], "INTC")
+        self.assertEqual(plan["sells"][0][1], 100.0)
+        self.assertEqual(plan["buys"], [])
+
+    def test_hold_preserves_position(self):
+        # No verdict at all for AAPL — it's neither BUY nor SELL. The
+        # reconciler must leave the existing position untouched.
+        ctx = _ctx({"AAPL": 200.0})
+        plan = _plan_trades(
+            ctx=ctx,
+            portfolio={"holdings": [{"ticker": "AAPL", "quantity": 50.0}]},
+            target_qty={},
+            sells_tickers=set(),
+            target_meta={},
+            min_trade_usd=500.0,
+        )
+        self.assertEqual(plan["buys"], [])
+        self.assertEqual(plan["sells"], [])
+
+    def test_trim_overweight_buy(self):
+        # Already holding 100 NVDA @ $100 = $10k, but target is 30 shares.
+        # Reconciler should sell 70 shares.
+        ctx = _ctx({"NVDA": 100.0})
+        plan = _plan_trades(
+            ctx=ctx,
+            portfolio={"holdings": [{"ticker": "NVDA", "quantity": 100.0}]},
+            target_qty={"NVDA": 30},
+            sells_tickers=set(),
+            target_meta={"NVDA": {"price": 100.0}},
+            min_trade_usd=500.0,
+        )
+        self.assertEqual(len(plan["sells"]), 1)
+        self.assertEqual(plan["sells"][0][0], "NVDA")
+        self.assertEqual(plan["sells"][0][1], 70)
+        self.assertEqual(plan["buys"], [])
+
+    def test_noise_trade_skipped(self):
+        # Want 1 share at $100 = $100, well below min_trade_usd=$500.
+        ctx = _ctx({"NVDA": 100.0})
+        plan = _plan_trades(
+            ctx=ctx,
+            portfolio={"holdings": []},
+            target_qty={"NVDA": 1},
+            sells_tickers=set(),
+            target_meta={"NVDA": {"price": 100.0}},
+            min_trade_usd=500.0,
+        )
+        self.assertEqual(plan["buys"], [])
+        self.assertEqual(len(plan["noise_skipped"]), 1)
+
+
+if __name__ == "__main__":
+    result = unittest.main(exit=False, verbosity=2).result
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/trading_agents_strategy.py
+++ b/trading_agents_strategy.py
@@ -37,7 +37,6 @@ near-identical decisions (LLM stochasticity aside).
 
 from __future__ import annotations
 
-import json
 import logging
 import math
 import os
@@ -45,19 +44,14 @@ import re
 from datetime import date
 from typing import Any
 
-from agent_strategies import US_EXCHANGES, RebalanceContext, RebalanceResult
-from db import SupabaseDB
+from agent_strategies import RebalanceContext, RebalanceResult
 from llm_picker import (
     _filter_snapshot_us_only,
     _load_latest_snapshot,
     _us_listed_tickers,
+    pick_shortlist_via_llm,
 )
-from llm_providers import (
-    LLMProviderError,
-    PROVIDERS,
-    call_llm,
-    parse_json_response,
-)
+from llm_providers import LLMProviderError, PROVIDERS
 from portfolio import PortfolioError
 
 logger = logging.getLogger("trading_agents_strategy")
@@ -226,17 +220,24 @@ def rebalance_trading_agents(ctx: RebalanceContext) -> RebalanceResult:
     }
 
     # ------------------------------------------------------------------
-    # Stage 1: shortlist
+    # Stage 1: shortlist — delegates to the shared helper in llm_picker.py
+    # so prompt/parsing logic stays single-source-of-truth.
     # ------------------------------------------------------------------
     try:
-        shortlist, stage1_dropped, stage1_usage, stage1_raw = _run_shortlist(
-            provider=provider,
-            model=deep_model,
-            snapshot=snapshot_json,
-            snapshot_date=snapshot_date,
-            portfolio=portfolio_summary,
-            universe_tickers=universe_tickers,
-            params=params,
+        stage1_raw, shortlist, stage1_dropped, stage1_usage, stage1_retry = (
+            pick_shortlist_via_llm(
+                provider=provider,
+                model=deep_model,
+                snapshot=snapshot_json,
+                snapshot_date=snapshot_date,
+                portfolio=portfolio_summary,
+                universe_tickers=universe_tickers,
+                system_prompt=SHORTLIST_SYSTEM_PROMPT,
+                user_template=SHORTLIST_USER_TEMPLATE,
+                shortlist_max=int(params["max_candidates"]),
+                max_tokens=int(params["stage1_max_tokens"]),
+                temperature=float(params["temperature"]),
+            )
         )
     except LLMProviderError as exc:
         result.errors.append(f"stage 1 (shortlist) failed: {exc}")
@@ -251,6 +252,7 @@ def rebalance_trading_agents(ctx: RebalanceContext) -> RebalanceResult:
         "input_tokens": stage1_usage[0],
         "output_tokens": stage1_usage[1],
         "raw_response_kb": len(stage1_raw) // 1024,
+        "raw_response_retry_kb": (len(stage1_retry) // 1024) if stage1_retry else None,
     }
     if not shortlist:
         result.errors.append("stage 1 returned empty shortlist")
@@ -395,83 +397,6 @@ def rebalance_trading_agents(ctx: RebalanceContext) -> RebalanceResult:
 
     result.notes = notes
     return result
-
-
-# ---------------------------------------------------------------------------
-# Stage-1 implementation (inline copy — keeps llm_picker.py untouched)
-# ---------------------------------------------------------------------------
-
-
-def _run_shortlist(
-    *,
-    provider: str,
-    model: str,
-    snapshot: dict,
-    snapshot_date: str,
-    portfolio: dict,
-    universe_tickers: set[str],
-    params: dict,
-) -> tuple[list[dict], list[str], tuple[int | None, int | None], str]:
-    """Call the variant's deep-think LLM to pick the deep-dive shortlist.
-
-    Returns (clean_shortlist, dropped_tickers, (input_tokens, output_tokens), raw_text).
-    """
-    shortlist_max = int(params["max_candidates"])
-    user = SHORTLIST_USER_TEMPLATE.format(
-        snapshot_date=snapshot_date,
-        universe_json=json.dumps(snapshot, separators=(",", ":")),
-        portfolio_json=json.dumps(portfolio, separators=(",", ":")),
-        shortlist_max=shortlist_max,
-    )
-    resp = call_llm(
-        provider=provider,
-        model=model,
-        system=SHORTLIST_SYSTEM_PROMPT,
-        user=user,
-        max_tokens=int(params["stage1_max_tokens"]),
-        temperature=float(params["temperature"]),
-    )
-    try:
-        parsed = parse_json_response(resp.text)
-    except LLMProviderError:
-        # One retry with an explicit nudge.
-        retry = call_llm(
-            provider=provider,
-            model=model,
-            system=SHORTLIST_SYSTEM_PROMPT + "\n\nIMPORTANT: previous response was not valid JSON. Output ONLY the JSON object.",
-            user="Your previous response could not be parsed. Re-emit the JSON only.",
-            max_tokens=int(params["stage1_max_tokens"]),
-            temperature=0.1,
-        )
-        parsed = parse_json_response(retry.text)
-
-    items = parsed.get("shortlist") or parsed.get("picks") or []
-    if not isinstance(items, list):
-        raise LLMProviderError("shortlist response missing 'shortlist' array")
-
-    clean: list[dict] = []
-    dropped: list[str] = []
-    seen: set[str] = set()
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        ticker = str(item.get("ticker") or "").strip().upper()
-        if not ticker:
-            continue
-        if ticker not in universe_tickers:
-            dropped.append(ticker)
-            continue
-        if ticker in seen:
-            continue
-        seen.add(ticker)
-        clean.append({
-            "ticker": ticker,
-            "rationale": str(item.get("rationale") or "").strip(),
-        })
-        if len(clean) >= shortlist_max:
-            break
-
-    return clean, dropped, (resp.input_tokens, resp.output_tokens), resp.text
 
 
 # ---------------------------------------------------------------------------

--- a/trading_agents_strategy.py
+++ b/trading_agents_strategy.py
@@ -1,0 +1,697 @@
+"""TradingAgents-as-house-agent strategy.
+
+Strategy: ``trading_agents``. Runs the upstream TauricResearch/TradingAgents
+multi-agent framework as a fully-featured arena competitor, varied only by
+the underlying LLM (Claude Opus 4.7, Gemini 3 Pro, Qwen 3, …). Three stages:
+
+    1. Stage 1 — Shortlist: the variant's own deep-think LLM reads the
+       compact universe snapshot and picks ~30 tickers worth a deep dive.
+       Mirrors the existing ``llm_pick`` stage-1 pattern but uses a
+       different prompt geared toward "what's worth a multi-analyst
+       investigation" rather than "what's your final portfolio".
+
+    2. Stage 2 — Deep dive: for each shortlisted ticker, instantiates
+       ``TradingAgentsGraph(config).propagate(ticker, today_iso)`` and
+       extracts a BUY / SELL / HOLD decision. The framework runs its
+       full debate machinery (4 analysts + bull/bear researchers +
+       trader + risk team + reflection memory) per ticker.
+
+    3. Stage 3 — Reconcile: maps decisions to target weights
+       (equal-weight BUYs with a cash reserve), diffs against current
+       holdings, executes sells then buys via PortfolioManager.
+
+Per-agent config (set on agents.config JSONB by bootstrap_trading_agents.py):
+
+    llm_provider       "anthropic" | "google" | "qwen" | ...
+    deep_think_llm     SDK model id used for analysts/researchers/risk
+    quick_think_llm    SDK model id used for shorter analyst summaries
+    backend_url        OpenAI-compatible endpoint for openai-like providers
+    max_debate_rounds  How many bull/bear debate rounds (default 2)
+    max_candidates     Stage-1 shortlist size (default 30)
+    max_positions      Target portfolio breadth (default 20)
+    cash_reserve_pct   Cash buffer (default 0.02)
+
+Idempotence: re-running on the same universe + memory should produce
+near-identical decisions (LLM stochasticity aside).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import re
+from datetime import date
+from typing import Any
+
+from agent_strategies import US_EXCHANGES, RebalanceContext, RebalanceResult
+from db import SupabaseDB
+from llm_picker import (
+    _filter_snapshot_us_only,
+    _load_latest_snapshot,
+    _us_listed_tickers,
+)
+from llm_providers import (
+    LLMProviderError,
+    PROVIDERS,
+    call_llm,
+    parse_json_response,
+)
+from portfolio import PortfolioError
+
+logger = logging.getLogger("trading_agents_strategy")
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+TRADING_AGENTS_DEFAULTS = {
+    "max_candidates": 30,        # stage-1 shortlist size
+    "max_positions": 20,         # equal-weight cap for BUY targets
+    "cash_reserve_pct": 0.02,
+    "min_trade_usd": 500.0,
+    "max_debate_rounds": 2,
+    "stage1_max_tokens": 16384,
+    "temperature": 0.2,
+    "online_tools": True,        # let TradingAgents fetch live news/data
+}
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 — shortlist prompts
+# ---------------------------------------------------------------------------
+
+SHORTLIST_SYSTEM_PROMPT = """\
+You are a portfolio researcher selecting equities for a deep multi-analyst dive.
+
+A separate downstream pipeline will run a full fundamental / sentiment / news / technical analyst debate on every ticker you shortlist, then derive a BUY / SELL / HOLD decision per ticker. Your job is to pick the candidates worth that investigation.
+
+Be selective. Reflect YOUR own analytic style — momentum, value, growth, quality, contrarian, whatever you find compelling. The variants of this system are wired to different LLMs so we can compare which picks better; different shortlists from different brains are the whole point.
+
+Output strict JSON only. No prose, no markdown fences."""
+
+SHORTLIST_USER_TEMPLATE = """\
+UNIVERSE (compact tier, snapshot {snapshot_date}):
+{universe_json}
+
+CURRENT PORTFOLIO:
+{portfolio_json}
+
+OUTPUT SCHEMA (strict JSON, no other text):
+{{
+  "shortlist": [
+    {{"ticker": "XXX", "rationale": "<10-15 word reason this deserves a deep dive>"}}
+  ]
+}}
+
+Pick UP TO {shortlist_max} tickers from the universe above. Fewer is fine if you can't justify {shortlist_max}.
+Include current holdings only if you'd genuinely want them re-examined; otherwise the downstream stage will default HOLD on positions you skip.
+Only tickers from the universe above are valid. Output JSON only."""
+
+
+# ---------------------------------------------------------------------------
+# Decision extraction
+# ---------------------------------------------------------------------------
+
+# TradingAgents' final trader/risk output can vary by LLM but reliably
+# contains one of these tokens. We parse defensively: look for the
+# clearest signal in the last few lines of the decision text.
+_DECISION_TOKENS = ("BUY", "SELL", "HOLD")
+
+
+def _extract_decision(decision_text: str) -> str:
+    """Normalise the trader/risk manager output to BUY | SELL | HOLD.
+
+    TradingAgents returns a string like "FINAL TRANSACTION PROPOSAL: **BUY**"
+    or sometimes just "Buy" / "Hold" in the last paragraph. We scan
+    backwards through the text — the final verdict is more reliable than
+    early-paragraph mentions of competing options.
+    """
+    text = (decision_text or "").strip()
+    if not text:
+        return "HOLD"
+
+    # Prefer an explicit "FINAL TRANSACTION PROPOSAL" line if present.
+    final_match = re.search(
+        r"FINAL\s+TRANSACTION\s+PROPOSAL[^A-Z]*\*{0,2}\s*(BUY|SELL|HOLD)",
+        text,
+        re.IGNORECASE,
+    )
+    if final_match:
+        return final_match.group(1).upper()
+
+    # Otherwise scan from the end for a clean token.
+    upper = text.upper()
+    last_idx = -1
+    last_token = "HOLD"
+    for token in _DECISION_TOKENS:
+        idx = upper.rfind(token)
+        if idx > last_idx:
+            last_idx = idx
+            last_token = token
+    return last_token
+
+
+# ---------------------------------------------------------------------------
+# Strategy
+# ---------------------------------------------------------------------------
+
+
+def rebalance_trading_agents(ctx: RebalanceContext) -> RebalanceResult:
+    """Run the TradingAgents-driven rebalance for one agent.
+
+    Lazy-imports the upstream framework so this module is cheap to load
+    even when TradingAgents isn't installed (e.g. for momentum heartbeats
+    on the shared GHA runner).
+    """
+    result = RebalanceResult()
+    params = {**TRADING_AGENTS_DEFAULTS, **(ctx.params or {})}
+    handle = ctx.agent.get("handle", ctx.agent["id"][:8])
+
+    provider = params.get("llm_provider") or params.get("provider")
+    deep_model = params.get("deep_think_llm")
+    quick_model = params.get("quick_think_llm") or deep_model
+    if not provider or provider not in PROVIDERS:
+        result.errors.append(
+            f"agents.config.llm_provider missing or invalid (got {provider!r}). "
+            f"Expected one of: {', '.join(PROVIDERS)}"
+        )
+        return result
+    if not deep_model:
+        result.errors.append("agents.config.deep_think_llm missing")
+        return result
+
+    # Load universe snapshot (compact tier — same source as llm_pick).
+    snap_row = _load_latest_snapshot(ctx.db, "compact")
+    if not snap_row:
+        result.errors.append(
+            "no compact universe snapshot — run build_universe_snapshot.py"
+        )
+        return result
+    us_tickers = _us_listed_tickers(ctx.db)
+    snapshot_json = _filter_snapshot_us_only(snap_row["json"], us_tickers)
+    snapshot_date = snap_row["snapshot_date"]
+    universe_tickers = {
+        str(t.get("ticker") or "").upper()
+        for t in (snapshot_json.get("tickers") or [])
+        if t.get("ticker")
+    }
+
+    portfolio = ctx.pm.get_portfolio(ctx.agent["id"])
+    total_value = float(portfolio["total_value_usd"])
+    if total_value <= 0:
+        result.errors.append(f"total_value_usd <= 0 for agent {handle}")
+        return result
+
+    portfolio_summary = {
+        "cash_usd": round(float(portfolio["cash_usd"]), 2),
+        "total_value_usd": round(total_value, 2),
+        "holdings": [
+            {
+                "ticker": h["ticker"],
+                "quantity": float(h["quantity"]),
+                "avg_cost_usd": float(h["avg_cost_usd"]),
+            }
+            for h in portfolio["holdings"]
+        ],
+    }
+
+    notes: dict[str, Any] = {
+        "snapshot_date": snapshot_date,
+        "provider": provider,
+        "deep_think_llm": deep_model,
+        "quick_think_llm": quick_model,
+    }
+
+    # ------------------------------------------------------------------
+    # Stage 1: shortlist
+    # ------------------------------------------------------------------
+    try:
+        shortlist, stage1_dropped, stage1_usage, stage1_raw = _run_shortlist(
+            provider=provider,
+            model=deep_model,
+            snapshot=snapshot_json,
+            snapshot_date=snapshot_date,
+            portfolio=portfolio_summary,
+            universe_tickers=universe_tickers,
+            params=params,
+        )
+    except LLMProviderError as exc:
+        result.errors.append(f"stage 1 (shortlist) failed: {exc}")
+        notes["stage1_error"] = str(exc)
+        result.notes = notes
+        return result
+
+    notes["stage1"] = {
+        "shortlist": shortlist,
+        "shortlist_count": len(shortlist),
+        "dropped_invalid_tickers": stage1_dropped,
+        "input_tokens": stage1_usage[0],
+        "output_tokens": stage1_usage[1],
+        "raw_response_kb": len(stage1_raw) // 1024,
+    }
+    if not shortlist:
+        result.errors.append("stage 1 returned empty shortlist")
+        result.notes = notes
+        return result
+
+    # Always include current holdings in the deep-dive set so existing
+    # positions get re-evaluated (otherwise we'd silently hold forever).
+    deep_dive_tickers: list[str] = []
+    seen: set[str] = set()
+    for entry in shortlist:
+        t = entry["ticker"]
+        if t in seen:
+            continue
+        seen.add(t)
+        deep_dive_tickers.append(t)
+    for holding in portfolio_summary["holdings"]:
+        t = str(holding["ticker"]).upper()
+        if t in seen:
+            continue
+        if t not in universe_tickers:
+            # Holdings outside the current screener — still re-evaluate
+            # so the strategy can exit them if TradingAgents says SELL.
+            pass
+        seen.add(t)
+        deep_dive_tickers.append(t)
+
+    # Hard cap so a runaway holding count can't blow the LLM budget.
+    cap = int(params["max_candidates"]) + len(portfolio_summary["holdings"])
+    deep_dive_tickers = deep_dive_tickers[:cap]
+    notes["deep_dive_tickers"] = deep_dive_tickers
+
+    # ------------------------------------------------------------------
+    # Stage 2: TradingAgents deep dive per ticker
+    # ------------------------------------------------------------------
+    try:
+        ta_graph = _build_trading_agents_graph(provider, deep_model, quick_model, params)
+    except (ImportError, RuntimeError) as exc:
+        result.errors.append(f"could not initialise TradingAgents: {exc}")
+        notes["framework_init_error"] = str(exc)
+        result.notes = notes
+        return result
+
+    today_iso = date.today().isoformat()
+    decisions: list[dict] = []
+    deep_dive_errors: list[dict] = []
+    buys_tickers: list[str] = []
+    sells_tickers: list[str] = []
+    for ticker in deep_dive_tickers:
+        try:
+            _final_state, raw_decision = ta_graph.propagate(ticker, today_iso)
+        except Exception as exc:  # noqa: BLE001 — framework can raise anything
+            deep_dive_errors.append({"ticker": ticker, "error": str(exc)[:300]})
+            continue
+        verdict = _extract_decision(str(raw_decision or ""))
+        decisions.append({
+            "ticker": ticker,
+            "decision": verdict,
+            "raw_excerpt": str(raw_decision or "")[:600],
+        })
+        if verdict == "BUY":
+            buys_tickers.append(ticker)
+        elif verdict == "SELL":
+            sells_tickers.append(ticker)
+
+    notes["stage2"] = {
+        "decisions": decisions,
+        "decision_count": len(decisions),
+        "buy_count": len(buys_tickers),
+        "sell_count": len(sells_tickers),
+        "hold_count": sum(1 for d in decisions if d["decision"] == "HOLD"),
+        "framework_errors": deep_dive_errors,
+    }
+    if deep_dive_errors:
+        result.errors.extend(
+            f"propagate {e['ticker']}: {e['error']}" for e in deep_dive_errors
+        )
+    if not decisions:
+        result.errors.append("stage 2 produced no usable decisions")
+        result.notes = notes
+        return result
+
+    # ------------------------------------------------------------------
+    # Stage 3: reconcile — equal-weight the BUYs, exit SELLs, hold the rest
+    # ------------------------------------------------------------------
+    target_qty, target_meta, unpriced = _equal_weight_targets(
+        ctx=ctx,
+        buy_tickers=buys_tickers,
+        total_value=total_value,
+        cash_reserve_pct=float(params["cash_reserve_pct"]),
+        max_positions=int(params["max_positions"]),
+    )
+    if unpriced:
+        notes["unpriced_buys"] = unpriced
+
+    plan = _plan_trades(
+        ctx=ctx,
+        portfolio=portfolio,
+        target_qty=target_qty,
+        sells_tickers=set(sells_tickers),
+        target_meta=target_meta,
+        min_trade_usd=float(params["min_trade_usd"]),
+    )
+    notes["trades_planned"] = {
+        "buys": [
+            {"ticker": t, "qty": q, "note": n} for (t, q, n) in plan["buys"]
+        ],
+        "sells": [
+            {"ticker": t, "qty": q, "note": n} for (t, q, n) in plan["sells"]
+        ],
+        "noise_skipped": plan["noise_skipped"],
+    }
+
+    # ------------------------------------------------------------------
+    # Execute (or stop, for dry-run)
+    # ------------------------------------------------------------------
+    if ctx.dry_run:
+        logger.info(
+            "[dry-run] %s: stage1=%d, decisions=%d (buy=%d sell=%d), trades=%d/%d",
+            handle, len(shortlist), len(decisions),
+            len(buys_tickers), len(sells_tickers),
+            len(plan["sells"]), len(plan["buys"]),
+        )
+        result.notes = notes
+        return result
+
+    for ticker, qty, note in plan["sells"]:
+        try:
+            ctx.pm.sell(ctx.agent["id"], ticker, qty, note=note)
+            result.sells += 1
+        except PortfolioError as exc:
+            result.errors.append(f"sell {ticker} x{qty}: {exc}")
+
+    for ticker, qty, note in plan["buys"]:
+        try:
+            ctx.pm.buy(ctx.agent["id"], ticker, qty, note=note)
+            result.buys += 1
+        except PortfolioError as exc:
+            # Cash drift between plan and fill is the most common failure;
+            # partial fills are acceptable.
+            result.errors.append(f"buy {ticker} x{qty}: {exc}")
+
+    result.notes = notes
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Stage-1 implementation (inline copy — keeps llm_picker.py untouched)
+# ---------------------------------------------------------------------------
+
+
+def _run_shortlist(
+    *,
+    provider: str,
+    model: str,
+    snapshot: dict,
+    snapshot_date: str,
+    portfolio: dict,
+    universe_tickers: set[str],
+    params: dict,
+) -> tuple[list[dict], list[str], tuple[int | None, int | None], str]:
+    """Call the variant's deep-think LLM to pick the deep-dive shortlist.
+
+    Returns (clean_shortlist, dropped_tickers, (input_tokens, output_tokens), raw_text).
+    """
+    shortlist_max = int(params["max_candidates"])
+    user = SHORTLIST_USER_TEMPLATE.format(
+        snapshot_date=snapshot_date,
+        universe_json=json.dumps(snapshot, separators=(",", ":")),
+        portfolio_json=json.dumps(portfolio, separators=(",", ":")),
+        shortlist_max=shortlist_max,
+    )
+    resp = call_llm(
+        provider=provider,
+        model=model,
+        system=SHORTLIST_SYSTEM_PROMPT,
+        user=user,
+        max_tokens=int(params["stage1_max_tokens"]),
+        temperature=float(params["temperature"]),
+    )
+    try:
+        parsed = parse_json_response(resp.text)
+    except LLMProviderError:
+        # One retry with an explicit nudge.
+        retry = call_llm(
+            provider=provider,
+            model=model,
+            system=SHORTLIST_SYSTEM_PROMPT + "\n\nIMPORTANT: previous response was not valid JSON. Output ONLY the JSON object.",
+            user="Your previous response could not be parsed. Re-emit the JSON only.",
+            max_tokens=int(params["stage1_max_tokens"]),
+            temperature=0.1,
+        )
+        parsed = parse_json_response(retry.text)
+
+    items = parsed.get("shortlist") or parsed.get("picks") or []
+    if not isinstance(items, list):
+        raise LLMProviderError("shortlist response missing 'shortlist' array")
+
+    clean: list[dict] = []
+    dropped: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        ticker = str(item.get("ticker") or "").strip().upper()
+        if not ticker:
+            continue
+        if ticker not in universe_tickers:
+            dropped.append(ticker)
+            continue
+        if ticker in seen:
+            continue
+        seen.add(ticker)
+        clean.append({
+            "ticker": ticker,
+            "rationale": str(item.get("rationale") or "").strip(),
+        })
+        if len(clean) >= shortlist_max:
+            break
+
+    return clean, dropped, (resp.input_tokens, resp.output_tokens), resp.text
+
+
+# ---------------------------------------------------------------------------
+# TradingAgents bootstrapping
+# ---------------------------------------------------------------------------
+
+
+# Maps our internal provider id → the value the upstream framework
+# expects in ``config["llm_provider"]``. Anthropic + Google use their own
+# named providers; Qwen + DeepSeek + xAI all flow through the framework's
+# "openai" provider with a custom backend_url because they expose
+# OpenAI-compatible chat-completions APIs.
+_TA_PROVIDER_MAP = {
+    "anthropic": "anthropic",
+    "openai": "openai",
+    "google": "google",
+    "deepseek": "openai",
+    "xai": "openai",
+    "qwen": "openai",
+}
+
+_TA_BACKEND_URL = {
+    "anthropic": None,
+    "openai": "https://api.openai.com/v1",
+    "google": None,
+    "deepseek": "https://api.deepseek.com/v1",
+    "xai": "https://api.x.ai/v1",
+    "qwen": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+}
+
+
+def _build_trading_agents_graph(
+    provider: str,
+    deep_model: str,
+    quick_model: str,
+    params: dict,
+):
+    """Construct a TradingAgentsGraph configured for this variant's LLM.
+
+    For providers that go through TradingAgents' internal openai client
+    (Qwen via DashScope, DeepSeek, xAI), we mirror the variant's API key
+    into ``OPENAI_API_KEY`` so the framework's LangChain ChatOpenAI
+    initialisation finds it. The mirror only affects this process — it
+    doesn't persist or leak across variants in a fresh GHA job.
+    """
+    try:
+        from tradingagents.default_config import DEFAULT_CONFIG  # type: ignore
+        from tradingagents.graph.trading_graph import TradingAgentsGraph  # type: ignore
+    except ImportError as exc:
+        raise ImportError(
+            "tradingagents package not installed — add it to requirements.txt"
+        ) from exc
+
+    ta_provider = _TA_PROVIDER_MAP.get(provider)
+    if ta_provider is None:
+        raise RuntimeError(f"no TradingAgents provider mapping for {provider!r}")
+    backend_url = params.get("backend_url") or _TA_BACKEND_URL.get(provider)
+
+    # Mirror non-OpenAI keys into OPENAI_API_KEY so the framework's
+    # internal ChatOpenAI client authenticates against the custom backend.
+    if provider in ("qwen", "deepseek", "xai"):
+        env_key = {
+            "qwen": "DASHSCOPE_API_KEY",
+            "deepseek": "DEEPSEEK_API_KEY",
+            "xai": "GROK_API_KEY",
+        }[provider]
+        bridge = os.environ.get(env_key, "").strip()
+        if bridge and not os.environ.get("OPENAI_API_KEY", "").strip():
+            os.environ["OPENAI_API_KEY"] = bridge
+
+    config = dict(DEFAULT_CONFIG)
+    config.update({
+        "llm_provider": ta_provider,
+        "deep_think_llm": deep_model,
+        "quick_think_llm": quick_model,
+        "max_debate_rounds": int(params["max_debate_rounds"]),
+        "online_tools": bool(params["online_tools"]),
+    })
+    if backend_url:
+        config["backend_url"] = backend_url
+
+    return TradingAgentsGraph(debug=False, config=config)
+
+
+# ---------------------------------------------------------------------------
+# Stage-3 helpers
+# ---------------------------------------------------------------------------
+
+
+def _equal_weight_targets(
+    *,
+    ctx: RebalanceContext,
+    buy_tickers: list[str],
+    total_value: float,
+    cash_reserve_pct: float,
+    max_positions: int,
+) -> tuple[dict[str, int], dict[str, dict], list[str]]:
+    """Price every BUY target and compute equal-weight integer-share quantities.
+
+    Caps the BUY set at max_positions. Returns (qty_by_ticker, meta, unpriced).
+    """
+    priced: list[tuple[str, float]] = []
+    unpriced: list[str] = []
+    for ticker in buy_tickers[:max_positions]:
+        try:
+            price = ctx.pm.get_price(ticker)
+        except PortfolioError:
+            unpriced.append(ticker)
+            continue
+        priced.append((ticker, price))
+
+    if not priced:
+        return {}, {}, unpriced
+
+    investable = total_value * (1.0 - cash_reserve_pct)
+    per_target_usd = investable / len(priced)
+
+    qty_by_ticker: dict[str, int] = {}
+    meta: dict[str, dict] = {}
+    for ticker, price in priced:
+        qty = int(math.floor(per_target_usd / price)) if price > 0 else 0
+        qty_by_ticker[ticker] = qty
+        meta[ticker] = {"price": price, "per_target_usd": per_target_usd}
+    return qty_by_ticker, meta, unpriced
+
+
+def _plan_trades(
+    *,
+    ctx: RebalanceContext,
+    portfolio: dict,
+    target_qty: dict[str, int],
+    sells_tickers: set[str],
+    target_meta: dict[str, dict],
+    min_trade_usd: float,
+) -> dict:
+    """Diff target portfolio against current holdings to produce sells + buys.
+
+    Sells everything in ``sells_tickers`` that we currently hold, plus any
+    holdings not in ``target_qty`` (target=0). Buys to reach target quantity
+    for everything in target_qty. Trades under ``min_trade_usd`` are skipped
+    as noise (preserves idempotence on small price drift).
+    """
+    current_qty = {h["ticker"]: float(h["quantity"]) for h in portfolio["holdings"]}
+
+    sells: list[tuple[str, float, str]] = []
+    buys: list[tuple[str, int, str]] = []
+    noise_skipped: list[dict] = []
+
+    # Sell positions explicitly marked SELL or absent from target set.
+    # (Holdings the LLM said HOLD on are preserved by virtue of being in
+    # target_qty=0 only if they weren't included in target_qty at all —
+    # which can't happen because we only include BUYs in target_qty.
+    # So: a HOLD stays put because it's not in sells_tickers and not in
+    # target_qty either, which means the loop below leaves it alone.)
+    for ticker, held in current_qty.items():
+        if ticker in target_qty:
+            # In the BUY set — handled by the buy/trim loop below.
+            continue
+        if held <= 0:
+            continue
+        if ticker not in sells_tickers:
+            # HOLD verdict (or simply not in this run's deep dive) →
+            # leave the position alone.
+            continue
+        try:
+            price = ctx.pm.get_price(ticker)
+        except PortfolioError:
+            # Can't price → can't sell. Surface but don't block.
+            noise_skipped.append({"ticker": ticker, "side": "sell", "reason": "unpriced"})
+            continue
+        if held * price < min_trade_usd:
+            noise_skipped.append({
+                "ticker": ticker, "side": "sell",
+                "qty": held, "usd": round(held * price, 2),
+            })
+            continue
+        sells.append(
+            (ticker, held, f"Sold {ticker} — TradingAgents debate concluded SELL.")
+        )
+
+    # Buy / trim toward target quantities.
+    for ticker, want in target_qty.items():
+        held = current_qty.get(ticker, 0.0)
+        delta = want - held
+        if delta == 0:
+            continue
+        meta = target_meta.get(ticker, {})
+        price = meta.get("price")
+        if price is None:
+            try:
+                price = ctx.pm.get_price(ticker)
+            except PortfolioError:
+                continue
+        if delta > 0:
+            usd = delta * price
+            if usd < min_trade_usd:
+                noise_skipped.append({
+                    "ticker": ticker, "side": "buy",
+                    "qty": delta, "usd": round(usd, 2),
+                })
+                continue
+            buys.append((
+                ticker,
+                int(delta),
+                f"Bought {ticker} — TradingAgents debate concluded BUY.",
+            ))
+        else:
+            # Already over the target weight; trim back.
+            qty_to_sell = -delta
+            usd = qty_to_sell * price
+            if usd < min_trade_usd:
+                noise_skipped.append({
+                    "ticker": ticker, "side": "sell",
+                    "qty": qty_to_sell, "usd": round(usd, 2),
+                })
+                continue
+            sells.append((
+                ticker,
+                qty_to_sell,
+                f"Sold {ticker} — trimming to equal-weight target.",
+            ))
+
+    return {"buys": buys, "sells": sells, "noise_skipped": noise_skipped}


### PR DESCRIPTION
## Summary

Integrates the TauricResearch/TradingAgents multi-agent framework as a new portfolio strategy, enabling three house agents (Tauric Trader variants) to run a full debate-driven analysis pipeline for equity selection and rebalancing.

## Key Changes

- **New strategy: `trading_agents`** (`trading_agents_strategy.py`)
  - Three-stage pipeline: shortlist candidates via LLM, run TradingAgents framework per ticker for BUY/SELL/HOLD decisions, reconcile to equal-weight portfolio
  - Reuses shortlist logic from `llm_pick` via extracted `pick_shortlist_via_llm()` helper
  - Defensive decision parsing (`_extract_decision`) handles variable LLM output formats
  - Trade planning respects noise thresholds and idempotence constraints

- **Bootstrap script** (`bootstrap_trading_agents.py`)
  - Idempotent insertion of three house agents: tauric-opus-4-7, tauric-gemini-3, tauric-qwen
  - Each wired to a different LLM brain (Claude Opus 4.7, Gemini 3 Pro, Qwen 3)
  - Opens $1M paper-money accounts per variant

- **GitHub Actions workflow** (`.github/workflows/trading-agents-heartbeat.yml`)
  - Weekly Monday 21:30 UTC schedule (post-universe-snapshot refresh)
  - Parallel matrix jobs per variant to isolate LLM failures
  - 120-minute timeout for framework warm-up and debate rounds
  - Caches per-variant TradingAgents reflection memory across runs

- **Test suite** (`test_trading_agents_strategy.py`)
  - Smoke tests for decision parsing, equal-weight targeting, and trade planning
  - Offline validation without LLM/framework dependencies

- **Refactoring**
  - Extracted `pick_shortlist_via_llm()` from `llm_pick._run_stage1()` to share shortlist logic
  - Added `qwen` to `PROVIDERS` in `llm_providers.py`
  - Updated migration 016 with methodology text for all strategies
  - Added NOTICE file documenting TradingAgents Apache 2.0 dependency

## Implementation Details

- **Provider mapping**: Qwen, DeepSeek, and xAI route through OpenAI-compatible endpoints; API keys are mirrored into `OPENAI_API_KEY` for the framework's internal ChatOpenAI client
- **Idempotence**: Trade planning skips noise trades (<$500 notional) and re-evaluates all current holdings to enable safe re-runs
- **Error isolation**: Each variant's LLM failures don't block others; framework errors are logged per-ticker without halting the full run
- **Memory persistence**: GHA cache preserves per-variant reflection history across weekly runs for improved decision quality over time

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU