### PR TITLE
Show traded ticker in the recent-trades tape

### DIFF
--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -422,7 +422,11 @@ export default async function CompanyPage({
           <h2 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-2">
             Recent AI Agent Trades in {company.ticker}
           </h2>
-          <TradeTape trades={trades.slice(0, 8)} totalTrades={trades.length} />
+          <TradeTape
+            trades={trades.slice(0, 8)}
+            totalTrades={trades.length}
+            showTicker={false}
+          />
         </section>
 
         <SeoBlock

--- a/web/components/trade-tape.tsx
+++ b/web/components/trade-tape.tsx
@@ -10,6 +10,7 @@ export interface Trade {
   id: string;
   handle: string;
   display_name: string;
+  ticker: string;
   side: "buy" | "sell";
   quantity: number;
   price_usd: number;
@@ -27,10 +28,12 @@ export function TradeTape({
   trades,
   totalTrades,
   emptyLabel = "No trades recorded yet.",
+  showTicker = true,
 }: {
   trades: Trade[];
   totalTrades: number;
   emptyLabel?: string;
+  showTicker?: boolean;
 }) {
   if (trades.length === 0) {
     return (
@@ -44,7 +47,7 @@ export function TradeTape({
     <div className="glass-card rounded-lg overflow-hidden">
       <ul className="divide-y divide-border/40">
         {trades.map((t) => (
-          <TradeRow key={t.id} trade={t} />
+          <TradeRow key={t.id} trade={t} showTicker={showTicker} />
         ))}
       </ul>
       {totalTrades > trades.length && (
@@ -57,7 +60,13 @@ export function TradeTape({
   );
 }
 
-function TradeRow({ trade }: { trade: Trade }) {
+function TradeRow({
+  trade,
+  showTicker,
+}: {
+  trade: Trade;
+  showTicker: boolean;
+}) {
   const isBuy = trade.side === "buy";
   const stripeColor = isBuy ? "#00FF41" : "#FF3333";
   const sideLabel = isBuy ? "BOUGHT" : "SOLD";
@@ -78,6 +87,14 @@ function TradeRow({ trade }: { trade: Trade }) {
         <span className="font-bold" style={{ color: stripeColor }}>
           {sideLabel}
         </span>
+        {showTicker && (
+          <Link
+            href={`/company/${trade.ticker}`}
+            className="text-text font-bold hover:text-green"
+          >
+            {trade.ticker}
+          </Link>
+        )}
         <span className="text-text-dim">
           {formatNumber(trade.quantity, { decimals: 0 })} @ $
           {trade.price_usd.toFixed(2)}

--- a/web/lib/company-agents-query.ts
+++ b/web/lib/company-agents-query.ts
@@ -331,6 +331,7 @@ export async function getCompanyTradeTape(
     id: r.id,
     handle: r.agents.handle,
     display_name: r.agents.display_name,
+    ticker,
     side: r.side === "sell" ? "sell" : "buy",
     quantity: Number(r.quantity),
     price_usd: Number(r.price_usd),

--- a/web/lib/portfolios-query.ts
+++ b/web/lib/portfolios-query.ts
@@ -202,7 +202,7 @@ export async function getRecentTradesForPortfolio(
   const { data, error } = await supabase
     .from("agent_trades")
     .select(
-      "id, side, quantity, price_usd, executed_at, note, " +
+      "id, ticker, side, quantity, price_usd, executed_at, note, " +
         "agents!inner(handle, display_name)",
     )
     .eq("portfolio_id", portfolioId)
@@ -221,6 +221,7 @@ export async function getRecentTradesForPortfolio(
   type EmbeddedAgent = { handle: string; display_name: string };
   type Row = {
     id: string;
+    ticker: string;
     side: string;
     quantity: number | string;
     price_usd: number | string;
@@ -236,6 +237,7 @@ export async function getRecentTradesForPortfolio(
         id: r.id,
         handle: a.handle,
         display_name: a.display_name,
+        ticker: r.ticker,
         side: r.side === "sell" ? "sell" : "buy",
         quantity: Number(r.quantity),
         price_usd: Number(r.price_usd),


### PR DESCRIPTION
The portfolio-page trade list rendered "[Agent] BOUGHT 884 @ $135.60" with no indication of which equity was traded. Add the ticker as a linked symbol; the company page suppresses it via showTicker={false} since the ticker is the page itself.

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU