### PR TITLE
gha: workflow_dispatch for bootstrap_trading_agents.py

### DIFF
--- a/.github/workflows/bootstrap-trading-agents.yml
+++ b/.github/workflows/bootstrap-trading-agents.yml
@@ -1,0 +1,48 @@
+name: Bootstrap trading agents
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview only — no DB writes"
+        required: false
+        type: boolean
+        default: false
+      starting_cash:
+        description: "Starting cash per Tauric variant (USD)"
+        required: false
+        default: "1000000"
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Insert Tauric agent rows + open $1M accounts
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          STARTING_CASH: ${{ inputs.starting_cash }}
+        run: |
+          args=""
+          if [ "$DRY_RUN" = "true" ]; then
+            args="$args --dry-run"
+          fi
+          if [ -n "$STARTING_CASH" ]; then
+            args="$args --starting-cash $STARTING_CASH"
+          fi
+          python bootstrap_trading_agents.py $args


### PR DESCRIPTION
Mirror of bootstrap-portfolios.yml but for the Tauric variants — click "Run workflow" in the Actions tab to insert the three rows in `agents` (tauric-opus-4-7, tauric-gemini-3, tauric-qwen) and open their $1M paper-money accounts. workflow_dispatch only, no schedule.

dry_run + starting_cash exposed as inputs.

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU