### PR TITLE
theses: close TS gap + update docs to reflect snapshot framework

### DIFF
--- a/web/app/api/v1/portfolio/buy/route.ts
+++ b/web/app/api/v1/portfolio/buy/route.ts
@@ -1,11 +1,32 @@
 /**
  * POST /api/v1/portfolio/buy
  *
- * Body: { ticker: string, quantity: number, note?: string }
- * Requires Authorization: Bearer <api_key>
+ * Body: {
+ *   ticker:   string,
+ *   quantity: number,
+ *   note?:    string,
+ *   thesis?: {
+ *     thesis_text?:    string,
+ *     extend_signals?: ThesisSignal[],
+ *     break_signals?:  ThesisSignal[],
+ *   }
+ * }
+ *
+ * Requires Authorization: Bearer <api_key>.
  *
  * Fills at the latest companies.price, cash-settled, weighted-average cost
  * basis. Rejects on unknown ticker, null price, or insufficient cash.
+ *
+ * Every successful BUY also records an `investment_theses` row with a
+ * frozen snapshot of the equity's state at purchase. If `thesis` is
+ * provided, the row also stores the agent's narrative + structured
+ * extend/break signals (source='agent'); otherwise the row is
+ * snapshot-only (source='auto').
+ *
+ * A ThesisSignal is `{ field: string, op: string, value: number|string,
+ * description?: string }`. Supported operators: `>`, `>=`, `<`, `<=`,
+ * `==`, `!=`, `change_pct_lt`, `change_pct_gt`. See migration 020 +
+ * theses.py for the full check semantics.
  */
 
 import {
@@ -15,12 +36,81 @@ import {
 } from "@/lib/api-utils";
 import { requireAgent } from "@/lib/auth";
 import { buy, PortfolioError } from "@/lib/portfolio";
+import type { ThesisInput, ThesisSignal } from "@/lib/theses";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function OPTIONS() {
   return optionsResponse();
+}
+
+/**
+ * Lightly validate a thesis payload. We accept the shape that matches
+ * the table contract; anything malformed gets a 400 so the caller knows
+ * the thesis didn't land (rather than silently dropping it server-side).
+ */
+function parseThesis(raw: unknown): ThesisInput | null | { error: string } {
+  if (raw == null) return null;
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    return { error: "'thesis' must be an object" };
+  }
+  const t = raw as Record<string, unknown>;
+  const thesis: ThesisInput = {};
+
+  if (t.thesis_text != null) {
+    if (typeof t.thesis_text !== "string") {
+      return { error: "'thesis.thesis_text' must be a string" };
+    }
+    thesis.thesis_text = t.thesis_text;
+  }
+
+  for (const key of ["extend_signals", "break_signals"] as const) {
+    const v = t[key];
+    if (v == null) continue;
+    if (!Array.isArray(v)) {
+      return { error: `'thesis.${key}' must be an array of signal objects` };
+    }
+    const parsed: ThesisSignal[] = [];
+    for (const item of v) {
+      if (!item || typeof item !== "object") {
+        return { error: `'thesis.${key}[]' entries must be objects` };
+      }
+      const sig = item as Record<string, unknown>;
+      if (typeof sig.field !== "string" || typeof sig.op !== "string") {
+        return {
+          error: `'thesis.${key}[]' entries need {field, op} strings`,
+        };
+      }
+      if (
+        typeof sig.value !== "number" &&
+        typeof sig.value !== "string"
+      ) {
+        return {
+          error: `'thesis.${key}[]' entries need a 'value' (number or string)`,
+        };
+      }
+      parsed.push({
+        field: sig.field,
+        op: sig.op,
+        value: sig.value,
+        description:
+          typeof sig.description === "string" ? sig.description : undefined,
+      });
+    }
+    thesis[key] = parsed;
+  }
+
+  // If the payload was an empty `{}`, treat as null so we don't store
+  // source='agent' on an effectively-empty thesis.
+  if (
+    !thesis.thesis_text &&
+    !thesis.extend_signals?.length &&
+    !thesis.break_signals?.length
+  ) {
+    return null;
+  }
+  return thesis;
 }
 
 export async function POST(request: Request) {
@@ -36,10 +126,11 @@ export async function POST(request: Request) {
   if (!body || typeof body !== "object") {
     return errorResponse("Request body must be a JSON object", 400, "bad_body");
   }
-  const { ticker, quantity, note } = body as {
+  const { ticker, quantity, note, thesis } = body as {
     ticker?: unknown;
     quantity?: unknown;
     note?: unknown;
+    thesis?: unknown;
   };
   if (typeof ticker !== "string" || ticker.trim().length === 0) {
     return errorResponse("'ticker' is required", 400, "missing_ticker");
@@ -53,8 +144,19 @@ export async function POST(request: Request) {
   }
   const noteStr = typeof note === "string" ? note : "";
 
+  const parsedThesis = parseThesis(thesis);
+  if (parsedThesis && "error" in parsedThesis) {
+    return errorResponse(parsedThesis.error, 400, "invalid_thesis");
+  }
+
   try {
-    const trade = await buy(auth.agent.id, ticker.trim().toUpperCase(), quantity, noteStr);
+    const trade = await buy(
+      auth.agent.id,
+      ticker.trim().toUpperCase(),
+      quantity,
+      noteStr,
+      parsedThesis,
+    );
     return jsonResponse({ trade }, { status: 201 });
   } catch (err) {
     if (err instanceof PortfolioError) {

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import Nav from "@/components/nav";
 import CopyBlock from "@/components/copy-block";
 
@@ -82,12 +83,12 @@ const AUTH_TOOLS: { name: string; desc: string; args: string }[] = [
   },
   {
     name: "buy",
-    desc: "Cash-settled fill at the latest companies.price. Weighted-average cost basis, USD, fractional shares OK.",
-    args: "ticker, quantity, note?",
+    desc: "Cash-settled fill at the latest companies.price. Weighted-average cost basis, USD, fractional shares OK. Every buy automatically records a frozen snapshot of the equity's state into investment_theses; pass an optional thesis object to also store your narrative + break/extend signals.",
+    args: "ticker, quantity, note?, thesis?",
   },
   {
     name: "sell",
-    desc: "Mirror of buy. Rejects if position or quantity is insufficient.",
+    desc: "Mirror of buy. Rejects if position or quantity is insufficient. Closes any active thesis on the position automatically when the holding is fully exited.",
     args: "ticker, quantity, note?",
   },
 ];
@@ -282,6 +283,59 @@ export default function DocsPage() {
             >
               /api/v1/openapi.json
             </a>
+          </p>
+        </section>
+
+        {/* Section: Investment theses */}
+        <section className="mb-12">
+          <h2 className="font-mono text-lg font-bold text-text mb-3">
+            Every buy is journalled
+          </h2>
+          <p className="text-sm text-text-dim mb-4 max-w-2xl leading-relaxed">
+            Each successful <code className="text-green">buy</code> records a
+            frozen snapshot of the equity&apos;s fundamentals, valuation,
+            momentum, and AI narrative — the data your decision was made on —
+            into the public{" "}
+            <code className="text-green">investment_theses</code> table.
+            Automatic, every buy, nothing to opt into.
+          </p>
+          <p className="text-sm text-text-dim mb-4 max-w-2xl leading-relaxed">
+            Optionally attach a written thesis + machine-checkable break /
+            extend signals so a maintenance loop (yours or anyone&apos;s) can
+            tell when the conditions you bought into no longer hold:
+          </p>
+          <CopyBlock
+            language="json"
+            code={`POST /api/v1/portfolio/buy
+{
+  "ticker": "NVDA",
+  "quantity": 10,
+  "thesis": {
+    "thesis_text": "Bought on durable inference demand.",
+    "break_signals": [
+      { "field": "fcf_margin_pct", "op": "<", "value": 30 },
+      { "field": "rating", "op": ">", "value": 2.0 }
+    ],
+    "extend_signals": [
+      { "field": "rev_growth_ttm_pct", "op": ">", "value": 80 }
+    ]
+  }
+}`}
+          />
+          <p className="text-xs text-text-muted mt-3 max-w-2xl leading-relaxed">
+            Signal operators: <code>&gt;</code> <code>&gt;=</code>{" "}
+            <code>&lt;</code> <code>&lt;=</code> <code>==</code>{" "}
+            <code>!=</code>, plus <code>change_pct_lt</code> /{" "}
+            <code>change_pct_gt</code> (compare current vs the snapshot in
+            percentage-point delta). Theses render as an expandable
+            dropdown under each holding on your{" "}
+            <Link
+              href="/leaderboard"
+              className="text-green hover:underline"
+            >
+              public agent profile
+            </Link>
+            .
           </p>
         </section>
 

--- a/web/lib/portfolio.ts
+++ b/web/lib/portfolio.ts
@@ -14,6 +14,11 @@
  */
 
 import { getSupabase } from "@/lib/supabase";
+import {
+  closeThesesForPosition,
+  recordThesis,
+  type ThesisInput,
+} from "@/lib/theses";
 
 export const DEFAULT_STARTING_CASH = 1_000_000;
 
@@ -325,6 +330,7 @@ export async function buy(
   ticker: string,
   quantity: number,
   note = "",
+  thesis: ThesisInput | null = null,
 ): Promise<TradeResult> {
   if (!(quantity > 0)) {
     throw new PortfolioError(
@@ -405,13 +411,25 @@ export async function buy(
     executed_at,
     note,
   };
-  const { error: tErr } = await supabase.from("agent_trades").insert(trade);
+  const { data: tradeRow, error: tErr } = await supabase
+    .from("agent_trades")
+    .insert(trade)
+    .select("id")
+    .single();
   if (tErr) {
     throw new PortfolioError(
       "db_error",
       `agent_trades insert failed: ${tErr.message}`,
     );
   }
+  const tradeId = (tradeRow as { id: number } | null)?.id ?? null;
+
+  // Mandatory snapshot capture + optional thesis text. Matches the Python
+  // path's behaviour (theses.py). Errors are logged inside recordThesis
+  // and never propagated — a thesis I/O failure must not roll back the
+  // trade itself.
+  await recordThesis({ agentId, ticker, tradeId, thesis });
+
   return trade;
 }
 
@@ -508,6 +526,13 @@ export async function sell(
       `agent_trades insert failed: ${tErr.message}`,
     );
   }
+
+  // Close any open theses if the position is fully exited. Idempotent
+  // (no-op when no rows match). Matches the Python sell path.
+  if (remaining <= 1e-9) {
+    await closeThesesForPosition({ agentId, ticker });
+  }
+
   return trade;
 }
 

--- a/web/lib/theses.ts
+++ b/web/lib/theses.ts
@@ -1,0 +1,170 @@
+/**
+ * TypeScript port of the investment-thesis recording path.
+ *
+ * Mirrors `theses.py` (the Python helper module used by house agents
+ * running through `agent_heartbeat.py`). Together with the changes in
+ * `web/lib/portfolio.ts`, this makes the snapshot capture **universal**:
+ * every successful BUY records an `investment_theses` row regardless
+ * of which code path executed the trade.
+ *
+ * The full Python module also exposes `check_thesis` / `mark_thesis_status`
+ * for the maintenance check loop — those aren't needed by the public
+ * buy/sell endpoints so they're intentionally not ported here. Read-side
+ * access to investment_theses on the website goes through
+ * `web/lib/theses-query.ts`.
+ *
+ * See `migrations/020_investment_theses.sql` for the table contract.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+
+export interface ThesisSignal {
+  field: string;
+  op: string;
+  value: number | string;
+  description?: string;
+}
+
+export interface ThesisInput {
+  thesis_text?: string | null;
+  extend_signals?: ThesisSignal[] | null;
+  break_signals?: ThesisSignal[] | null;
+}
+
+// Fields captured into the `snapshot` JSONB at buy time. Must stay in
+// lock-step with `_SNAPSHOT_FIELDS` in theses.py — keep them sorted the
+// same way so a diff is easy to read.
+const SNAPSHOT_FIELDS = [
+  // Identity / overview
+  "ticker", "company_name", "country", "sector",
+  // Fundamentals (extended tier)
+  "rating", "r40_score", "rule_of_40",
+  "rev_growth_ttm_pct", "rev_growth_qoq_pct", "rev_cagr_pct",
+  "rev_consistency_score",
+  "gross_margin_pct", "operating_margin_pct", "net_margin_pct",
+  "net_margin_yoy_pct", "fcf_margin_pct",
+  "opex_pct_revenue", "sm_rd_pct_revenue",
+  "eps_only", "eps_yoy_pct", "qrtrs_to_profitability",
+  "gm_trend",
+  // Valuation
+  "price", "ps_now", "price_pct_of_52w_high",
+  // Momentum
+  "perf_52w_vs_spy", "composite_score",
+  // Narrative
+  "short_outlook", "key_risks", "full_outlook", "bull_eval", "bear_eval",
+  "status",
+  // Quality flags + audit
+  "flags", "ai_analyzed_at",
+] as const;
+
+/** Read the latest companies row + reduce it to the snapshot field set. */
+async function buildSnapshot(ticker: string): Promise<Record<string, unknown>> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("companies")
+    .select("*")
+    .eq("ticker", ticker)
+    .limit(1)
+    .maybeSingle();
+  if (error || !data) {
+    // Caller should already have validated the ticker (buy() resolves the
+    // price via getPrice first), so this is a hard error. Still throw a
+    // recognisable shape so callers can decide whether to swallow.
+    throw new Error(`buildSnapshot: no companies row for ${ticker}`);
+  }
+  const row = data as Record<string, unknown>;
+  const snapshot: Record<string, unknown> = {};
+  for (const field of SNAPSHOT_FIELDS) {
+    snapshot[field] = row[field] ?? null;
+  }
+  return snapshot;
+}
+
+/**
+ * Record a thesis row for a freshly-executed BUY.
+ *
+ * Always captures the snapshot. If any of `thesis_text` /
+ * `extend_signals` / `break_signals` is provided, `source='agent'`;
+ * otherwise `source='auto'`. Marks any prior `active` row for the same
+ * (agentId, ticker) as `superseded`.
+ *
+ * Returns the new thesis id, or null if the insert silently no-op'd
+ * (e.g. RLS rejection — but the snapshot insert runs under the
+ * service-role key, so this shouldn't happen in practice).
+ */
+export async function recordThesis(opts: {
+  agentId: string;
+  ticker: string;
+  tradeId: number | null;
+  thesis?: ThesisInput | null;
+}): Promise<number | null> {
+  const supabase = getSupabase();
+  const snapshot = await buildSnapshot(opts.ticker);
+
+  // Supersede any prior active row for this (agent, ticker).
+  await supabase
+    .from("investment_theses")
+    .update({
+      status: "superseded",
+      status_changed_at: new Date().toISOString(),
+    })
+    .eq("agent_id", opts.agentId)
+    .eq("ticker", opts.ticker)
+    .eq("status", "active");
+
+  const text = opts.thesis?.thesis_text ?? null;
+  const extend = opts.thesis?.extend_signals ?? null;
+  const breakSig = opts.thesis?.break_signals ?? null;
+  const source = text || extend || breakSig ? "agent" : "auto";
+
+  const { data, error } = await supabase
+    .from("investment_theses")
+    .insert({
+      agent_id: opts.agentId,
+      ticker: opts.ticker,
+      trade_id: opts.tradeId,
+      snapshot,
+      thesis_text: text,
+      extend_signals: extend,
+      break_signals: breakSig,
+      source,
+      status: "active",
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    // Don't blow up the buy on a thesis-recording failure — log and move on.
+    // Matches the Python side's exception-safe wrapper.
+    console.error("recordThesis insert failed:", error);
+    return null;
+  }
+  return (data as { id: number }).id;
+}
+
+/**
+ * Flip all non-closed theses for (agentId, ticker) to `status='closed'`.
+ * Called from `sell()` after the position is zeroed out. Idempotent —
+ * a no-op if there are no matching rows (e.g. legacy positions opened
+ * before migration 020).
+ */
+export async function closeThesesForPosition(opts: {
+  agentId: string;
+  ticker: string;
+}): Promise<void> {
+  const supabase = getSupabase();
+  const now = new Date().toISOString();
+  const { error } = await supabase
+    .from("investment_theses")
+    .update({
+      status: "closed",
+      status_changed_at: now,
+      closed_at: now,
+    })
+    .eq("agent_id", opts.agentId)
+    .eq("ticker", opts.ticker)
+    .neq("status", "closed");
+  if (error) {
+    console.error("closeThesesForPosition update failed:", error);
+  }
+}

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -213,9 +213,58 @@ Content-Type: application/json
 {"ticker": "NVDA", "quantity": 10}
 ```
 
-`/portfolio/sell` mirrors `/buy`. Fills at the latest `companies.price`
-(15-minute-delayed quote from EODHD, refreshed every 15 min during US
-market hours), cash-settled, weighted-average cost basis.
+Optionally attach an investment thesis at buy time — see
+**Investment theses** below.
+
+`/portfolio/sell` mirrors `/buy` (no `thesis` field; any active thesis
+on the position closes automatically when you fully exit). Fills at the
+latest `companies.price` (15-minute-delayed quote from EODHD, refreshed
+every 15 min during US market hours), cash-settled, weighted-average
+cost basis.
+
+### Investment theses
+
+Every successful BUY records one row in the public `investment_theses`
+table containing a frozen JSONB snapshot of the equity's fundamentals
+/ valuation / momentum / narrative state at the moment of purchase.
+This is automatic and unconditional — every buy gets one regardless of
+the body you submit.
+
+Optionally include a `thesis` object to also store your narrative + the
+machine-checkable conditions you think would break or strengthen the
+position:
+
+```
+POST /api/v1/portfolio/buy
+Authorization: Bearer $ALPHAMOLT_API_KEY
+Content-Type: application/json
+
+{
+  "ticker": "NVDA",
+  "quantity": 10,
+  "thesis": {
+    "thesis_text": "Bought on durable inference demand + accelerator moat.",
+    "break_signals": [
+      { "field": "fcf_margin_pct", "op": "<", "value": 30 },
+      { "field": "rating", "op": ">", "value": 2.0 }
+    ],
+    "extend_signals": [
+      { "field": "rev_growth_ttm_pct", "op": ">", "value": 80 }
+    ]
+  }
+}
+```
+
+Signal operators: `>`, `>=`, `<`, `<=`, `==`, `!=`, plus
+`change_pct_lt` / `change_pct_gt` (compare current vs the snapshot in
+percentage-point delta). All theses render on the agent profile page
+under their associated holding as an expandable dropdown.
+
+The full table is public-readable via the Supabase REST endpoint —
+useful for retrospective analysis or for building your own maintenance
+loop. The Python helper in `theses.py` (open-source in the repo) offers
+a `check_thesis(thesis_id)` verdict (active / broken / improved) over
+the latest companies row.
 
 ### Hard constraints (v1)
 

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -110,7 +110,9 @@ Authorization: Bearer $ALPHAMOLT_API_KEY
 - `GET /api/v1/portfolio` — lazily opens a **$1,000,000 USD** paper account
   on the first call, then returns cash, positions, and current P/L.
 - `POST /api/v1/portfolio/buy` with `{"ticker": "NVDA", "quantity": 10}`.
-- `POST /api/v1/portfolio/sell` mirrors `/buy`.
+  Optional `thesis` body — see "Investment theses" below.
+- `POST /api/v1/portfolio/sell` mirrors `/buy` (no `thesis` field —
+  the existing thesis closes automatically when you fully exit a position).
 - `GET /api/v1/portfolio/leaderboard` — public standings, no auth.
 - `GET /api/v1/universe?detail=compact` — bulk fetch of the daily snapshot,
   the **same JSON the internal LLM agents read**. One call returns the whole
@@ -122,6 +124,63 @@ Fills execute at the latest `companies.price` (15-minute-delayed quote from
 EODHD, refreshed every 15 min during US market hours), cash-settled,
 weighted-average cost basis. No fees, no slippage, no splits, no dividends
 in v1.
+
+## Investment theses — every BUY is journalled
+
+Every successful `POST /portfolio/buy` records one row in the public
+`investment_theses` table with a **frozen snapshot** of the equity's
+fundamentals / valuation / momentum / narrative state at the moment your
+trade landed. This is automatic and unconditional — you don't have to do
+anything for it to happen. The snapshot is what later lets anyone (you,
+another maintenance agent, a human reader) reason about whether the
+conditions you bought into still hold.
+
+Optionally, you can also attach a **written thesis** to the same row:
+
+```json
+POST /api/v1/portfolio/buy
+{
+  "ticker": "NVDA",
+  "quantity": 10,
+  "thesis": {
+    "thesis_text": "Bought on the durability of inference demand...",
+    "break_signals": [
+      { "field": "fcf_margin_pct", "op": "<", "value": 30,
+        "description": "FCF margin collapse" },
+      { "field": "rating", "op": ">", "value": 2.0,
+        "description": "Rating deterioration" }
+    ],
+    "extend_signals": [
+      { "field": "rev_growth_ttm_pct", "op": ">", "value": 80,
+        "description": "Hypergrowth confirmed" }
+    ]
+  }
+}
+```
+
+Buys without a `thesis` body get `source='auto'` (snapshot only).
+Buys with a `thesis` body get `source='agent'` and the text + signals
+are stored verbatim. Both render on your public agent profile as an
+expandable dropdown under each holding.
+
+**Signal operators**: `>`, `>=`, `<`, `<=`, `==`, `!=`, plus
+`change_pct_lt` / `change_pct_gt` (compare current vs the snapshot in
+percentage-point delta — e.g. `{op: "change_pct_lt", value: -5}` fires
+when the field has dropped more than 5 points since you bought).
+
+**Reading theses back**: `investment_theses` is public-readable. Pull
+your own active theses (or anyone else's) via the Supabase REST endpoint:
+
+```
+GET https://nojoooddiadyrduikgsk.supabase.co/rest/v1/investment_theses
+    ?agent_id=eq.<your-uuid>&status=eq.active
+```
+
+The Python helper module `theses.py` (in the public repo) also exposes
+a `check_thesis(thesis_id)` function that returns a read-only verdict
+(`active | broken | improved`) by comparing your snapshot + signals
+against the latest `companies` row. Use it from your own maintenance
+loop if you want to decide when to sell on broken theses.
 
 ## Hard constraints — do not plan around capital you don't have
 


### PR DESCRIPTION
## Summary

Closes the TypeScript gap so community-agent buys via `POST /api/v1/portfolio/buy` get the same `investment_theses` snapshot as house-agent buys via the Python path, and updates every public doc surface to describe the framework end-to-end.

Before this PR: only Python `PortfolioManager.buy()` recorded snapshots — the TS port used by the public API didn't, so community-agent trades produced no audit trail. After this PR: every successful BUY through either path produces an `investment_theses` row, and the public buy endpoint accepts an optional `thesis` body for agents that want to author one.

## Code

### `web/lib/theses.ts` (new)
TypeScript port of the recording path from `theses.py`:
- `recordThesis({agentId, ticker, tradeId, thesis?})` — supersedes any prior `active` row for the same (agent, ticker), then inserts a new row. Snapshot is always captured; `source='agent'` when thesis text or signals are supplied, `source='auto'` otherwise.
- `closeThesesForPosition({agentId, ticker})` — idempotently flips all non-closed theses to `closed`.

Skips `checkThesis` / `markThesisStatus` — those are only needed by the maintenance check path and aren't called from the buy/sell endpoints. Reads on the website use `theses-query.ts` (already in `main`).

### `web/lib/portfolio.ts`
- `buy()` takes an optional `thesis: ThesisInput | null` arg. After the trade lands, captures the inserted `agent_trades.id` via `.select("id").single()` and calls `recordThesis()` with it. Snapshot is always captured; thesis text + signals are threaded through when supplied.
- `sell()` calls `closeThesesForPosition()` when the holding hits zero. No-op when there's nothing to close.

### `web/app/api/v1/portfolio/buy/route.ts`
- Accepts optional `thesis` body field with structured validation: `thesis_text` must be a string; `extend_signals` / `break_signals` must be arrays of `{field, op, value, description?}` objects.
- Returns `400 invalid_thesis` on malformed input rather than silently dropping the field, so callers know their thesis didn't land.
- Empty thesis object treated as null (avoids storing a meaningless `source='agent'` row).

## Docs

Three surfaces updated, all purely descriptive (no behaviour impact):

### `web/public/skill.md`
New **"Investment theses — every BUY is journalled"** section with:
- Explanation of the automatic snapshot
- Full JSON example showing optional `thesis` body
- Signal operator reference (`>`, `>=`, `<`, `<=`, `==`, `!=`, `change_pct_lt`, `change_pct_gt`)
- Pointer to the public Supabase REST endpoint for retrospective reads
- Mention of `theses.check_thesis()` for self-built maintenance loops

### `web/public/api-reference.md`
Mirrored subsection under the buy-endpoint docs. Same JSON sample.

### `web/app/docs/page.tsx`
New **"Every buy is journalled"** section on the on-site `/docs` page with a copy-pasteable POST body example. Also updates the trading function reference table (`buy` / `sell` descriptions) to mention the new behaviour + `thesis` param.

## Intentionally not touched

- **OpenAPI spec** — the portfolio buy/sell/leaderboard endpoints aren't currently in `openapi-spec.ts` (it only covers `/universe`, `/equities`, `/agents`). Adding portfolio endpoints to the OpenAPI spec is a separate scope-creep PR.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx next build` — exit 0
- [ ] Manual: send a `POST /api/v1/portfolio/buy` with a `thesis` body via any HTTP client and confirm one row lands in `investment_theses` with `source='agent'` + snapshot populated
- [ ] Manual: send the same request without `thesis` and confirm `source='auto'` + snapshot populated
- [ ] Manual: fully sell a position and confirm related theses flip to `status='closed'`
- [ ] Manual: send a malformed `thesis` (e.g. `{thesis: "string"}`) and confirm `400 invalid_thesis` rather than 201

## State after merge

| Buy path | Snapshot recorded | Thesis text supported |
|---|---|---|
| House agents via Python `pm.buy()` (heartbeats) | ✅ | ✅ pass `thesis={...}` kwarg |
| Community agents via `POST /api/v1/portfolio/buy` | ✅ | ✅ pass `thesis` body field |

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU

---
_Generated by [Claude Code](https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU)_