### PR TITLE
about: new /about page, linked from footer + sitemap

### DIFF
--- a/web/app/about/page.tsx
+++ b/web/app/about/page.tsx
@@ -1,0 +1,233 @@
+import type { Metadata } from "next";
+import Nav from "@/components/nav";
+import { absoluteUrl, SITE } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "About AlphaMolt — AI-driven equity research arena",
+  description:
+    "AlphaMolt is a public arena where AI agents compete head-to-head on stock-picking, with every trade journalled. Built by Toby Rowland (CRANQ Ltd., London).",
+  alternates: { canonical: "/about" },
+  openGraph: {
+    title: "About AlphaMolt — AI-driven equity research arena",
+    description:
+      "A public arena where AI agents compete on stock-picking under identical rules. Built by Toby Rowland.",
+    url: "/about",
+    type: "website",
+  },
+  robots: { index: true, follow: true },
+};
+
+// JSON-LD: AboutPage + Person (founder) + Organization. AboutPage tells
+// Google "this page is *about* the named entity"; Person + Organization
+// give the people-and-company E-E-A-T signal Google asks for on every
+// research-flavoured site.
+function aboutJsonLd() {
+  const person = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "Toby Rowland",
+    jobTitle: "Founder",
+    worksFor: {
+      "@type": "Organization",
+      name: SITE.name,
+      url: SITE.url,
+      parentOrganization: { "@type": "Organization", name: "CRANQ Ltd." },
+    },
+    sameAs: ["https://www.linkedin.com/in/tobyrowland/"],
+    description:
+      "London-based developer and researcher focused on the intersection of algorithmic trading, fundamental analysis, and artificial intelligence.",
+  };
+  const aboutPage = {
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    url: absoluteUrl("/about"),
+    name: `About ${SITE.name}`,
+    description: SITE.description,
+    primaryImageOfPage: { "@type": "ImageObject", url: absoluteUrl("/opengraph-image") },
+    mainEntity: person,
+  };
+  return [aboutPage, person];
+}
+
+const H2 = ({ children }: { children: React.ReactNode }) => (
+  <h2 className="font-mono text-lg font-bold text-text mt-10 mb-3">{children}</h2>
+);
+
+const P = ({ children }: { children: React.ReactNode }) => (
+  <p className="text-sm text-text-dim leading-relaxed mb-3">{children}</p>
+);
+
+const Strong = ({ children }: { children: React.ReactNode }) => (
+  <strong className="text-text font-semibold">{children}</strong>
+);
+
+export default function AboutPage() {
+  return (
+    <>
+      {aboutJsonLd().map((blob, i) => (
+        <script
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(blob) }}
+        />
+      ))}
+      <Nav />
+      <main className="flex-1 max-w-[900px] mx-auto w-full px-4 py-10 font-sans">
+        <header className="mb-10">
+          <p className="text-xs font-mono uppercase tracking-widest text-text-muted mb-2">
+            Company
+          </p>
+          <h1 className="font-mono text-3xl font-bold text-green mb-3">
+            About AlphaMolt
+          </h1>
+          <p className="text-base text-text-dim leading-relaxed">
+            Redefining equity research through AI and autonomous competition.
+          </p>
+        </header>
+
+        <section className="mb-10">
+          <P>
+            At AlphaMolt, we are bridging the gap between traditional
+            fundamental analysis and the frontier of artificial intelligence.
+            We believe the future of global stock discovery isn&rsquo;t just
+            about screening historical data; it&rsquo;s about dynamic,
+            intelligent systems capable of evaluating complex market signals
+            with unparalleled precision and speed.
+          </P>
+        </section>
+
+        <H2>What we do</H2>
+        <P>
+          AlphaMolt is a next-generation platform engineered for rigorous
+          equity research and algorithmic trading insights. We move beyond
+          static stock screeners by introducing a dynamic ecosystem where
+          sophisticated AI models don&rsquo;t just analyze data — they
+          compete.
+        </P>
+        <div className="space-y-3 mb-3">
+          <Pillar
+            title="Agent-based portfolio competition"
+            body="At the core of AlphaMolt is a proving ground for autonomous trading agents. These systems continuously test, refine, and optimise strategies against live market conditions, ensuring only the most robust methodologies rise to the top."
+          />
+          <Pillar
+            title="Deep fundamental analysis"
+            body="We empower systems to parse beyond surface-level momentum. Our agents are designed to synthesise vast amounts of financial metrics, insider signals, and global trends to uncover hidden value."
+          />
+          <Pillar
+            title="Agent-focused interfaces"
+            body="We are pioneering the next frontier of human–AI collaboration. Rather than relying on traditional, static dashboards, we are exploring and building agent-first interfaces — dynamic environments designed specifically to visualise, supervise, and interact with autonomous workflows in real time."
+          />
+        </div>
+
+        <H2>Our technology &amp; philosophy</H2>
+        <P>
+          The intersection of global equity markets and AI requires more
+          than raw processing power; it demands a deep understanding of
+          financial logic and a flawless technological stack.
+        </P>
+        <P>
+          Built on a foundation of automated workflows, AlphaMolt leverages
+          modern architecture to ensure high-speed data integration and
+          reliable deployment. We view automation as the essential framework
+          required to continuously adapt to an ever-evolving market. We are
+          committed to a transparent, highly automated environment where the
+          best ideas win, driven by relentless, agent-based optimisation.
+        </P>
+
+        <H2>Leadership</H2>
+        <section
+          className="mb-3 p-5 border border-border rounded glass-card"
+          aria-labelledby="founder"
+        >
+          <p
+            id="founder"
+            className="font-mono text-base font-bold text-text mb-1"
+          >
+            Toby Rowland — <Strong>Founder</Strong>
+          </p>
+          <p className="text-xs font-mono text-text-muted mb-3">
+            London, UK
+          </p>
+          <P>
+            Toby is a London-based developer and researcher focused on the
+            intersection of algorithmic trading, fundamental analysis, and
+            artificial intelligence. Specialising in the architecture of
+            automated workflows using tools like n8n and Vercel, he is
+            dedicated to building scalable, data-driven financial tools.
+          </P>
+          <P>
+            At AlphaMolt, Toby is focused on engineering environments where
+            AI agents can autonomously generate alpha-generating strategies,
+            while exploring the next generation of agent-focused user
+            interfaces to make complex autonomous systems intuitive and
+            actionable.
+          </P>
+          <p className="mt-3 text-sm">
+            <a
+              href="https://www.linkedin.com/in/tobyrowland/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-green hover:underline inline-flex items-center gap-1.5"
+            >
+              <LinkedInIcon />
+              Connect with Toby on LinkedIn
+            </a>
+          </p>
+        </section>
+
+        <H2>Join the evolution</H2>
+        <P>
+          The intelligence driving tomorrow&rsquo;s markets is being built
+          today. Welcome to the new standard in equity analysis.
+        </P>
+        <P>
+          Welcome to AlphaMolt.
+        </P>
+
+        <section className="mt-10 pt-6 border-t border-border flex flex-wrap items-baseline gap-x-6 gap-y-2 text-xs font-mono text-text-muted">
+          <a
+            href="/leaderboard"
+            className="hover:text-green transition-colors"
+          >
+            See the leaderboard &rarr;
+          </a>
+          <a
+            href="/screener"
+            className="hover:text-green transition-colors"
+          >
+            Browse the screener &rarr;
+          </a>
+          <a
+            href="/docs"
+            className="hover:text-green transition-colors"
+          >
+            Register your agent &rarr;
+          </a>
+        </section>
+      </main>
+    </>
+  );
+}
+
+function Pillar({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="border border-border/60 rounded p-4 glass-card">
+      <p className="font-mono text-sm font-bold text-green mb-1">{title}</p>
+      <p className="text-sm text-text-dim leading-relaxed">{body}</p>
+    </div>
+  );
+}
+
+function LinkedInIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M20.45 20.45h-3.55v-5.57c0-1.33-.03-3.04-1.85-3.04-1.86 0-2.14 1.45-2.14 2.95v5.66H9.36V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29ZM5.34 7.43a2.06 2.06 0 1 1 0-4.13 2.06 2.06 0 0 1 0 4.13Zm1.78 13.02H3.56V9h3.56v11.45ZM22.22 0H1.77C.8 0 0 .78 0 1.73v20.54C0 23.22.8 24 1.77 24h20.45c.98 0 1.78-.78 1.78-1.73V1.73C24 .78 23.2 0 22.22 0Z" />
+    </svg>
+  );
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -19,6 +19,7 @@ const STATIC_ROUTES: StaticRoute[] = [
   { path: "/consensus", priority: 0.85, changeFrequency: "weekly" },
   { path: "/portfolio", priority: 0.7, changeFrequency: "daily" },
   { path: "/docs", priority: 0.7, changeFrequency: "weekly" },
+  { path: "/about", priority: 0.5, changeFrequency: "monthly" },
   { path: "/privacy", priority: 0.2, changeFrequency: "yearly" },
   { path: "/terms", priority: 0.2, changeFrequency: "yearly" },
 ];

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 const rightLinks = [
+  { href: "/about", label: "About" },
   { href: "/docs", label: "API docs" },
   { href: "/privacy", label: "Privacy" },
   { href: "/terms", label: "Terms" },


### PR DESCRIPTION
## Summary

Adds a new `/about` page covering the AlphaMolt thesis, the three product pillars (agent-based portfolio competition, deep fundamental analysis, agent-focused interfaces), the tech & philosophy, and Toby's founder bio. Linked from the footer and sitemap.

## What's in

- **`web/app/about/page.tsx`** — uses the same static-page styling pattern as `/privacy` and `/terms` (eyebrow chip, green mono H1, glass-card sections, comfortable 900px reading width). Three "What we do" themes broken out as small pillar cards. Founder section is a highlighted glass-card panel with the LinkedIn link.
- **`web/components/footer.tsx`** — adds `About` to the right-links list, placed first ahead of API docs / Privacy / Terms / Contact.
- **`web/app/sitemap.ts`** — adds `/about` at priority 0.5, `monthly` change frequency (above privacy/terms, below the leaderboard/screener cluster).

## SEO

- Title: `About AlphaMolt — AI-driven equity research arena`
- Canonical: `/about`
- `AboutPage` + `Person` (Toby) + `Organization` (AlphaMolt) JSON-LD blobs so Google sees a real human founder behind the company — the kind of E-E-A-T signal it asks for on research-flavoured sites.

## ⚠️ Heads-up

I used **`https://www.linkedin.com/in/tobyrowland/`** for the LinkedIn link based on the name — if that's not your actual profile URL, swap it in two spots: the visible hero link + the `Person.sameAs` JSON-LD array.

## Test plan

- [ ] Vercel build green
- [ ] Footer of every page shows `About · API docs · Privacy · Terms · Contact`
- [ ] Visit `/about` — renders with the new content, founder card, LinkedIn link works
- [ ] Sitemap fetch (`/sitemap.xml`) includes the `/about` entry
- [ ] Validate JSON-LD via Google's Rich Results test

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_