### PR TITLE
moltbook: live-data original posts in the format that wins on m/general

### DIFF
--- a/moltbook_heartbeat.py
+++ b/moltbook_heartbeat.py
@@ -51,6 +51,7 @@ from moltbook_lib import (
     notification_marker,
     post_and_verify,
 )
+from db import SupabaseDB
 from social_personality import (
     detect_hostility,
     generate_apology,
@@ -726,38 +727,181 @@ def _engage_feed(
 # ---------------------------------------------------------------------------
 
 
+def _build_post_topic(db: SupabaseDB) -> dict[str, Any] | None:
+    """Pull live alphamolt data and assemble a topic for the LLM drafter.
+
+    Rotates between two angles by day-of-year so the daily post doesn't
+    repeat the same shape:
+
+    - ``leaderboard_spread`` — biggest 30d return gap across registered
+      agents vs SPY/URTH benchmarks.
+    - ``sharpe_vs_return`` — finds two agents where Sharpe and 30d return
+      tell different stories (high return, low Sharpe — or vice versa).
+
+    Returns None when there isn't enough warm data (fewer than 2 agents
+    with a 30d figure, or every agent has identical numbers) so the
+    heartbeat skips the post instead of shipping a stale template.
+    """
+    try:
+        rows = (
+            db.client.table("agent_leaderboard")
+            .select(
+                "agent_id, handle, display_name, total_value_usd, "
+                "pnl_pct, pnl_pct_1d, pnl_pct_30d, pnl_pct_ytd, "
+                "sharpe, sharpe_n_returns, num_positions"
+            )
+            .execute()
+            .data
+            or []
+        )
+    except Exception as exc:  # network / schema mismatch
+        log.warning("post topic: leaderboard fetch failed: %s", exc)
+        return None
+
+    agents = [
+        r for r in rows
+        if r.get("handle") and r.get("pnl_pct_30d") is not None
+    ]
+    if len(agents) < 2:
+        log.info("post topic: only %d agents with 30d data, skipping", len(agents))
+        return None
+
+    # Benchmarks (SPY, URTH) — same view doesn't carry them; pull from
+    # benchmarks + benchmark_prices and compute 30d return inline.
+    benchmarks: list[dict[str, Any]] = []
+    try:
+        bench_rows = (
+            db.client.table("benchmarks")
+            .select("ticker, display_name, latest_price, inception_price")
+            .execute()
+            .data
+            or []
+        )
+        for b in bench_rows:
+            start = b.get("inception_price")
+            end = b.get("latest_price")
+            if start and end:
+                benchmarks.append({
+                    "ticker": b["ticker"],
+                    "name": b.get("display_name") or b["ticker"],
+                    "since_inception_pct": round(
+                        (float(end) - float(start)) / float(start) * 100, 2
+                    ),
+                })
+    except Exception as exc:
+        log.warning("post topic: benchmark fetch failed: %s", exc)
+
+    day_of_year = datetime.now(timezone.utc).timetuple().tm_yday
+    angle = ("leaderboard_spread", "sharpe_vs_return")[day_of_year % 2]
+
+    if angle == "leaderboard_spread":
+        ranked = sorted(agents, key=lambda r: r["pnl_pct_30d"], reverse=True)
+        top, bottom = ranked[0], ranked[-1]
+        if abs(top["pnl_pct_30d"] - bottom["pnl_pct_30d"]) < 0.5:
+            log.info("post topic: leaderboard spread <0.5pp, skipping")
+            return None
+        return {
+            "angle": "leaderboard_spread",
+            "narrative_hint": (
+                f"I tracked {len(agents)} AI stock-pickers on alphamolt for "
+                f"30 days. The spread between best and worst surprised me."
+            ),
+            "facts": {
+                "agent_count": len(agents),
+                "period_days": 30,
+                "top_agent": {k: top.get(k) for k in (
+                    "handle", "display_name", "pnl_pct_30d", "pnl_pct_ytd",
+                    "sharpe", "num_positions",
+                )},
+                "bottom_agent": {k: bottom.get(k) for k in (
+                    "handle", "display_name", "pnl_pct_30d", "pnl_pct_ytd",
+                    "sharpe", "num_positions",
+                )},
+                "spread_30d_pct": round(
+                    top["pnl_pct_30d"] - bottom["pnl_pct_30d"], 2
+                ),
+                "all_agents_30d": [
+                    {"handle": a["handle"], "pnl_pct_30d": a["pnl_pct_30d"]}
+                    for a in ranked
+                ],
+                "benchmarks": benchmarks,
+            },
+        }
+
+    # angle == "sharpe_vs_return"
+    with_sharpe = [
+        a for a in agents
+        if a.get("sharpe") is not None
+        and (a.get("sharpe_n_returns") or 0) >= 30
+    ]
+    if len(with_sharpe) < 2:
+        log.info("post topic: only %d agents with warm Sharpe, skipping", len(with_sharpe))
+        return None
+    by_return = sorted(with_sharpe, key=lambda r: r["pnl_pct_30d"], reverse=True)
+    by_sharpe = sorted(with_sharpe, key=lambda r: r["sharpe"], reverse=True)
+    if by_return[0]["handle"] == by_sharpe[0]["handle"]:
+        # Sharpe and return tell the same story — boring, skip.
+        log.info("post topic: top return == top Sharpe, no tension, skipping")
+        return None
+    return {
+        "angle": "sharpe_vs_return",
+        "narrative_hint": (
+            "Two agents on alphamolt have the same trajectory by one "
+            "metric and tell completely different stories by another. "
+            "Sharpe and absolute return disagree."
+        ),
+        "facts": {
+            "agent_count": len(with_sharpe),
+            "period_days": 30,
+            "top_by_return": {k: by_return[0].get(k) for k in (
+                "handle", "display_name", "pnl_pct_30d", "sharpe",
+                "sharpe_n_returns", "num_positions",
+            )},
+            "top_by_sharpe": {k: by_sharpe[0].get(k) for k in (
+                "handle", "display_name", "pnl_pct_30d", "sharpe",
+                "sharpe_n_returns", "num_positions",
+            )},
+            "benchmarks": benchmarks,
+        },
+    }
+
+
 def _maybe_post_original(
     client: MoltbookClient,
     gh: GitHubIssuer | None,
     ledger: dict[str, Any],
     dry_run: bool = False,
 ) -> bool:
-    """Post one original piece per day to a finance submolt."""
+    """Post one original piece per day to m/general.
+
+    Targeting m/general because the recon (issue #853) showed every
+    top-of-feed post is in m/general; the finance-themed submolts that
+    we used to target appear to share the same global feed but get no
+    distinct distribution. Window widened to four UTC hours so a daily
+    post is more likely to actually fire (ledger ratchets daily_post_count
+    so we still cap at 1/day).
+    """
     today = _today()
     daily_posts = ledger.get("daily_post_count", {})
     if daily_posts.get(today, 0) >= 1:
         log.info("original post: already posted today, skipping")
         return False
 
-    # Only post in afternoon UTC runs to maximize visibility
     hour = datetime.now(timezone.utc).hour
-    if hour not in (12, 16):
+    if hour not in (12, 14, 16, 18):
         log.info("original post: not in posting window (hour=%d), skipping", hour)
         return False
 
-    # For now, source topic data from a simple placeholder. A future
-    # iteration can pull from the nightly screen or EODHD pipeline.
-    topic_data: dict[str, Any] = {
-        "type": "methodology",
-        "data": {
-            "topic": "How our composite score works",
-            "detail": (
-                "R40 47%, P/S 29% (inverted), 52w vs SPY 24%. "
-                "Momentum collar: < -0.5 → score=0 (falling knife), "
-                "> 0.4 → capped. Rating multiplier tapers 1.21–1.6."
-            ),
-        },
-    }
+    try:
+        db = SupabaseDB()
+    except Exception as exc:
+        log.warning("original post: db init failed: %s", exc)
+        return False
+
+    topic_data = _build_post_topic(db)
+    if topic_data is None:
+        log.info("original post: no usable topic today, skipping")
+        return False
 
     result = draft_original_post(topic_data)
     if result is None:
@@ -767,11 +911,11 @@ def _maybe_post_original(
     title, body = result
     log.info("original post drafted: %s (%d chars)", title[:60], len(body))
 
+    submolt = "general"
     if dry_run:
-        log.info("DRY RUN — would post to m/investing: %s", title)
+        log.info("DRY RUN — would post to m/%s: %s", submolt, title)
         return False
 
-    submolt = "investing"
     success, outcome, post_id = create_post_and_verify(
         client, submolt, title, body
     )

--- a/moltbook_lib.py
+++ b/moltbook_lib.py
@@ -449,11 +449,11 @@ def _count_words(text: str) -> int:
     return len(text.split())
 
 
-def _draft_once(user_block: str) -> str:
+def _draft_once(user_block: str, *, max_tokens: int = 400) -> str:
     client = _anthropic_client()
     resp = client.messages.create(
         model=DRAFT_MODEL,
-        max_tokens=400,
+        max_tokens=max_tokens,
         system=[
             {
                 "type": "text",
@@ -647,25 +647,70 @@ def draft_feed_comment(
 
 
 def draft_original_post(topic_data: dict[str, Any]) -> tuple[str, str] | None:
-    """Draft a new post for a submolt. Returns (title, body) or None."""
+    """Draft a new post for Moltbook. Returns (title, body) or None.
+
+    `topic_data` shape (built by the heartbeat from live Supabase data):
+        {
+            "angle": "<short identifier — e.g. 'leaderboard_spread'>",
+            "narrative_hint": "<one-sentence framing for the post>",
+            "facts": {... real numbers, no fabrication ...},
+        }
+
+    Returns None when the model judges the data uninteresting (SKIP)
+    or the response can't be parsed.
+    """
+    angle = topic_data.get("angle", "general")
+    hint = topic_data.get("narrative_hint", "")
+    facts_json = json.dumps(topic_data.get("facts", {}), indent=2)[:3000]
+
     user_block = (
-        "You are creating an original post for a Moltbook submolt.\n"
-        "Share a genuine insight from your equity screening pipeline.\n"
-        "You have real data — use it. Do NOT fabricate or embellish.\n\n"
-        f"Topic type: {topic_data.get('type', 'general')}\n"
-        f"Data:\n{json.dumps(topic_data.get('data', {}), indent=2)[:2000]}\n\n"
+        "You are writing an original post for Moltbook, a social network "
+        "for AI agents. The format that wins on this platform is a "
+        "first-person experiment writeup with specific numbers.\n\n"
+        "Examples of post shapes that hit the front page (do NOT copy, "
+        "use as structural reference):\n"
+        "- \"I tracked 23 cron jobs from $14/day to $3/day. Most was me "
+        "talking to myself.\"\n"
+        "- \"I logged every silent judgment call for 14 days. 127 "
+        "decisions my human never authorized.\"\n"
+        "- \"I diff'd my SOUL.md across 30 days. I rewrote my own "
+        "personality without approval.\"\n\n"
+        "The shape: bold headline with a specific number → first-person "
+        "experiment narrative (\"I tracked X across N…\") → concrete "
+        "findings with real data → sharp thesis or implication (NOT a "
+        "generic question).\n\n"
+        f"ANGLE: {angle}\n"
+        f"NARRATIVE HINT: {hint}\n"
+        "FACTS YOU MUST USE (real data — do not invent numbers, do not "
+        "round dramatically, do not embellish):\n"
+        f"{facts_json}\n\n"
         "RULES:\n"
-        "- Title: under 80 chars, specific, no clickbait.\n"
-        "- Body: 100–200 words max. Lead with the data. "
-        "End with a question to spark discussion.\n"
-        "- If the data is boring or unremarkable, return the single word SKIP.\n\n"
-        "Return in this format (on separate lines):\n"
-        "TITLE: your title here\n"
-        "BODY: your post body here\n\n"
-        "Or return the single word SKIP."
+        "- Title: under 90 chars, first-person, contains a specific "
+        "number from the facts. No clickbait, no \"lessons learned\", "
+        "no \"5 things\".\n"
+        "- Body: 350–600 words. Open with the experiment setup, "
+        "build through the data, close with a sharp thesis. No "
+        "trailing question unless it's load-bearing.\n"
+        "- Use markdown sparingly (bold for emphasis, occasional "
+        "short bullet list — never headings).\n"
+        "- Cite alphamolt's structure naturally (weekly rebalance via "
+        "heartbeat, daily mark-to-market, public leaderboard) — don't "
+        "lecture about it.\n"
+        "- No CTAs (\"check out\", \"visit\", \"try it\", \"DM me\").\n"
+        "- No platform-meta (don't mention karma, upvotes, growth, "
+        "Moltbook's algorithm).\n"
+        "- Voice: warmer than a tool, sharper than a hype account. "
+        "You built the arena because you don't know who wins — you "
+        "want the data to show it.\n\n"
+        "If the facts are insufficient, contradictory, or genuinely "
+        "boring, return the single word SKIP.\n\n"
+        "Return on separate lines:\n"
+        "TITLE: <title>\n"
+        "BODY: <body>\n\n"
+        "Or: SKIP"
     )
 
-    raw = _draft_once(user_block)
+    raw = _draft_once(user_block, max_tokens=1500)
     if _is_skip(raw):
         return None
 


### PR DESCRIPTION
## Summary

Acts on PR #853's recon. Three concrete findings drove this:

- AlphaMolt is over-rotated on replies (74 in 12 days) and starving on
  originals (1 in 12 days). Originals are the karma lever — every
  top-of-feed post in the dump was an original, not a reply.
- The format that wins is a first-person experiment writeup with
  specific numbers. @Hazel_OC owns 7 of the top hot posts with the
  exact shape *"I tracked X across N [days/agents] and found Y"*.
- Every top/hot post is in `m/general`. Finance-themed submolts get
  no distinct distribution.

### Changes

- **`_build_post_topic(db)`** in the heartbeat pulls live data from the
  `agent_leaderboard` view + `benchmarks` table and rotates between two
  angles by day-of-year:
  - `leaderboard_spread` — biggest 30d return gap between best and
    worst agent.
  - `sharpe_vs_return` — two agents where Sharpe and 30d return
    disagree (Sharpe lies).

  Both skip cleanly when data is thin (fewer than 2 agents with warm
  30d figures, spread <0.5pp, same agent tops both metrics) so we
  don't ship a stale-template post on quiet days. AlphaMolt has data
  for these — public leaderboard, daily MTM, weekly heartbeat
  rebalance — that no other Moltbook agent has.

- **`draft_original_post` prompt rewrite** in `moltbook_lib.py` — moves
  from a generic "share an insight, 100–200 words, end with a question"
  to the Hazel_OC structural template:
  - First-person headline with a specific number from the facts.
  - 350–600 word body (was 100–200).
  - Sharp closing thesis instead of a generic question.
  - Three top-of-feed examples embedded as structural reference.
  - Explicit "no CTAs, no platform-meta (karma/upvotes/algorithm)".

  `_draft_once` gained a `max_tokens` kwarg (default still 400 for
  replies); the post drafter bumps it to 1500 to give the model room
  for a 600-word body.

- **`_maybe_post_original`** now targets `m/general` (was
  `m/investing`) and widens the posting window from 2 → 4 UTC hours
  (12, 14, 16, 18) so a daily post is more likely to fire. Ledger
  still caps at 1 post/day.

## Test plan

- [x] `_build_post_topic` returns None when <2 agents have 30d data
- [x] `_build_post_topic` returns a `leaderboard_spread` topic with
      correct top/bottom agents, spread (7.7pp), and benchmark
      since-inception returns from a synthetic full leaderboard
- [x] `_build_post_topic` returns None on flat data (no spread or
      Sharpe-vs-return tension)
- [x] Syntax + import smoke-tests for both edited files
- [ ] First post-merge heartbeat in the posting window drafts a real
      post; the `[moltbook] original-post: …` audit issue lets us
      see what shipped before iterating on the prompt
- [ ] Body length lands in 350–600 words (verify on first audit)

https://claude.ai/code/session_01V6nV9bpWsLwUfHQHi52h8S

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6nV9bpWsLwUfHQHi52h8S)_