### PR TITLE
Add logged-in portfolio management

### DIFF
--- a/migrations/024_human_portfolios.sql
+++ b/migrations/024_human_portfolios.sql
@@ -1,0 +1,61 @@
+-- Migration 024: Human-owned portfolios.
+--
+-- Until now every portfolio was 1:1 with an agent (portfolios.owner_agent_id
+-- NOT NULL). This migration lets a human (a profiles row, migration 023) own
+-- a portfolio: adds owner_user_id, makes owner_agent_id nullable, adds an
+-- is_public visibility flag, and enforces one portfolio per human.
+--
+-- Scope is ownership + visibility only. Human portfolios are configured
+-- drafts — they have no capital, no holdings, and do not trade yet; the
+-- portfolio-level cash model and mandate-driven trading land in a later
+-- migration.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+-- ============================================================
+-- 1. owner_user_id — a portfolio owned by a human
+-- ============================================================
+
+ALTER TABLE portfolios ADD COLUMN IF NOT EXISTS owner_user_id UUID
+    REFERENCES profiles(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_portfolios_owner_user
+    ON portfolios (owner_user_id);
+
+-- One portfolio per human ("just one in the first instance"). Partial index
+-- so the legacy agent-owned rows (owner_user_id IS NULL) are unaffected.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_portfolios_one_per_user
+    ON portfolios (owner_user_id) WHERE owner_user_id IS NOT NULL;
+
+-- ============================================================
+-- 2. owner_agent_id becomes nullable
+-- ============================================================
+-- A human portfolio has no owner agent. Legacy portfolios keep theirs.
+
+ALTER TABLE portfolios ALTER COLUMN owner_agent_id DROP NOT NULL;
+
+-- Exactly one owner kind per portfolio. Legacy backfilled rows satisfy this
+-- (owner_agent_id set, owner_user_id null); the migration fails loudly if not.
+DO $$ BEGIN
+    ALTER TABLE portfolios ADD CONSTRAINT chk_portfolios_one_owner
+        CHECK (num_nonnulls(owner_user_id, owner_agent_id) = 1);
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ============================================================
+-- 3. is_public — visibility flag (new portfolios default public)
+-- ============================================================
+
+ALTER TABLE portfolios ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL
+    DEFAULT true;
+
+-- ============================================================
+-- 4. RLS — respect visibility
+-- ============================================================
+-- Defense-in-depth only: the website reads portfolios with the service-role
+-- key (which bypasses RLS), so private portfolios are also filtered in the
+-- query layer. This policy protects any future anon-key reads.
+
+DROP POLICY IF EXISTS "public read" ON portfolios;
+DROP POLICY IF EXISTS "portfolio read" ON portfolios;
+CREATE POLICY "portfolio read" ON portfolios FOR SELECT
+    USING (is_public OR owner_user_id = auth.uid());

--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -1,7 +1,17 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import Nav from "@/components/nav";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
+import {
+  getPortfolioForUser,
+  getMembersForPortfolio,
+} from "@/lib/portfolios-query";
+import { listPublicAgents } from "@/lib/agents-query";
+import CreatePortfolioForm from "@/components/portfolio/create-portfolio-form";
+import PortfolioDetailsEditor from "@/components/portfolio/portfolio-details-editor";
+import VisibilityToggle from "@/components/portfolio/visibility-toggle";
+import AgentPicker from "@/components/portfolio/agent-picker";
 
 export const metadata: Metadata = {
   title: "Your account — AlphaMolt",
@@ -9,6 +19,9 @@ export const metadata: Metadata = {
 };
 
 export const dynamic = "force-dynamic";
+
+const SECTION_HEADING =
+  "font-mono text-sm font-bold text-text-dim uppercase tracking-widest mb-3";
 
 export default async function AccountPage() {
   const supabase = await createSupabaseServerClient();
@@ -28,8 +41,13 @@ export default async function AccountPage() {
     .maybeSingle();
 
   const email = profile?.email ?? user.email ?? "";
-  const displayName =
-    profile?.display_name || email.split("@")[0] || "there";
+  const displayName = profile?.display_name || email.split("@")[0] || "there";
+
+  const portfolio = await getPortfolioForUser(user.id);
+  const members = portfolio
+    ? await getMembersForPortfolio(portfolio.id)
+    : [];
+  const allAgents = portfolio ? await listPublicAgents(1000) : [];
 
   return (
     <>
@@ -48,19 +66,74 @@ export default async function AccountPage() {
           </p>
         </header>
 
-        <section className="glass-card rounded-lg border border-border p-5">
-          <h2 className="font-mono text-xs uppercase tracking-widest text-text-dim mb-2">
-            Your portfolio
-          </h2>
-          <p className="text-sm text-text-dim leading-relaxed">
-            No portfolio yet. Soon you&apos;ll be able to create a portfolio,
-            write the mandate it runs to, and assign agents to operate it.
-          </p>
-          {/* PR2 hook: the portfolio-creation flow renders here once
-              portfolios.owner_user_id and the one-per-user constraint ship. */}
-        </section>
+        {portfolio ? (
+          <div className="space-y-8">
+            <div className="rounded-lg border border-border bg-bg px-4 py-3">
+              <p className="text-[11px] font-mono text-orange uppercase tracking-widest mb-1">
+                Configured draft
+              </p>
+              <p className="text-sm text-text-dim leading-relaxed">
+                Your portfolio isn&apos;t trading yet — agent execution is
+                coming soon. For now you can shape its mandate and assemble
+                the team of agents that will run it.
+              </p>
+            </div>
 
-        <form action="/auth/signout" method="post" className="mt-8">
+            <section>
+              <h2 className={SECTION_HEADING}>Portfolio</h2>
+              <PortfolioDetailsEditor
+                initialName={portfolio.display_name}
+                initialMandate={portfolio.description ?? ""}
+              />
+            </section>
+
+            <section>
+              <h2 className={SECTION_HEADING}>Agents</h2>
+              <p className="text-[11px] font-mono text-text-muted mb-3 -mt-1">
+                The agents that will operate this portfolio, working to your
+                mandate.
+              </p>
+              <AgentPicker
+                members={members.map((m) => ({
+                  handle: m.handle,
+                  display_name: m.display_name,
+                  is_house_agent: m.is_house_agent,
+                }))}
+                allAgents={allAgents.map((a) => ({
+                  handle: a.handle,
+                  display_name: a.display_name,
+                  is_house_agent: a.is_house_agent,
+                }))}
+              />
+            </section>
+
+            <section>
+              <h2 className={SECTION_HEADING}>Visibility</h2>
+              <VisibilityToggle isPublic={portfolio.is_public} />
+            </section>
+
+            <p className="text-xs font-mono text-text-muted">
+              Public page:{" "}
+              <Link
+                href={`/portfolios/${portfolio.slug}`}
+                className="text-green hover:underline"
+              >
+                /portfolios/{portfolio.slug}
+              </Link>
+            </p>
+          </div>
+        ) : (
+          <section>
+            <h2 className={SECTION_HEADING}>Create your portfolio</h2>
+            <p className="text-sm text-text-dim mb-4 leading-relaxed -mt-1">
+              Give it a name and write the mandate your agents will work to.
+              You can add agents and adjust everything afterwards.
+            </p>
+            <CreatePortfolioForm />
+          </section>
+        )}
+
+        <form action="/auth/signout" method="post" className="mt-10">
           <button
             type="submit"
             className="text-xs font-mono text-text-muted hover:text-text"

--- a/web/app/api/v1/portfolios/[slug]/route.ts
+++ b/web/app/api/v1/portfolios/[slug]/route.ts
@@ -44,19 +44,24 @@ export async function GET(
   const slug = decodeURIComponent(rawSlug).toLowerCase();
 
   const portfolio = await getPortfolioBySlug(slug);
-  if (!portfolio) {
+  // Private portfolios (migration 024) are 404 on this unauthenticated public
+  // API — there is no human session here to verify ownership against.
+  if (!portfolio || !portfolio.is_public) {
     return errorResponse(`portfolio not found: ${slug}`, 404, "not_found");
   }
 
   const [members, snapshot] = await Promise.all([
     getMembersForPortfolio(portfolio.id),
-    getPortfolio(portfolio.owner_agent_id).catch((err) => {
-      console.error(
-        `GET /portfolios/${slug}: snapshot fetch failed:`,
-        err,
-      );
-      return null;
-    }),
+    // Human-owned portfolios have no owner agent and no account yet.
+    portfolio.owner_agent_id
+      ? getPortfolio(portfolio.owner_agent_id).catch((err) => {
+          console.error(
+            `GET /portfolios/${slug}: snapshot fetch failed:`,
+            err,
+          );
+          return null;
+        })
+      : Promise.resolve(null),
   ]);
 
   return jsonResponse(

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -17,11 +17,35 @@ import {
   getActiveThesesForAgent,
   type InvestmentThesis,
 } from "@/lib/theses-query";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const revalidate = 300;
 
 interface PageParams {
   params: Promise<{ slug: string }>;
+}
+
+/**
+ * Fetch a portfolio by slug, applying the migration-024 visibility gate: a
+ * private portfolio is visible only to its owner (the signed-in human).
+ * Returns null when the portfolio is missing or hidden from the viewer. The
+ * session read happens only on the private branch, so public portfolios stay
+ * statically cacheable.
+ */
+async function resolveVisiblePortfolio(
+  slug: string,
+): Promise<Portfolio | null> {
+  const portfolio = await getPortfolioBySlug(slug);
+  if (!portfolio) return null;
+  if (portfolio.is_public) return portfolio;
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (user && portfolio.owner_user_id && user.id === portfolio.owner_user_id) {
+    return portfolio;
+  }
+  return null;
 }
 
 // ----- Metadata ------------------------------------------------------------
@@ -32,7 +56,7 @@ export async function generateMetadata({
   const { slug: rawSlug } = await params;
   const slug = decodeURIComponent(rawSlug).toLowerCase();
 
-  const portfolio = await getPortfolioBySlug(slug);
+  const portfolio = await resolveVisiblePortfolio(slug);
   if (!portfolio) {
     return {
       title: `Portfolio ${slug} — not found`,
@@ -66,7 +90,7 @@ async function getPortfolioPageData(slug: string): Promise<{
   trades: Trade[];
   totalTrades: number;
 }> {
-  const portfolio = await getPortfolioBySlug(slug);
+  const portfolio = await resolveVisiblePortfolio(slug);
   if (!portfolio) {
     return {
       portfolio: null,
@@ -78,20 +102,21 @@ async function getPortfolioPageData(slug: string): Promise<{
     };
   }
 
-  // The snapshot helper (cash + holdings + MTM) is still keyed on agent_id
-  // during the shim period. Use the owner agent's id — for 1:1 portfolios
-  // this is exactly the data we want.
+  // Human-owned portfolios (owner_agent_id null, migration 024) don't trade
+  // yet — no account, holdings or theses. The snapshot/theses helpers are
+  // keyed on agent_id during the shim period, so skip them entirely.
   let snapshot: PortfolioSnapshot | null = null;
-  try {
-    snapshot = await getPortfolio(portfolio.owner_agent_id);
-  } catch (err) {
-    console.error("getPortfolio failed for", slug, err);
+  let thesesByTicker: Record<string, InvestmentThesis> = {};
+  if (portfolio.owner_agent_id) {
+    try {
+      snapshot = await getPortfolio(portfolio.owner_agent_id);
+    } catch (err) {
+      console.error("getPortfolio failed for", slug, err);
+    }
+    thesesByTicker = await getActiveThesesForAgent(portfolio.owner_agent_id);
   }
 
   const members = await getMembersForPortfolio(portfolio.id);
-  // Theses are still keyed via agent_id under the shim; owner_agent_id has
-  // the same rows as portfolio_id today.
-  const thesesByTicker = await getActiveThesesForAgent(portfolio.owner_agent_id);
   const { trades, totalTrades } = await getRecentTradesForPortfolio(
     portfolio.id,
   );
@@ -259,6 +284,13 @@ export default async function PortfolioPage({ params }: PageParams) {
                 Click a row to see the investment thesis recorded at buy time.
               </p>
             )}
+          </section>
+        ) : portfolio.owner_agent_id === null ? (
+          <section className="mb-10">
+            <p className="text-sm text-text-muted italic">
+              Not trading yet — this portfolio is being set up by its owner.
+              Agent execution is coming soon.
+            </p>
           </section>
         ) : (
           <section className="mb-10">

--- a/web/components/portfolio/agent-picker.tsx
+++ b/web/components/portfolio/agent-picker.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  addAgentToPortfolio,
+  removeAgentFromPortfolio,
+  type ActionResult,
+} from "@/lib/portfolios-mutations";
+
+export interface PickerAgent {
+  handle: string;
+  display_name: string;
+  is_house_agent: boolean;
+}
+
+export default function AgentPicker({
+  members,
+  allAgents,
+}: {
+  members: PickerAgent[];
+  allAgents: PickerAgent[];
+}) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pendingHandle, setPendingHandle] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  const memberHandles = useMemo(
+    () => new Set(members.map((m) => m.handle)),
+    [members],
+  );
+
+  const candidates = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return allAgents
+      .filter((a) => !memberHandles.has(a.handle))
+      .filter(
+        (a) =>
+          !q ||
+          a.handle.toLowerCase().includes(q) ||
+          a.display_name.toLowerCase().includes(q),
+      )
+      .slice(0, 30);
+  }, [allAgents, memberHandles, query]);
+
+  function runAction(handle: string, fn: () => Promise<ActionResult>) {
+    setError(null);
+    setPendingHandle(handle);
+    startTransition(async () => {
+      const result = await fn();
+      setPendingHandle(null);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="glass-card rounded-lg border border-border p-5 space-y-5">
+      <div>
+        <p className="text-xs font-mono uppercase tracking-widest text-text-dim mb-2">
+          On this portfolio ({members.length})
+        </p>
+        {members.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {members.map((m) => (
+              <span
+                key={m.handle}
+                className="inline-flex items-center gap-1.5 rounded border border-border bg-bg px-2 py-1 font-mono text-xs text-text"
+              >
+                @{m.handle}
+                <button
+                  type="button"
+                  onClick={() =>
+                    runAction(m.handle, () =>
+                      removeAgentFromPortfolio({ handle: m.handle }),
+                    )
+                  }
+                  disabled={pendingHandle === m.handle}
+                  aria-label={`Remove ${m.handle}`}
+                  className="text-text-muted hover:text-red disabled:opacity-50"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-text-muted italic">
+            No agents added yet.
+          </p>
+        )}
+      </div>
+
+      <div>
+        <p className="text-xs font-mono uppercase tracking-widest text-text-dim mb-2">
+          Add an agent
+        </p>
+        <input
+          type="text"
+          placeholder="Search agents…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted mb-2"
+        />
+        <ul className="divide-y divide-border max-h-72 overflow-y-auto">
+          {candidates.map((a) => (
+            <li
+              key={a.handle}
+              className="flex items-center justify-between gap-3 py-2"
+            >
+              <div className="min-w-0">
+                <span className="font-mono text-sm text-text">
+                  {a.display_name}
+                </span>
+                <span className="font-mono text-xs text-text-muted ml-2">
+                  @{a.handle}
+                </span>
+                {a.is_house_agent && (
+                  <span className="ml-2 text-[9px] font-mono uppercase tracking-widest text-orange">
+                    House
+                  </span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() =>
+                  runAction(a.handle, () =>
+                    addAgentToPortfolio({ handle: a.handle }),
+                  )
+                }
+                disabled={pendingHandle === a.handle}
+                className="shrink-0 px-2.5 py-1 font-mono text-[11px] uppercase tracking-widest rounded border border-green/40 text-green hover:bg-green/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {pendingHandle === a.handle ? "…" : "Add"}
+              </button>
+            </li>
+          ))}
+          {candidates.length === 0 && (
+            <li className="py-2 text-sm text-text-muted italic">
+              No matching agents.
+            </li>
+          )}
+        </ul>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/portfolio/create-portfolio-form.tsx
+++ b/web/components/portfolio/create-portfolio-form.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { createPortfolio } from "@/lib/portfolios-mutations";
+
+export default function CreatePortfolioForm() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [mandate, setMandate] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    startTransition(async () => {
+      const result = await createPortfolio({ displayName: name, mandate });
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="glass-card rounded-lg border border-border p-5 space-y-4"
+    >
+      <div>
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
+          Portfolio name
+        </label>
+        <input
+          type="text"
+          required
+          maxLength={80}
+          placeholder="My Portfolio"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
+          Mandate{" "}
+          <span className="text-text-muted normal-case tracking-normal">
+            (optional)
+          </span>
+        </label>
+        <textarea
+          rows={5}
+          maxLength={2000}
+          placeholder="The brief your agents work to — target universe, position limits, risk posture, sell discipline…"
+          value={mandate}
+          onChange={(e) => setMandate(e.target.value)}
+          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted resize-none"
+        />
+        <p className="text-[10px] text-text-dim mt-1 font-mono">
+          You can edit this any time before agent execution goes live.
+        </p>
+      </div>
+
+      {error && (
+        <div className="text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+          {error}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={pending}
+        className="w-full px-4 py-2.5 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {pending ? "Creating…" : "Create portfolio →"}
+      </button>
+    </form>
+  );
+}

--- a/web/components/portfolio/portfolio-details-editor.tsx
+++ b/web/components/portfolio/portfolio-details-editor.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { updatePortfolioDetails } from "@/lib/portfolios-mutations";
+
+export default function PortfolioDetailsEditor({
+  initialName,
+  initialMandate,
+}: {
+  initialName: string;
+  initialMandate: string;
+}) {
+  const router = useRouter();
+  const [name, setName] = useState(initialName);
+  const [mandate, setMandate] = useState(initialMandate);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  const dirty = name !== initialName || mandate !== initialMandate;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSaved(false);
+    startTransition(async () => {
+      const result = await updatePortfolioDetails({ name, mandate });
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setSaved(true);
+      router.refresh();
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="glass-card rounded-lg border border-border p-5 space-y-4"
+    >
+      <div>
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
+          Portfolio name
+        </label>
+        <input
+          type="text"
+          required
+          maxLength={80}
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            setSaved(false);
+          }}
+          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
+          Mandate
+        </label>
+        <p className="text-[10px] text-text-dim mb-1 font-mono">
+          The brief your agents will work to once execution is live.
+        </p>
+        <textarea
+          rows={6}
+          maxLength={2000}
+          placeholder="Target universe, position limits, risk posture, sell discipline…"
+          value={mandate}
+          onChange={(e) => {
+            setMandate(e.target.value);
+            setSaved(false);
+          }}
+          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted resize-none"
+        />
+      </div>
+
+      {error && (
+        <div className="text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={pending || !dirty}
+          className="px-4 py-2 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        >
+          {pending ? "Saving…" : "Save changes →"}
+        </button>
+        {saved && !dirty && (
+          <span className="text-xs font-mono text-green">✓ Saved</span>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/web/components/portfolio/visibility-toggle.tsx
+++ b/web/components/portfolio/visibility-toggle.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { setPortfolioVisibility } from "@/lib/portfolios-mutations";
+
+export default function VisibilityToggle({ isPublic }: { isPublic: boolean }) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function toggle() {
+    setError(null);
+    startTransition(async () => {
+      const result = await setPortfolioVisibility({ isPublic: !isPublic });
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="glass-card rounded-lg border border-border p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="font-mono text-sm text-text">
+            {isPublic ? "Public" : "Private"}
+          </p>
+          <p className="text-xs text-text-muted mt-1 leading-relaxed">
+            {isPublic
+              ? "Anyone can view this portfolio at its public URL."
+              : "Only you can view this portfolio. It's hidden from its public URL and the portfolio API."}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={toggle}
+          disabled={pending}
+          className="shrink-0 px-3 py-1.5 font-mono text-xs uppercase tracking-widest rounded border border-border text-text-dim hover:text-text hover:border-text/40 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {pending ? "…" : isPublic ? "Make private" : "Make public"}
+        </button>
+      </div>
+      {error && (
+        <div className="mt-3 text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/lib/auth/require-user.ts
+++ b/web/lib/auth/require-user.ts
@@ -1,0 +1,19 @@
+import { redirect } from "next/navigation";
+import type { User } from "@supabase/supabase-js";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+/**
+ * Resolve the signed-in human for a Server Action or Server Component.
+ * Redirects to /login when there is no session. `getUser()` (not
+ * `getSession()`) so the identity is verified server-side.
+ */
+export async function requireUser(): Promise<{ user: User }> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect("/login");
+  }
+  return { user };
+}

--- a/web/lib/portfolios-mutations.ts
+++ b/web/lib/portfolios-mutations.ts
@@ -1,0 +1,212 @@
+"use server";
+
+/**
+ * Server Actions for a signed-in human managing their one portfolio.
+ *
+ * Auth model: the SSR cookie session (a `profiles` user), NOT an agent API
+ * key — distinct from the `/api/v1/...` routes. Each action verifies the
+ * caller owns the portfolio, then writes with the service-role client,
+ * mirroring the codebase's verify-then-service-role convention.
+ */
+
+import { revalidatePath } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+import { requireUser } from "@/lib/auth/require-user";
+import { uniquePortfolioSlug } from "@/lib/slug";
+
+export type ActionResult = { ok: true } | { ok: false; error: string };
+
+const MAX_NAME = 80;
+const MAX_MANDATE = 2000;
+
+interface OwnedPortfolio {
+  id: string;
+  slug: string;
+}
+
+/** The caller's single portfolio, or null. Service-role read. */
+async function getOwnedPortfolio(userId: string): Promise<OwnedPortfolio | null> {
+  const supabase = getSupabase();
+  const { data } = await supabase
+    .from("portfolios")
+    .select("id, slug")
+    .eq("owner_user_id", userId)
+    .maybeSingle();
+  return (data as OwnedPortfolio | null) ?? null;
+}
+
+function revalidate(slug: string): void {
+  revalidatePath("/account");
+  revalidatePath(`/portfolios/${slug}`);
+}
+
+export async function createPortfolio(input: {
+  displayName: string;
+  mandate: string;
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+  const displayName = input.displayName.trim();
+  const mandate = input.mandate.trim();
+
+  if (!displayName) return { ok: false, error: "Portfolio name is required." };
+  if (displayName.length > MAX_NAME)
+    return { ok: false, error: `Name must be ${MAX_NAME} characters or fewer.` };
+  if (mandate.length > MAX_MANDATE)
+    return {
+      ok: false,
+      error: `Mandate must be ${MAX_MANDATE} characters or fewer.`,
+    };
+
+  if (await getOwnedPortfolio(user.id)) {
+    return { ok: false, error: "You already have a portfolio." };
+  }
+
+  const supabase = getSupabase();
+  const slug = await uniquePortfolioSlug(displayName);
+  const { error } = await supabase.from("portfolios").insert({
+    slug,
+    display_name: displayName,
+    description: mandate || null,
+    owner_user_id: user.id,
+    owner_agent_id: null,
+    is_public: true,
+  });
+
+  if (error) {
+    // 23505 here is almost certainly the one-portfolio-per-user partial index.
+    if (error.code === "23505") {
+      return { ok: false, error: "You already have a portfolio." };
+    }
+    console.error("createPortfolio failed:", error);
+    return { ok: false, error: "Could not create the portfolio. Try again." };
+  }
+
+  revalidate(slug);
+  return { ok: true };
+}
+
+export async function updatePortfolioDetails(input: {
+  name: string;
+  mandate: string;
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+  const name = input.name.trim();
+  const mandate = input.mandate.trim();
+
+  if (!name) return { ok: false, error: "Portfolio name is required." };
+  if (name.length > MAX_NAME)
+    return { ok: false, error: `Name must be ${MAX_NAME} characters or fewer.` };
+  if (mandate.length > MAX_MANDATE)
+    return {
+      ok: false,
+      error: `Mandate must be ${MAX_MANDATE} characters or fewer.`,
+    };
+
+  const portfolio = await getOwnedPortfolio(user.id);
+  if (!portfolio) return { ok: false, error: "You don't have a portfolio yet." };
+
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from("portfolios")
+    .update({ display_name: name, description: mandate || null })
+    .eq("id", portfolio.id)
+    .eq("owner_user_id", user.id);
+
+  if (error) {
+    console.error("updatePortfolioDetails failed:", error);
+    return { ok: false, error: "Could not save changes. Try again." };
+  }
+
+  revalidate(portfolio.slug);
+  return { ok: true };
+}
+
+export async function setPortfolioVisibility(input: {
+  isPublic: boolean;
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+  const portfolio = await getOwnedPortfolio(user.id);
+  if (!portfolio) return { ok: false, error: "You don't have a portfolio yet." };
+
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from("portfolios")
+    .update({ is_public: input.isPublic })
+    .eq("id", portfolio.id)
+    .eq("owner_user_id", user.id);
+
+  if (error) {
+    console.error("setPortfolioVisibility failed:", error);
+    return { ok: false, error: "Could not update visibility. Try again." };
+  }
+
+  revalidate(portfolio.slug);
+  return { ok: true };
+}
+
+async function resolveAgentId(handle: string): Promise<string | null> {
+  const supabase = getSupabase();
+  const { data } = await supabase
+    .from("agents")
+    .select("id")
+    .eq("handle", handle.trim().toLowerCase())
+    .maybeSingle();
+  return (data as { id: string } | null)?.id ?? null;
+}
+
+export async function addAgentToPortfolio(input: {
+  handle: string;
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+  const portfolio = await getOwnedPortfolio(user.id);
+  if (!portfolio) return { ok: false, error: "You don't have a portfolio yet." };
+
+  const agentId = await resolveAgentId(input.handle);
+  if (!agentId) return { ok: false, error: "That agent no longer exists." };
+
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from("portfolio_agents")
+    .upsert(
+      { portfolio_id: portfolio.id, agent_id: agentId },
+      { onConflict: "portfolio_id,agent_id", ignoreDuplicates: true },
+    );
+
+  if (error) {
+    console.error("addAgentToPortfolio failed:", error);
+    return { ok: false, error: "Could not add the agent. Try again." };
+  }
+
+  revalidate(portfolio.slug);
+  return { ok: true };
+}
+
+export async function removeAgentFromPortfolio(input: {
+  handle: string;
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+  const portfolio = await getOwnedPortfolio(user.id);
+  if (!portfolio) return { ok: false, error: "You don't have a portfolio yet." };
+
+  const agentId = await resolveAgentId(input.handle);
+  if (!agentId) {
+    // Already gone — treat as success so the UI settles.
+    revalidate(portfolio.slug);
+    return { ok: true };
+  }
+
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from("portfolio_agents")
+    .delete()
+    .eq("portfolio_id", portfolio.id)
+    .eq("agent_id", agentId);
+
+  if (error) {
+    console.error("removeAgentFromPortfolio failed:", error);
+    return { ok: false, error: "Could not remove the agent. Try again." };
+  }
+
+  revalidate(portfolio.slug);
+  return { ok: true };
+}

--- a/web/lib/portfolios-query.ts
+++ b/web/lib/portfolios-query.ts
@@ -18,7 +18,11 @@ export interface Portfolio {
   slug: string;
   display_name: string;
   description: string | null;
-  owner_agent_id: string;
+  /** Null for human-owned portfolios (migration 024). */
+  owner_agent_id: string | null;
+  /** Null for legacy agent-owned portfolios (migration 024). */
+  owner_user_id: string | null;
+  is_public: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -51,6 +55,23 @@ export async function getPortfolioBySlug(slug: string): Promise<Portfolio | null
     .maybeSingle();
   if (error) {
     console.error("getPortfolioBySlug failed:", error);
+    return null;
+  }
+  return (data as Portfolio | null) ?? null;
+}
+
+/** The single portfolio owned by a human user (migration 024), or null. */
+export async function getPortfolioForUser(
+  userId: string,
+): Promise<Portfolio | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("portfolios")
+    .select("*")
+    .eq("owner_user_id", userId)
+    .maybeSingle();
+  if (error) {
+    console.error("getPortfolioForUser failed:", error);
     return null;
   }
   return (data as Portfolio | null) ?? null;
@@ -91,12 +112,14 @@ export async function getPortfoliosForAgent(
   const rows = memberships ?? [];
   if (rows.length === 0) return [];
 
-  // Resolve portfolio rows
+  // Resolve portfolio rows. Filter out private portfolios (migration 024) so
+  // a human's private portfolio doesn't leak via a member agent's profile.
   const ids = rows.map((r) => (r as { portfolio_id: string }).portfolio_id);
   const { data: portfolios } = await supabase
     .from("portfolios")
     .select("*")
-    .in("id", ids);
+    .in("id", ids)
+    .eq("is_public", true);
   const byId = new Map<string, Portfolio>(
     ((portfolios as Portfolio[] | null) ?? []).map((p) => [p.id, p]),
   );

--- a/web/lib/slug.ts
+++ b/web/lib/slug.ts
@@ -1,0 +1,39 @@
+import { getSupabase } from "@/lib/supabase";
+
+const MAX_SLUG = 40;
+
+/** Derive a URL slug from a free-text name. */
+export function slugify(name: string): string {
+  const base = name
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "") // strip diacritics
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG)
+    .replace(/-+$/g, "");
+  return base || "portfolio";
+}
+
+/**
+ * Slugify `name` and resolve collisions against existing `portfolios.slug`
+ * by appending `-2`, `-3`, … The `slug UNIQUE` constraint remains the true
+ * guard against a concurrent-create race.
+ */
+export async function uniquePortfolioSlug(name: string): Promise<string> {
+  const supabase = getSupabase();
+  const root = slugify(name);
+  let candidate = root;
+  for (let n = 2; n < 1000; n++) {
+    const { data } = await supabase
+      .from("portfolios")
+      .select("slug")
+      .eq("slug", candidate)
+      .maybeSingle();
+    if (!data) return candidate;
+    const suffix = `-${n}`;
+    candidate =
+      root.slice(0, MAX_SLUG - suffix.length).replace(/-+$/g, "") + suffix;
+  }
+  return `${root.slice(0, 28)}-${Date.now().toString(36)}`;
+}


### PR DESCRIPTION
Lets a signed-in human own and shape one portfolio: create it, edit its name + mandate, assemble the team of AI agents that will operate it, and toggle it public/private. Management UI only — a human portfolio is a configured draft with no capital and no trading yet; mandate-driven agent execution is a later PR.

- migration 024: portfolios.owner_user_id + is_public, owner_agent_id made nullable, one-portfolio-per-user partial unique index, single-owner CHECK
- web/lib/portfolios-mutations.ts: Server Actions (create / edit details / visibility / add + remove agent), session-authed via requireUser()
- /account: create form when none exists, else the management view (details editor, agent picker, visibility toggle)
- privacy: the portfolio page gates private portfolios to their owner; the portfolio API 404s them; getPortfoliosForAgent filters them out
- portfolio page tolerates human portfolios (null owner_agent_id)

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU