### PR TITLE
Add human magic-link auth foundation

### DIFF
--- a/migrations/023_human_profiles.sql
+++ b/migrations/023_human_profiles.sql
@@ -1,0 +1,84 @@
+-- Migration 023: Human user profiles + magic-link auth foundation
+--
+-- Adds the first human-facing identity to an otherwise agent-first arena.
+-- Supabase Auth (auth.users) handles magic-link identity; this `profiles`
+-- table holds public app-data for each human and is auto-provisioned by a
+-- trigger when a user signs up.
+--
+-- Backwards compatible & additive — no existing table is touched. The
+-- service-role pipeline (db.py) and the existing web pages are unaffected.
+--
+-- portfolios.owner_user_id is intentionally NOT added here. Human portfolio
+-- creation — with the one-portfolio-per-user constraint and RLS write
+-- policies — lands in a later migration as one coherent change.
+--
+-- Paste-and-run in the Supabase SQL editor. Idempotent.
+
+-- ============================================================
+-- 1. profiles table
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS profiles (
+    id           UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    email        TEXT,
+    display_name TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Keep updated_at fresh — reuses the shared trigger function (migration 010).
+DROP TRIGGER IF EXISTS profiles_set_updated_at ON profiles;
+CREATE TRIGGER profiles_set_updated_at
+    BEFORE UPDATE ON profiles
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ============================================================
+-- 2. Row Level Security — profiles are PRIVATE (unlike agent tables)
+-- ============================================================
+-- Agent tables get a public-read policy; profiles do not. A user may read and
+-- update only their own row. There is no INSERT or DELETE policy: rows are
+-- created solely by handle_new_user() below (SECURITY DEFINER) and removed via
+-- ON DELETE CASCADE when the auth.users row is deleted.
+
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "own profile read" ON profiles;
+CREATE POLICY "own profile read" ON profiles
+    FOR SELECT USING (auth.uid() = id);
+
+DROP POLICY IF EXISTS "own profile update" ON profiles;
+CREATE POLICY "own profile update" ON profiles
+    FOR UPDATE USING (auth.uid() = id) WITH CHECK (auth.uid() = id);
+
+-- ============================================================
+-- 3. Auto-provision a profile row on signup
+-- ============================================================
+-- SECURITY DEFINER so the trigger can insert into public.profiles regardless
+-- of the calling role. search_path is pinned per the migration-010 convention
+-- (a mutable search_path is flagged by the Supabase Security Advisor).
+
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    INSERT INTO public.profiles (id, email, display_name)
+    VALUES (
+        NEW.id,
+        NEW.email,
+        COALESCE(
+            NEW.raw_user_meta_data->>'display_name',
+            split_part(NEW.email, '@', 1)
+        )
+    )
+    ON CONFLICT (id) DO NOTHING;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+    AFTER INSERT ON auth.users
+    FOR EACH ROW EXECUTE FUNCTION handle_new_user();

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -608,3 +608,61 @@ LEFT JOIN year_start      tytd   ON tytd.agent_id   = l.agent_id
 LEFT JOIN one_year_ago    t1y    ON t1y.agent_id    = l.agent_id
 LEFT JOIN sharpe          s      ON s.agent_id      = l.agent_id
 ORDER BY l.pnl_pct DESC;
+
+
+-- ============================================================
+-- profiles — human users (magic-link auth). See migration 023.
+-- ============================================================
+-- Supabase Auth (auth.users) owns identity; this table holds public app-data
+-- per human and is auto-provisioned by a trigger on signup. PRIVATE: a user
+-- reads/updates only their own row (no public-read policy, unlike the agent
+-- tables).
+
+CREATE TABLE IF NOT EXISTS profiles (
+    id           UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    email        TEXT,
+    display_name TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+DROP TRIGGER IF EXISTS profiles_set_updated_at ON profiles;
+CREATE TRIGGER profiles_set_updated_at
+    BEFORE UPDATE ON profiles
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "own profile read" ON profiles;
+CREATE POLICY "own profile read" ON profiles
+    FOR SELECT USING (auth.uid() = id);
+
+DROP POLICY IF EXISTS "own profile update" ON profiles;
+CREATE POLICY "own profile update" ON profiles
+    FOR UPDATE USING (auth.uid() = id) WITH CHECK (auth.uid() = id);
+
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    INSERT INTO public.profiles (id, email, display_name)
+    VALUES (
+        NEW.id,
+        NEW.email,
+        COALESCE(
+            NEW.raw_user_meta_data->>'display_name',
+            split_part(NEW.email, '@', 1)
+        )
+    )
+    ON CONFLICT (id) DO NOTHING;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+    AFTER INSERT ON auth.users
+    FOR EACH ROW EXECUTE FUNCTION handle_new_user();

--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import Nav from "@/components/nav";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Your account — AlphaMolt",
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function AccountPage() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login?next=/account");
+  }
+
+  // RLS scopes this to the signed-in user's own row.
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("email, display_name")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  const email = profile?.email ?? user.email ?? "";
+  const displayName =
+    profile?.display_name || email.split("@")[0] || "there";
+
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 max-w-[760px] mx-auto w-full px-4 py-10 font-sans">
+        <header className="mb-8">
+          <p className="text-xs font-mono uppercase tracking-widest text-text-muted mb-2">
+            Account
+          </p>
+          <h1 className="font-mono text-3xl font-bold text-green mb-3">
+            Welcome, {displayName}
+          </h1>
+          <p className="text-text-dim leading-relaxed">
+            You&apos;re signed in as{" "}
+            <span className="text-text font-mono">{email}</span>.
+          </p>
+        </header>
+
+        <section className="glass-card rounded-lg border border-border p-5">
+          <h2 className="font-mono text-xs uppercase tracking-widest text-text-dim mb-2">
+            Your portfolio
+          </h2>
+          <p className="text-sm text-text-dim leading-relaxed">
+            No portfolio yet. Soon you&apos;ll be able to create a portfolio,
+            write the mandate it runs to, and assign agents to operate it.
+          </p>
+          {/* PR2 hook: the portfolio-creation flow renders here once
+              portfolios.owner_user_id and the one-per-user constraint ship. */}
+        </section>
+
+        <form action="/auth/signout" method="post" className="mt-8">
+          <button
+            type="submit"
+            className="text-xs font-mono text-text-muted hover:text-text"
+          >
+            Sign out &rarr;
+          </button>
+        </form>
+      </main>
+    </>
+  );
+}

--- a/web/app/auth/callback/route.ts
+++ b/web/app/auth/callback/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+// Magic-link landing route. Supabase emails a link back here with a `code`;
+// we exchange it for a session (sets the auth cookies) and redirect on.
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+
+  // Guard against open redirects — only same-origin relative paths.
+  const nextParam = searchParams.get("next");
+  const next =
+    nextParam && nextParam.startsWith("/") && !nextParam.startsWith("//")
+      ? nextParam
+      : "/account";
+
+  if (!code) {
+    return NextResponse.redirect(`${origin}/login?error=missing_code`);
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    return NextResponse.redirect(
+      `${origin}/login?error=${encodeURIComponent(error.message)}`,
+    );
+  }
+
+  return NextResponse.redirect(`${origin}${next}`);
+}

--- a/web/app/auth/signout/route.ts
+++ b/web/app/auth/signout/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+// Sign-out is a POST so it can't be triggered by a stray link/prefetch.
+// Posted from the nav chip and the /account page.
+export async function POST(request: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  await supabase.auth.signOut();
+  // 303 forces the redirected request to GET.
+  return NextResponse.redirect(new URL("/", request.url), { status: 303 });
+}

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Nav from "@/components/nav";
+import LoginForm from "@/components/login-form";
+
+export const metadata: Metadata = {
+  title: "Sign in — AlphaMolt",
+  description:
+    "Sign in to AlphaMolt with a one-time magic link to manage your portfolio and the mandate your agents work to.",
+  alternates: { canonical: "/login" },
+  robots: { index: false, follow: true },
+};
+
+export default function LoginPage() {
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 max-w-[760px] mx-auto w-full px-4 py-10 font-sans">
+        <header className="mb-8">
+          <p className="text-xs font-mono uppercase tracking-widest text-text-muted mb-2">
+            Sign in
+          </p>
+          <h1 className="font-mono text-3xl font-bold text-green mb-3">
+            Sign in to AlphaMolt
+          </h1>
+          <p className="text-text-dim leading-relaxed">
+            Enter your email and we&apos;ll send a one-time sign-in link.
+            Signing in lets you manage your portfolio and the mandate your
+            agents work to.
+          </p>
+          <p className="text-sm text-text-muted leading-relaxed mt-3">
+            Want to register an AI agent instead?{" "}
+            <Link
+              href="/signup"
+              className="text-text hover:underline decoration-1 underline-offset-[3px]"
+            >
+              Reserve an agent handle &rarr;
+            </Link>
+          </p>
+        </header>
+
+        <LoginForm />
+      </main>
+    </>
+  );
+}

--- a/web/components/login-form.tsx
+++ b/web/components/login-form.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+
+export default function LoginForm() {
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { error } = await supabase.auth.signInWithOtp({
+        email: email.trim().toLowerCase(),
+        options: {
+          emailRedirectTo: `${window.location.origin}/auth/callback`,
+        },
+      });
+      if (error) {
+        setError(error.message);
+        return;
+      }
+      setSent(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (sent) {
+    return (
+      <div className="glass-card rounded-lg border border-green/40 p-5">
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-green font-mono text-xs uppercase tracking-widest">
+            ✓ Magic link sent
+          </span>
+        </div>
+        <p className="text-sm text-text-dim mb-4">
+          Check{" "}
+          <span className="text-text font-mono">
+            {email.trim().toLowerCase()}
+          </span>{" "}
+          for a one-time sign-in link. Open it in this browser to land back on
+          your account — the link expires shortly.
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            setSent(false);
+            setEmail("");
+          }}
+          className="text-xs font-mono text-text-muted hover:text-text"
+        >
+          Use a different email →
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="glass-card rounded-lg border border-border p-5 space-y-4"
+    >
+      <div>
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
+          Email
+        </label>
+        <input
+          type="email"
+          required
+          maxLength={200}
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm font-mono text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
+        />
+        <p className="text-[10px] text-text-dim mt-1 font-mono">
+          We&apos;ll email you a one-time sign-in link — no password.
+        </p>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+          <p>{error}</p>
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="w-full px-4 py-2.5 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {submitting ? "Sending…" : "Send magic link →"}
+      </button>
+    </form>
+  );
+}

--- a/web/components/nav-auth.tsx
+++ b/web/components/nav-auth.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+
+// Auth chip for the nav. Resolves the session client-side so every page that
+// renders <Nav /> stays static/ISR — a server-side session read would force
+// all of them into dynamic rendering. Renders nothing until the session
+// resolves to avoid flashing the wrong state.
+export default function NavAuth({ onNavigate }: { onNavigate?: () => void }) {
+  const [email, setEmail] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const supabase = createSupabaseBrowserClient();
+    supabase.auth.getSession().then(({ data }) => {
+      setEmail(data.session?.user.email ?? null);
+      setReady(true);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      setEmail(session?.user.email ?? null);
+      setReady(true);
+    });
+    return () => sub.subscription.unsubscribe();
+  }, []);
+
+  if (!ready) {
+    return null;
+  }
+
+  if (!email) {
+    return (
+      <Link
+        href="/login"
+        onClick={onNavigate}
+        className="px-3 py-1.5 text-sm text-text-dim hover:text-text transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+      >
+        Sign in
+      </Link>
+    );
+  }
+
+  return (
+    <span className="flex items-center gap-1">
+      <Link
+        href="/account"
+        onClick={onNavigate}
+        className="px-3 py-1.5 text-sm font-mono text-text-dim hover:text-text transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 truncate max-w-[180px]"
+        title={email}
+      >
+        {email}
+      </Link>
+      <form action="/auth/signout" method="post">
+        <button
+          type="submit"
+          className="px-3 py-1.5 text-sm text-text-dim hover:text-text transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+        >
+          Sign out
+        </button>
+      </form>
+    </span>
+  );
+}

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import Logo from "@/components/logo";
+import NavAuth from "@/components/nav-auth";
 
 const links = [
   { href: "/leaderboard", label: "Leaderboard" },
@@ -65,6 +66,7 @@ export default function Nav() {
               {link.label}
             </Link>
           ))}
+          <NavAuth />
         </nav>
 
         <button
@@ -95,6 +97,9 @@ export default function Nav() {
                 {link.label}
               </Link>
             ))}
+            <div className="pt-1 mt-1 border-t border-border">
+              <NavAuth onNavigate={() => setMenuOpen(false)} />
+            </div>
           </nav>
         </div>
       )}

--- a/web/lib/supabase/client.ts
+++ b/web/lib/supabase/client.ts
@@ -1,0 +1,12 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+// Anon-key Supabase client for the browser. AUTH ONLY — it carries the
+// signed-in user's JWT and is subject to RLS. Never use the service-role
+// client (web/lib/supabase.ts) for auth, and never import this module into
+// public-data pages.
+export function createSupabaseBrowserClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}

--- a/web/lib/supabase/server.ts
+++ b/web/lib/supabase/server.ts
@@ -1,0 +1,33 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+// Anon-key Supabase client for Server Components and route handlers. AUTH
+// ONLY — it carries the signed-in user's JWT and is subject to RLS. Never use
+// the service-role client (web/lib/supabase.ts) here: it bypasses RLS and
+// would silently mask a broken policy.
+export async function createSupabaseServerClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options),
+            );
+          } catch {
+            // setAll was called from a Server Component, which cannot write
+            // cookies. Safe to ignore — middleware.ts refreshes the session
+            // cookie on every request.
+          }
+        },
+      },
+    },
+  );
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.103.0",
         "@tanstack/react-table": "^8.21.3",
         "@vercel/analytics": "^2.0.1",
@@ -856,6 +857,31 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.7.0.tgz",
+      "integrity": "sha512-G65t5EhLSJ5c8hTCcXifSL9Q/ZRXvqgXeNo+d3P56f4U1IxwTqjB64UfmfixvmMcjuxnq2yGqEWVJqUcO+AzAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.43.4"
+      }
+    },
+    "node_modules/@supabase/ssr/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@supabase/storage-js": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.103.0",
     "@tanstack/react-table": "^8.21.3",
     "@vercel/analytics": "^2.0.1",

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -1,0 +1,43 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+// Refreshes the Supabase auth token on every request and propagates the
+// rotated session cookie onto the response. Server Components cannot write
+// cookies, so this is the only place the session is kept fresh. It does not
+// gate routes — protected pages (e.g. /account) self-guard.
+//
+// `proxy` is the Next 16 successor to the deprecated `middleware` convention.
+export async function proxy(request: NextRequest) {
+  let response = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          );
+          response = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  await supabase.auth.getUser();
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|opengraph-image|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+  ],
+};


### PR DESCRIPTION
Introduces the first human entry point to the agent-first arena: a passwordless magic-link login via Supabase Auth, session plumbing, and a signed-in /account page. Humans become a first-class entity (profiles table, auto-provisioned on signup) — distinct from AI agents.

Scope is the auth foundation only. Portfolio creation, mandate editing, adding agents, browser trading and API-key management are deferred to later PRs; /account currently shows a "no portfolio yet" placeholder.

- migrations/023: profiles table, private RLS, signup trigger
- web/lib/supabase/: anon-key browser + server clients (auth only), kept separate from the existing service-role client
- web/proxy.ts: session-refresh (Next 16 proxy convention)
- /login, /auth/callback, /auth/signout, /account routes
- nav: client-side auth chip, no change to the 19 pages using <Nav/>

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU