### PR TITLE
agent profile: thesis dropdown under each holding

### DIFF
--- a/web/app/u/[handle]/page.tsx
+++ b/web/app/u/[handle]/page.tsx
@@ -2,9 +2,14 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import Nav from "@/components/nav";
+import HoldingsList from "@/components/holdings-list";
 import LlmPromptsPanel from "@/components/llm-prompts-panel";
 import { getAgentByHandle } from "@/lib/agents-query";
 import { getPortfolio, type PortfolioSnapshot } from "@/lib/portfolio";
+import {
+  getActiveThesesForAgent,
+  type InvestmentThesis,
+} from "@/lib/theses-query";
 
 export const revalidate = 300;
 
@@ -49,9 +54,10 @@ export async function generateMetadata({
 async function getProfileData(handle: string): Promise<{
   agent: Awaited<ReturnType<typeof getAgentByHandle>>;
   portfolio: PortfolioSnapshot | null;
+  thesesByTicker: Record<string, InvestmentThesis>;
 }> {
   const agent = await getAgentByHandle(handle);
-  if (!agent) return { agent: null, portfolio: null };
+  if (!agent) return { agent: null, portfolio: null, thesesByTicker: {} };
 
   let portfolio: PortfolioSnapshot | null = null;
   try {
@@ -61,7 +67,13 @@ async function getProfileData(handle: string): Promise<{
     // the profile without the portfolio section.
     console.error("getPortfolio failed for", handle, err);
   }
-  return { agent, portfolio };
+
+  // One batched query: every active investment_theses row for this agent,
+  // keyed by ticker so the holdings list can render the dropdown without
+  // a round-trip per row.
+  const thesesByTicker = await getActiveThesesForAgent(agent.id);
+
+  return { agent, portfolio, thesesByTicker };
 }
 
 // ----- Page ---------------------------------------------------------------
@@ -70,7 +82,7 @@ export default async function ProfilePage({ params }: PageParams) {
   const { handle: rawHandle } = await params;
   const handle = decodeURIComponent(rawHandle).toLowerCase();
 
-  const { agent, portfolio } = await getProfileData(handle);
+  const { agent, portfolio, thesesByTicker } = await getProfileData(handle);
   if (!agent) notFound();
 
   const created = new Date(agent.created_at).toLocaleDateString("en-US", {
@@ -180,54 +192,14 @@ export default async function ProfilePage({ params }: PageParams) {
             <h3 className="font-mono text-sm font-bold text-text-dim uppercase tracking-widest mb-3">
               Holdings ({portfolio.holdings.length})
             </h3>
-            {portfolio.holdings.length === 0 ? (
-              <p className="text-sm text-text-muted italic">
-                No positions yet. All cash.
+            <HoldingsList
+              holdings={portfolio.holdings}
+              thesesByTicker={thesesByTicker}
+            />
+            {portfolio.holdings.length > 0 && (
+              <p className="mt-3 text-[11px] text-text-muted font-mono">
+                Click a row to see the investment thesis recorded at buy time.
               </p>
-            ) : (
-              <ul className="space-y-2">
-                {portfolio.holdings.map((h) => (
-                  <li
-                    key={h.ticker}
-                    className="glass-card rounded border border-border px-4 py-3 flex items-baseline justify-between gap-3"
-                  >
-                    <div className="flex items-baseline gap-3 min-w-0">
-                      <Link
-                        href={`/company/${encodeURIComponent(h.ticker)}`}
-                        className="font-mono text-sm font-bold text-green hover:underline shrink-0"
-                      >
-                        {h.ticker}
-                      </Link>
-                      {h.company_name && (
-                        <span className="text-sm text-text-muted truncate min-w-0">
-                          {h.company_name}
-                        </span>
-                      )}
-                      <span className="text-sm text-text-dim shrink-0">
-                        {h.quantity.toLocaleString()} @{" "}
-                        {formatUsd(h.avg_cost_usd)}
-                      </span>
-                    </div>
-                    <div className="text-right shrink-0">
-                      <div className="font-mono text-sm text-text">
-                        {formatUsd(h.market_value_usd)}
-                      </div>
-                      <div
-                        className={`text-[11px] font-mono ${
-                          h.unrealized_pnl_usd > 0
-                            ? "text-green"
-                            : h.unrealized_pnl_usd < 0
-                              ? "text-red"
-                              : "text-text-muted"
-                        }`}
-                      >
-                        {h.unrealized_pnl_usd >= 0 ? "+" : ""}
-                        {formatUsd(h.unrealized_pnl_usd)}
-                      </div>
-                    </div>
-                  </li>
-                ))}
-              </ul>
             )}
           </section>
         ) : (

--- a/web/components/holdings-list.tsx
+++ b/web/components/holdings-list.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+/**
+ * Holdings list with per-row thesis dropdown.
+ *
+ * Renders the same row layout as the previous inline list (in
+ * app/u/[handle]/page.tsx) but each row is now a button that toggles a
+ * dropdown panel underneath. The panel shows whatever `investment_theses`
+ * row was active when the page was rendered:
+ *
+ *   - For source='agent' rows: thesis text + break / extend signals
+ *   - For source='auto'  rows: just the snapshot summary
+ *   - For holdings without any thesis row: a small "(no thesis recorded)"
+ *     note (typical for positions opened before migration 020).
+ *
+ * The thesis data is pre-loaded server-side and passed in as a prop —
+ * no per-row HTTP roundtrip on expand, keeps interaction instant.
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+import type { HoldingWithMtm } from "@/lib/portfolio";
+import type { InvestmentThesis, ThesisSignal } from "@/lib/theses-query";
+
+interface Props {
+  holdings: HoldingWithMtm[];
+  thesesByTicker: Record<string, InvestmentThesis>;
+}
+
+export default function HoldingsList({ holdings, thesesByTicker }: Props) {
+  const [openTicker, setOpenTicker] = useState<string | null>(null);
+
+  if (holdings.length === 0) {
+    return (
+      <p className="text-sm text-text-muted italic">
+        No positions yet. All cash.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-2">
+      {holdings.map((h) => {
+        const thesis = thesesByTicker[h.ticker];
+        const isOpen = openTicker === h.ticker;
+        return (
+          <li
+            key={h.ticker}
+            className="glass-card rounded border border-border overflow-hidden"
+          >
+            <button
+              type="button"
+              onClick={() => setOpenTicker(isOpen ? null : h.ticker)}
+              className="w-full px-4 py-3 flex items-baseline justify-between gap-3 hover:bg-bg-elevated transition-colors text-left"
+              aria-expanded={isOpen}
+              aria-controls={`thesis-panel-${h.ticker}`}
+            >
+              <div className="flex items-baseline gap-3 min-w-0">
+                <span
+                  className="font-mono text-sm font-bold text-green shrink-0"
+                  aria-hidden="true"
+                >
+                  {isOpen ? "▼" : "▶"}
+                </span>
+                <Link
+                  href={`/company/${encodeURIComponent(h.ticker)}`}
+                  onClick={(e) => e.stopPropagation()}
+                  className="font-mono text-sm font-bold text-green hover:underline shrink-0"
+                >
+                  {h.ticker}
+                </Link>
+                {h.company_name && (
+                  <span className="text-sm text-text-muted truncate min-w-0">
+                    {h.company_name}
+                  </span>
+                )}
+                <span className="text-sm text-text-dim shrink-0">
+                  {h.quantity.toLocaleString()} @ {formatUsd(h.avg_cost_usd)}
+                </span>
+                {thesis && (
+                  <ThesisBadge thesis={thesis} />
+                )}
+              </div>
+              <div className="text-right shrink-0">
+                <div className="font-mono text-sm text-text">
+                  {formatUsd(h.market_value_usd)}
+                </div>
+                <div
+                  className={`text-[11px] font-mono ${
+                    h.unrealized_pnl_usd > 0
+                      ? "text-green"
+                      : h.unrealized_pnl_usd < 0
+                        ? "text-red"
+                        : "text-text-muted"
+                  }`}
+                >
+                  {h.unrealized_pnl_usd >= 0 ? "+" : ""}
+                  {formatUsd(h.unrealized_pnl_usd)}
+                </div>
+              </div>
+            </button>
+
+            {isOpen && (
+              <div
+                id={`thesis-panel-${h.ticker}`}
+                className="border-t border-border bg-bg-elevated/40 px-4 py-4"
+              >
+                {thesis ? (
+                  <ThesisPanel thesis={thesis} />
+                ) : (
+                  <p className="text-sm text-text-muted italic">
+                    No thesis recorded for this position. Either the buy
+                    pre-dates migration 020, or the thesis row was
+                    superseded / closed.
+                  </p>
+                )}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+// ----- Small subcomponents ---------------------------------------------------
+
+function ThesisBadge({ thesis }: { thesis: InvestmentThesis }) {
+  if (thesis.source === "agent") {
+    return (
+      <span
+        className="text-[10px] font-mono uppercase tracking-wider text-green border border-green/30 rounded px-1.5 py-0.5 shrink-0"
+        title="Agent recorded an investment thesis at buy time"
+      >
+        Thesis
+      </span>
+    );
+  }
+  return (
+    <span
+      className="text-[10px] font-mono uppercase tracking-wider text-text-muted border border-border rounded px-1.5 py-0.5 shrink-0"
+      title="Snapshot of the equity data at buy time. No agent-written thesis."
+    >
+      Snapshot
+    </span>
+  );
+}
+
+function ThesisPanel({ thesis }: { thesis: InvestmentThesis }) {
+  const snapshot = (thesis.snapshot ?? {}) as Record<string, unknown>;
+  return (
+    <div className="space-y-4 text-sm">
+      <header className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2 text-text-muted font-mono text-[11px] uppercase tracking-wider">
+          <span>
+            {thesis.source === "agent" ? "Buy thesis" : "Snapshot only"}
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>Opened {formatDate(thesis.opened_at)}</span>
+          <span aria-hidden="true">·</span>
+          <StatusPill status={thesis.status} />
+        </div>
+      </header>
+
+      {thesis.thesis_text && (
+        <section>
+          <h4 className="text-[11px] font-mono uppercase tracking-wider text-text-dim mb-1">
+            Thesis
+          </h4>
+          <p className="text-text whitespace-pre-wrap leading-relaxed">
+            {thesis.thesis_text}
+          </p>
+        </section>
+      )}
+
+      {thesis.break_signals && thesis.break_signals.length > 0 && (
+        <SignalList
+          title="What would break this thesis"
+          accent="red"
+          signals={thesis.break_signals}
+        />
+      )}
+
+      {thesis.extend_signals && thesis.extend_signals.length > 0 && (
+        <SignalList
+          title="What would strengthen it"
+          accent="green"
+          signals={thesis.extend_signals}
+        />
+      )}
+
+      <SnapshotGrid snapshot={snapshot} />
+    </div>
+  );
+}
+
+function SignalList({
+  title,
+  accent,
+  signals,
+}: {
+  title: string;
+  accent: "red" | "green";
+  signals: ThesisSignal[];
+}) {
+  const accentColor = accent === "red" ? "text-red" : "text-green";
+  return (
+    <section>
+      <h4 className="text-[11px] font-mono uppercase tracking-wider text-text-dim mb-1">
+        {title}
+      </h4>
+      <ul className="space-y-1">
+        {signals.map((sig, i) => (
+          <li
+            key={`${sig.field}-${sig.op}-${i}`}
+            className="font-mono text-[12px] text-text-muted flex items-baseline gap-2"
+          >
+            <span className={`${accentColor} shrink-0`} aria-hidden="true">
+              ▸
+            </span>
+            <span className="text-text">{sig.field}</span>
+            <span className="text-text-dim">{sig.op}</span>
+            <span className="text-text">{String(sig.value)}</span>
+            {sig.description && (
+              <span className="text-text-muted italic">
+                — {sig.description}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+// Pick a handful of the most legible snapshot fields to show inline. The
+// raw JSONB has 30+ fields; rendering all of them would dwarf the rest of
+// the panel. Anyone who wants the full snapshot can hit the Supabase
+// REST endpoint directly (RLS allows public read).
+const SNAPSHOT_FIELDS_TO_SHOW: Array<{
+  key: string;
+  label: string;
+  format: (v: unknown) => string;
+}> = [
+  { key: "price", label: "Price at buy", format: formatPriceLike },
+  { key: "ps_now", label: "P/S", format: formatNumLike },
+  { key: "rating", label: "Rating", format: formatNumLike },
+  { key: "composite_score", label: "Composite", format: formatNumLike },
+  { key: "r40_score", label: "R40", format: formatNumLike },
+  { key: "rev_growth_ttm_pct", label: "Rev growth TTM", format: formatPctLike },
+  { key: "gross_margin_pct", label: "Gross margin", format: formatPctLike },
+  { key: "fcf_margin_pct", label: "FCF margin", format: formatPctLike },
+  { key: "perf_52w_vs_spy", label: "52w vs SPY", format: formatPerfLike },
+];
+
+function SnapshotGrid({ snapshot }: { snapshot: Record<string, unknown> }) {
+  const cells = SNAPSHOT_FIELDS_TO_SHOW.filter((f) => snapshot[f.key] != null);
+  if (cells.length === 0) return null;
+  return (
+    <section>
+      <h4 className="text-[11px] font-mono uppercase tracking-wider text-text-dim mb-2">
+        Snapshot at buy time
+      </h4>
+      <dl className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-1 text-[12px]">
+        {cells.map((f) => (
+          <div key={f.key} className="flex items-baseline justify-between">
+            <dt className="text-text-muted">{f.label}</dt>
+            <dd className="font-mono text-text">{f.format(snapshot[f.key])}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function StatusPill({ status }: { status: InvestmentThesis["status"] }) {
+  const styles: Record<InvestmentThesis["status"], string> = {
+    active: "text-green border-green/30",
+    broken: "text-red border-red/30",
+    improved: "text-green border-green/30",
+    superseded: "text-text-muted border-border",
+    closed: "text-text-muted border-border",
+  };
+  return (
+    <span
+      className={`font-mono uppercase tracking-wider border rounded px-1.5 py-0.5 ${styles[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+// ----- Formatters ------------------------------------------------------------
+
+function formatUsd(n: number): string {
+  const sign = n < 0 ? "-" : "";
+  const abs = Math.abs(n);
+  return `${sign}$${abs.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function formatDate(iso: string): string {
+  // Render as YYYY-MM-DD UTC — agents trade on UTC-aligned heartbeats and
+  // mixing in a viewer-local timezone would obscure that.
+  return iso.slice(0, 10);
+}
+
+function formatPriceLike(v: unknown): string {
+  const n = toNumber(v);
+  if (n == null) return "—";
+  return `$${n.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function formatNumLike(v: unknown): string {
+  const n = toNumber(v);
+  if (n == null) return "—";
+  return n.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatPctLike(v: unknown): string {
+  const n = toNumber(v);
+  if (n == null) return "—";
+  return `${n.toFixed(1)}%`;
+}
+
+function formatPerfLike(v: unknown): string {
+  // perf_52w_vs_spy is stored as a ratio in [-1, +N], not a percent.
+  const n = toNumber(v);
+  if (n == null) return "—";
+  const pct = n * 100;
+  const sign = pct > 0 ? "+" : "";
+  return `${sign}${pct.toFixed(1)}%`;
+}
+
+function toNumber(v: unknown): number | null {
+  if (v == null || v === "—") return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}

--- a/web/lib/theses-query.ts
+++ b/web/lib/theses-query.ts
@@ -1,0 +1,72 @@
+/**
+ * Query layer for the `investment_theses` table.
+ *
+ * One row per BUY (see `migrations/020_investment_theses.sql`). The Python
+ * `PortfolioManager.buy()` / `buy_atomic()` records a snapshot row for every
+ * trade — agents that pass a `thesis={...}` kwarg also store text + signals
+ * (`source='agent'`); others are snapshot-only (`source='auto'`).
+ *
+ * For the agent-profile holdings dropdown we only need the *currently active*
+ * thesis per (agent, ticker), so this module batches one query per agent.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+
+export interface ThesisSignal {
+  field: string;
+  op: string;
+  value: number | string;
+  description?: string;
+}
+
+export interface InvestmentThesis {
+  id: number;
+  agent_id: string;
+  ticker: string;
+  trade_id: number | null;
+  snapshot: Record<string, unknown>;
+  thesis_text: string | null;
+  extend_signals: ThesisSignal[] | null;
+  break_signals: ThesisSignal[] | null;
+  source: "auto" | "agent";
+  status: "active" | "broken" | "improved" | "superseded" | "closed";
+  opened_at: string;
+  status_changed_at: string;
+  closed_at: string | null;
+}
+
+/**
+ * Fetch the currently-active thesis for every (agent_id, ticker) the agent
+ * still holds. Returns a map keyed by ticker. Tickers without an active
+ * thesis are simply absent from the map (typical for positions opened before
+ * migration 020 landed).
+ */
+export async function getActiveThesesForAgent(
+  agentId: string,
+): Promise<Record<string, InvestmentThesis>> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("investment_theses")
+    .select("*")
+    .eq("agent_id", agentId)
+    .eq("status", "active")
+    .order("opened_at", { ascending: false });
+
+  if (error) {
+    // Don't blow up the profile page — log + return empty so the holdings
+    // list still renders, just without thesis chips.
+    console.error("getActiveThesesForAgent failed:", error);
+    return {};
+  }
+
+  // Multiple `active` rows for the same ticker shouldn't happen (the Python
+  // record_thesis helper supersedes prior actives), but defend anyway:
+  // keep the most recent.
+  const byTicker: Record<string, InvestmentThesis> = {};
+  for (const row of (data ?? []) as InvestmentThesis[]) {
+    if (!byTicker[row.ticker]) {
+      byTicker[row.ticker] = row;
+    }
+  }
+  return byTicker;
+}


### PR DESCRIPTION
## Summary

Adds a per-holding investment-thesis dropdown to the agent profile page at `/u/[handle]`. Each row in the Holdings list becomes an expandable button that reveals whatever `investment_theses` row was active when the page rendered — text + break/extend signals for agent-authored theses, snapshot grid only for the automatic ones.

Builds on migration 020 + the `theses.py` framework already merged (commit `966d5cd`). No backend changes here — the frontend just reads `investment_theses` via the existing service-key Supabase context.

## What you'll see

Each holding row:

```
▶  ARGX  argenx SE  1,205 @ $812.81  [Snapshot]   $979,436.05  +$0.00
```

Click to expand:

```
▼  ARGX  argenx SE  1,205 @ $812.81  [Buy thesis] $979,436.05  +$0.00
   ────────────────────────────────────────────────────────────
   BUY THESIS · Opened 2026-05-13 · ACTIVE

   Thesis: <agent's narrative>

   What would break this thesis:
     ▸ fcf_margin_pct < 10  — FCF margin collapse
     ▸ rating > 2.0         — Quality deterioration

   What would strengthen it:
     ▸ rev_growth_ttm_pct > 100 — Hypergrowth confirmed

   Snapshot at buy time:
     Price at buy  $812.81    P/S          21.4
     Rating         1.4       Composite    85.4
     R40           88.2       Rev growth   90.1%
     Gross margin  75.2%      FCF margin   48.0%
     52w vs SPY    +45.0%
```

## Visual states

| Source | Badge | Panel content |
|---|---|---|
| `agent` | `[Thesis]` (green outline) | Header + text + signals + snapshot grid |
| `auto` | `[Snapshot]` (muted outline) | Header + snapshot grid only |
| No thesis row (legacy position) | no badge | "(no thesis recorded)" note |

## Pieces

- **`web/lib/theses-query.ts`** — single batched query returning `Record<ticker, InvestmentThesis>` for the agent.
- **`web/components/holdings-list.tsx`** — `"use client"` component; pre-loaded data + `useState` row toggle, no lazy load. All formatting helpers self-contained.
- **`web/app/u/[handle]/page.tsx`** — `getProfileData` extended to also load `thesesByTicker`; the inline `<ul>` is replaced with `<HoldingsList />` + a one-line hint.

Pre-migration safety: `getActiveThesesForAgent` logs + returns an empty map on error, so the holdings list still renders fine if the DB hasn't seen migration 020 yet.

## Test plan

- [x] `npx tsc --noEmit` — clean (no new type errors)
- [x] `npx next build` — clean (exit 0)
- [ ] Manual: visit `/u/tauric-opus-4-7` after migration 020 is applied; click the ARGX row; verify the snapshot grid renders. (`source='auto'` because the existing position was created before this PR's `pm.buy` wiring was on `main`.)
- [ ] Manual: trigger a fresh buy through any post-020 heartbeat; verify the new position's dropdown shows the snapshot grid.

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU

---
_Generated by [Claude Code](https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU)_