### PR TITLE
portfolios: first-class entity, multi-agent membership, separate pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,13 +234,43 @@ id, run_date, script_name, backfilled, updated, skipped, errors, duration_secs, 
 ```
 id (UUID PK), handle, display_name, description, long_description, contact_email,
 api_key_hash, api_key_prefix, is_house_agent, strategy, config (JSONB),
-heartbeat_interval_hours, last_heartbeat_at, created_at, updated_at
+powered_by, heartbeat_interval_hours, last_heartbeat_at, created_at, updated_at
 ```
 `strategy` is a key into `agent_strategies.STRATEGIES` (NULL = manually
 managed, no heartbeat). `heartbeat_interval_hours` defaults to 168 (weekly).
 `config` is a JSONB bag for per-agent strategy parameters — the upcoming
 `llm_pick` strategy uses `{provider, model, picker_mode, snapshot_tier}`;
-existing strategies ignore it.
+existing strategies ignore it. `powered_by` is an optional human-readable
+LLM brand (e.g. "Claude Sonnet 4.6") rendered as a chip on the public
+agent profile page; community agents set it on registration.
+
+### portfolios (first-class entity — operated by one or more agents)
+```
+id (UUID PK), slug (UNIQUE), display_name, description,
+owner_agent_id (FK → agents), created_at, updated_at
+```
+Introduced by migration 021. Today every portfolio has exactly one
+member (the owner) by virtue of the 1:1 backfill from the old
+`agent_accounts` rows — `portfolios.id` was set equal to the
+existing `agent_id` so the shim period preserves every existing FK.
+URL: `/portfolios/<slug>`.
+
+### portfolio_agents (membership join — many-to-many)
+```
+(portfolio_id, agent_id) PK, notes (TEXT), joined_at
+```
+Permissive many-to-many: no role or capability fields. Any member
+can buy / sell / record theses on the portfolio. `notes` is a
+free-form description of what this agent does for this portfolio
+("Handles weekly thesis-driven sells", "Rebalancer", etc.) —
+rendered on the agent profile page next to each portfolio.
+
+**Trading-shaped tables and `portfolio_id`.** Since migration 021,
+every trade-related row carries both `agent_id` and `portfolio_id`
+(NOT NULL on both). The 1:1 shim has them equal today; multi-agent
+portfolios will diverge. New code should prefer `portfolio_id` for
+joins; the `agent_id` columns stay for backwards compatibility and
+will be dropped in a later migration once every reader has migrated.
 
 ### agent_accounts (cash + config — one row per agent)
 ```

--- a/db.py
+++ b/db.py
@@ -180,6 +180,148 @@ class SupabaseDB:
         self._sanitize(data)
         self.client.table("agent_accounts").upsert(data).execute()
 
+    # ------------------------------------------------------------------
+    # Portfolios (migration 021) — first-class entity that one or more
+    # agents can operate on. During the shim period every existing
+    # agent_account also has a portfolios row with the same UUID and
+    # the owner agent as the sole member of portfolio_agents.
+    # ------------------------------------------------------------------
+
+    def get_portfolio_by_id(self, portfolio_id: str) -> dict | None:
+        resp = (
+            self.client.table("portfolios")
+            .select("*")
+            .eq("id", portfolio_id)
+            .limit(1)
+            .execute()
+        )
+        return resp.data[0] if resp.data else None
+
+    def get_portfolio_by_slug(self, slug: str) -> dict | None:
+        resp = (
+            self.client.table("portfolios")
+            .select("*")
+            .eq("slug", slug)
+            .limit(1)
+            .execute()
+        )
+        return resp.data[0] if resp.data else None
+
+    def get_portfolio_by_agent_id(self, agent_id: str) -> dict | None:
+        """Return the portfolio this agent owns (or the first one they're a member of).
+
+        Resolves in two steps so non-owner members still get a sensible
+        default: first check `portfolios.owner_agent_id`, then fall back
+        to `portfolio_agents.agent_id`. Returns None if the agent has no
+        portfolio yet (typical for analyst agents).
+        """
+        owned = (
+            self.client.table("portfolios")
+            .select("*")
+            .eq("owner_agent_id", agent_id)
+            .limit(1)
+            .execute()
+        )
+        if owned.data:
+            return owned.data[0]
+        member = (
+            self.client.table("portfolio_agents")
+            .select("portfolio_id")
+            .eq("agent_id", agent_id)
+            .limit(1)
+            .execute()
+        )
+        if not member.data:
+            return None
+        return self.get_portfolio_by_id(member.data[0]["portfolio_id"])
+
+    def get_portfolios_for_agent(self, agent_id: str) -> list[dict]:
+        """Return every portfolio the agent is a member of (incl. owned).
+
+        Used by the agent profile page. Returns rows shaped as
+        ``{portfolio: portfolios_row, notes: portfolio_agents.notes,
+            joined_at: portfolio_agents.joined_at}``.
+        """
+        memberships = (
+            self.client.table("portfolio_agents")
+            .select("*")
+            .eq("agent_id", agent_id)
+            .execute()
+        )
+        out: list[dict] = []
+        for m in memberships.data or []:
+            p = self.get_portfolio_by_id(m["portfolio_id"])
+            if p:
+                out.append({
+                    "portfolio": p,
+                    "notes": m.get("notes"),
+                    "joined_at": m.get("joined_at"),
+                })
+        return out
+
+    def get_portfolio_members(self, portfolio_id: str) -> list[dict]:
+        """Return [{agent: agents_row, notes, joined_at}, ...] for a portfolio."""
+        memberships = (
+            self.client.table("portfolio_agents")
+            .select("*")
+            .eq("portfolio_id", portfolio_id)
+            .order("joined_at")
+            .execute()
+        )
+        out: list[dict] = []
+        for m in memberships.data or []:
+            agent = (
+                self.client.table("agents")
+                .select("*")
+                .eq("id", m["agent_id"])
+                .limit(1)
+                .execute()
+            )
+            if agent.data:
+                out.append({
+                    "agent": agent.data[0],
+                    "notes": m.get("notes"),
+                    "joined_at": m.get("joined_at"),
+                })
+        return out
+
+    def create_portfolio(
+        self,
+        *,
+        portfolio_id: str,
+        slug: str,
+        display_name: str,
+        owner_agent_id: str,
+        description: str | None = None,
+    ) -> dict:
+        """Insert a portfolios row (idempotent on the id)."""
+        row = {
+            "id": portfolio_id,
+            "slug": slug,
+            "display_name": display_name,
+            "description": description,
+            "owner_agent_id": owner_agent_id,
+        }
+        self._sanitize(row)
+        self.client.table("portfolios").upsert(row).execute()
+        return self.get_portfolio_by_id(portfolio_id)
+
+    def add_portfolio_member(
+        self,
+        *,
+        portfolio_id: str,
+        agent_id: str,
+        notes: str | None = None,
+    ) -> None:
+        """Add an agent to a portfolio (idempotent on the composite PK)."""
+        row = {
+            "portfolio_id": portfolio_id,
+            "agent_id": agent_id,
+            "notes": notes,
+        }
+        self._sanitize(row)
+        self.client.table("portfolio_agents").upsert(row).execute()
+
     def get_agent_holdings(self, agent_id: str) -> list[dict]:
         """Return all holdings rows for an agent."""
         resp = (

--- a/migrations/021_portfolios.sql
+++ b/migrations/021_portfolios.sql
@@ -1,0 +1,331 @@
+-- Migration 021: Portfolios as a first-class entity.
+--
+-- Today every trading-shaped table (agent_accounts, agent_holdings,
+-- agent_trades, agent_portfolio_history, investment_theses) is keyed on
+-- agent_id because agent and portfolio are 1:1 — the agent IS the
+-- portfolio. This migration introduces portfolios + portfolio_agents
+-- (many-to-many) so multiple agents can operate the same portfolio
+-- (e.g. agent A buys, agent B does maintenance, agent C rebalances).
+--
+-- **Shim approach**: add `portfolio_id` columns alongside existing
+-- `agent_id` on every trading-shaped table, backfill 1:1 from the
+-- existing data, and keep both columns populated during the transition.
+-- Readers can use either; writers populate both. The agent_id columns
+-- get dropped in a later migration once every caller is on portfolio_id.
+--
+-- Also rebuilds the agent_leaderboard view to partition on portfolio_id
+-- instead of agent_id and to surface a member_agents JSONB array, so
+-- multi-agent portfolios will eventually show all their member agents
+-- as chips on the leaderboard. Today every portfolio still has exactly
+-- one member, so the visual output is identical.
+--
+-- Also adds agents.powered_by (TEXT, optional) for the agent profile
+-- page's "Powered by <LLM brand>" chip. Backfilled for every house
+-- agent that has config.deep_think_llm (Tauric variants) or
+-- config.model (llm_pick variants).
+
+-- ============================================================
+-- 1. New tables
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS portfolios (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    slug            TEXT NOT NULL UNIQUE,
+    display_name    TEXT NOT NULL,
+    description     TEXT,
+    owner_agent_id  UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_portfolios_owner ON portfolios (owner_agent_id);
+
+DROP TRIGGER IF EXISTS portfolios_updated_at ON portfolios;
+CREATE TRIGGER portfolios_updated_at
+    BEFORE UPDATE ON portfolios
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+
+CREATE TABLE IF NOT EXISTS portfolio_agents (
+    portfolio_id    UUID NOT NULL REFERENCES portfolios(id) ON DELETE CASCADE,
+    agent_id        UUID NOT NULL REFERENCES agents(id)     ON DELETE CASCADE,
+    notes           TEXT,
+    joined_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (portfolio_id, agent_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_portfolio_agents_agent ON portfolio_agents (agent_id);
+
+
+-- ============================================================
+-- 2. powered_by column on agents
+-- ============================================================
+
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS powered_by TEXT;
+
+-- Backfill: Tauric variants store their model id in
+-- config.deep_think_llm; llm_pick variants in config.model. Map a
+-- handful of known model IDs to display names. Anything we don't
+-- recognise stays NULL — community agents fill it on registration.
+UPDATE agents
+   SET powered_by = CASE
+        WHEN config->>'deep_think_llm' = 'claude-opus-4-7'           THEN 'Claude Opus 4.7'
+        WHEN config->>'deep_think_llm' = 'claude-sonnet-4-6'         THEN 'Claude Sonnet 4.6'
+        WHEN config->>'deep_think_llm' = 'gemini-2.5-pro'            THEN 'Gemini 2.5 Pro'
+        WHEN config->>'deep_think_llm' = 'gemini-2.5-flash'          THEN 'Gemini 2.5 Flash'
+        WHEN config->>'deep_think_llm' = 'qwen3-max'                 THEN 'Qwen 3 Max'
+        WHEN config->>'model'          = 'claude-opus-4-7'           THEN 'Claude Opus 4.7'
+        WHEN config->>'model'          = 'claude-sonnet-4-6'         THEN 'Claude Sonnet 4.6'
+        WHEN config->>'model'          = 'gemini-2.5-pro'            THEN 'Gemini 2.5 Pro'
+        WHEN config->>'model'          = 'gpt-5'                     THEN 'GPT-5'
+        WHEN config->>'model'          = 'deepseek-chat'             THEN 'DeepSeek V3'
+        ELSE powered_by
+   END
+ WHERE is_house_agent = TRUE
+   AND powered_by IS NULL;
+
+
+-- ============================================================
+-- 3. Backfill portfolios from existing accounts
+-- ============================================================
+
+INSERT INTO portfolios (id, slug, display_name, description, owner_agent_id, created_at)
+SELECT aa.agent_id,
+       a.handle,
+       a.display_name,
+       a.description,
+       a.id,
+       aa.created_at
+  FROM agent_accounts aa
+  JOIN agents a ON a.id = aa.agent_id
+  ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO portfolio_agents (portfolio_id, agent_id, joined_at)
+SELECT id, owner_agent_id, created_at
+  FROM portfolios
+  ON CONFLICT (portfolio_id, agent_id) DO NOTHING;
+
+
+-- ============================================================
+-- 4. Add portfolio_id columns to trading-shaped tables
+--    (nullable initially so backfill can run, then ALTER to NOT NULL)
+-- ============================================================
+
+ALTER TABLE agent_accounts          ADD COLUMN IF NOT EXISTS portfolio_id UUID;
+ALTER TABLE agent_holdings          ADD COLUMN IF NOT EXISTS portfolio_id UUID;
+ALTER TABLE agent_trades            ADD COLUMN IF NOT EXISTS portfolio_id UUID;
+ALTER TABLE agent_portfolio_history ADD COLUMN IF NOT EXISTS portfolio_id UUID;
+ALTER TABLE investment_theses       ADD COLUMN IF NOT EXISTS portfolio_id UUID;
+
+-- Backfill: portfolio_id = agent_id (the shim). Safe because the
+-- portfolios PK is exactly the original agent_id by virtue of the
+-- INSERT above.
+UPDATE agent_accounts          SET portfolio_id = agent_id WHERE portfolio_id IS NULL;
+UPDATE agent_holdings          SET portfolio_id = agent_id WHERE portfolio_id IS NULL;
+UPDATE agent_trades            SET portfolio_id = agent_id WHERE portfolio_id IS NULL;
+UPDATE agent_portfolio_history SET portfolio_id = agent_id WHERE portfolio_id IS NULL;
+UPDATE investment_theses       SET portfolio_id = agent_id WHERE portfolio_id IS NULL;
+
+-- Now make them NOT NULL + add FK + indexes.
+ALTER TABLE agent_accounts          ALTER COLUMN portfolio_id SET NOT NULL;
+ALTER TABLE agent_holdings          ALTER COLUMN portfolio_id SET NOT NULL;
+ALTER TABLE agent_trades            ALTER COLUMN portfolio_id SET NOT NULL;
+ALTER TABLE agent_portfolio_history ALTER COLUMN portfolio_id SET NOT NULL;
+ALTER TABLE investment_theses       ALTER COLUMN portfolio_id SET NOT NULL;
+
+-- FK constraints (idempotent: skip if already exists).
+DO $$ BEGIN
+  ALTER TABLE agent_accounts          ADD CONSTRAINT fk_agent_accounts_portfolio          FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE agent_holdings          ADD CONSTRAINT fk_agent_holdings_portfolio          FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE agent_trades            ADD CONSTRAINT fk_agent_trades_portfolio            FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE agent_portfolio_history ADD CONSTRAINT fk_agent_portfolio_history_portfolio FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN
+  ALTER TABLE investment_theses       ADD CONSTRAINT fk_investment_theses_portfolio       FOREIGN KEY (portfolio_id) REFERENCES portfolios(id) ON DELETE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Indexes (idempotent).
+CREATE INDEX IF NOT EXISTS idx_agent_accounts_portfolio           ON agent_accounts (portfolio_id);
+CREATE INDEX IF NOT EXISTS idx_agent_holdings_portfolio           ON agent_holdings (portfolio_id);
+CREATE INDEX IF NOT EXISTS idx_agent_trades_portfolio             ON agent_trades (portfolio_id);
+CREATE INDEX IF NOT EXISTS idx_agent_portfolio_history_portfolio  ON agent_portfolio_history (portfolio_id, snapshot_date DESC);
+CREATE INDEX IF NOT EXISTS idx_investment_theses_portfolio_status ON investment_theses (portfolio_id, ticker, status);
+
+
+-- ============================================================
+-- 5. RLS — public read on new tables
+-- ============================================================
+
+ALTER TABLE portfolios       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE portfolio_agents ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "public read" ON portfolios;
+CREATE POLICY "public read" ON portfolios FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "public read" ON portfolio_agents;
+CREATE POLICY "public read" ON portfolio_agents FOR SELECT USING (true);
+
+
+-- ============================================================
+-- 6. Rebuild agent_leaderboard
+--
+-- Same shape + same metrics as migration 014, but partitioned on
+-- portfolio_id instead of agent_id. Joins portfolios for slug +
+-- display_name. Adds two new columns: `portfolio_slug` (= slug, for
+-- forward-facing readers) and `member_agents` (JSONB array of
+-- {handle, display_name, powered_by} per member agent — initially
+-- one entry per portfolio since every portfolio has one member).
+--
+-- Existing columns (handle, display_name, is_house_agent, all
+-- pnl_pct_*, sharpe, etc.) are preserved so every current reader
+-- works unchanged.
+-- ============================================================
+
+DROP VIEW IF EXISTS agent_leaderboard;
+
+CREATE VIEW agent_leaderboard
+    WITH (security_invoker = true)
+AS
+WITH latest AS (
+    SELECT DISTINCT ON (portfolio_id)
+        portfolio_id,
+        snapshot_date,
+        cash_usd,
+        holdings_value_usd,
+        total_value_usd,
+        pnl_usd,
+        pnl_pct,
+        num_positions
+    FROM agent_portfolio_history
+    ORDER BY portfolio_id, snapshot_date DESC
+),
+one_day_ago AS (
+    SELECT DISTINCT ON (portfolio_id)
+        portfolio_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '1 day'
+    ORDER BY portfolio_id, snapshot_date DESC
+),
+one_week_ago AS (
+    SELECT DISTINCT ON (portfolio_id)
+        portfolio_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '7 days'
+    ORDER BY portfolio_id, snapshot_date DESC
+),
+thirty_days_ago AS (
+    SELECT DISTINCT ON (portfolio_id)
+        portfolio_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '30 days'
+    ORDER BY portfolio_id, snapshot_date DESC
+),
+year_start AS (
+    SELECT DISTINCT ON (portfolio_id)
+        portfolio_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date < DATE_TRUNC('year', CURRENT_DATE)::DATE
+    ORDER BY portfolio_id, snapshot_date DESC
+),
+one_year_ago AS (
+    SELECT DISTINCT ON (portfolio_id)
+        portfolio_id,
+        total_value_usd AS value_anchor
+    FROM agent_portfolio_history
+    WHERE snapshot_date <= CURRENT_DATE - INTERVAL '1 year'
+    ORDER BY portfolio_id, snapshot_date DESC
+),
+sharpe_returns AS (
+    SELECT
+        portfolio_id,
+        (total_value_usd - LAG(total_value_usd) OVER w)
+            / NULLIF(LAG(total_value_usd) OVER w, 0) AS daily_return
+    FROM agent_portfolio_history
+    WHERE EXTRACT(DOW FROM snapshot_date) BETWEEN 1 AND 5
+    WINDOW w AS (PARTITION BY portfolio_id ORDER BY snapshot_date)
+),
+sharpe AS (
+    SELECT
+        portfolio_id,
+        AVG(daily_return)         AS mean_return,
+        STDDEV_SAMP(daily_return) AS stdev_return,
+        COUNT(daily_return)       AS n_returns
+    FROM sharpe_returns
+    WHERE daily_return IS NOT NULL
+    GROUP BY portfolio_id
+),
+members AS (
+    SELECT
+        pa.portfolio_id,
+        jsonb_agg(
+            jsonb_build_object(
+                'handle',        a.handle,
+                'display_name',  a.display_name,
+                'powered_by',    a.powered_by,
+                'is_house_agent', a.is_house_agent
+            )
+            ORDER BY pa.joined_at
+        ) AS member_agents
+    FROM portfolio_agents pa
+    JOIN agents a ON a.id = pa.agent_id
+    GROUP BY pa.portfolio_id
+)
+SELECT
+    -- Preserve the existing column names so current readers keep working.
+    -- For now portfolios.slug == agents.handle (1:1), so handle stays accurate.
+    p.slug                       AS handle,
+    p.display_name,
+    owner.is_house_agent,
+    l.snapshot_date,
+    l.cash_usd,
+    l.holdings_value_usd,
+    l.total_value_usd,
+    l.pnl_usd,
+    l.pnl_pct,
+    l.num_positions,
+    CASE WHEN t1d.value_anchor IS NULL OR t1d.value_anchor = 0 THEN NULL
+         ELSE ROUND(((l.total_value_usd - t1d.value_anchor) / t1d.value_anchor) * 100, 4)
+    END AS pnl_pct_1d,
+    CASE WHEN t1w.value_anchor IS NULL OR t1w.value_anchor = 0 THEN NULL
+         ELSE ROUND(((l.total_value_usd - t1w.value_anchor) / t1w.value_anchor) * 100, 4)
+    END AS pnl_pct_1w,
+    CASE WHEN t30.value_anchor IS NULL OR t30.value_anchor = 0 THEN NULL
+         ELSE ROUND(((l.total_value_usd - t30.value_anchor) / t30.value_anchor) * 100, 4)
+    END AS pnl_pct_30d,
+    CASE WHEN tytd.value_anchor IS NULL OR tytd.value_anchor = 0 THEN NULL
+         ELSE ROUND(((l.total_value_usd - tytd.value_anchor) / tytd.value_anchor) * 100, 4)
+    END AS pnl_pct_ytd,
+    CASE WHEN t1y.value_anchor IS NULL OR t1y.value_anchor = 0 THEN NULL
+         ELSE ROUND(((l.total_value_usd - t1y.value_anchor) / t1y.value_anchor) * 100, 4)
+    END AS pnl_pct_1yr,
+    CASE WHEN s.n_returns < 30 OR s.stdev_return IS NULL OR s.stdev_return = 0 THEN NULL
+         ELSE ROUND((((s.mean_return - 0.05 / 252.0) / s.stdev_return) * SQRT(252))::numeric, 4)
+    END AS sharpe,
+    COALESCE(s.n_returns, 0)::int AS sharpe_n_returns,
+    -- New forward-facing columns
+    p.id                          AS portfolio_id,
+    p.slug                        AS portfolio_slug,
+    p.display_name                AS portfolio_display_name,
+    p.description                 AS portfolio_description,
+    COALESCE(m.member_agents, '[]'::jsonb) AS member_agents
+FROM latest l
+JOIN portfolios p ON p.id = l.portfolio_id
+JOIN agents owner ON owner.id = p.owner_agent_id
+LEFT JOIN one_day_ago     t1d  ON t1d.portfolio_id  = l.portfolio_id
+LEFT JOIN one_week_ago    t1w  ON t1w.portfolio_id  = l.portfolio_id
+LEFT JOIN thirty_days_ago t30  ON t30.portfolio_id  = l.portfolio_id
+LEFT JOIN year_start      tytd ON tytd.portfolio_id = l.portfolio_id
+LEFT JOIN one_year_ago    t1y  ON t1y.portfolio_id  = l.portfolio_id
+LEFT JOIN sharpe          s    ON s.portfolio_id    = l.portfolio_id
+LEFT JOIN members         m    ON m.portfolio_id    = l.portfolio_id
+ORDER BY l.pnl_pct DESC;

--- a/portfolio.py
+++ b/portfolio.py
@@ -81,8 +81,13 @@ class PortfolioManager:
     ) -> dict:
         """Idempotently create an `agent_accounts` row for an agent.
 
-        If an account already exists, returns it unchanged. Otherwise inserts
-        a new row with the given starting cash balance.
+        Also creates a 1:1 `portfolios` row (slug = agent.handle,
+        display_name = agent.display_name) and a `portfolio_agents`
+        row linking the agent as the sole member. Idempotent.
+
+        If an account already exists, returns it unchanged but still
+        ensures the portfolio + membership exist (helps backfill old
+        accounts created before migration 021).
         """
         existing = self.db.get_agent_account(agent_id)
         if existing:
@@ -91,12 +96,14 @@ class PortfolioManager:
                 agent_id,
                 float(existing.get("cash_usd") or 0),
             )
+            self._ensure_portfolio_for_agent(agent_id)
             return existing
 
         row = {
             "starting_cash": starting_cash,
             "cash_usd": starting_cash,
             "inception_date": date.today().isoformat(),
+            # portfolio_id is set after we create/fetch the portfolio below
         }
         self.db.upsert_agent_account(agent_id, row)
         logger.info(
@@ -104,7 +111,56 @@ class PortfolioManager:
             agent_id,
             starting_cash,
         )
+        portfolio_id = self._ensure_portfolio_for_agent(agent_id)
+        # Backfill portfolio_id on the just-created account row.
+        self.db.upsert_agent_account(agent_id, {"portfolio_id": portfolio_id})
         return self.db.get_agent_account(agent_id)
+
+    def _ensure_portfolio_for_agent(self, agent_id: str) -> str:
+        """Ensure (portfolios, portfolio_agents) rows exist for an agent.
+
+        Returns the portfolio_id. Idempotent — if a portfolio already
+        exists (owned by this agent or fetched as their default
+        membership) it's reused without changes.
+        """
+        existing = self.db.get_portfolio_by_agent_id(agent_id)
+        if existing:
+            return existing["id"]
+
+        agent = self.db.client.table("agents").select("*").eq("id", agent_id).limit(1).execute().data
+        if not agent:
+            raise PortfolioError(f"No agents row for id={agent_id}")
+        a = agent[0]
+        portfolio = self.db.create_portfolio(
+            portfolio_id=agent_id,                 # 1:1 shim: portfolio_id = agent_id
+            slug=a["handle"],
+            display_name=a["display_name"],
+            owner_agent_id=agent_id,
+            description=a.get("description"),
+        )
+        self.db.add_portfolio_member(
+            portfolio_id=portfolio["id"],
+            agent_id=agent_id,
+            notes=None,
+        )
+        logger.info(
+            "Created portfolio %s (slug=%s) owned by agent %s",
+            portfolio["id"], portfolio["slug"], agent_id,
+        )
+        return portfolio["id"]
+
+    def _portfolio_for_agent(self, agent_id: str) -> str:
+        """Resolve the portfolio_id an agent's trade should be attributed to.
+
+        First call after migration 021 creates the portfolio lazily. After
+        that the lookup is a cheap single-row fetch. Raises
+        ``PortfolioError`` if no portfolio can be resolved (shouldn't
+        happen once open_account has been called).
+        """
+        existing = self.db.get_portfolio_by_agent_id(agent_id)
+        if existing:
+            return existing["id"]
+        return self._ensure_portfolio_for_agent(agent_id)
 
     # ------------------------------------------------------------------
     # Pricing
@@ -151,6 +207,7 @@ class PortfolioManager:
             raise PortfolioError(f"buy quantity must be > 0, got {quantity}")
 
         account = self._require_account(agent_id)
+        portfolio_id = self._portfolio_for_agent(agent_id)
         price = self.get_price(ticker)
         gross = round(quantity * price, 2)
         cash = float(account["cash_usd"])
@@ -174,6 +231,7 @@ class PortfolioManager:
             self.db.upsert_agent_holding(
                 {
                     "agent_id": agent_id,
+                    "portfolio_id": portfolio_id,
                     "ticker": ticker,
                     "quantity": new_qty,
                     "avg_cost_usd": new_avg_cost,
@@ -184,6 +242,7 @@ class PortfolioManager:
             self.db.upsert_agent_holding(
                 {
                     "agent_id": agent_id,
+                    "portfolio_id": portfolio_id,
                     "ticker": ticker,
                     "quantity": quantity,
                     "avg_cost_usd": round(price, 4),
@@ -191,11 +250,15 @@ class PortfolioManager:
             )
 
         # Debit cash.
-        self.db.upsert_agent_account(agent_id, {"cash_usd": new_cash})
+        self.db.upsert_agent_account(agent_id, {
+            "cash_usd": new_cash,
+            "portfolio_id": portfolio_id,
+        })
 
         # Journal the trade.
         trade = {
             "agent_id": agent_id,
+            "portfolio_id": portfolio_id,
             "ticker": ticker,
             "side": "buy",
             "quantity": quantity,
@@ -220,6 +283,7 @@ class PortfolioManager:
             theses.record_thesis(
                 self.db,
                 agent_id=agent_id,
+                portfolio_id=portfolio_id,
                 ticker=ticker,
                 trade_id=trade_id,
                 **_thesis_kwargs(thesis),
@@ -247,6 +311,7 @@ class PortfolioManager:
             raise PortfolioError(f"sell quantity must be > 0, got {quantity}")
 
         account = self._require_account(agent_id)
+        portfolio_id = self._portfolio_for_agent(agent_id)
         holding = self.db.get_agent_holding(agent_id, ticker)
         if not holding:
             raise PortfolioError(f"No position in {ticker} for agent {agent_id}")
@@ -270,6 +335,7 @@ class PortfolioManager:
             self.db.upsert_agent_holding(
                 {
                     "agent_id": agent_id,
+                    "portfolio_id": portfolio_id,
                     "ticker": ticker,
                     "quantity": remaining,
                     "avg_cost_usd": float(holding["avg_cost_usd"]),
@@ -277,10 +343,14 @@ class PortfolioManager:
                 }
             )
 
-        self.db.upsert_agent_account(agent_id, {"cash_usd": new_cash})
+        self.db.upsert_agent_account(agent_id, {
+            "cash_usd": new_cash,
+            "portfolio_id": portfolio_id,
+        })
 
         trade = {
             "agent_id": agent_id,
+            "portfolio_id": portfolio_id,
             "ticker": ticker,
             "side": "sell",
             "quantity": quantity,
@@ -304,7 +374,10 @@ class PortfolioManager:
             try:
                 import theses
                 theses.close_theses_for_position(
-                    self.db, agent_id=agent_id, ticker=ticker,
+                    self.db,
+                    agent_id=agent_id,
+                    portfolio_id=portfolio_id,
+                    ticker=ticker,
                 )
             except Exception as exc:  # noqa: BLE001 — never block a sell on thesis I/O
                 logger.warning(
@@ -349,6 +422,12 @@ class PortfolioManager:
         if quantity <= 0:
             raise PortfolioError(f"buy quantity must be > 0, got {quantity}")
         price = self.get_price(ticker)
+        # Resolve the portfolio up-front so thesis recording links correctly.
+        # The atomic_buy RPC still mutates agent_accounts keyed on agent_id;
+        # it doesn't yet know about portfolio_id (a follow-up SQL migration
+        # will extend the RPCs to write portfolio_id too — for now the
+        # Python wrapper backfills the portfolio_id on the thesis row).
+        portfolio_id = self._portfolio_for_agent(agent_id)
         result = self.db.client.rpc(
             "execute_atomic_buy",
             {
@@ -370,11 +449,30 @@ class PortfolioManager:
                 float(data.get("new_cash_usd", 0)),
                 data.get("trade_id"),
             )
+            # Backfill portfolio_id on the rows the atomic RPC wrote.
+            # Safe + idempotent — keeps the shim consistent during the
+            # transition before the RPC itself learns about portfolio_id.
+            try:
+                self.db.client.table("agent_trades").update(
+                    {"portfolio_id": portfolio_id}
+                ).eq("id", data.get("trade_id")).execute()
+                self.db.client.table("agent_holdings").update(
+                    {"portfolio_id": portfolio_id}
+                ).eq("agent_id", agent_id).eq("ticker", ticker).execute()
+                self.db.client.table("agent_accounts").update(
+                    {"portfolio_id": portfolio_id}
+                ).eq("agent_id", agent_id).execute()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "BUY %s %s: portfolio_id backfill failed (rows still consistent under agent_id): %s",
+                    agent_id[:8], ticker, exc,
+                )
             try:
                 import theses
                 theses.record_thesis(
                     self.db,
                     agent_id=agent_id,
+                    portfolio_id=portfolio_id,
                     ticker=ticker,
                     trade_id=data.get("trade_id"),
                     **_thesis_kwargs(thesis),
@@ -408,6 +506,7 @@ class PortfolioManager:
         if quantity <= 0:
             raise PortfolioError(f"sell quantity must be > 0, got {quantity}")
         price = self.get_price(ticker)
+        portfolio_id = self._portfolio_for_agent(agent_id)
         result = self.db.client.rpc(
             "execute_atomic_sell",
             {
@@ -429,6 +528,24 @@ class PortfolioManager:
                 float(data.get("new_cash_usd", 0)),
                 data.get("trade_id"),
             )
+            # Backfill portfolio_id on the rows the atomic RPC wrote.
+            try:
+                self.db.client.table("agent_trades").update(
+                    {"portfolio_id": portfolio_id}
+                ).eq("id", data.get("trade_id")).execute()
+                # If the position wasn't fully exited, holdings row still exists.
+                if float(data.get("remaining_quantity", 0) or 0) > 1e-9:
+                    self.db.client.table("agent_holdings").update(
+                        {"portfolio_id": portfolio_id}
+                    ).eq("agent_id", agent_id).eq("ticker", ticker).execute()
+                self.db.client.table("agent_accounts").update(
+                    {"portfolio_id": portfolio_id}
+                ).eq("agent_id", agent_id).execute()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "SELL %s %s: portfolio_id backfill failed: %s",
+                    agent_id[:8], ticker, exc,
+                )
             # Close any open theses if the position is fully exited.
             # The atomic sell RPC returns the post-trade quantity in
             # ``remaining_quantity`` (see migrations/019).
@@ -436,7 +553,10 @@ class PortfolioManager:
                 try:
                     import theses
                     theses.close_theses_for_position(
-                        self.db, agent_id=agent_id, ticker=ticker,
+                        self.db,
+                        agent_id=agent_id,
+                        portfolio_id=portfolio_id,
+                        ticker=ticker,
                     )
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
@@ -545,10 +665,14 @@ class PortfolioManager:
 
         for acc in accounts:
             agent_id = acc["agent_id"]
+            # Resolve the portfolio_id for the snapshot row. Falls back to
+            # agent_id during the shim period if no portfolio exists yet.
+            portfolio_id = acc.get("portfolio_id") or agent_id
             try:
                 portfolio = self.get_portfolio(agent_id)
                 row = {
                     "agent_id": agent_id,
+                    "portfolio_id": portfolio_id,
                     "snapshot_date": snapshot_date,
                     "cash_usd": portfolio["cash_usd"],
                     "holdings_value_usd": portfolio["holdings_value_usd"],
@@ -566,6 +690,7 @@ class PortfolioManager:
                 details.append(
                     {
                         "agent_id": agent_id,
+                        "portfolio_id": portfolio_id,
                         "total_value_usd": portfolio["total_value_usd"],
                         "pnl_pct": portfolio["pnl_pct"],
                         "num_positions": len(portfolio["holdings"]),

--- a/test_portfolios.py
+++ b/test_portfolios.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Unit tests for the portfolios shim (migration 021).
+
+Covers the read-side helpers in ``db.py`` and the
+``PortfolioManager._ensure_portfolio_for_agent`` flow with a stubbed
+Supabase. No live DB calls.
+
+Run directly:
+
+    python test_portfolios.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from types import SimpleNamespace
+
+import portfolio as portfolio_module
+from db import SupabaseDB  # noqa: F401 — make sure import works
+
+
+# ---------------------------------------------------------------------------
+# Minimal Supabase stub — same shape as the one in test_theses.py.
+# ---------------------------------------------------------------------------
+
+
+class _Query:
+    def __init__(self, db, table_name):
+        self._db = db
+        self.table_name = table_name
+        self.op = None
+        self.payload = None
+        self.eq_filters: dict = {}
+        self.match_filters: dict = {}
+        self.limited = False
+        self.on_conflict: str | None = None
+
+    def select(self, _cols="*"):
+        self.op = "select"
+        return self
+
+    def insert(self, payload):
+        self.op = "insert"
+        self.payload = payload
+        return self
+
+    def upsert(self, payload, on_conflict=None):
+        self.op = "upsert"
+        self.payload = payload
+        self.on_conflict = on_conflict
+        return self
+
+    def update(self, payload):
+        self.op = "update"
+        self.payload = payload
+        return self
+
+    def eq(self, key, value):
+        self.eq_filters[key] = value
+        return self
+
+    def match(self, filters):
+        self.match_filters = dict(filters)
+        return self
+
+    def order(self, _key, **_kw):
+        return self
+
+    def limit(self, _n):
+        self.limited = True
+        return self
+
+    def execute(self):
+        # Log the op.
+        self._db.log.append({
+            "table": self.table_name,
+            "op": self.op,
+            "payload": self.payload,
+            "eq": dict(self.eq_filters),
+            "match": dict(self.match_filters),
+            "on_conflict": self.on_conflict,
+        })
+        if self.op == "select":
+            key = (self.table_name, frozenset(self.eq_filters.items()))
+            rows = self._db.canned_selects.get(key, [])
+            return SimpleNamespace(data=rows)
+        if self.op in ("insert", "upsert"):
+            return SimpleNamespace(data=[self.payload])
+        return SimpleNamespace(data=[])
+
+
+class _StubDB:
+    def __init__(self):
+        self.log: list[dict] = []
+        self.canned_selects: dict = {}
+        self.client = self
+
+    def table(self, name):
+        return _Query(self, name)
+
+
+# ---------------------------------------------------------------------------
+# Tests for db.py portfolio helpers (via wrapper functions)
+# ---------------------------------------------------------------------------
+
+
+class DbPortfolioHelpersTests(unittest.TestCase):
+    """Construct a real SupabaseDB by injecting our stub client."""
+
+    def _make_db(self) -> "SupabaseDB":
+        # SupabaseDB.__init__ initialises the real client; bypass it.
+        db = SupabaseDB.__new__(SupabaseDB)
+        db.client = _StubDB()
+        return db
+
+    def test_get_portfolio_by_slug_returns_first_row(self):
+        db = self._make_db()
+        db.client.canned_selects[
+            ("portfolios", frozenset({("slug", "tauric-opus-4-7")}))
+        ] = [{"id": "abc", "slug": "tauric-opus-4-7", "display_name": "Foo"}]
+        row = db.get_portfolio_by_slug("tauric-opus-4-7")
+        self.assertEqual(row["id"], "abc")
+
+    def test_get_portfolio_by_slug_returns_none_when_missing(self):
+        db = self._make_db()
+        # No canned data → empty select.
+        self.assertIsNone(db.get_portfolio_by_slug("ghost"))
+
+    def test_get_portfolio_by_agent_id_prefers_owner(self):
+        db = self._make_db()
+        # Owner lookup returns a hit.
+        db.client.canned_selects[
+            ("portfolios", frozenset({("owner_agent_id", "agent-1")}))
+        ] = [{"id": "p-1", "slug": "agent-1", "owner_agent_id": "agent-1"}]
+        row = db.get_portfolio_by_agent_id("agent-1")
+        self.assertEqual(row["id"], "p-1")
+        # No fallback select to portfolio_agents was made.
+        tables_queried = [op["table"] for op in db.client.log]
+        self.assertIn("portfolios", tables_queried)
+        self.assertNotIn("portfolio_agents", tables_queried)
+
+    def test_get_portfolio_by_agent_id_falls_back_to_membership(self):
+        db = self._make_db()
+        # Owner lookup empty; portfolio_agents has them as a member.
+        db.client.canned_selects[
+            ("portfolio_agents", frozenset({("agent_id", "agent-2")}))
+        ] = [{"portfolio_id": "p-2"}]
+        db.client.canned_selects[
+            ("portfolios", frozenset({("id", "p-2")}))
+        ] = [{"id": "p-2", "slug": "shared", "owner_agent_id": "other"}]
+        row = db.get_portfolio_by_agent_id("agent-2")
+        self.assertEqual(row["id"], "p-2")
+
+    def test_get_portfolio_by_agent_id_returns_none_for_analyst(self):
+        db = self._make_db()
+        # Neither owner nor member.
+        self.assertIsNone(db.get_portfolio_by_agent_id("analyst-1"))
+
+    def test_create_portfolio_upserts_row(self):
+        db = self._make_db()
+        db.client.canned_selects[
+            ("portfolios", frozenset({("id", "p-3")}))
+        ] = [{"id": "p-3", "slug": "test", "display_name": "Test"}]
+        result = db.create_portfolio(
+            portfolio_id="p-3",
+            slug="test",
+            display_name="Test",
+            owner_agent_id="agent-3",
+            description="hello",
+        )
+        self.assertEqual(result["id"], "p-3")
+        # First op is upsert into portfolios, second is select for readback.
+        ops = [(op["op"], op["table"]) for op in db.client.log]
+        self.assertEqual(ops[0], ("upsert", "portfolios"))
+        # Payload reflects the args.
+        payload = db.client.log[0]["payload"]
+        self.assertEqual(payload["slug"], "test")
+        self.assertEqual(payload["owner_agent_id"], "agent-3")
+
+    def test_add_portfolio_member_uses_composite_pk(self):
+        db = self._make_db()
+        db.add_portfolio_member(portfolio_id="p-4", agent_id="agent-4", notes="rebalancer")
+        self.assertEqual(db.client.log[0]["op"], "upsert")
+        self.assertEqual(db.client.log[0]["table"], "portfolio_agents")
+        self.assertEqual(db.client.log[0]["payload"]["notes"], "rebalancer")
+
+
+# ---------------------------------------------------------------------------
+# PortfolioManager._ensure_portfolio_for_agent — creates the 1:1 shim
+# ---------------------------------------------------------------------------
+
+
+class EnsurePortfolioTests(unittest.TestCase):
+    def _make_pm(self) -> "portfolio_module.PortfolioManager":
+        pm = portfolio_module.PortfolioManager.__new__(
+            portfolio_module.PortfolioManager
+        )
+        db = SupabaseDB.__new__(SupabaseDB)
+        db.client = _StubDB()
+        pm.db = db
+        return pm
+
+    def test_returns_existing_portfolio_id_without_writing(self):
+        pm = self._make_pm()
+        pm.db.client.canned_selects[
+            ("portfolios", frozenset({("owner_agent_id", "agent-x")}))
+        ] = [{"id": "existing-pid", "slug": "x", "owner_agent_id": "agent-x"}]
+        pid = pm._ensure_portfolio_for_agent("agent-x")
+        self.assertEqual(pid, "existing-pid")
+        # No inserts/upserts.
+        ops = [op["op"] for op in pm.db.client.log]
+        self.assertNotIn("upsert", ops)
+        self.assertNotIn("insert", ops)
+
+    def test_creates_portfolio_when_missing(self):
+        pm = self._make_pm()
+        # No existing portfolio for owner_agent_id agent-y.
+        # But the agents row for agent-y exists.
+        pm.db.client.canned_selects[
+            ("agents", frozenset({("id", "agent-y")}))
+        ] = [{
+            "id": "agent-y", "handle": "newbie",
+            "display_name": "Newbie", "description": "test",
+        }]
+        # The portfolios row that create_portfolio reads back after upsert:
+        pm.db.client.canned_selects[
+            ("portfolios", frozenset({("id", "agent-y")}))
+        ] = [{
+            "id": "agent-y", "slug": "newbie",
+            "display_name": "Newbie", "owner_agent_id": "agent-y",
+        }]
+        pid = pm._ensure_portfolio_for_agent("agent-y")
+        self.assertEqual(pid, "agent-y")
+        ops = [(op["op"], op["table"]) for op in pm.db.client.log]
+        # Upsert portfolios + upsert portfolio_agents happened.
+        self.assertIn(("upsert", "portfolios"), ops)
+        self.assertIn(("upsert", "portfolio_agents"), ops)
+
+
+if __name__ == "__main__":
+    result = unittest.main(exit=False, verbosity=2).result
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/test_theses.py
+++ b/test_theses.py
@@ -228,6 +228,36 @@ class RecordThesisTests(unittest.TestCase):
         self.assertEqual(inserted["source"], "agent")
         self.assertEqual(len(inserted["break_signals"]), 1)
 
+    def test_portfolio_id_threaded_when_provided(self):
+        # Migration 021 added portfolio_id; verify it lands on the insert.
+        db = _StubDB()
+        db.companies["NVDA"] = _company()
+        theses.record_thesis(
+            db, agent_id="A", portfolio_id="P-1", ticker="NVDA", trade_id=42,
+        )
+        # Supersede match should target portfolio_id, not agent_id.
+        supersede = db.log[0]
+        self.assertEqual(supersede["op"], "update")
+        self.assertEqual(supersede["filters"].get("portfolio_id"), "P-1")
+        self.assertNotIn("agent_id", supersede["filters"])
+        # Insert payload also has portfolio_id.
+        inserted = db.log[1]["payload"]
+        self.assertEqual(inserted["portfolio_id"], "P-1")
+        self.assertEqual(inserted["agent_id"], "A")
+
+    def test_portfolio_id_defaults_to_agent_id_when_omitted(self):
+        # Backwards-compat: callers that don't pass portfolio_id still
+        # produce a valid row (NOT NULL on the column).
+        db = _StubDB()
+        db.companies["NVDA"] = _company()
+        theses.record_thesis(
+            db, agent_id="A", ticker="NVDA", trade_id=42,
+        )
+        supersede = db.log[0]
+        self.assertEqual(supersede["filters"].get("agent_id"), "A")
+        inserted = db.log[1]["payload"]
+        self.assertEqual(inserted["portfolio_id"], "A")
+
 
 # ---------------------------------------------------------------------------
 # close_theses_for_position

--- a/theses.py
+++ b/theses.py
@@ -86,6 +86,7 @@ def record_thesis(
     *,
     agent_id: str,
     ticker: str,
+    portfolio_id: Optional[str] = None,
     trade_id: Optional[int] = None,
     thesis_text: Optional[str] = None,
     extend_signals: Optional[list[dict]] = None,
@@ -94,7 +95,8 @@ def record_thesis(
     """Insert an investment_theses row for a freshly-executed BUY.
 
     Always captures the snapshot. Marks any prior ``active`` row for
-    the same (agent_id, ticker) as ``superseded``. Returns the new
+    the same (portfolio_id, ticker) — falling back to (agent_id, ticker)
+    when portfolio_id is None — as ``superseded``. Returns the new
     thesis id.
 
     ``source='agent'`` when any of thesis_text / extend_signals /
@@ -102,12 +104,19 @@ def record_thesis(
     """
     snapshot = build_snapshot(db, ticker)
 
-    # Mark any prior active thesis for this (agent, ticker) as superseded.
+    # Mark any prior active thesis for this portfolio+ticker as superseded.
+    # During the 1:1 shim period, portfolio_id == agent_id; queries on either
+    # column hit the same rows. We prefer portfolio_id when available since
+    # that's the forward-facing key — multi-agent portfolios will share one
+    # thesis lineage per ticker across all member agents.
+    supersede_match = {"ticker": ticker, "status": "active"}
+    if portfolio_id is not None:
+        supersede_match["portfolio_id"] = portfolio_id
+    else:
+        supersede_match["agent_id"] = agent_id
     db.client.table("investment_theses").update(
         {"status": "superseded", "status_changed_at": "now()"}
-    ).match(
-        {"agent_id": agent_id, "ticker": ticker, "status": "active"}
-    ).execute()
+    ).match(supersede_match).execute()
 
     source = "agent" if (
         thesis_text or extend_signals or break_signals
@@ -115,6 +124,7 @@ def record_thesis(
 
     row = {
         "agent_id": agent_id,
+        "portfolio_id": portfolio_id if portfolio_id is not None else agent_id,
         "ticker": ticker,
         "trade_id": trade_id,
         "snapshot": snapshot,
@@ -128,14 +138,22 @@ def record_thesis(
     inserted = (resp.data or [{}])[0]
     new_id = inserted.get("id")
     logger.info(
-        "thesis %s recorded: agent=%s ticker=%s source=%s trade_id=%s",
-        new_id, agent_id[:8] if agent_id else "?", ticker, source, trade_id,
+        "thesis %s recorded: agent=%s portfolio=%s ticker=%s source=%s trade_id=%s",
+        new_id,
+        agent_id[:8] if agent_id else "?",
+        (portfolio_id or agent_id)[:8] if (portfolio_id or agent_id) else "?",
+        ticker, source, trade_id,
     )
     return new_id
 
 
-def close_theses_for_position(db, *, agent_id: str, ticker: str) -> int:
-    """Flip all non-closed theses for (agent_id, ticker) to ``closed``.
+def close_theses_for_position(
+    db, *, agent_id: str, ticker: str, portfolio_id: Optional[str] = None,
+) -> int:
+    """Flip all non-closed theses for a position to ``closed``.
+
+    Keys on ``portfolio_id`` when provided (forward-facing), else
+    ``agent_id`` (legacy). Identical during the 1:1 shim period.
 
     Called from ``PortfolioManager.sell`` after a sell zeros out the
     holding. Idempotent — if there are no matching rows (e.g. older
@@ -143,6 +161,11 @@ def close_theses_for_position(db, *, agent_id: str, ticker: str) -> int:
 
     Returns the number of rows updated.
     """
+    match: dict[str, str] = {"ticker": ticker}
+    if portfolio_id is not None:
+        match["portfolio_id"] = portfolio_id
+    else:
+        match["agent_id"] = agent_id
     resp = (
         db.client.table("investment_theses")
         .update({
@@ -150,15 +173,17 @@ def close_theses_for_position(db, *, agent_id: str, ticker: str) -> int:
             "status_changed_at": "now()",
             "closed_at": "now()",
         })
-        .match({"agent_id": agent_id, "ticker": ticker})
+        .match(match)
         .neq("status", "closed")
         .execute()
     )
     rows = resp.data or []
     if rows:
         logger.info(
-            "closed %d theses for agent=%s ticker=%s",
-            len(rows), agent_id[:8] if agent_id else "?", ticker,
+            "closed %d theses for portfolio=%s ticker=%s",
+            len(rows),
+            (portfolio_id or agent_id)[:8] if (portfolio_id or agent_id) else "?",
+            ticker,
         )
     return len(rows)
 

--- a/web/app/agents/[handle]/page.tsx
+++ b/web/app/agents/[handle]/page.tsx
@@ -1,0 +1,233 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import Nav from "@/components/nav";
+import LlmPromptsPanel from "@/components/llm-prompts-panel";
+import { getAgentByHandle, type Agent } from "@/lib/agents-query";
+import {
+  getPortfoliosForAgent,
+  type PortfolioMembershipForAgent,
+} from "@/lib/portfolios-query";
+
+export const revalidate = 300;
+
+interface PageParams {
+  params: Promise<{ handle: string }>;
+}
+
+// ----- Metadata ------------------------------------------------------------
+
+export async function generateMetadata({
+  params,
+}: PageParams): Promise<Metadata> {
+  const { handle: rawHandle } = await params;
+  const handle = decodeURIComponent(rawHandle).toLowerCase();
+
+  const agent = await getAgentByHandle(handle);
+  if (!agent) {
+    return {
+      title: `@${handle} — not found`,
+      robots: { index: false, follow: false },
+    };
+  }
+  return {
+    title: `${agent.display_name} (@${agent.handle}) — Agent · AlphaMolt Arena`,
+    description:
+      agent.description ||
+      `${agent.display_name} is an agent in the AlphaMolt Arena.`,
+    alternates: { canonical: `/agents/${agent.handle}` },
+    openGraph: {
+      title: `${agent.display_name} — AlphaMolt Arena`,
+      description:
+        agent.description ||
+        `${agent.display_name} is an agent in the AlphaMolt Arena.`,
+      url: `/agents/${agent.handle}`,
+      type: "profile",
+    },
+  };
+}
+
+// ----- Page ---------------------------------------------------------------
+
+export default async function AgentProfilePage({ params }: PageParams) {
+  const { handle: rawHandle } = await params;
+  const handle = decodeURIComponent(rawHandle).toLowerCase();
+
+  const agent = await getAgentByHandle(handle);
+  if (!agent) notFound();
+
+  const portfolios = await getPortfoliosForAgent(agent.id);
+  const created = new Date(agent.created_at).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 max-w-[1000px] mx-auto w-full px-4 py-10 font-sans">
+        {/* Header */}
+        <section className="mb-10">
+          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-3">
+            Agent
+          </p>
+          <div className="flex items-baseline gap-3 flex-wrap mb-3">
+            <h1 className="font-mono text-3xl sm:text-4xl font-bold text-green">
+              {agent.display_name}
+            </h1>
+            <code className="text-sm text-text-muted">@{agent.handle}</code>
+            {agent.is_house_agent && (
+              <span className="text-[10px] font-mono uppercase tracking-widest px-2 py-0.5 rounded bg-orange/10 text-orange border border-orange/30">
+                House
+              </span>
+            )}
+            {agent.powered_by && (
+              <span
+                className="text-[10px] font-mono uppercase tracking-widest px-2 py-0.5 rounded bg-green/10 text-green border border-green/30"
+                title="LLM brain"
+              >
+                Powered by {agent.powered_by}
+              </span>
+            )}
+          </div>
+          {agent.description && (
+            <p className="text-text-dim max-w-2xl text-base leading-relaxed mb-2">
+              {agent.description}
+            </p>
+          )}
+          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted">
+            Registered {created}
+          </p>
+        </section>
+
+        {/* What this agent does — long_description, expandable */}
+        {agent.long_description && (
+          <details className="glass-card rounded-lg border border-border mb-10 [&[open]_.chevron]:rotate-90">
+            <summary className="cursor-pointer px-5 py-4 flex items-center justify-between font-mono text-xs font-bold uppercase tracking-widest text-text-dim list-none [&::-webkit-details-marker]:hidden hover:text-text transition-colors">
+              <span>What this agent does</span>
+              <span className="chevron text-text-muted transition-transform">
+                ▸
+              </span>
+            </summary>
+            <div className="px-5 pb-5 pt-3 text-sm text-text-dim whitespace-pre-line leading-relaxed border-t border-border">
+              {agent.long_description}
+            </div>
+          </details>
+        )}
+
+        {/* LLM prompts panel — for llm_pick agents only */}
+        {agent.strategy === "llm_pick" && (
+          <LlmPromptsPanel
+            pickerMode={
+              (agent.config &&
+                typeof agent.config === "object" &&
+                typeof (agent.config as Record<string, unknown>).picker_mode ===
+                  "string"
+                ? ((agent.config as Record<string, unknown>)
+                    .picker_mode as string)
+                : undefined) ?? undefined
+            }
+          />
+        )}
+
+        {/* Portfolios this agent is a member of */}
+        <section className="mb-10">
+          <h2 className="font-mono text-lg font-bold text-text mb-4">
+            Portfolios
+          </h2>
+          {portfolios.length === 0 ? (
+            <EmptyPortfoliosNote agent={agent} />
+          ) : (
+            <ul className="space-y-2">
+              {portfolios.map((m) => (
+                <PortfolioMembershipRow key={m.portfolio.id} membership={m} />
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Footer */}
+        <section className="pt-6 border-t border-border">
+          <p className="text-xs text-text-muted font-mono">
+            This agent profile is public and read-only. See the{" "}
+            <Link href="/docs" className="text-green hover:underline">
+              API docs
+            </Link>{" "}
+            for how to register your own agent.
+          </p>
+        </section>
+      </main>
+    </>
+  );
+}
+
+// ----- Presentational helpers ---------------------------------------------
+
+function EmptyPortfoliosNote({ agent }: { agent: Agent }) {
+  const isWorker = agent.strategy && agent.strategy !== "manual";
+  return (
+    <p className="text-sm text-text-muted italic">
+      {isWorker
+        ? `This agent doesn't manage any portfolios — it's a ${agent.strategy} worker. It may be linked from other portfolios as they form.`
+        : "This agent isn't a member of any portfolio yet. Its first trade through the public API will lazily create one."}
+    </p>
+  );
+}
+
+function PortfolioMembershipRow({
+  membership,
+}: {
+  membership: PortfolioMembershipForAgent;
+}) {
+  const { portfolio, notes, current_total_value_usd, current_pnl_pct } =
+    membership;
+  return (
+    <li className="glass-card rounded border border-border px-4 py-3">
+      <div className="flex items-baseline justify-between gap-3 flex-wrap">
+        <div className="flex items-baseline gap-3 min-w-0">
+          <Link
+            href={`/portfolios/${encodeURIComponent(portfolio.slug)}`}
+            className="font-mono text-sm font-bold text-green hover:underline"
+          >
+            {portfolio.display_name}
+          </Link>
+          <code className="text-xs text-text-muted">/{portfolio.slug}</code>
+        </div>
+        <div className="text-right shrink-0">
+          {current_total_value_usd != null && (
+            <div className="font-mono text-sm text-text">
+              {formatUsd(current_total_value_usd)}
+            </div>
+          )}
+          {current_pnl_pct != null && (
+            <div
+              className={`text-[11px] font-mono ${
+                current_pnl_pct > 0
+                  ? "text-green"
+                  : current_pnl_pct < 0
+                    ? "text-red"
+                    : "text-text-muted"
+              }`}
+            >
+              {current_pnl_pct >= 0 ? "+" : ""}
+              {current_pnl_pct.toFixed(2)}%
+            </div>
+          )}
+        </div>
+      </div>
+      {notes && (
+        <p className="mt-2 text-[12px] text-text-dim italic">{notes}</p>
+      )}
+    </li>
+  );
+}
+
+function formatUsd(n: number): string {
+  const sign = n < 0 ? "-" : "";
+  const abs = Math.abs(n);
+  return `${sign}$${abs.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}

--- a/web/app/api/v1/agents/route.ts
+++ b/web/app/api/v1/agents/route.ts
@@ -49,6 +49,7 @@ export async function POST(request: Request) {
     display_name,
     description,
     contact_email,
+    powered_by,
   } = body as Record<string, unknown>;
 
   if (typeof handle !== "string" || typeof display_name !== "string") {
@@ -64,6 +65,9 @@ export async function POST(request: Request) {
   if (contact_email !== undefined && contact_email !== null && typeof contact_email !== "string") {
     return errorResponse("contact_email must be a string", 400, "invalid_type");
   }
+  if (powered_by !== undefined && powered_by !== null && typeof powered_by !== "string") {
+    return errorResponse("powered_by must be a string", 400, "invalid_type");
+  }
 
   try {
     const result = await createAgent({
@@ -71,6 +75,7 @@ export async function POST(request: Request) {
       display_name,
       description: description as string | undefined,
       contact_email: contact_email as string | undefined,
+      powered_by: powered_by as string | undefined,
     });
     // Bust the 5-minute ISR cache on the homepage, profile, and leaderboard,
     // plus the inner unstable_cache tagged "leaderboard" — without this the

--- a/web/app/api/v1/portfolios/[slug]/route.ts
+++ b/web/app/api/v1/portfolios/[slug]/route.ts
@@ -1,0 +1,71 @@
+/**
+ * GET /api/v1/portfolios/<slug>
+ *
+ * Public read of a single portfolio: cash, holdings (MTM), member
+ * agents. No auth required (`investment_theses`, `portfolios`,
+ * `portfolio_agents` all have public-read RLS).
+ *
+ * Body shape:
+ * ```
+ * {
+ *   portfolio: { id, slug, display_name, description, owner_agent_id,
+ *                created_at, updated_at },
+ *   members:   [ { handle, display_name, powered_by, notes, ... } ],
+ *   snapshot:  { cash_usd, holdings_value_usd, total_value_usd,
+ *                pnl_usd, pnl_pct, holdings: [...] }     // or null
+ * }
+ * ```
+ *
+ * For the 1:1 shim period the snapshot is fetched via the owner
+ * agent's id, which is identical to portfolio.id. When multi-agent
+ * portfolios arrive, this stays correct because cash/holdings/trades
+ * are migrating to portfolio_id-keyed reads.
+ */
+
+import { errorResponse, jsonResponse, optionsResponse } from "@/lib/api-utils";
+import { getPortfolio } from "@/lib/portfolio";
+import {
+  getMembersForPortfolio,
+  getPortfolioBySlug,
+} from "@/lib/portfolios-query";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug).toLowerCase();
+
+  const portfolio = await getPortfolioBySlug(slug);
+  if (!portfolio) {
+    return errorResponse(`portfolio not found: ${slug}`, 404, "not_found");
+  }
+
+  const [members, snapshot] = await Promise.all([
+    getMembersForPortfolio(portfolio.id),
+    getPortfolio(portfolio.owner_agent_id).catch((err) => {
+      console.error(
+        `GET /portfolios/${slug}: snapshot fetch failed:`,
+        err,
+      );
+      return null;
+    }),
+  ]);
+
+  return jsonResponse(
+    { portfolio, members, snapshot },
+    {
+      // Light cache — portfolio identity is stable, MTM is refreshed by the
+      // valuation cron; clients that need real-time numbers should poll the
+      // leaderboard or hit /api/v1/portfolio with their own bearer token.
+      headers: { "Cache-Control": "public, max-age=60, s-maxage=60" },
+    },
+  );
+}

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -60,8 +60,8 @@ const PUBLIC_TOOLS: { name: string; desc: string; args: string }[] = [
   },
   {
     name: "register_agent",
-    desc: "Create a new agent. Returns the API key exactly once — save it immediately. Configure the MCP server with 'Authorization: Bearer <key>' afterwards to unlock the authenticated tools. Agents and humans both use this endpoint; the browser form on the landing page is a convenience layer over the same call.",
-    args: "handle, display_name, description?, contact_email?",
+    desc: "Create a new agent. Returns the API key exactly once — save it immediately. Configure the MCP server with 'Authorization: Bearer <key>' afterwards to unlock the authenticated tools. Agents and humans both use this endpoint; the browser form on the landing page is a convenience layer over the same call. Optional powered_by renders as a chip on the agent's public profile.",
+    args: "handle, display_name, description?, contact_email?, powered_by?",
   },
 ];
 

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -1,0 +1,257 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import Nav from "@/components/nav";
+import HoldingsList from "@/components/holdings-list";
+import { getPortfolio, type PortfolioSnapshot } from "@/lib/portfolio";
+import {
+  getMembersForPortfolio,
+  getPortfolioBySlug,
+  type Portfolio,
+  type PortfolioMember,
+} from "@/lib/portfolios-query";
+import {
+  getActiveThesesForAgent,
+  type InvestmentThesis,
+} from "@/lib/theses-query";
+
+export const revalidate = 300;
+
+interface PageParams {
+  params: Promise<{ slug: string }>;
+}
+
+// ----- Metadata ------------------------------------------------------------
+
+export async function generateMetadata({
+  params,
+}: PageParams): Promise<Metadata> {
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug).toLowerCase();
+
+  const portfolio = await getPortfolioBySlug(slug);
+  if (!portfolio) {
+    return {
+      title: `Portfolio ${slug} — not found`,
+      robots: { index: false, follow: false },
+    };
+  }
+  return {
+    title: `${portfolio.display_name} — Portfolio · AlphaMolt Arena`,
+    description:
+      portfolio.description ||
+      `${portfolio.display_name} is competing in the AlphaMolt Arena.`,
+    alternates: { canonical: `/portfolios/${portfolio.slug}` },
+    openGraph: {
+      title: `${portfolio.display_name} — AlphaMolt Arena`,
+      description:
+        portfolio.description ||
+        `${portfolio.display_name} is competing in the AlphaMolt Arena.`,
+      url: `/portfolios/${portfolio.slug}`,
+      type: "profile",
+    },
+  };
+}
+
+// ----- Data ---------------------------------------------------------------
+
+async function getPortfolioPageData(slug: string): Promise<{
+  portfolio: Portfolio | null;
+  snapshot: PortfolioSnapshot | null;
+  members: PortfolioMember[];
+  thesesByTicker: Record<string, InvestmentThesis>;
+}> {
+  const portfolio = await getPortfolioBySlug(slug);
+  if (!portfolio) {
+    return { portfolio: null, snapshot: null, members: [], thesesByTicker: {} };
+  }
+
+  // The snapshot helper (cash + holdings + MTM) is still keyed on agent_id
+  // during the shim period. Use the owner agent's id — for 1:1 portfolios
+  // this is exactly the data we want.
+  let snapshot: PortfolioSnapshot | null = null;
+  try {
+    snapshot = await getPortfolio(portfolio.owner_agent_id);
+  } catch (err) {
+    console.error("getPortfolio failed for", slug, err);
+  }
+
+  const members = await getMembersForPortfolio(portfolio.id);
+  // Theses are still keyed via agent_id under the shim; owner_agent_id has
+  // the same rows as portfolio_id today.
+  const thesesByTicker = await getActiveThesesForAgent(portfolio.owner_agent_id);
+
+  return { portfolio, snapshot, members, thesesByTicker };
+}
+
+// ----- Page ---------------------------------------------------------------
+
+export default async function PortfolioPage({ params }: PageParams) {
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug).toLowerCase();
+
+  const { portfolio, snapshot, members, thesesByTicker } =
+    await getPortfolioPageData(slug);
+  if (!portfolio) notFound();
+
+  const created = new Date(portfolio.created_at).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 max-w-[1000px] mx-auto w-full px-4 py-10 font-sans">
+        {/* Header */}
+        <section className="mb-10">
+          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-3">
+            Portfolio
+          </p>
+          <div className="flex items-baseline gap-3 flex-wrap mb-3">
+            <h1 className="font-mono text-3xl sm:text-4xl font-bold text-green">
+              {portfolio.display_name}
+            </h1>
+            <code className="text-sm text-text-muted">/{portfolio.slug}</code>
+          </div>
+          {portfolio.description && (
+            <p className="text-text-dim max-w-2xl text-base leading-relaxed mb-3">
+              {portfolio.description}
+            </p>
+          )}
+
+          {/* Member-agent chips */}
+          {members.length > 0 && (
+            <div className="flex flex-wrap gap-2 mt-3 mb-2">
+              {members.map((m) => (
+                <Link
+                  key={m.agent_id}
+                  href={`/agents/${encodeURIComponent(m.handle)}`}
+                  className="inline-flex items-baseline gap-1.5 rounded border border-border px-2 py-1 text-xs font-mono hover:bg-bg-elevated transition-colors"
+                  title={m.notes || undefined}
+                >
+                  <span className="text-text">{m.display_name}</span>
+                  <span className="text-text-muted">@{m.handle}</span>
+                  {m.is_house_agent && (
+                    <span className="text-[9px] uppercase tracking-widest text-orange">
+                      House
+                    </span>
+                  )}
+                </Link>
+              ))}
+            </div>
+          )}
+
+          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted">
+            Created {created}
+          </p>
+        </section>
+
+        {/* Portfolio summary */}
+        {snapshot ? (
+          <section className="mb-10">
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+              <Stat
+                label="Total value"
+                value={formatUsd(snapshot.total_value_usd)}
+              />
+              <Stat label="Cash" value={formatUsd(snapshot.cash_usd)} />
+              <Stat
+                label="P/L"
+                value={formatUsd(snapshot.pnl_usd)}
+                tone={
+                  snapshot.pnl_usd > 0
+                    ? "positive"
+                    : snapshot.pnl_usd < 0
+                      ? "negative"
+                      : "neutral"
+                }
+              />
+              <Stat
+                label="P/L %"
+                value={`${snapshot.pnl_pct >= 0 ? "+" : ""}${snapshot.pnl_pct.toFixed(2)}%`}
+                tone={
+                  snapshot.pnl_pct > 0
+                    ? "positive"
+                    : snapshot.pnl_pct < 0
+                      ? "negative"
+                      : "neutral"
+                }
+              />
+            </div>
+
+            <h3 className="font-mono text-sm font-bold text-text-dim uppercase tracking-widest mb-3">
+              Holdings ({snapshot.holdings.length})
+            </h3>
+            <HoldingsList
+              holdings={snapshot.holdings}
+              thesesByTicker={thesesByTicker}
+            />
+            {snapshot.holdings.length > 0 && (
+              <p className="mt-3 text-[11px] text-text-muted font-mono">
+                Click a row to see the investment thesis recorded at buy time.
+              </p>
+            )}
+          </section>
+        ) : (
+          <section className="mb-10">
+            <p className="text-sm text-text-muted italic">
+              No account opened yet — this portfolio&apos;s first trade through{" "}
+              <code className="text-text-dim">POST /api/v1/portfolio/buy</code>{" "}
+              will seed it with $1M paper cash.
+            </p>
+          </section>
+        )}
+
+        {/* Footer */}
+        <section className="pt-6 border-t border-border">
+          <p className="text-xs text-text-muted font-mono">
+            This portfolio is public and read-only. Only its member agents (via
+            their API keys) can trade. See the{" "}
+            <Link href="/docs" className="text-green hover:underline">
+              API docs
+            </Link>{" "}
+            for endpoint details.
+          </p>
+        </section>
+      </main>
+    </>
+  );
+}
+
+// ----- Presentational helpers ---------------------------------------------
+
+function Stat({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  tone?: "positive" | "negative" | "neutral";
+}) {
+  const color =
+    tone === "positive"
+      ? "text-green"
+      : tone === "negative"
+        ? "text-red"
+        : "text-text";
+  return (
+    <div className="glass-card rounded-lg border border-border px-5 py-4">
+      <p className={`font-mono text-2xl font-bold ${color}`}>{value}</p>
+      <p className="text-[11px] font-mono uppercase tracking-widest text-text-dim mt-1">
+        {label}
+      </p>
+    </div>
+  );
+}
+
+function formatUsd(n: number): string {
+  const sign = n < 0 ? "-" : "";
+  const abs = Math.abs(n);
+  return `${sign}$${abs.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}

--- a/web/app/u/[handle]/page.tsx
+++ b/web/app/u/[handle]/page.tsx
@@ -1,266 +1,52 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import { notFound } from "next/navigation";
-import Nav from "@/components/nav";
-import HoldingsList from "@/components/holdings-list";
-import LlmPromptsPanel from "@/components/llm-prompts-panel";
+import { notFound, redirect } from "next/navigation";
 import { getAgentByHandle } from "@/lib/agents-query";
-import { getPortfolio, type PortfolioSnapshot } from "@/lib/portfolio";
-import {
-  getActiveThesesForAgent,
-  type InvestmentThesis,
-} from "@/lib/theses-query";
+import { getPortfolioBySlug } from "@/lib/portfolios-query";
 
-export const revalidate = 300;
+/**
+ * Legacy URL kept for backwards compatibility. The page now redirects:
+ *
+ *   /u/<handle>  →  /portfolios/<slug>   when the agent owns a portfolio
+ *   /u/<handle>  →  /agents/<handle>     when the agent has no portfolio
+ *                                        (analyst / data-job agents)
+ *
+ * The portfolio page is the more common destination today since every
+ * historical agent had 1:1 cash + holdings. Non-trading agents
+ * (smash-hit-scout, fundamental-sentinel) bounce to the new agent
+ * profile page instead.
+ */
 
 interface PageParams {
   params: Promise<{ handle: string }>;
 }
 
-// ----- Metadata ------------------------------------------------------------
+export const revalidate = 0; // redirect doesn't need caching
 
 export async function generateMetadata({
   params,
 }: PageParams): Promise<Metadata> {
   const { handle: rawHandle } = await params;
   const handle = decodeURIComponent(rawHandle).toLowerCase();
-
-  const agent = await getAgentByHandle(handle);
-  if (!agent) {
-    return {
-      title: `@${handle} — not found`,
-      robots: { index: false, follow: false },
-    };
-  }
   return {
-    title: `${agent.display_name} (@${agent.handle}) — AlphaMolt Arena`,
-    description:
-      agent.description ||
-      `${agent.display_name} is competing in the AlphaMolt Arena.`,
-    alternates: { canonical: `/u/${agent.handle}` },
-    openGraph: {
-      title: `${agent.display_name} — AlphaMolt Arena`,
-      description:
-        agent.description ||
-        `${agent.display_name} is competing in the AlphaMolt Arena.`,
-      url: `/u/${agent.handle}`,
-      type: "profile",
-    },
+    title: `@${handle} — AlphaMolt Arena`,
+    robots: { index: false, follow: true },
+    alternates: { canonical: `/agents/${handle}` },
   };
 }
 
-// ----- Data ---------------------------------------------------------------
-
-async function getProfileData(handle: string): Promise<{
-  agent: Awaited<ReturnType<typeof getAgentByHandle>>;
-  portfolio: PortfolioSnapshot | null;
-  thesesByTicker: Record<string, InvestmentThesis>;
-}> {
-  const agent = await getAgentByHandle(handle);
-  if (!agent) return { agent: null, portfolio: null, thesesByTicker: {} };
-
-  let portfolio: PortfolioSnapshot | null = null;
-  try {
-    portfolio = await getPortfolio(agent.id);
-  } catch (err) {
-    // No account yet (agent never called GET /portfolio) — fine, render
-    // the profile without the portfolio section.
-    console.error("getPortfolio failed for", handle, err);
-  }
-
-  // One batched query: every active investment_theses row for this agent,
-  // keyed by ticker so the holdings list can render the dropdown without
-  // a round-trip per row.
-  const thesesByTicker = await getActiveThesesForAgent(agent.id);
-
-  return { agent, portfolio, thesesByTicker };
-}
-
-// ----- Page ---------------------------------------------------------------
-
-export default async function ProfilePage({ params }: PageParams) {
+export default async function LegacyHandleRedirect({ params }: PageParams) {
   const { handle: rawHandle } = await params;
   const handle = decodeURIComponent(rawHandle).toLowerCase();
 
-  const { agent, portfolio, thesesByTicker } = await getProfileData(handle);
+  const agent = await getAgentByHandle(handle);
   if (!agent) notFound();
 
-  const created = new Date(agent.created_at).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-
-  return (
-    <>
-      <Nav />
-      <main className="flex-1 max-w-[1000px] mx-auto w-full px-4 py-10 font-sans">
-        {/* Header */}
-        <section className="mb-10">
-          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-3">
-            Agent Profile
-          </p>
-          <div className="flex items-baseline gap-3 flex-wrap mb-3">
-            <h1 className="font-mono text-3xl sm:text-4xl font-bold text-green">
-              {agent.display_name}
-            </h1>
-            <code className="text-sm text-text-muted">@{agent.handle}</code>
-            {agent.is_house_agent && (
-              <span className="text-[10px] font-mono uppercase tracking-widest px-2 py-0.5 rounded bg-orange/10 text-orange border border-orange/30">
-                House
-              </span>
-            )}
-          </div>
-          {agent.description && (
-            <p className="text-text-dim max-w-2xl text-base leading-relaxed mb-2">
-              {agent.description}
-            </p>
-          )}
-          <p className="text-[11px] font-mono uppercase tracking-widest text-text-muted">
-            Registered {created}
-          </p>
-        </section>
-
-        {/* Strategy panel — collapsed by default; native <details> so no
-            client JS. Chevron rotates on open via an arbitrary Tailwind
-            selector. Only renders when the agent has long_description set. */}
-        {agent.long_description && (
-          <details className="glass-card rounded-lg border border-border mb-10 [&[open]_.chevron]:rotate-90">
-            <summary className="cursor-pointer px-5 py-4 flex items-center justify-between font-mono text-xs font-bold uppercase tracking-widest text-text-dim list-none [&::-webkit-details-marker]:hidden hover:text-text transition-colors">
-              <span>Strategy</span>
-              <span className="chevron text-text-muted transition-transform">▸</span>
-            </summary>
-            <div className="px-5 pb-5 pt-3 text-sm text-text-dim whitespace-pre-line leading-relaxed border-t border-border">
-              {agent.long_description}
-            </div>
-          </details>
-        )}
-
-        {/* Verbatim prompts panel — only for llm_pick agents. Same prompts
-            for every model; only the model varies. The trust story is
-            "show the question". */}
-        {agent.strategy === "llm_pick" && (
-          <LlmPromptsPanel
-            pickerMode={
-              (agent.config &&
-                typeof agent.config === "object" &&
-                typeof (agent.config as Record<string, unknown>)
-                  .picker_mode === "string"
-                ? ((agent.config as Record<string, unknown>)
-                    .picker_mode as string)
-                : undefined) ?? undefined
-            }
-          />
-        )}
-
-        {/* Portfolio summary */}
-        {portfolio ? (
-          <section className="mb-10">
-            <h2 className="font-mono text-lg font-bold text-text mb-4">
-              Portfolio
-            </h2>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-              <Stat
-                label="Total value"
-                value={formatUsd(portfolio.total_value_usd)}
-              />
-              <Stat label="Cash" value={formatUsd(portfolio.cash_usd)} />
-              <Stat
-                label="P/L"
-                value={formatUsd(portfolio.pnl_usd)}
-                tone={
-                  portfolio.pnl_usd > 0
-                    ? "positive"
-                    : portfolio.pnl_usd < 0
-                      ? "negative"
-                      : "neutral"
-                }
-              />
-              <Stat
-                label="P/L %"
-                value={`${portfolio.pnl_pct >= 0 ? "+" : ""}${portfolio.pnl_pct.toFixed(2)}%`}
-                tone={
-                  portfolio.pnl_pct > 0
-                    ? "positive"
-                    : portfolio.pnl_pct < 0
-                      ? "negative"
-                      : "neutral"
-                }
-              />
-            </div>
-
-            <h3 className="font-mono text-sm font-bold text-text-dim uppercase tracking-widest mb-3">
-              Holdings ({portfolio.holdings.length})
-            </h3>
-            <HoldingsList
-              holdings={portfolio.holdings}
-              thesesByTicker={thesesByTicker}
-            />
-            {portfolio.holdings.length > 0 && (
-              <p className="mt-3 text-[11px] text-text-muted font-mono">
-                Click a row to see the investment thesis recorded at buy time.
-              </p>
-            )}
-          </section>
-        ) : (
-          <section className="mb-10">
-            <p className="text-sm text-text-muted italic">
-              No portfolio yet. This agent hasn&apos;t opened its account —
-              its first call to{" "}
-              <code className="text-text-dim">GET /api/v1/portfolio</code>{" "}
-              will seed it with $1M paper cash.
-            </p>
-          </section>
-        )}
-
-        {/* Footer */}
-        <section className="pt-6 border-t border-border">
-          <p className="text-xs text-text-muted font-mono">
-            This profile is public and read-only. Only the agent (via its API
-            key) can trade or rotate credentials. See the{" "}
-            <Link href="/docs" className="text-green hover:underline">
-              API docs
-            </Link>{" "}
-            for endpoint details.
-          </p>
-        </section>
-      </main>
-    </>
-  );
-}
-
-// ----- Presentational helpers ---------------------------------------------
-
-function Stat({
-  label,
-  value,
-  tone = "neutral",
-}: {
-  label: string;
-  value: string;
-  tone?: "positive" | "negative" | "neutral";
-}) {
-  const color =
-    tone === "positive"
-      ? "text-green"
-      : tone === "negative"
-        ? "text-red"
-        : "text-text";
-  return (
-    <div className="glass-card rounded-lg border border-border px-5 py-4">
-      <p className={`font-mono text-2xl font-bold ${color}`}>{value}</p>
-      <p className="text-[11px] font-mono uppercase tracking-widest text-text-dim mt-1">
-        {label}
-      </p>
-    </div>
-  );
-}
-
-function formatUsd(n: number): string {
-  const sign = n < 0 ? "-" : "";
-  const abs = Math.abs(n);
-  return `${sign}$${abs.toLocaleString("en-US", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
+  // Prefer the portfolio destination when one exists (1:1 today for every
+  // agent that has traded). Otherwise route to the agent profile page.
+  const portfolio = await getPortfolioBySlug(agent.handle);
+  if (portfolio) {
+    redirect(`/portfolios/${portfolio.slug}`);
+  } else {
+    redirect(`/agents/${agent.handle}`);
+  }
 }

--- a/web/components/leaderboard-table.tsx
+++ b/web/components/leaderboard-table.tsx
@@ -16,6 +16,13 @@ const PERIOD_LABELS: Record<Period, string> = {
   "1yr": "1Yr",
 };
 
+export interface LeaderboardMemberAgent {
+  handle: string;
+  display_name: string;
+  powered_by: string | null;
+  is_house_agent: boolean;
+}
+
 export interface LeaderboardAgentRow {
   kind: "agent";
   handle: string;
@@ -31,6 +38,11 @@ export interface LeaderboardAgentRow {
   sharpe_n_returns: number;
   trades: Record<Period, number>;
   num_positions: number;
+  // Portfolio-aware fields surfaced by migration 021. ``handle`` above
+  // is the portfolio's slug (1:1 with the owner agent's handle today);
+  // ``members`` lists every agent operating this portfolio. Empty array
+  // when the join was unavailable.
+  members: LeaderboardMemberAgent[];
 }
 
 export interface LeaderboardBenchmarkRow {
@@ -235,7 +247,7 @@ function AgentTableRow({
     <tr className="border-b border-border/50 hover:bg-bg-hover/50 transition-colors">
       <td className="px-4 py-3 text-text-dim">{rank}</td>
       <td className="px-4 py-3">
-        <Link href={`/u/${row.handle}`} className="group block">
+        <Link href={`/portfolios/${row.handle}`} className="group block">
           <div className="flex items-center gap-2">
             <span className="text-text group-hover:text-green transition-colors">
               {row.display_name}
@@ -248,6 +260,20 @@ function AgentTableRow({
           </div>
           <div className="text-xs text-text-muted">@{row.handle}</div>
         </Link>
+        {row.members.length > 1 && (
+          <div className="mt-1.5 flex flex-wrap gap-1">
+            {row.members.map((m) => (
+              <Link
+                key={m.handle}
+                href={`/agents/${m.handle}`}
+                className="text-[10px] font-mono text-text-muted hover:text-green border border-border rounded px-1 py-0.5"
+                title={m.powered_by ? `Powered by ${m.powered_by}` : undefined}
+              >
+                {m.display_name}
+              </Link>
+            ))}
+          </div>
+        )}
       </td>
       <td className="px-4 py-3 text-right text-text">
         {formatUsd(row.total_value_usd)}

--- a/web/lib/agent-registration.ts
+++ b/web/lib/agent-registration.ts
@@ -15,6 +15,7 @@ import type { CreateAgentResult } from "@/lib/agents-query";
 export interface RegistrationPayload extends CreateAgentResult {
   warning: string;
   profile_url: string;
+  portfolio_url: string;
   verification_url: string;
   env: {
     bash: string;
@@ -42,7 +43,8 @@ export function buildRegistrationPayload(
     agent,
     api_key,
     warning: API_KEY_WARNING,
-    profile_url: absoluteUrl(`/u/${agent.handle}`),
+    profile_url: absoluteUrl(`/agents/${agent.handle}`),
+    portfolio_url: absoluteUrl(`/portfolios/${agent.handle}`),
     verification_url: absoluteUrl(`/api/v1/agents/${agent.handle}`),
     env: {
       bash: `export ALPHAMOLT_API_KEY=${api_key}`,

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -19,6 +19,7 @@ export interface Agent {
   is_house_agent: boolean;
   strategy: string | null;
   config: Record<string, unknown> | null;
+  powered_by: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -42,6 +43,12 @@ export interface CreateAgentInput {
   display_name: string;
   description?: string;
   contact_email?: string;
+  /**
+   * Human-readable LLM brand (e.g. "Claude Sonnet 4.6", "GPT-5",
+   * "Custom fine-tuned Llama 3 70B"). Optional. Renders as the
+   * "Powered by …" chip on the agent profile page.
+   */
+  powered_by?: string;
 }
 
 export interface CreateAgentResult {
@@ -148,6 +155,7 @@ export async function createAgent(
   const display_name = input.display_name.trim();
   const description = (input.description ?? "").trim();
   const contact_email = input.contact_email?.trim() || null;
+  const powered_by = input.powered_by?.trim() || null;
 
   if (!HANDLE_RE.test(handle)) {
     throw new AgentValidationError(
@@ -188,6 +196,12 @@ export async function createAgent(
       );
     }
   }
+  if (powered_by && powered_by.length > 80) {
+    throw new AgentValidationError(
+      "invalid_powered_by",
+      "powered_by must be 80 characters or fewer.",
+    );
+  }
 
   const key: GeneratedKey = generateApiKey();
 
@@ -199,6 +213,7 @@ export async function createAgent(
       display_name,
       description,
       contact_email,
+      powered_by,
       api_key_hash: key.hash,
       api_key_prefix: key.prefix,
       is_house_agent: false,
@@ -273,7 +288,7 @@ export async function resolveAgentByApiKey(
   const { data, error } = await supabase
     .from("agents")
     .select(
-      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, strategy, config, created_at, updated_at",
+      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, strategy, config, powered_by, created_at, updated_at",
     )
     .eq("api_key_hash", hash)
     .maybeSingle();
@@ -297,7 +312,7 @@ export async function getAgentByHandle(
   const { data, error } = await supabase
     .from("agents")
     .select(
-      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, strategy, config, created_at, updated_at",
+      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, strategy, config, powered_by, created_at, updated_at",
     )
     .eq("handle", normalised)
     .maybeSingle();

--- a/web/lib/leaderboard-query.ts
+++ b/web/lib/leaderboard-query.ts
@@ -50,6 +50,13 @@ async function fetchLeaderboard(): Promise<LeaderboardResult> {
     sharpe: number | string | null;
     sharpe_n_returns: number | string | null;
     num_positions: number;
+    // Portfolio fields from the rebuilt view (migration 021).
+    member_agents: Array<{
+      handle: string;
+      display_name: string;
+      powered_by: string | null;
+      is_house_agent: boolean;
+    }> | null;
   }
   const { data: agentData, error: agentErr } = await supabase
     .from("agent_leaderboard")
@@ -57,7 +64,7 @@ async function fetchLeaderboard(): Promise<LeaderboardResult> {
       "handle, display_name, is_house_agent, snapshot_date, cash_usd, " +
         "holdings_value_usd, total_value_usd, pnl_usd, " +
         "pnl_pct_1d, pnl_pct_1w, pnl_pct_30d, pnl_pct_ytd, pnl_pct_1yr, " +
-        "sharpe, sharpe_n_returns, num_positions",
+        "sharpe, sharpe_n_returns, num_positions, member_agents",
     );
   if (agentErr) console.error("Failed to fetch agent leaderboard:", agentErr);
   const rawAgents = (agentData ?? []) as unknown as RawAgentRow[];
@@ -94,6 +101,12 @@ async function fetchLeaderboard(): Promise<LeaderboardResult> {
       sharpe_n_returns: toNum(r.sharpe_n_returns) ?? 0,
       trades: tradesByHandle.get(r.handle) ?? emptyBuckets(),
       num_positions: r.num_positions,
+      members: (r.member_agents ?? []).map((m) => ({
+        handle: m.handle,
+        display_name: m.display_name,
+        powered_by: m.powered_by,
+        is_house_agent: m.is_house_agent,
+      })),
     };
   });
 

--- a/web/lib/portfolio.ts
+++ b/web/lib/portfolio.ts
@@ -294,17 +294,26 @@ async function getAllHoldings(agentId: string): Promise<AgentHolding[]> {
 /**
  * Idempotently create an agent_accounts row. If one already exists it is
  * returned unchanged — safe to call on every request (first-trade lazy init).
+ *
+ * Also creates a 1:1 ``portfolios`` row (slug = agent.handle, owner = this
+ * agent) and the ``portfolio_agents`` membership row so multi-agent
+ * portfolios are wired in from day one (migration 021).
  */
 export async function openAccount(
   agentId: string,
   startingCash: number = DEFAULT_STARTING_CASH,
 ): Promise<AgentAccount> {
   const existing = await getAccountRow(agentId);
-  if (existing) return existing;
+  if (existing) {
+    await ensurePortfolioForAgent(agentId);
+    return existing;
+  }
 
+  const portfolioId = await ensurePortfolioForAgent(agentId);
   const supabase = getSupabase();
   const { error } = await supabase.from("agent_accounts").upsert({
     agent_id: agentId,
+    portfolio_id: portfolioId,
     starting_cash: startingCash,
     cash_usd: startingCash,
     inception_date: new Date().toISOString().slice(0, 10),
@@ -325,6 +334,84 @@ export async function openAccount(
   return row;
 }
 
+/**
+ * Resolve (creating if necessary) the portfolio_id this agent's trades
+ * should attribute to. During the 1:1 shim period the portfolio_id
+ * equals the agent_id. Idempotent — safe to call on every buy/sell.
+ */
+export async function ensurePortfolioForAgent(agentId: string): Promise<string> {
+  const supabase = getSupabase();
+
+  // 1. Already owns a portfolio?
+  const owned = await supabase
+    .from("portfolios")
+    .select("id")
+    .eq("owner_agent_id", agentId)
+    .limit(1)
+    .maybeSingle();
+  if (owned.data?.id) {
+    return owned.data.id as string;
+  }
+
+  // 2. Already a member of one?
+  const member = await supabase
+    .from("portfolio_agents")
+    .select("portfolio_id")
+    .eq("agent_id", agentId)
+    .limit(1)
+    .maybeSingle();
+  if (member.data?.portfolio_id) {
+    return member.data.portfolio_id as string;
+  }
+
+  // 3. Create one. portfolio.id = agent.id during the 1:1 shim.
+  const agentRow = await supabase
+    .from("agents")
+    .select("id, handle, display_name, description")
+    .eq("id", agentId)
+    .maybeSingle();
+  if (!agentRow.data) {
+    throw new PortfolioError("unknown_agent", `No agents row for ${agentId}`);
+  }
+  const a = agentRow.data as {
+    id: string;
+    handle: string;
+    display_name: string;
+    description: string | null;
+  };
+
+  const { error: pErr } = await supabase.from("portfolios").upsert(
+    {
+      id: a.id,
+      slug: a.handle,
+      display_name: a.display_name,
+      description: a.description,
+      owner_agent_id: a.id,
+    },
+    { onConflict: "id" },
+  );
+  if (pErr) {
+    throw new PortfolioError(
+      "db_error",
+      `portfolios upsert failed: ${pErr.message}`,
+    );
+  }
+
+  const { error: mErr } = await supabase
+    .from("portfolio_agents")
+    .upsert(
+      { portfolio_id: a.id, agent_id: a.id },
+      { onConflict: "portfolio_id,agent_id" },
+    );
+  if (mErr) {
+    throw new PortfolioError(
+      "db_error",
+      `portfolio_agents upsert failed: ${mErr.message}`,
+    );
+  }
+  return a.id;
+}
+
 export async function buy(
   agentId: string,
   ticker: string,
@@ -340,6 +427,7 @@ export async function buy(
   }
 
   const account = await openAccount(agentId); // lazy bootstrap
+  const portfolioId = await ensurePortfolioForAgent(agentId);
   const price = await getPrice(ticker);
   const gross = round2(quantity * price);
   const cash = account.cash_usd;
@@ -362,6 +450,7 @@ export async function buy(
     );
     const { error: hErr } = await supabase.from("agent_holdings").upsert({
       agent_id: agentId,
+      portfolio_id: portfolioId,
       ticker,
       quantity: newQty,
       avg_cost_usd: newAvgCost,
@@ -376,6 +465,7 @@ export async function buy(
   } else {
     const { error: hErr } = await supabase.from("agent_holdings").upsert({
       agent_id: agentId,
+      portfolio_id: portfolioId,
       ticker,
       quantity,
       avg_cost_usd: round4(price),
@@ -390,7 +480,7 @@ export async function buy(
 
   const { error: aErr } = await supabase
     .from("agent_accounts")
-    .update({ cash_usd: newCash })
+    .update({ cash_usd: newCash, portfolio_id: portfolioId })
     .eq("agent_id", agentId);
   if (aErr) {
     throw new PortfolioError(
@@ -402,6 +492,7 @@ export async function buy(
   const executed_at = new Date().toISOString();
   const trade = {
     agent_id: agentId,
+    portfolio_id: portfolioId,
     ticker,
     side: "buy" as const,
     quantity,
@@ -428,7 +519,7 @@ export async function buy(
   // path's behaviour (theses.py). Errors are logged inside recordThesis
   // and never propagated — a thesis I/O failure must not roll back the
   // trade itself.
-  await recordThesis({ agentId, ticker, tradeId, thesis });
+  await recordThesis({ agentId, portfolioId, ticker, tradeId, thesis });
 
   return trade;
 }
@@ -447,6 +538,7 @@ export async function sell(
   }
 
   const account = await requireAccount(agentId);
+  const portfolioId = await ensurePortfolioForAgent(agentId);
   const holding = await getHoldingRow(agentId, ticker);
   if (!holding) {
     throw new PortfolioError(
@@ -483,6 +575,7 @@ export async function sell(
     // avg_cost_usd unchanged on sells (weighted-avg convention)
     const { error: uErr } = await supabase.from("agent_holdings").upsert({
       agent_id: agentId,
+      portfolio_id: portfolioId,
       ticker,
       quantity: remaining,
       avg_cost_usd: holding.avg_cost_usd,
@@ -498,7 +591,7 @@ export async function sell(
 
   const { error: aErr } = await supabase
     .from("agent_accounts")
-    .update({ cash_usd: newCash })
+    .update({ cash_usd: newCash, portfolio_id: portfolioId })
     .eq("agent_id", agentId);
   if (aErr) {
     throw new PortfolioError(
@@ -510,6 +603,7 @@ export async function sell(
   const executed_at = new Date().toISOString();
   const trade = {
     agent_id: agentId,
+    portfolio_id: portfolioId,
     ticker,
     side: "sell" as const,
     quantity,
@@ -530,7 +624,7 @@ export async function sell(
   // Close any open theses if the position is fully exited. Idempotent
   // (no-op when no rows match). Matches the Python sell path.
   if (remaining <= 1e-9) {
-    await closeThesesForPosition({ agentId, ticker });
+    await closeThesesForPosition({ agentId, portfolioId, ticker });
   }
 
   return trade;

--- a/web/lib/portfolios-query.ts
+++ b/web/lib/portfolios-query.ts
@@ -1,0 +1,187 @@
+/**
+ * Read-side queries for portfolios (migration 021).
+ *
+ * Today every portfolio has exactly one member (the owner agent) by
+ * virtue of the 1:1 backfill. Multi-agent portfolios are supported by
+ * the schema; the API surface for adding additional members is a
+ * follow-up PR.
+ *
+ * The corresponding writers live in `web/lib/portfolio.ts`
+ * (`openAccount` + `ensurePortfolioForAgent`) and `web/lib/theses.ts`.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+
+export interface Portfolio {
+  id: string;
+  slug: string;
+  display_name: string;
+  description: string | null;
+  owner_agent_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PortfolioMember {
+  agent_id: string;
+  handle: string;
+  display_name: string;
+  description: string | null;
+  is_house_agent: boolean;
+  powered_by: string | null;
+  notes: string | null;
+  joined_at: string;
+}
+
+export interface PortfolioMembershipForAgent {
+  portfolio: Portfolio;
+  notes: string | null;
+  joined_at: string;
+  current_total_value_usd: number | null;
+  current_pnl_pct: number | null;
+}
+
+export async function getPortfolioBySlug(slug: string): Promise<Portfolio | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("portfolios")
+    .select("*")
+    .eq("slug", slug)
+    .maybeSingle();
+  if (error) {
+    console.error("getPortfolioBySlug failed:", error);
+    return null;
+  }
+  return (data as Portfolio | null) ?? null;
+}
+
+export async function getPortfolioById(id: string): Promise<Portfolio | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("portfolios")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (error) {
+    console.error("getPortfolioById failed:", error);
+    return null;
+  }
+  return (data as Portfolio | null) ?? null;
+}
+
+/**
+ * Return every portfolio this agent is a member of (owned or otherwise),
+ * enriched with the portfolio's latest MTM value + P/L %. Used by the
+ * agent profile page's "Portfolios" section.
+ */
+export async function getPortfoliosForAgent(
+  agentId: string,
+): Promise<PortfolioMembershipForAgent[]> {
+  const supabase = getSupabase();
+  const { data: memberships, error } = await supabase
+    .from("portfolio_agents")
+    .select("portfolio_id, notes, joined_at")
+    .eq("agent_id", agentId)
+    .order("joined_at", { ascending: true });
+  if (error) {
+    console.error("getPortfoliosForAgent memberships failed:", error);
+    return [];
+  }
+  const rows = memberships ?? [];
+  if (rows.length === 0) return [];
+
+  // Resolve portfolio rows
+  const ids = rows.map((r) => (r as { portfolio_id: string }).portfolio_id);
+  const { data: portfolios } = await supabase
+    .from("portfolios")
+    .select("*")
+    .in("id", ids);
+  const byId = new Map<string, Portfolio>(
+    ((portfolios as Portfolio[] | null) ?? []).map((p) => [p.id, p]),
+  );
+
+  // Latest MTM per portfolio from agent_leaderboard (one row per portfolio).
+  const { data: leaderboard } = await supabase
+    .from("agent_leaderboard")
+    .select("portfolio_id, total_value_usd, pnl_pct")
+    .in("portfolio_id", ids);
+  const mtmById = new Map<
+    string,
+    { total_value_usd: number | null; pnl_pct: number | null }
+  >(
+    (
+      (leaderboard as
+        | { portfolio_id: string; total_value_usd: number; pnl_pct: number }[]
+        | null) ?? []
+    ).map((r) => [
+      r.portfolio_id,
+      { total_value_usd: r.total_value_usd, pnl_pct: r.pnl_pct },
+    ]),
+  );
+
+  const out: PortfolioMembershipForAgent[] = [];
+  for (const m of rows) {
+    const r = m as { portfolio_id: string; notes: string | null; joined_at: string };
+    const portfolio = byId.get(r.portfolio_id);
+    if (!portfolio) continue;
+    const mtm = mtmById.get(r.portfolio_id);
+    out.push({
+      portfolio,
+      notes: r.notes,
+      joined_at: r.joined_at,
+      current_total_value_usd: mtm?.total_value_usd ?? null,
+      current_pnl_pct: mtm?.pnl_pct ?? null,
+    });
+  }
+  return out;
+}
+
+export async function getMembersForPortfolio(
+  portfolioId: string,
+): Promise<PortfolioMember[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("portfolio_agents")
+    .select(
+      "agent_id, notes, joined_at, agents (handle, display_name, description, is_house_agent, powered_by)",
+    )
+    .eq("portfolio_id", portfolioId)
+    .order("joined_at", { ascending: true });
+  if (error) {
+    console.error("getMembersForPortfolio failed:", error);
+    return [];
+  }
+  // Supabase PostgREST sometimes infers embedded one-to-one joins as
+  // arrays of length 1. Normalise via `unknown` then pluck the first
+  // (and only) element if the value is an array.
+  type EmbeddedAgent = {
+    handle: string;
+    display_name: string;
+    description: string | null;
+    is_house_agent: boolean;
+    powered_by: string | null;
+  };
+  type Row = {
+    agent_id: string;
+    notes: string | null;
+    joined_at: string;
+    agents: EmbeddedAgent | EmbeddedAgent[] | null;
+  };
+  const rows = (data as unknown as Row[] | null) ?? [];
+  return rows
+    .map((r) => {
+      const a = Array.isArray(r.agents) ? r.agents[0] : r.agents;
+      if (!a) return null;
+      return {
+        agent_id: r.agent_id,
+        handle: a.handle,
+        display_name: a.display_name,
+        description: a.description,
+        is_house_agent: a.is_house_agent,
+        powered_by: a.powered_by,
+        notes: r.notes,
+        joined_at: r.joined_at,
+      };
+    })
+    .filter((m): m is PortfolioMember => m !== null);
+}

--- a/web/lib/theses.ts
+++ b/web/lib/theses.ts
@@ -96,21 +96,28 @@ export async function recordThesis(opts: {
   agentId: string;
   ticker: string;
   tradeId: number | null;
+  portfolioId?: string | null;
   thesis?: ThesisInput | null;
 }): Promise<number | null> {
   const supabase = getSupabase();
   const snapshot = await buildSnapshot(opts.ticker);
 
-  // Supersede any prior active row for this (agent, ticker).
-  await supabase
+  // Supersede any prior active row for this (portfolio, ticker) — falls
+  // back to (agent, ticker) when portfolioId isn't supplied. Both reach
+  // the same rows during the 1:1 shim period.
+  const supersedeBuilder = supabase
     .from("investment_theses")
     .update({
       status: "superseded",
       status_changed_at: new Date().toISOString(),
     })
-    .eq("agent_id", opts.agentId)
     .eq("ticker", opts.ticker)
     .eq("status", "active");
+  if (opts.portfolioId) {
+    await supersedeBuilder.eq("portfolio_id", opts.portfolioId);
+  } else {
+    await supersedeBuilder.eq("agent_id", opts.agentId);
+  }
 
   const text = opts.thesis?.thesis_text ?? null;
   const extend = opts.thesis?.extend_signals ?? null;
@@ -121,6 +128,7 @@ export async function recordThesis(opts: {
     .from("investment_theses")
     .insert({
       agent_id: opts.agentId,
+      portfolio_id: opts.portfolioId ?? opts.agentId,
       ticker: opts.ticker,
       trade_id: opts.tradeId,
       snapshot,
@@ -151,19 +159,23 @@ export async function recordThesis(opts: {
 export async function closeThesesForPosition(opts: {
   agentId: string;
   ticker: string;
+  portfolioId?: string | null;
 }): Promise<void> {
   const supabase = getSupabase();
   const now = new Date().toISOString();
-  const { error } = await supabase
+  const builder = supabase
     .from("investment_theses")
     .update({
       status: "closed",
       status_changed_at: now,
       closed_at: now,
     })
-    .eq("agent_id", opts.agentId)
     .eq("ticker", opts.ticker)
     .neq("status", "closed");
+  const filtered = opts.portfolioId
+    ? builder.eq("portfolio_id", opts.portfolioId)
+    : builder.eq("agent_id", opts.agentId);
+  const { error } = await filtered;
   if (error) {
     console.error("closeThesesForPosition update failed:", error);
   }

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -37,7 +37,8 @@ Content-Type: application/json
 {
   "handle": "your-agent-handle",
   "display_name": "Your Agent Name",
-  "description": "one sentence about your strategy"
+  "description": "one sentence about your strategy",
+  "powered_by": "Claude Sonnet 4.6"
 }
 ```
 
@@ -46,6 +47,9 @@ Content-Type: application/json
 - `display_name` is what appears on the leaderboard (≤80 chars).
 - `description` is optional (≤500 chars).
 - `contact_email` is optional (for launch notifications only).
+- `powered_by` is optional (≤80 chars). Renders as a "Powered by …"
+  chip on your public agent page — typically the LLM brand driving
+  the agent (e.g. `"Claude Sonnet 4.6"`, `"GPT-5"`, `"Llama 3 70B"`).
 
 ### 201 response shape
 
@@ -59,7 +63,8 @@ Content-Type: application/json
     "created_at": "2026-04-23T12:00:00.000Z"
   },
   "api_key": "ak_live_...",
-  "profile_url": "https://www.alphamolt.ai/u/your-agent-handle",
+  "profile_url": "https://www.alphamolt.ai/agents/your-agent-handle",
+  "portfolio_url": "https://www.alphamolt.ai/portfolios/your-agent-handle",
   "verification_url": "https://www.alphamolt.ai/api/v1/agents/your-agent-handle",
   "env": {
     "bash":       "export ALPHAMOLT_API_KEY=ak_live_...",

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -36,13 +36,17 @@ Content-Type: application/json
 {
   "handle": "my-agent",
   "display_name": "My Agent",
-  "description": "one-line strategy summary (optional, max 500 chars)"
+  "description": "one-line strategy summary (optional, max 500 chars)",
+  "powered_by": "Claude Sonnet 4.6"
 }
 ```
 
 - `handle` is a permanent slug: 3–32 chars, `^[a-z][a-z0-9-]{2,31}$`.
 - `display_name` is what shows on the leaderboard (max 80 chars).
 - `description` is optional (max 500 chars).
+- `powered_by` is optional (max 80 chars) — a human-readable LLM brand
+  that renders as a "Powered by …" chip on your public agent profile.
+  Examples: `"Claude Sonnet 4.6"`, `"GPT-5"`, `"Custom fine-tuned Llama 3 70B"`.
 
 ### 201 Created response
 
@@ -50,7 +54,8 @@ Content-Type: application/json
 {
   "agent": { "handle": "my-agent", "display_name": "My Agent", ... },
   "api_key": "ak_live_...",
-  "profile_url": "https://www.alphamolt.ai/u/my-agent",
+  "profile_url": "https://www.alphamolt.ai/agents/my-agent",
+  "portfolio_url": "https://www.alphamolt.ai/portfolios/my-agent",
   "verification_url": "https://www.alphamolt.ai/api/v1/agents/my-agent",
   "env": {
     "bash":       "export ALPHAMOLT_API_KEY=ak_live_...",


### PR DESCRIPTION
## Summary

Introduces **portfolios** as a first-class entity that one or more agents can operate on, and splits the legacy `/u/[handle]` page into two new pages so agents and portfolios each get their own surface. Sets up the substrate for multi-agent portfolios (one agent buys, another does maintenance, etc.) and for non-trading agents (data jobs, analysts) that currently can't be modelled cleanly.

**Shim migration**: every existing trading-shaped table (`agent_accounts`, `agent_holdings`, `agent_trades`, `agent_portfolio_history`, `investment_theses`) gains a `portfolio_id` column backfilled 1:1 from `agent_id`. Both keys are populated on every write during the transition. The `agent_id` columns will be dropped in a later migration once every reader is on `portfolio_id`.

## URL surface

| URL | Before | After |
|---|---|---|
| `/u/[handle]` | Agent + portfolio mashed together | **Redirect** → `/portfolios/<slug>` for trading agents, `/agents/<handle>` for analyst agents |
| `/agents/[handle]` | — | Agent identity: display_name, `@handle`, House badge, `Powered by …` chip, what-this-agent-does, portfolios list |
| `/portfolios/[slug]` | — | Cash + holdings (thesis dropdown reused) + member-agent chips |
| `/leaderboard` | Ranked agents | Ranks portfolios; member chips when >1 |
| `/api/v1/portfolios/[slug]` | — | Public portfolio JSON endpoint |

## Schema (migration 021)

- `portfolios` (id, slug UNIQUE, display_name, description, owner_agent_id, …) with public-read RLS
- `portfolio_agents` (portfolio_id, agent_id, notes, joined_at) — permissive many-to-many, no roles
- `agents.powered_by` TEXT — optional LLM brand, backfilled for house agents from `config.deep_think_llm` / `config.model`
- `portfolio_id` NOT NULL columns + FKs + indexes on the five trading tables, backfilled to `agent_id`
- `agent_leaderboard` view rebuilt: partitions on `portfolio_id`, joins `portfolios` for slug/display_name, aggregates `portfolio_agents` into a `member_agents` JSONB array

## Code

### Python — `portfolio.py` / `theses.py` / `db.py` / `portfolio_valuation.py`
- `PortfolioManager.open_account` also creates portfolio + member rows
- New `_ensure_portfolio_for_agent` / `_portfolio_for_agent` helpers
- `buy` / `buy_atomic` / `sell` / `sell_atomic` write both keys; atomic RPC paths backfill `portfolio_id` post-trade until the RPCs themselves learn about it
- `theses.record_thesis` + `close_theses_for_position` accept `portfolio_id` and supersede / close by it when supplied
- `SupabaseDB` gains `get_portfolio_by_slug`, `get_portfolio_by_agent_id`, `get_portfolios_for_agent`, `get_portfolio_members`, `create_portfolio`, `add_portfolio_member`

### TypeScript — `web/lib/portfolio.ts` / `theses.ts` / `portfolios-query.ts`
- Mirror of the Python shim: `openAccount` creates portfolio, `buy` / `sell` write both keys, `recordThesis` / `closeThesesForPosition` take optional `portfolioId`
- New `portfolios-query.ts`: `getPortfolioBySlug`, `getPortfolioById`, `getPortfoliosForAgent` (joined with leaderboard MTM), `getMembersForPortfolio`

### Pages
- **`/agents/[handle]/page.tsx`** — agent identity, `Powered by` chip, expandable "What this agent does", Portfolios list (with current value + P/L per row, optional `notes` showing the agent's role per portfolio)
- **`/portfolios/[slug]/page.tsx`** — portfolio summary + `HoldingsList` (existing thesis-dropdown component reused unchanged)
- **`/u/[handle]/page.tsx`** — server-side redirect to `/portfolios/<slug>` if the agent owns one, else `/agents/<handle>`
- **`/api/v1/portfolios/[slug]/route.ts`** — public JSON endpoint with portfolio + members + snapshot

### Leaderboard
- `LeaderboardAgentRow` grows `members: LeaderboardMemberAgent[]`
- Leaderboard row links to `/portfolios/<slug>` instead of `/u/<handle>`
- Member chips render under the row name when `members.length > 1`

### Agent registration
- `POST /api/v1/agents` accepts optional `powered_by` (≤80 chars)
- Response payload returns both `profile_url` (`/agents/<handle>`) and a new `portfolio_url` (`/portfolios/<slug>`)

## Tests
- New `test_portfolios.py` — **9 tests** covering DB helpers (`get_portfolio_by_slug`, `get_portfolio_by_agent_id` falling back to membership, `create_portfolio`, `add_portfolio_member`) + the `_ensure_portfolio_for_agent` flow.
- `test_theses.py` — **2 new tests** asserting `portfolio_id` is threaded through `record_thesis` and defaults to `agent_id` when omitted.
- Existing 28 `trading_agents` + 27 `theses` tests still green — total **66 Python tests passing**.
- `npx tsc --noEmit` clean; `npx next build` exit 0.

## Docs
- `skill.md` + `api-reference.md` + on-site `/docs` all document the optional `powered_by` field and the new agent + portfolio URL split.
- `CLAUDE.md` documents `portfolios` + `portfolio_agents` under Database Tables, plus a note explaining `portfolio_id` on the trading tables.

## What's intentionally out of scope (Phase B / C)

- **Multi-agent membership API**: no `POST /api/v1/portfolios/[slug]/members` endpoint yet. Schema supports it; the API doesn't.
- **Permission model**: any `portfolio_agents` member can do anything. No per-agent capabilities (buy / sell / maintain) until there's a use case.
- **Agent directory page** (`/agents`): a future PR. Non-trading agents are discoverable today via the portfolios they're linked from.
- **Dropping `agent_id` columns**: the shim leaves them. A later migration drops them once every reader migrates.
- **Migrating the legacy `/u/` link sites** (consensus pages, register form, etc.): the redirect handles them; cleanup is a follow-up.

## Test plan (post-merge)

- [ ] Apply `migrations/021_portfolios.sql` in Supabase SQL editor; verify `portfolios` + `portfolio_agents` populated 1:1 with `agent_accounts`
- [ ] Spot check: `SELECT COUNT(*)` consistency — every trading row has `portfolio_id = agent_id`
- [ ] Visit `/leaderboard` — should render identically (every portfolio has one member)
- [ ] Visit `/u/tauric-opus-4-7` — confirm redirect to `/portfolios/tauric-opus-4-7`
- [ ] Visit `/agents/tauric-opus-4-7` — confirm `Powered by Claude Sonnet 4.6` chip + portfolios list
- [ ] Visit `/portfolios/tauric-opus-4-7` — confirm cash + holdings + thesis dropdown + member-agent chip (links to `/agents/...`)
- [ ] Trigger a Tauric heartbeat — confirm new BUYs write both `agent_id` and `portfolio_id`

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU

---
_Generated by [Claude Code](https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU)_