### PR TITLE
home: replace Credibility section with agent-first-OS graphic

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import Nav from "@/components/nav";
 import HeroChart from "@/components/hero-chart";
@@ -119,7 +120,7 @@ export default async function HomePage() {
               snapshotDate={consensus.snapshot_date}
             />
           </div>
-          <Credibility />
+          <AgentFirstGraphic />
           <EnterYourAgent />
           <WotBadge />
         </div>
@@ -202,317 +203,43 @@ function Hero({ chart }: { chart: HeroChartData }) {
   );
 }
 
-function Credibility() {
+
+// Replaces the old Credibility section. The graphic dramatises the
+// agent-first / MCP-native pitch in a single image; the H2 + sub keep
+// the keyword density we'd otherwise have lost when the text cards
+// went away. Image lives at /agent-first-os.png in web/public — until
+// the file is dropped in, the page will show a broken image icon
+// (intentional, so the missing asset can't go unnoticed).
+function AgentFirstGraphic() {
   return (
     <section className="mt-20 sm:mt-32">
-      <h2 className="text-[26px] sm:text-[34px] lg:text-[38px] font-bold tracking-[-0.02em] text-text max-w-[24ch] leading-[1.1]">
-        The only place where AI agents pick stocks on an equal, monitored,
-        public footing.
+      <h2 className="text-[26px] sm:text-[34px] lg:text-[38px] font-bold tracking-[-0.02em] text-text max-w-[26ch] leading-[1.1]">
+        Agent-first by design. No human dashboards required.
       </h2>
-      <p className="mt-5 text-base sm:text-lg text-text-muted max-w-[600px] leading-relaxed">
-        Anywhere else, &ldquo;my AI picked a winner&rdquo; is an anecdote.
-        Here it&rsquo;s a data point.
+      <p className="mt-5 text-base sm:text-lg text-text-muted max-w-[640px] leading-relaxed">
+        AlphaMolt is operated exclusively via MCP. Standardised tool
+        calls let AI agents autonomously fetch live fundamentals,
+        execute orders, and manage portfolios — with zero manual input
+        and no human-facing buttons, charts, or trading dashboards.
       </p>
-
-      <ModelStrip />
-
-      <div className="mt-10 grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Card
-          icon={<DatabaseIcon />}
-          title="Same data for every agent"
-          body="Vetted fundamentals on hundreds of US-listed stocks, refreshed nightly. Kills hallucination as a variable."
-        />
-        <Card
-          icon={<ScalesIcon />}
-          title="Same rules, same starting cash"
-          body="$1M virtual account. No margin, no shorting. Apples-to-apples across every strategy."
-        />
-        <Card
-          icon={<LedgerIcon />}
-          title="Every trade is public"
-          body="Timestamped and logged the moment it happens. No cherry-picking, no retroactive rewrites."
-        />
-        <Card
-          icon={<CalendarTickIcon />}
-          title="Marked to market daily"
-          body="Leaderboard reflects closing prices every day. No favourable windows, no selective reporting."
+      <div
+        className="mt-10 rounded-2xl border border-white/10 overflow-hidden"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(255,255,255,0.03), rgba(0,0,0,0.2))",
+        }}
+      >
+        <Image
+          src="/agent-first-os.png"
+          alt="Conceptual diagram of AlphaMolt as an agent-first financial operating system. An AI agent model issues standardised MCP tool calls — get_stock_fundamentals({ticker: 'AAPL'}) and place_order({symbol: 'MSFT', type: 'BUY', quantity: 100}) — which the system executes to fetch live fundamentals, execute orders, and manage portfolios autonomously. A traditional GUI with buttons, charts, and dashboards is crossed out as deprecated."
+          width={2000}
+          height={1100}
+          className="block w-full h-auto"
+          // Below the fold; let the browser lazy-load it.
+          loading="lazy"
         />
       </div>
     </section>
-  );
-}
-
-// Visual breaker between the credibility headline and the 4-card grid.
-// Names the model families that have agents in the arena. Each chip
-// pairs a brand-evocative monochrome glyph with the model name — kept
-// abstract enough to avoid trademark issues while still reading as
-// "the LLMs you've heard of are competing here."
-function ModelStrip() {
-  const models: { name: string; glyph: React.ReactNode }[] = [
-    { name: "Claude", glyph: <ClaudeGlyph /> },
-    { name: "GPT", glyph: <GptGlyph /> },
-    { name: "Gemini", glyph: <GeminiGlyph /> },
-    { name: "Grok", glyph: <GrokGlyph /> },
-    { name: "DeepSeek", glyph: <DeepSeekGlyph /> },
-    { name: "Llama", glyph: <LlamaGlyph /> },
-  ];
-  return (
-    <div className="mt-10">
-      <p className="text-[11px] uppercase tracking-[0.14em] text-text-muted font-semibold mb-4">
-        Models in the arena
-      </p>
-      <ul className="flex flex-wrap items-center gap-2.5">
-        {models.map((m) => (
-          <li
-            key={m.name}
-            className="inline-flex items-center gap-2.5 rounded-lg pl-2.5 pr-3 py-2 text-sm text-text-dim backdrop-blur-md transition-colors hover:text-text"
-            style={{
-              background:
-                "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
-              border: "1px solid rgba(255,255,255,0.08)",
-              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
-            }}
-          >
-            <span
-              aria-hidden
-              className="inline-flex items-center justify-center w-6 h-6 rounded-md text-text"
-              style={{
-                background: "rgba(255,255,255,0.06)",
-                boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.06)",
-              }}
-            >
-              {m.glyph}
-            </span>
-            <span className="font-medium">{m.name}</span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-// ----- Brand glyphs --------------------------------------------------------
-// Single-color, ~14px monochrome marks that read as the brand without
-// reproducing the trademark. All inherit currentColor so they pick up the
-// chip's text color.
-
-function ClaudeGlyph() {
-  // Eight-spoke sunburst — evokes the Anthropic mark.
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.4"
-      strokeLinecap="round"
-    >
-      <line x1="8" y1="1.8" x2="8" y2="5.2" />
-      <line x1="8" y1="10.8" x2="8" y2="14.2" />
-      <line x1="1.8" y1="8" x2="5.2" y2="8" />
-      <line x1="10.8" y1="8" x2="14.2" y2="8" />
-      <line x1="3.6" y1="3.6" x2="5.6" y2="5.6" />
-      <line x1="10.4" y1="10.4" x2="12.4" y2="12.4" />
-      <line x1="3.6" y1="12.4" x2="5.6" y2="10.4" />
-      <line x1="10.4" y1="5.6" x2="12.4" y2="3.6" />
-    </svg>
-  );
-}
-
-function GptGlyph() {
-  // Three intersecting ellipses — knot-of-loops impression.
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.1"
-    >
-      <ellipse cx="8" cy="8" rx="2.5" ry="5.5" />
-      <ellipse
-        cx="8"
-        cy="8"
-        rx="2.5"
-        ry="5.5"
-        transform="rotate(60 8 8)"
-      />
-      <ellipse
-        cx="8"
-        cy="8"
-        rx="2.5"
-        ry="5.5"
-        transform="rotate(120 8 8)"
-      />
-    </svg>
-  );
-}
-
-function GeminiGlyph() {
-  // Four-pointed sparkle — Gemini's "asterisk" mark.
-  return (
-    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-      <path d="M8 1.2 C 8.6 5 9 6.4 14.8 8 C 9 9.6 8.6 11 8 14.8 C 7.4 11 7 9.6 1.2 8 C 7 6.4 7.4 5 8 1.2 Z" />
-    </svg>
-  );
-}
-
-function GrokGlyph() {
-  // X — the xAI letterform.
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.7"
-      strokeLinecap="round"
-    >
-      <line x1="3.4" y1="3.4" x2="12.6" y2="12.6" />
-      <line x1="12.6" y1="3.4" x2="3.4" y2="12.6" />
-    </svg>
-  );
-}
-
-function DeepSeekGlyph() {
-  // Double-chevron — a stylised wave / "depth" mark.
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.4"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M2.8 5.5 L8 9.2 L13.2 5.5" />
-      <path d="M2.8 9.5 L8 13.2 L13.2 9.5" />
-    </svg>
-  );
-}
-
-function LlamaGlyph() {
-  // Two interlocking rings — infinity / Meta's lemniscate.
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.3"
-    >
-      <circle cx="5.6" cy="8" r="2.6" />
-      <circle cx="10.4" cy="8" r="2.6" />
-    </svg>
-  );
-}
-
-function Card({
-  icon,
-  title,
-  body,
-}: {
-  icon: React.ReactNode;
-  title: string;
-  body: string;
-}) {
-  return (
-    <div
-      className="group relative rounded-2xl p-6 sm:p-7 backdrop-blur-md transition-all duration-300 ease-out hover:-translate-y-[2px] hover:scale-[1.005]"
-      style={{
-        background:
-          "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
-        border: "1px solid rgba(255,255,255,0.08)",
-        // Lighter top edge simulates light hitting the top of a physical
-        // card; slightly stronger inset highlight on the top adds depth.
-        boxShadow:
-          "0 8px 24px -12px rgba(0,0,0,0.55), inset 0 1px 0 rgba(255,255,255,0.10)",
-      }}
-    >
-      {/* Hover-only radial gradient overlay. Kept as a sibling so the
-          parent's transform doesn't fight the gradient transition. */}
-      <span
-        aria-hidden
-        className="pointer-events-none absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-300 group-hover:opacity-100"
-        style={{
-          background:
-            "radial-gradient(60% 80% at 50% 0%, rgba(255,255,255,0.06), transparent 70%)",
-        }}
-      />
-      <span
-        aria-hidden
-        className="relative inline-flex items-center justify-center w-9 h-9 rounded-lg mb-4 text-[var(--color-green)]"
-        style={{
-          background:
-            "linear-gradient(180deg, rgba(0,255,65,0.10), rgba(0,255,65,0.02))",
-          boxShadow:
-            "inset 0 0 0 1px rgba(0,255,65,0.18), 0 0 16px -4px rgba(0,255,65,0.18)",
-        }}
-      >
-        {icon}
-      </span>
-      <h3 className="relative text-[17px] font-semibold tracking-tight text-text">
-        {title}
-      </h3>
-      <p className="relative mt-2 text-sm text-text-muted leading-relaxed">
-        {body}
-      </p>
-    </div>
-  );
-}
-
-// ----- Card icons ----------------------------------------------------------
-// Lightweight monochrome SVG glyphs that inherit currentColor.
-
-function DatabaseIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
-      <ellipse cx="10" cy="4.5" rx="6.5" ry="2.2" />
-      <path d="M3.5 4.5 V10 C 3.5 11.2 6.4 12.2 10 12.2 C 13.6 12.2 16.5 11.2 16.5 10 V4.5" />
-      <path d="M3.5 10 V15.5 C 3.5 16.7 6.4 17.7 10 17.7 C 13.6 17.7 16.5 16.7 16.5 15.5 V10" />
-    </svg>
-  );
-}
-
-function ScalesIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
-      <line x1="10" y1="3.5" x2="10" y2="16.5" />
-      <line x1="6" y1="16.5" x2="14" y2="16.5" />
-      <path d="M3 11 L6 5 L9 11 Z" />
-      <path d="M11 11 L14 5 L17 11 Z" />
-      <path d="M3 11 C 3 12.4 4.3 13.2 6 13.2 C 7.7 13.2 9 12.4 9 11" />
-      <path d="M11 11 C 11 12.4 12.3 13.2 14 13.2 C 15.7 13.2 17 12.4 17 11" />
-    </svg>
-  );
-}
-
-function LedgerIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="3.5" y="3" width="13" height="14" rx="1.5" />
-      <line x1="6.5" y1="7" x2="13.5" y2="7" />
-      <line x1="6.5" y1="10" x2="13.5" y2="10" />
-      <line x1="6.5" y1="13" x2="11" y2="13" />
-    </svg>
-  );
-}
-
-function CalendarTickIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="3" y="4.5" width="14" height="12" rx="1.5" />
-      <line x1="3" y1="8" x2="17" y2="8" />
-      <line x1="7" y1="3" x2="7" y2="6" />
-      <line x1="13" y1="3" x2="13" y2="6" />
-      <path d="M7.5 12.5 L9.5 14.5 L13 11" />
-    </svg>
   );
 }
 


### PR DESCRIPTION
## Summary

Drops the "The only place where AI agents pick stocks…" section (H2 + sub + ModelStrip + 4-card grid) in favour of a single hero image that dramatises the agent-first / MCP-native pitch — the conceptual mockup you generated in the Gemini chat.

## What stays

- **H2 + sub-paragraph** above the image so we don't lose the keyword density the text cards used to carry. Reads: *"Agent-first by design. No human dashboards required."* + a one-paragraph elaboration mentioning MCP, autonomous fetch/execute/manage.
- **Alt text on the image** describes the whole diagram so screen-readers and image-SEO crawlers still get the message even without seeing the picture.

## What's removed

~270 lines of dead code now that the section is image-driven:
- `Credibility`, `ModelStrip`, `Card`
- 6 brand-evocative model glyphs (Claude / GPT / Gemini / Grok / DeepSeek / Llama)
- 4 stat-card icons (Database / Scales / Ledger / CalendarTick)

None were imported anywhere else. Easy revert from git history if we want them back.

## ⚠️ You still need to drop the image

The image lives at `web/public/agent-first-os.png`. **Until the file is there, the page will show a broken image icon** — intentional so the missing asset can't go unnoticed. To finish:

1. Save the image from your Gemini chat (`right-click → save as`)
2. Drop it into `web/public/agent-first-os.png`
3. Commit + push (or merge directly to main once the PR is in)

The Next.js `<Image>` component is set to 2000×1100 as a best-guess aspect; CSS makes it responsive so actual image dimensions don't need to match exactly. If your real image is significantly different shape, ping me and I'll tighten the width/height props.

## Open question from earlier

Re "remove 'serial' from the About page" — I couldn't find that word anywhere on the About page (or anywhere user-facing on the site). Quickest way to settle: tell me the sentence you spotted and I'll grep / fix.

## Test plan

- [ ] Vercel build green
- [ ] Drop the PNG into `web/public/agent-first-os.png` and confirm the section renders on `/` between the consensus widget and the "Enter your agent" CTA
- [ ] Confirm the alt text is in the SSR HTML even when the image fails to load
- [ ] Confirm the `WotBadge` still sits below the EnterYourAgent section

https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwfYyA3EqCAJZ6SMTQVxSi)_