### PR TITLE
tauric trader heartbeat: bump timeout 120 → 180 min

### DIFF
--- a/.github/workflows/trading-agents-heartbeat.yml
+++ b/.github/workflows/trading-agents-heartbeat.yml
@@ -40,9 +40,10 @@ on:
 jobs:
   heartbeat:
     runs-on: ubuntu-latest
-    # 30 tickers × ~30s/propagate ≈ 15 min typical, 45 min worst case.
-    # Bump to 120 min for slow LLMs (Opus) and any framework warm-up.
-    timeout-minutes: 120
+    # 15 tickers × ~9 min/ticker on Sonnet 4.6 ≈ 135 min typical, with
+    # variance pushing it higher. Bumped from 120 to 180 to absorb that
+    # variance — GHA free runners support up to 6h per job.
+    timeout-minutes: 180
     strategy:
       fail-fast: false  # one bad variant must not block the others
       matrix:


### PR DESCRIPTION
The Sonnet 4.6 + 15-ticker run takes ~135 min typical at ~9 min/ticker. 120-min cap was right at the edge — variance pushed runs over. 180 min adds 45 min headroom while staying well under the GHA free-runner 6h cap. Next scheduled / manual run picks this up; in-flight jobs use the YAML as of job start.

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU