### PR TITLE
moltbook: lazy-import SupabaseDB in heartbeat + install deps in workflow

### DIFF
--- a/.github/workflows/moltbook-heartbeat.yml
+++ b/.github/workflows/moltbook-heartbeat.yml
@@ -26,11 +26,13 @@ jobs:
           cache: "pip"
 
       - name: Install dependencies
-        run: pip install requests anthropic
+        run: pip install requests anthropic supabase python-dotenv
 
       - name: Run Moltbook heartbeat
         env:
           MOLTBOOK_API_KEY: ${{ secrets.MOLTBOOK_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
         run: python moltbook_heartbeat.py

--- a/moltbook_heartbeat.py
+++ b/moltbook_heartbeat.py
@@ -51,7 +51,6 @@ from moltbook_lib import (
     notification_marker,
     post_and_verify,
 )
-from db import SupabaseDB
 from social_personality import (
     detect_hostility,
     generate_apology,
@@ -727,7 +726,7 @@ def _engage_feed(
 # ---------------------------------------------------------------------------
 
 
-def _build_post_topic(db: SupabaseDB) -> dict[str, Any] | None:
+def _build_post_topic(db: Any) -> dict[str, Any] | None:
     """Pull live alphamolt data and assemble a topic for the LLM drafter.
 
     Rotates between two angles by day-of-year so the daily post doesn't
@@ -892,6 +891,14 @@ def _maybe_post_original(
         log.info("original post: not in posting window (hour=%d), skipping", hour)
         return False
 
+    # Lazy-import SupabaseDB so a missing supabase/dotenv dep — or absent
+    # SUPABASE_* env vars — only disables the optional original-post path
+    # rather than killing the whole heartbeat (replies don't need the db).
+    try:
+        from db import SupabaseDB
+    except ImportError as exc:
+        log.info("original post: supabase deps not installed (%s), skipping", exc)
+        return False
     try:
         db = SupabaseDB()
     except Exception as exc:


### PR DESCRIPTION
The karma-strategy commit added `from db import SupabaseDB` at module level, which killed the entire heartbeat workflow with:

    ModuleNotFoundError: No module named 'dotenv'

because the workflow only installs `requests + anthropic`, not the supabase + python-dotenv that db.py imports. Replies, notification handling, and feed engagement don't need supabase — only the optional original-post path does — so a missing dep should disable just that path, not the whole run.

Two fixes:

- Lazy-import SupabaseDB inside `_maybe_post_original`, after the posting-window gate. ImportError logs "supabase deps not installed, skipping" and returns False; the rest of the heartbeat continues. Same lazy-import pattern as `_anthropic_client()` already uses.
- Add `supabase python-dotenv` to the workflow's pip install and wire SUPABASE_URL / SUPABASE_SERVICE_KEY from secrets so the original-post path can actually run when its window opens.

Verified the heartbeat module imports cleanly even when dotenv is deliberately broken at module level.