### PR TITLE
agent_heartbeat: exclude trading_agents + always advance last_heartbeat_at

### DIFF
--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -84,7 +84,12 @@ def _journal(
         "error_message": error_message,
     }
     db.insert_agent_heartbeat(row)
-    if status in {"ok", "dry-run"} and not dry_run:
+    # Update last_heartbeat_at on every persisted attempt — success or error.
+    # This honours the agents.heartbeat_interval_hours interval guard even when
+    # the strategy errored (e.g. tauric-qwen's parked-with-9999h state stays
+    # in effect after a permanent-failure attempt; transient errors back off
+    # by the same interval as successful runs).
+    if not dry_run:
         db.update_agent_last_heartbeat(agent_id, _now_utc().isoformat())
 
 
@@ -209,6 +214,15 @@ def main() -> int:
         agents = [agent]
     else:
         agents = db.get_all_agents()
+        # The `trading_agents` strategy (Tauric Trader variants) takes
+        # 15–45 min per ticker × 15 tickers — way past this workflow's
+        # timeout. They run from their dedicated `trading-agents-heartbeat`
+        # workflow with a 180-min timeout instead. Explicit `--handle`
+        # invocations (the dedicated workflow's matrix uses one) still
+        # work because the filter is only applied to the bulk path.
+        agents = [
+            a for a in agents if a.get("strategy") != "trading_agents"
+        ]
 
     logger.info(
         "=== agent_heartbeat: %d agents (dry_run=%s, force=%s) ===",


### PR DESCRIPTION
## Summary

Two small fixes surfaced by the 2026-05-14 heartbeat run (see PR #872 thread):

1. **Exclude `strategy='trading_agents'` from the bulk `agent_heartbeat.py` loop**
2. **Always advance `last_heartbeat_at`** so the interval guard works for permanent-failure agents

## (1) Why exclude trading_agents from the broad loop

The Tauric Trader variants take 15–45 min per ticker × ~15 tickers each. Three of them in the bulk Sunday heartbeat alongside the quick rule-based / llm_pick agents was guaranteed to drag the workflow into its cancellation:

```
Sunday  07:00 UTC — agent_heartbeat   (bulk loop, all agents)
Monday  21:30 UTC — trading-agents-heartbeat   (dedicated, 180-min timeout)
```

The dedicated `trading-agents-heartbeat.yml` workflow already runs them with a 180-min timeout. The bulk one shouldn't touch them at all.

The filter only applies on the bulk path (no `--handle`) — explicit `python agent_heartbeat.py --handle tauric-opus-4-7` (which is what the dedicated workflow's matrix calls) still runs them.

## (2) Why advance `last_heartbeat_at` on every persisted attempt

Previously:
```python
if status in {"ok", "dry-run"} and not dry_run:
    db.update_agent_last_heartbeat(agent_id, _now_utc().isoformat())
```

Errors journalled an `agent_heartbeats` row but left `last_heartbeat_at` untouched. Effect: an agent with a permanent failure mode (e.g., `tauric-qwen`'s parked-with-9999h state + DashScope/Responses API mismatch) got retried **every single heartbeat run**, because the interval guard never engaged.

After:
```python
if not dry_run:
    db.update_agent_last_heartbeat(agent_id, _now_utc().isoformat())
```

Success and error both advance it. Only `--dry-run` leaves it untouched (matching the existing `--dry-run` help text). Transient failures back off by the same interval as successful runs — slightly less aggressive than before but predictable; users wanting immediate retry can pass `--force`.

## Test plan (post-merge)

- [ ] Next Sunday's `Agent Heartbeat` cron — confirm the three Tauric variants are absent from the iteration list at the top of the log
- [ ] Same cron — confirm `tauric-qwen` doesn't error fast at the bottom (because it's now excluded from the bulk path)
- [ ] Trigger the dedicated `Tauric Trader Heartbeat` workflow with `handle=tauric-opus-4-7` — confirm the `--handle` path still works (the filter only applies on the bulk path)
- [ ] After any failing community-agent's heartbeat — confirm their next attempt is skipped by the interval guard rather than retried every run

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU

---
_Generated by [Claude Code](https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU)_