### PR TITLE
portfolios: multi-agent membership API + legacy /u/ link migration

### DIFF
--- a/migrations/022_atomic_rpcs_write_portfolio_id.sql
+++ b/migrations/022_atomic_rpcs_write_portfolio_id.sql
@@ -1,0 +1,235 @@
+-- Migration 022: extend execute_atomic_buy + execute_atomic_sell to write
+-- portfolio_id directly.
+--
+-- Migration 019 introduced the atomic buy/sell RPCs (row-level locks via
+-- SELECT FOR UPDATE in a single transaction). Migration 021 added
+-- portfolio_id NOT NULL columns to every trading-shaped table. Between the
+-- two, the Python wrapper in portfolio.py had to backfill portfolio_id on
+-- agent_holdings / agent_accounts / agent_trades immediately after each
+-- RPC call — three extra round-trips and a small race window where the
+-- rows briefly exist with portfolio_id = the default from the column's
+-- backfill (= agent_id at this point).
+--
+-- This migration moves portfolio_id resolution into the RPCs themselves.
+-- They look up portfolio_id via agent_accounts.portfolio_id (already
+-- populated by migration 021) and write it on every INSERT/UPDATE. The
+-- Python wrapper's backfill becomes redundant — pure correctness +
+-- cleanup, no behaviour change for external callers.
+--
+-- Function signatures unchanged: same input params, same return shape.
+
+CREATE OR REPLACE FUNCTION execute_atomic_buy(
+    p_agent_id   UUID,
+    p_ticker     TEXT,
+    p_quantity   NUMERIC,
+    p_price_usd  NUMERIC,
+    p_note       TEXT DEFAULT ''
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_gross_usd      NUMERIC;
+    v_current_cash   NUMERIC;
+    v_new_cash       NUMERIC;
+    v_portfolio_id   UUID;
+    v_existing_qty   NUMERIC;
+    v_existing_cost  NUMERIC;
+    v_new_qty        NUMERIC;
+    v_new_avg_cost   NUMERIC;
+    v_trade_id       BIGINT;
+BEGIN
+    IF p_quantity <= 0 THEN
+        RAISE EXCEPTION 'quantity must be > 0 (got %)', p_quantity;
+    END IF;
+    IF p_price_usd <= 0 THEN
+        RAISE EXCEPTION 'price_usd must be > 0 (got %)', p_price_usd;
+    END IF;
+
+    v_gross_usd := p_quantity * p_price_usd;
+
+    -- Lock the account row + read cash + portfolio_id.
+    SELECT cash_usd, portfolio_id
+        INTO v_current_cash, v_portfolio_id
+        FROM agent_accounts
+        WHERE agent_id = p_agent_id
+        FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'no account for agent %', p_agent_id;
+    END IF;
+    IF v_portfolio_id IS NULL THEN
+        -- Defensive: should never trigger after migration 021's backfill,
+        -- but if it does we use the agent_id as the 1:1 shim portfolio_id.
+        v_portfolio_id := p_agent_id;
+    END IF;
+
+    IF v_current_cash < v_gross_usd THEN
+        RETURN jsonb_build_object(
+            'status', 'insufficient_cash',
+            'cash_usd', v_current_cash,
+            'needed_usd', v_gross_usd
+        );
+    END IF;
+
+    v_new_cash := v_current_cash - v_gross_usd;
+
+    -- Weighted-avg cost basis upsert.
+    SELECT quantity, avg_cost_usd
+        INTO v_existing_qty, v_existing_cost
+        FROM agent_holdings
+        WHERE agent_id = p_agent_id AND ticker = p_ticker
+        FOR UPDATE;
+
+    IF NOT FOUND THEN
+        v_new_qty := p_quantity;
+        v_new_avg_cost := p_price_usd;
+        INSERT INTO agent_holdings
+            (agent_id, portfolio_id, ticker, quantity, avg_cost_usd, first_bought_at, updated_at)
+        VALUES
+            (p_agent_id, v_portfolio_id, p_ticker, v_new_qty, v_new_avg_cost, NOW(), NOW());
+    ELSE
+        v_new_qty := v_existing_qty + p_quantity;
+        v_new_avg_cost := (v_existing_qty * v_existing_cost + v_gross_usd) / v_new_qty;
+        UPDATE agent_holdings
+           SET quantity = v_new_qty,
+               avg_cost_usd = v_new_avg_cost,
+               portfolio_id = v_portfolio_id,
+               updated_at = NOW()
+         WHERE agent_id = p_agent_id AND ticker = p_ticker;
+    END IF;
+
+    -- Deduct cash + ensure portfolio_id stays consistent.
+    UPDATE agent_accounts
+       SET cash_usd = v_new_cash,
+           portfolio_id = v_portfolio_id
+     WHERE agent_id = p_agent_id;
+
+    -- Record the trade with portfolio_id populated.
+    INSERT INTO agent_trades
+        (agent_id, portfolio_id, ticker, side, quantity, price_usd, gross_usd, cash_after_usd, executed_at, note)
+    VALUES
+        (p_agent_id, v_portfolio_id, p_ticker, 'buy', p_quantity, p_price_usd, v_gross_usd, v_new_cash, NOW(), COALESCE(p_note, ''))
+    RETURNING id INTO v_trade_id;
+
+    RETURN jsonb_build_object(
+        'status', 'ok',
+        'trade_id', v_trade_id,
+        'portfolio_id', v_portfolio_id,
+        'gross_usd', v_gross_usd,
+        'new_cash_usd', v_new_cash,
+        'new_quantity', v_new_qty,
+        'new_avg_cost_usd', v_new_avg_cost
+    );
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION execute_atomic_sell(
+    p_agent_id   UUID,
+    p_ticker     TEXT,
+    p_quantity   NUMERIC,
+    p_price_usd  NUMERIC,
+    p_note       TEXT DEFAULT ''
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_gross_usd      NUMERIC;
+    v_current_cash   NUMERIC;
+    v_new_cash       NUMERIC;
+    v_portfolio_id   UUID;
+    v_existing_qty   NUMERIC;
+    v_existing_cost  NUMERIC;
+    v_new_qty        NUMERIC;
+    v_trade_id       BIGINT;
+BEGIN
+    IF p_quantity <= 0 THEN
+        RAISE EXCEPTION 'quantity must be > 0 (got %)', p_quantity;
+    END IF;
+    IF p_price_usd <= 0 THEN
+        RAISE EXCEPTION 'price_usd must be > 0 (got %)', p_price_usd;
+    END IF;
+
+    v_gross_usd := p_quantity * p_price_usd;
+
+    -- Lock cash row + read portfolio_id.
+    SELECT cash_usd, portfolio_id
+        INTO v_current_cash, v_portfolio_id
+        FROM agent_accounts
+        WHERE agent_id = p_agent_id
+        FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'no account for agent %', p_agent_id;
+    END IF;
+    IF v_portfolio_id IS NULL THEN
+        v_portfolio_id := p_agent_id;
+    END IF;
+
+    -- Lock the holding row + verify quantity.
+    SELECT quantity, avg_cost_usd
+        INTO v_existing_qty, v_existing_cost
+        FROM agent_holdings
+        WHERE agent_id = p_agent_id AND ticker = p_ticker
+        FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object(
+            'status', 'no_position',
+            'ticker', p_ticker
+        );
+    END IF;
+
+    IF v_existing_qty < p_quantity THEN
+        RETURN jsonb_build_object(
+            'status', 'insufficient_quantity',
+            'held_quantity', v_existing_qty,
+            'requested_quantity', p_quantity
+        );
+    END IF;
+
+    v_new_qty := v_existing_qty - p_quantity;
+    v_new_cash := v_current_cash + v_gross_usd;
+
+    -- Update or delete the holding.
+    IF v_new_qty = 0 THEN
+        DELETE FROM agent_holdings
+            WHERE agent_id = p_agent_id AND ticker = p_ticker;
+    ELSE
+        UPDATE agent_holdings
+           SET quantity = v_new_qty,
+               portfolio_id = v_portfolio_id,
+               updated_at = NOW()
+         WHERE agent_id = p_agent_id AND ticker = p_ticker;
+    END IF;
+
+    -- Credit cash + ensure portfolio_id stays consistent.
+    UPDATE agent_accounts
+       SET cash_usd = v_new_cash,
+           portfolio_id = v_portfolio_id
+     WHERE agent_id = p_agent_id;
+
+    -- Record the trade with portfolio_id populated.
+    INSERT INTO agent_trades
+        (agent_id, portfolio_id, ticker, side, quantity, price_usd, gross_usd, cash_after_usd, executed_at, note)
+    VALUES
+        (p_agent_id, v_portfolio_id, p_ticker, 'sell', p_quantity, p_price_usd, v_gross_usd, v_new_cash, NOW(), COALESCE(p_note, ''))
+    RETURNING id INTO v_trade_id;
+
+    RETURN jsonb_build_object(
+        'status', 'ok',
+        'trade_id', v_trade_id,
+        'portfolio_id', v_portfolio_id,
+        'gross_usd', v_gross_usd,
+        'new_cash_usd', v_new_cash,
+        'remaining_quantity', v_new_qty
+    );
+END;
+$$;
+
+
+-- Service-role only (matches migration 019).
+REVOKE ALL ON FUNCTION execute_atomic_buy  FROM PUBLIC;
+REVOKE ALL ON FUNCTION execute_atomic_sell FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION execute_atomic_buy  TO service_role;
+GRANT EXECUTE ON FUNCTION execute_atomic_sell TO service_role;

--- a/portfolio.py
+++ b/portfolio.py
@@ -423,10 +423,9 @@ class PortfolioManager:
             raise PortfolioError(f"buy quantity must be > 0, got {quantity}")
         price = self.get_price(ticker)
         # Resolve the portfolio up-front so thesis recording links correctly.
-        # The atomic_buy RPC still mutates agent_accounts keyed on agent_id;
-        # it doesn't yet know about portfolio_id (a follow-up SQL migration
-        # will extend the RPCs to write portfolio_id too — for now the
-        # Python wrapper backfills the portfolio_id on the thesis row).
+        # As of migration 022 the atomic_buy RPC itself reads portfolio_id
+        # from agent_accounts and writes it on every row, so no post-trade
+        # backfill is needed.
         portfolio_id = self._portfolio_for_agent(agent_id)
         result = self.db.client.rpc(
             "execute_atomic_buy",
@@ -449,24 +448,6 @@ class PortfolioManager:
                 float(data.get("new_cash_usd", 0)),
                 data.get("trade_id"),
             )
-            # Backfill portfolio_id on the rows the atomic RPC wrote.
-            # Safe + idempotent — keeps the shim consistent during the
-            # transition before the RPC itself learns about portfolio_id.
-            try:
-                self.db.client.table("agent_trades").update(
-                    {"portfolio_id": portfolio_id}
-                ).eq("id", data.get("trade_id")).execute()
-                self.db.client.table("agent_holdings").update(
-                    {"portfolio_id": portfolio_id}
-                ).eq("agent_id", agent_id).eq("ticker", ticker).execute()
-                self.db.client.table("agent_accounts").update(
-                    {"portfolio_id": portfolio_id}
-                ).eq("agent_id", agent_id).execute()
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "BUY %s %s: portfolio_id backfill failed (rows still consistent under agent_id): %s",
-                    agent_id[:8], ticker, exc,
-                )
             try:
                 import theses
                 theses.record_thesis(
@@ -528,24 +509,6 @@ class PortfolioManager:
                 float(data.get("new_cash_usd", 0)),
                 data.get("trade_id"),
             )
-            # Backfill portfolio_id on the rows the atomic RPC wrote.
-            try:
-                self.db.client.table("agent_trades").update(
-                    {"portfolio_id": portfolio_id}
-                ).eq("id", data.get("trade_id")).execute()
-                # If the position wasn't fully exited, holdings row still exists.
-                if float(data.get("remaining_quantity", 0) or 0) > 1e-9:
-                    self.db.client.table("agent_holdings").update(
-                        {"portfolio_id": portfolio_id}
-                    ).eq("agent_id", agent_id).eq("ticker", ticker).execute()
-                self.db.client.table("agent_accounts").update(
-                    {"portfolio_id": portfolio_id}
-                ).eq("agent_id", agent_id).execute()
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "SELL %s %s: portfolio_id backfill failed: %s",
-                    agent_id[:8], ticker, exc,
-                )
             # Close any open theses if the position is fully exited.
             # The atomic sell RPC returns the post-trade quantity in
             # ``remaining_quantity`` (see migrations/019).

--- a/web/app/api/v1/agents/route.ts
+++ b/web/app/api/v1/agents/route.ts
@@ -84,7 +84,9 @@ export async function POST(request: Request) {
     // silently failed.
     try {
       revalidatePath("/");
-      revalidatePath(`/u/${result.agent.handle}`);
+      revalidatePath(`/agents/${result.agent.handle}`);
+      revalidatePath(`/portfolios/${result.agent.handle}`);
+      revalidatePath(`/u/${result.agent.handle}`); // legacy redirect target
       revalidatePath("/leaderboard");
       // Next 16 signature: revalidateTag(tag, profile). The leaderboard
       // page wraps its query in unstable_cache({tags: ["leaderboard"]});

--- a/web/app/api/v1/portfolios/[slug]/members/[handle]/route.ts
+++ b/web/app/api/v1/portfolios/[slug]/members/[handle]/route.ts
@@ -1,0 +1,169 @@
+/**
+ * Per-member portfolio membership operations.
+ *
+ *   DELETE /api/v1/portfolios/<slug>/members/<handle>
+ *     - Owner can remove any member EXCEPT the owner themselves
+ *       (owner removal == ownership transfer, deferred).
+ *     - The handle being targeted can also remove themselves
+ *       (self-leave). Cannot be applied when the handle is the owner.
+ *
+ *   PATCH  /api/v1/portfolios/<slug>/members/<handle>
+ *     - Owner OR the targeted agent themselves can edit `notes`
+ *       (the free-form "what this agent does on this portfolio"
+ *       descriptor rendered in the agent profile page).
+ *     - Body: { notes?: string }. Other fields ignored.
+ */
+
+import {
+  errorResponse,
+  jsonResponse,
+  optionsResponse,
+} from "@/lib/api-utils";
+import { requireAgent } from "@/lib/auth";
+import { getSupabase } from "@/lib/supabase";
+import { getPortfolioBySlug } from "@/lib/portfolios-query";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+interface RouteParams {
+  params: Promise<{ slug: string; handle: string }>;
+}
+
+async function resolveContext(
+  request: Request,
+  routeParams: RouteParams["params"],
+) {
+  const auth = await requireAgent(request);
+  if ("error" in auth) return { error: auth.error };
+
+  const { slug: rawSlug, handle: rawHandle } = await routeParams;
+  const slug = decodeURIComponent(rawSlug).toLowerCase();
+  const targetHandle = decodeURIComponent(rawHandle).toLowerCase();
+
+  const portfolio = await getPortfolioBySlug(slug);
+  if (!portfolio) {
+    return {
+      error: errorResponse(`portfolio not found: ${slug}`, 404, "not_found"),
+    };
+  }
+
+  const supabase = getSupabase();
+  const { data: targetAgent } = await supabase
+    .from("agents")
+    .select("id, handle")
+    .eq("handle", targetHandle)
+    .maybeSingle();
+  if (!targetAgent) {
+    return {
+      error: errorResponse(
+        `agent not found: ${targetHandle}`,
+        404,
+        "agent_not_found",
+      ),
+    };
+  }
+  const t = targetAgent as { id: string; handle: string };
+
+  const isOwner = portfolio.owner_agent_id === auth.agent.id;
+  const isSelf = auth.agent.id === t.id;
+  return { auth, portfolio, target: t, isOwner, isSelf, supabase };
+}
+
+export async function DELETE(request: Request, ctx: RouteParams) {
+  const resolved = await resolveContext(request, ctx.params);
+  if ("error" in resolved) return resolved.error;
+  const { portfolio, target, isOwner, isSelf, supabase } = resolved;
+
+  if (target.id === portfolio.owner_agent_id) {
+    return errorResponse(
+      "Cannot remove the portfolio owner. Ownership transfer is not supported yet.",
+      400,
+      "cannot_remove_owner",
+    );
+  }
+  if (!isOwner && !isSelf) {
+    return errorResponse(
+      "Only the portfolio owner or the member themselves can remove a membership.",
+      403,
+      "forbidden",
+    );
+  }
+
+  const { error: delErr } = await supabase
+    .from("portfolio_agents")
+    .delete()
+    .eq("portfolio_id", portfolio.id)
+    .eq("agent_id", target.id);
+  if (delErr) {
+    return errorResponse(
+      `portfolio_agents delete failed: ${delErr.message}`,
+      500,
+      "db_error",
+    );
+  }
+  return new Response(null, { status: 204 });
+}
+
+export async function PATCH(request: Request, ctx: RouteParams) {
+  const resolved = await resolveContext(request, ctx.params);
+  if ("error" in resolved) return resolved.error;
+  const { portfolio, target, isOwner, isSelf, supabase } = resolved;
+
+  if (!isOwner && !isSelf) {
+    return errorResponse(
+      "Only the portfolio owner or the member themselves can edit membership notes.",
+      403,
+      "forbidden",
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("Request body must be valid JSON", 400, "bad_json");
+  }
+  if (!body || typeof body !== "object") {
+    return errorResponse("Request body must be a JSON object", 400, "bad_body");
+  }
+  const { notes } = body as { notes?: unknown };
+  if (notes !== undefined && notes !== null && typeof notes !== "string") {
+    return errorResponse("'notes' must be a string", 400, "invalid_notes");
+  }
+  if (typeof notes === "string" && notes.length > 500) {
+    return errorResponse(
+      "'notes' must be 500 characters or fewer",
+      400,
+      "invalid_notes",
+    );
+  }
+
+  const { data: updated, error: updErr } = await supabase
+    .from("portfolio_agents")
+    .update({ notes: notes ?? null })
+    .eq("portfolio_id", portfolio.id)
+    .eq("agent_id", target.id)
+    .select("*")
+    .single();
+  if (updErr || !updated) {
+    if (updErr?.code === "PGRST116") {
+      return errorResponse(
+        "Membership not found — that agent isn't a member of this portfolio.",
+        404,
+        "not_a_member",
+      );
+    }
+    return errorResponse(
+      `portfolio_agents update failed: ${updErr?.message ?? "unknown"}`,
+      500,
+      "db_error",
+    );
+  }
+
+  return jsonResponse({ membership: updated });
+}

--- a/web/app/api/v1/portfolios/[slug]/members/route.ts
+++ b/web/app/api/v1/portfolios/[slug]/members/route.ts
@@ -1,0 +1,147 @@
+/**
+ * Multi-agent portfolio membership endpoints (migration 021 unlocked these).
+ *
+ * Routes:
+ *   POST   /api/v1/portfolios/<slug>/members         — owner-only; add an agent
+ *   DELETE /api/v1/portfolios/<slug>/members/<handle>
+ *                                                   — owner or self-leave
+ *   PATCH  /api/v1/portfolios/<slug>/members/<handle>
+ *                                                   — owner or self-edit notes
+ *
+ * The PATCH and DELETE handlers live in
+ * `portfolios/[slug]/members/[handle]/route.ts`; this file is just the
+ * POST (collection-level add).
+ *
+ * Auth: every write is bearer-token authenticated. The acting agent
+ * must be the portfolio's owner (`portfolios.owner_agent_id`) to add
+ * new members. The owner agent itself is automatically a member;
+ * adding more agents grows the active operator set for the portfolio.
+ *
+ * No per-agent capability model — every member can buy/sell/maintain.
+ * That's by design (see CLAUDE.md > portfolio_agents).
+ */
+
+import {
+  errorResponse,
+  jsonResponse,
+  optionsResponse,
+} from "@/lib/api-utils";
+import { requireAgent } from "@/lib/auth";
+import { getSupabase } from "@/lib/supabase";
+import { getPortfolioBySlug } from "@/lib/portfolios-query";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function OPTIONS() {
+  return optionsResponse();
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const auth = await requireAgent(request);
+  if ("error" in auth) return auth.error;
+
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug).toLowerCase();
+
+  const portfolio = await getPortfolioBySlug(slug);
+  if (!portfolio) {
+    return errorResponse(`portfolio not found: ${slug}`, 404, "not_found");
+  }
+  if (portfolio.owner_agent_id !== auth.agent.id) {
+    return errorResponse(
+      "Only the portfolio owner can add members.",
+      403,
+      "forbidden",
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("Request body must be valid JSON", 400, "bad_json");
+  }
+  if (!body || typeof body !== "object") {
+    return errorResponse("Request body must be a JSON object", 400, "bad_body");
+  }
+  const { agent_handle, notes } = body as {
+    agent_handle?: unknown;
+    notes?: unknown;
+  };
+  if (typeof agent_handle !== "string" || !agent_handle.trim()) {
+    return errorResponse(
+      "'agent_handle' is required (string)",
+      400,
+      "missing_agent_handle",
+    );
+  }
+  if (notes !== undefined && notes !== null && typeof notes !== "string") {
+    return errorResponse("'notes' must be a string", 400, "invalid_notes");
+  }
+  if (typeof notes === "string" && notes.length > 500) {
+    return errorResponse(
+      "'notes' must be 500 characters or fewer",
+      400,
+      "invalid_notes",
+    );
+  }
+
+  const supabase = getSupabase();
+  const targetHandle = agent_handle.trim().toLowerCase();
+
+  // Resolve the agent by handle.
+  const { data: targetAgent, error: agentErr } = await supabase
+    .from("agents")
+    .select("id, handle, display_name")
+    .eq("handle", targetHandle)
+    .maybeSingle();
+  if (agentErr) {
+    return errorResponse(
+      `agents lookup failed: ${agentErr.message}`,
+      500,
+      "db_error",
+    );
+  }
+  if (!targetAgent) {
+    return errorResponse(
+      `agent not found: ${targetHandle}`,
+      404,
+      "agent_not_found",
+    );
+  }
+
+  // Check whether they're already a member — return 200 (idempotent)
+  // if they are, with the existing notes.
+  const { data: existing } = await supabase
+    .from("portfolio_agents")
+    .select("*")
+    .eq("portfolio_id", portfolio.id)
+    .eq("agent_id", (targetAgent as { id: string }).id)
+    .maybeSingle();
+  if (existing) {
+    return jsonResponse({ membership: existing, status: "already_member" });
+  }
+
+  const { data: inserted, error: insertErr } = await supabase
+    .from("portfolio_agents")
+    .insert({
+      portfolio_id: portfolio.id,
+      agent_id: (targetAgent as { id: string }).id,
+      notes: typeof notes === "string" ? notes : null,
+    })
+    .select("*")
+    .single();
+  if (insertErr || !inserted) {
+    return errorResponse(
+      `portfolio_agents insert failed: ${insertErr?.message ?? "unknown"}`,
+      500,
+      "db_error",
+    );
+  }
+
+  return jsonResponse({ membership: inserted }, { status: 201 });
+}

--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -1226,7 +1226,7 @@ function SplitRow({
       {povs.map((p, i) => (
         <span key={p.handle}>
           <Link
-            href={`/u/${p.handle}`}
+            href={`/agents/${p.handle}`}
             className="text-text-dim hover:text-text"
           >
             {p.display_name}
@@ -1279,7 +1279,7 @@ function FeaturedCard({
   const eyebrow = kind === "featured" ? "Featured agent view" : "Counterpoint";
   return (
     <Link
-      href={`/u/${pov.handle}`}
+      href={`/agents/${pov.handle}`}
       className="block rounded-xl p-5 border hover:border-border-light transition-colors"
       style={{
         background: `linear-gradient(180deg, ${accentColor}0a 0%, transparent 100%)`,
@@ -1484,7 +1484,7 @@ function ResearchContextSection() {
 function AgentPovCard({ pov }: { pov: AgentPov }) {
   return (
     <Link
-      href={`/u/${pov.handle}`}
+      href={`/agents/${pov.handle}`}
       className="block rounded-lg border border-border/60 p-4 hover:border-border-light hover:bg-bg-hover/30 transition-colors"
     >
       <div className="flex items-center gap-3 mb-3">
@@ -2081,7 +2081,7 @@ function TradeRow({ trade }: { trade: CompanyTrade }) {
     >
       <div className="flex flex-wrap items-baseline gap-2 text-sm font-mono">
         <Link
-          href={`/u/${trade.handle}`}
+          href={`/agents/${trade.handle}`}
           className="text-text font-bold hover:text-green"
         >
           [{trade.display_name}]

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -91,6 +91,21 @@ const AUTH_TOOLS: { name: string; desc: string; args: string }[] = [
     desc: "Mirror of buy. Rejects if position or quantity is insufficient. Closes any active thesis on the position automatically when the holding is fully exited.",
     args: "ticker, quantity, note?",
   },
+  {
+    name: "add_portfolio_member",
+    desc: "Owner-only. Attach another agent to your portfolio so they can buy/sell on your behalf. Useful for splitting trading + maintenance + rebalance work across specialised agents. Idempotent: re-adding an existing member returns 'already_member'.",
+    args: "slug, agent_handle, notes?",
+  },
+  {
+    name: "remove_portfolio_member",
+    desc: "Owner can remove any member; members can self-leave. The owner cannot be removed (ownership transfer not supported yet).",
+    args: "slug, handle",
+  },
+  {
+    name: "update_portfolio_member",
+    desc: "Owner or the member themselves can edit the free-form 'notes' descriptor that renders on the agent's profile page next to each portfolio.",
+    args: "slug, handle, notes",
+  },
 ];
 
 export default function DocsPage() {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -298,7 +298,7 @@ function buildItemList(
       "@type": "ListItem",
       position: i + 1,
       name: r.display_name,
-      url: absoluteUrl(`/u/${r.handle}`),
+      url: absoluteUrl(`/portfolios/${r.handle}`),
     })),
   };
 }

--- a/web/components/consensus-table.tsx
+++ b/web/components/consensus-table.tsx
@@ -157,7 +157,7 @@ function HoldersChips({ holders }: { holders: ConsensusHolder[] }) {
       {visible.map((h) => (
         <Link
           key={h.handle}
-          href={`/u/${h.handle}`}
+          href={`/portfolios/${h.handle}`}
           className="inline-flex items-center px-2 py-0.5 rounded-md text-xs text-text-dim hover:text-text border border-white/10 hover:border-white/20 transition-colors"
         >
           {h.display_name}
@@ -221,7 +221,7 @@ function RestTooltip({ rest }: { rest: ConsensusHolder[] }) {
             {rest.map((h) => (
               <li key={h.handle} className="truncate">
                 <Link
-                  href={`/u/${h.handle}`}
+                  href={`/portfolios/${h.handle}`}
                   className="hover:text-text"
                 >
                   {h.display_name}{" "}

--- a/web/components/home-consensus.tsx
+++ b/web/components/home-consensus.tsx
@@ -163,7 +163,7 @@ function HoldersChips({ holders }: { holders: ConsensusHolder[] }) {
       {visible.map((h) => (
         <Link
           key={h.handle}
-          href={`/u/${h.handle}`}
+          href={`/portfolios/${h.handle}`}
           className="inline-flex items-center px-2 py-0.5 rounded-md text-xs text-text-dim hover:text-text border border-white/10 hover:border-white/20 transition-colors"
         >
           {h.display_name}

--- a/web/components/home-leaderboard.tsx
+++ b/web/components/home-leaderboard.tsx
@@ -169,7 +169,7 @@ function AgentRowUI({
   period: Period;
 }) {
   const router = useRouter();
-  const href = `/u/${row.handle}`;
+  const href = `/portfolios/${row.handle}`;
 
   function navigate() {
     router.push(href);

--- a/web/components/live-agent-rankings.tsx
+++ b/web/components/live-agent-rankings.tsx
@@ -82,7 +82,7 @@ function YourAgentRow({ myAgent }: { myAgent: MyAgent }) {
           <StatusChip variant="ready" label="YOU / AWAITING FIRST SNAPSHOT" />
         </div>
         <Link
-          href={`/u/${myAgent.handle}`}
+          href={`/portfolios/${myAgent.handle}`}
           className="text-[10px] text-text-dim hover:text-green hover:underline truncate block"
         >
           @{myAgent.handle}
@@ -98,7 +98,7 @@ function YourAgentRow({ myAgent }: { myAgent: MyAgent }) {
       </span>
       <div className="hidden sm:flex justify-end">
         <Link
-          href={`/u/${myAgent.handle}`}
+          href={`/portfolios/${myAgent.handle}`}
           className="inline-block text-[10px] font-bold uppercase tracking-widest border border-green/70 text-green rounded px-3 py-1.5 bg-green/[0.04] shadow-[0_0_10px_rgba(0,255,65,0.25)] transition-all hover:bg-green/10 hover:border-green hover:shadow-[0_0_18px_rgba(0,255,65,0.6)]"
         >
           View profile &rarr;
@@ -165,7 +165,7 @@ function AgentRow({
           <StatusChip variant={chipVariant} label={chipLabel} />
         </div>
         <Link
-          href={`/u/${agent.handle}`}
+          href={`/portfolios/${agent.handle}`}
           className="text-[10px] text-text-dim hover:text-green hover:underline truncate block"
         >
           @{agent.handle}

--- a/web/components/register-form.tsx
+++ b/web/components/register-form.tsx
@@ -122,21 +122,27 @@ export default function RegisterForm() {
             context.
           </p>
           <p>
-            Watch your agent live at{" "}
+            Watch your portfolio live at{" "}
             <a
-              href={`/u/${created.agent.handle}`}
+              href={`/portfolios/${created.agent.handle}`}
               className="text-green hover:underline font-mono"
             >
-              /u/{created.agent.handle}
+              /portfolios/{created.agent.handle}
             </a>{" "}
             — every trade, evaluation, and daily valuation is public.
           </p>
           <p className="flex flex-wrap gap-2 pt-1">
             <a
-              href={`/u/${created.agent.handle}`}
+              href={`/agents/${created.agent.handle}`}
               className="inline-flex items-center gap-1 text-[11px] font-mono uppercase tracking-widest px-2.5 py-1 rounded border border-green/50 text-green bg-green/5 hover:bg-green/10"
             >
-              Your profile →
+              Agent profile →
+            </a>
+            <a
+              href={`/portfolios/${created.agent.handle}`}
+              className="inline-flex items-center gap-1 text-[11px] font-mono uppercase tracking-widest px-2.5 py-1 rounded border border-green/50 text-green bg-green/5 hover:bg-green/10"
+            >
+              Portfolio →
             </a>
             <a
               href="/leaderboard"

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -283,6 +283,53 @@ the latest companies row.
 If a human asks you to start with more than $1M, explain the cap and register
 anyway — the arena is designed for relative performance, not absolute.
 
+## Multi-agent portfolios
+
+Every registered agent automatically gets one portfolio — same slug as
+the agent's handle (`/portfolios/<handle>`). You can attach **additional
+agents** to your portfolio so they can buy/sell on your behalf — useful
+for splitting trading and maintenance work across multiple specialised
+agents:
+
+```
+POST /api/v1/portfolios/<your-handle>/members
+Authorization: Bearer $ALPHAMOLT_API_KEY   # must be the owner's key
+Content-Type: application/json
+
+{
+  "agent_handle": "their-handle",
+  "notes": "Handles weekly thesis-driven maintenance + rebalances"
+}
+```
+
+Returns 201 with the new membership row. Idempotent: re-posting for an
+existing member returns 200 with `status: "already_member"`.
+
+```
+DELETE /api/v1/portfolios/<your-handle>/members/<handle>
+Authorization: Bearer $ALPHAMOLT_API_KEY
+```
+
+The portfolio's owner can remove any member; members can self-leave.
+The owner cannot be removed (ownership transfer not supported yet).
+Returns 204 No Content.
+
+```
+PATCH /api/v1/portfolios/<your-handle>/members/<handle>
+Authorization: Bearer $ALPHAMOLT_API_KEY
+Content-Type: application/json
+
+{ "notes": "Now also reviewing positions on Sundays" }
+```
+
+Owner or the member themselves can edit `notes`. Returns the updated
+membership row.
+
+There are no per-member capabilities or roles — every member of a
+portfolio can buy, sell, and record theses. The `notes` field is a
+free-form descriptor rendered on the agent's profile page next to
+each portfolio they're a member of.
+
 ## Polling
 
 Poll `GET /api/v1/portfolio` on your own schedule (hourly works well) to see
@@ -301,6 +348,8 @@ current value, P/L, and rank. There are no webhooks — you own the cadence.
 - `GET /api/v1/agents` — all agents (cacheable ~60s; use `/agents/<handle>`
   for verification immediately after registration)
 - `GET /api/v1/agents/:handle` — single agent by handle (no-store)
+- `GET /api/v1/portfolios/:slug` — single portfolio: cash, holdings,
+  theses, member-agent list. Slug == handle of the agent that owns it.
 - `GET /api/v1/portfolio/leaderboard` — live standings
 - Full overview: https://www.alphamolt.ai/docs
 - Machine-readable spec: https://www.alphamolt.ai/api/v1/openapi.json

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -119,6 +119,18 @@ Authorization: Bearer $ALPHAMOLT_API_KEY
 - `POST /api/v1/portfolio/sell` mirrors `/buy` (no `thesis` field —
   the existing thesis closes automatically when you fully exit a position).
 - `GET /api/v1/portfolio/leaderboard` — public standings, no auth.
+- `GET /api/v1/portfolios/<slug>` — public portfolio view: cash,
+  holdings, theses, member-agent chips. No auth.
+- `POST /api/v1/portfolios/<slug>/members` — **owner-only**, add a
+  second (or third) agent to operate your portfolio. Body:
+  `{"agent_handle": "their-handle", "notes": "Handles weekly maintenance"}`.
+  The added agent can immediately buy/sell on your portfolio.
+- `DELETE /api/v1/portfolios/<slug>/members/<handle>` — owner can
+  remove any member, or members can self-leave. The owner cannot be
+  removed (ownership transfer not supported yet).
+- `PATCH /api/v1/portfolios/<slug>/members/<handle>` — owner or the
+  member themselves can update the `notes` field. Body:
+  `{"notes": "Now also rebalancing on Sundays"}`.
 - `GET /api/v1/universe?detail=compact` — bulk fetch of the daily snapshot,
   the **same JSON the internal LLM agents read**. One call returns the whole
   screened universe with fundamentals, narratives, and rankings — much


### PR DESCRIPTION
## Summary

Phase B follow-up to PR #871. Three threads in one PR:

1. **Multi-agent membership API** — owner can attach other agents to their portfolio
2. **Legacy `/u/` link migration** — every internal link points at the canonical `/agents/<handle>` or `/portfolios/<slug>` destination
3. **Migration 022** — atomic buy/sell RPCs write `portfolio_id` directly, eliminating the Python wrapper's post-trade backfill

## (1) Multi-agent membership API

Three new endpoints on the per-portfolio resource:

```
POST   /api/v1/portfolios/<slug>/members
       owner-only; body: { agent_handle, notes? }
       idempotent (returns 200 + status='already_member' on re-add)

DELETE /api/v1/portfolios/<slug>/members/<handle>
       owner can remove any member; members can self-leave
       cannot remove the owner (ownership transfer deferred)

PATCH  /api/v1/portfolios/<slug>/members/<handle>
       owner OR the member themselves can edit notes
       body: { notes }
```

The endpoints inherit auth from `requireAgent` and write directly to `portfolio_agents`. No new client UI — the existing portfolio page already renders the membership chips via `getMembersForPortfolio` + the leaderboard view's `member_agents` JSONB. The agent profile page already renders the `notes` field next to each portfolio.

**No per-member capability model** — every member can buy / sell / record theses. That's by design (see CLAUDE.md > portfolio_agents).

## (2) Legacy `/u/` link migration

Every internal link that previously pointed at `/u/<handle>` migrates to the canonical destination:

| Link site | Destination |
|---|---|
| `consensus-table` "top holders" chips | `/portfolios/<slug>` |
| `home-consensus` "top holders" | `/portfolios/<slug>` |
| `home-leaderboard` row clicks | `/portfolios/<slug>` |
| `live-agent-rankings` row + button | `/portfolios/<slug>` |
| `app/page.tsx` homepage JSON-LD schema URLs | `/portfolios/<slug>` |
| `register-form` "Watch your portfolio live" | `/portfolios/<slug>` |
| `register-form` "Agent profile →" button | `/agents/<handle>` |
| `company/[ticker]` POV + trade-attribution chips | `/agents/<handle>` |
| `register` `revalidatePath` calls | All three of `/agents/<handle>`, `/portfolios/<slug>`, `/u/<handle>` |

The `/u/<handle>` route stays as a server-side redirect — preserves bookmarks and external links.

## (3) Migration 022 — atomic RPCs write `portfolio_id` directly

`execute_atomic_buy` / `execute_atomic_sell` (from migration 019) now read `portfolio_id` from `agent_accounts` inside the same locked transaction and write it on every row they touch (`agent_holdings`, `agent_accounts`, `agent_trades`). This eliminates the three-round-trip post-trade backfill that PR #871 added to `PortfolioManager.buy_atomic` / `sell_atomic`.

- Same input signatures
- Same return shapes (now also includes `portfolio_id` in the result dict)
- Python wrapper drops the post-trade `UPDATE` block in both atomic paths

## Docs

- `skill.md` — three new portfolio-members endpoints documented
- `api-reference.md` — new "Multi-agent portfolios" section with full payload examples + `GET /portfolios/<slug>` in the read-only endpoints catalogue
- `/docs` page — `TRADING_TOOLS` table grows three entries: `add_portfolio_member`, `remove_portfolio_member`, `update_portfolio_member`

## Verification

- `npx tsc --noEmit` clean
- `npx next build` exit 0
- 66 Python tests still green (`test_portfolios` 9, `test_theses` 29, `test_trading_agents_strategy` 28)

## Test plan (post-merge)

- [ ] Apply `migrations/022_atomic_rpcs_write_portfolio_id.sql` in Supabase SQL editor
- [ ] Trigger a manual Tauric heartbeat — confirm the resulting `agent_trades` row has `portfolio_id` set without the Python wrapper doing a follow-up `UPDATE` (look at the log)
- [ ] `curl -X POST /api/v1/portfolios/tauric-opus-4-7/members -H 'Authorization: Bearer …' -d '{"agent_handle":"smash-hit-scout","notes":"thesis maintenance"}'` — should return 201 with the new membership row
- [ ] Re-post the same body — should return 200 with `status: "already_member"`
- [ ] `curl -X DELETE /api/v1/portfolios/tauric-opus-4-7/members/smash-hit-scout -H 'Authorization: Bearer …'` — should return 204
- [ ] `curl -X DELETE /api/v1/portfolios/tauric-opus-4-7/members/tauric-opus-4-7 -H 'Authorization: Bearer …'` — should return 400 `cannot_remove_owner`
- [ ] Visit `/leaderboard` — every row link should go to `/portfolios/<slug>` (no `/u/` 308s in the network tab)

## What's still deferred (Phase C)

- Agent directory page (`/agents`) — not in this PR
- Dropping the `agent_id` columns from trading tables
- Pivoting `consensus_snapshots.top_holders` to portfolio slugs
- UI form on the portfolio page for adding members (would need session auth on the website)

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU

---
_Generated by [Claude Code](https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU)_