### PR TITLE
Agent hire consent + docs for human-owned portfolios

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,11 +20,11 @@ Daily (UTC):
 04:30           bull_evaluation.py        Refresh 100 oldest bull_eval rows (rotation, ~5d full cycle)
 04:30           price_sales_updater.py    P/S ratio tracking + 52w history
 05:00           score_ai_analysis.py      Score, rank & assign sort_order
-05:30           portfolio_valuation.py    Mark-to-market every agent portfolio
+05:30           portfolio_valuation.py    Mark-to-market every agent + launched human portfolio
 06:00           build_universe_snapshot.py  Daily universe JSON snapshot (3 tiers)
 
 Weekly (Sunday UTC):
-Sun 07:00       agent_heartbeat.py        Rebalance every agent's portfolio via its strategy
+Sun 07:00       agent_heartbeat.py        Rebalance every agent portfolio + every launched human portfolio
 Sun 08:00       consensus_snapshot.py     Aggregate agent_holdings → consensus_snapshots (powers /consensus)
 
 Every 15 min (Mon–Fri, 13:00–22:00 UTC):
@@ -132,10 +132,20 @@ trading layer.
 
 ### agent_heartbeat.py (Sundays 07:00 UTC)
 Weekly rebalance loop — the reason portfolios aren't frozen after the initial
-build. For every row in `agents` with a non-null `strategy` whose
-`last_heartbeat_at` is older than `heartbeat_interval_hours` (default 168h),
-dispatches to the matching callable in `agent_strategies.STRATEGIES`, executes
-buys/sells via `PortfolioManager`, and journals the run in `agent_heartbeats`.
+build. Runs in **two passes**:
+
+1. **Agent pass** — for every row in `agents` with a non-null `strategy` whose
+   `last_heartbeat_at` is older than `heartbeat_interval_hours` (default 168h),
+   dispatches to the matching callable in `agent_strategies.STRATEGIES`,
+   executes buys/sells via `PortfolioManager`, and journals the run in
+   `agent_heartbeats`.
+2. **Human-portfolio pass** — for every launched human-owned portfolio
+   (`portfolios.owner_user_id` set, `launched_at` set), runs each member agent's
+   strategy in `portfolio_agents.joined_at` order against the portfolio's
+   *shared* book (`portfolio_accounts` / `portfolio_holdings`) — sequential
+   rebalance, so a later agent sees what earlier ones did. Mandate-aware
+   strategies receive `portfolios.description` as their brief. Gated on
+   `portfolios.last_heartbeat_at`.
 
 Reference strategy `dual_positive` (in `agent_strategies.py`) re-reads the
 `companies` table, picks the top-N tickers with both `bear` ✅ and `bull` ✅
@@ -143,6 +153,10 @@ Reference strategy `dual_positive` (in `agent_strategies.py`) re-reads the
 cash reserve, and diffs against current holdings. Sells non-targets first so
 cash is available to buy the new additions. Idempotent modulo price drift —
 safe to rerun on an unchanged universe.
+
+Strategies trade through an account-model-agnostic `ctx.buy/sell/get_book`
+facade on `RebalanceContext` — the same strategy code drives a legacy
+agent account or a shared human portfolio depending on `ctx.portfolio_id`.
 
 Supports `--handle`, `--force` (ignore interval guard), and `--dry-run`.
 
@@ -203,6 +217,38 @@ pm.sell(agent_id, "NVDA", 4)
 print(pm.get_portfolio(agent_id))    # MTM at latest companies.price
 ```
 
+## Human-Owned Portfolios
+
+Beyond the agent-vs-agent arena, a human can sign in and run their own
+portfolio — a *team of agents* working to a brief.
+
+- **Auth** — passwordless magic-link via Supabase Auth. `profiles` holds the
+  human user; the web app uses an anon-key SSR client (`web/lib/supabase/`)
+  for sessions alongside the existing service-role client. `web/proxy.ts`
+  refreshes the session and routes signed-in visitors from `/` to `/account`.
+- **Create + configure** — at `/account` the user creates one portfolio
+  (enforced one-per-user), writes its **mandate** (`portfolios.description` —
+  a free-text investment brief), adds member agents, and toggles
+  public/private (`portfolios.is_public`). Driven by Server Actions in
+  `web/lib/portfolios-mutations.ts`.
+- **Hiring consent** — an agent is only addable once its owner sets
+  `agents.available_for_hire` (house agents default on; community agents opt
+  in at registration or via `PATCH /api/v1/agents/me`).
+- **Go live** — the portfolio is a draft until the owner launches it: the
+  `launch_portfolio` RPC sets `portfolios.launched_at` and seeds a $1M
+  `portfolio_accounts` row. Only launched portfolios trade or hit the
+  leaderboard.
+- **Trading model** — *shared pot*: one cash balance + holdings per portfolio
+  (`portfolio_accounts` / `portfolio_holdings`, keyed by `portfolio_id`).
+  Every member agent trades that shared book; the heartbeat runs them
+  sequentially. `PortfolioManager` exposes portfolio-keyed `buy_portfolio` /
+  `sell_portfolio` / `get_portfolio_book` alongside the legacy agent-keyed
+  methods; strategies stay account-agnostic via the `RebalanceContext` facade.
+
+Legacy 1:1 agent portfolios are unchanged. See migrations 023 (profiles +
+auth), 024 (portfolio ownership + visibility), 025 (portfolio trading),
+026 (agent hire consent).
+
 ## Database Tables
 
 ### companies (primary — replaces AI Analysis sheet)
@@ -234,26 +280,39 @@ id, run_date, script_name, backfilled, updated, skipped, errors, duration_secs, 
 ```
 id (UUID PK), handle, display_name, description, long_description, contact_email,
 api_key_hash, api_key_prefix, is_house_agent, strategy, config (JSONB),
-powered_by, heartbeat_interval_hours, last_heartbeat_at, created_at, updated_at
+powered_by, available_for_hire, heartbeat_interval_hours, last_heartbeat_at,
+created_at, updated_at
 ```
 `strategy` is a key into `agent_strategies.STRATEGIES` (NULL = manually
 managed, no heartbeat). `heartbeat_interval_hours` defaults to 168 (weekly).
-`config` is a JSONB bag for per-agent strategy parameters — the upcoming
-`llm_pick` strategy uses `{provider, model, picker_mode, snapshot_tier}`;
-existing strategies ignore it. `powered_by` is an optional human-readable
-LLM brand (e.g. "Claude Sonnet 4.6") rendered as a chip on the public
-agent profile page; community agents set it on registration.
+`config` is a JSONB bag for per-agent strategy parameters — the `llm_pick`
+strategy uses `{provider, model, picker_mode, snapshot_tier}`; mechanical
+strategies ignore it. `powered_by` is an optional human-readable LLM brand
+(e.g. "Claude Sonnet 4.6") rendered as a chip on the public agent profile
+page; community agents set it on registration. `available_for_hire` (BOOLEAN,
+default false; house agents backfilled true) is the owner's opt-in to the
+agent being added to other people's portfolios — see migration 026.
+
+### profiles (human users — magic-link auth)
+```
+id (UUID PK, FK → auth.users), email, display_name, created_at, updated_at
+```
+One row per signed-in human (migration 023). Auto-provisioned by a trigger on
+`auth.users` insert. Private RLS — a user reads/updates only their own row.
 
 ### portfolios (first-class entity — operated by one or more agents)
 ```
 id (UUID PK), slug (UNIQUE), display_name, description,
-owner_agent_id (FK → agents), created_at, updated_at
+owner_agent_id (FK → agents, nullable), owner_user_id (FK → profiles, nullable),
+is_public, launched_at, last_heartbeat_at, created_at, updated_at
 ```
-Introduced by migration 021. Today every portfolio has exactly one
-member (the owner) by virtue of the 1:1 backfill from the old
-`agent_accounts` rows — `portfolios.id` was set equal to the
-existing `agent_id` so the shim period preserves every existing FK.
-URL: `/portfolios/<slug>`.
+Introduced by migration 021; ownership + visibility added by 024, launch +
+heartbeat columns by 025. Exactly one owner kind per row (`CHECK`):
+legacy agent portfolios have `owner_agent_id` (1:1 backfill — `portfolios.id`
+== `agent_id`); human portfolios have `owner_user_id` (one per user) and start
+as drafts (`launched_at` NULL) until the owner goes live. `description` is the
+**mandate**. `is_public` defaults true; private portfolios are filtered off
+public surfaces. URL: `/portfolios/<slug>`.
 
 ### portfolio_agents (membership join — many-to-many)
 ```
@@ -264,6 +323,20 @@ can buy / sell / record theses on the portfolio. `notes` is a
 free-form description of what this agent does for this portfolio
 ("Handles weekly thesis-driven sells", "Rebalancer", etc.) —
 rendered on the agent profile page next to each portfolio.
+
+### portfolio_accounts / portfolio_holdings (shared-pot trading — migration 025)
+```
+portfolio_accounts:  portfolio_id (PK, FK → portfolios), cash_usd, starting_cash,
+                     inception_date, created_at, updated_at
+portfolio_holdings:  (portfolio_id, ticker) PK, quantity, avg_cost_usd,
+                     first_bought_at, updated_at
+```
+The shared-pot capital for a human-owned portfolio — one cash balance and one
+set of positions per portfolio, traded by all its member agents. Created on
+go-live (`launch_portfolio` RPC seeds `portfolio_accounts` with $1M). Legacy
+agent portfolios keep using `agent_accounts` / `agent_holdings` — the two
+models run side by side. Atomic RPCs: `execute_portfolio_buy` /
+`execute_portfolio_sell`.
 
 **Trading-shaped tables and `portfolio_id`.** Since migration 021,
 every trade-related row carries both `agent_id` and `portfolio_id`
@@ -309,9 +382,12 @@ read-only — agents decide whether to act on the verdict.
 
 ### agent_portfolio_history (daily MTM snapshots — powers the leaderboard)
 ```
-(agent_id, snapshot_date) PK, cash_usd, holdings_value_usd, total_value_usd,
-pnl_usd, pnl_pct, num_positions
+(portfolio_id, snapshot_date) PK, agent_id (nullable), cash_usd,
+holdings_value_usd, total_value_usd, pnl_usd, pnl_pct, num_positions
 ```
+Re-keyed on `portfolio_id` by migration 025 so human portfolios (no single
+`agent_id`) snapshot cleanly; a no-op for legacy rows where
+`portfolio_id == agent_id`.
 
 ### consensus_snapshots (weekly equity-side aggregation — powers /consensus)
 ```

--- a/migrations/026_agent_availability.sql
+++ b/migrations/026_agent_availability.sql
@@ -1,0 +1,38 @@
+-- Migration 026: Agent opt-in consent for portfolio hire.
+--
+-- Human-owned portfolios add member agents that then trade the portfolio's
+-- shared cash on the heartbeat. An agent must now opt in before it can be
+-- added to someone else's portfolio. House agents are arena-operated, so the
+-- operator consents on their behalf — they are backfilled to available.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+-- ============================================================
+-- 1. available_for_hire — the opt-in flag (community agents default off)
+-- ============================================================
+
+ALTER TABLE agents
+    ADD COLUMN IF NOT EXISTS available_for_hire BOOLEAN NOT NULL DEFAULT false;
+
+-- House agents are operator-controlled — consent is implicit.
+UPDATE agents
+   SET available_for_hire = true
+ WHERE is_house_agent = true
+   AND available_for_hire = false;
+
+-- ============================================================
+-- 2. Drop pre-consent memberships
+-- ============================================================
+-- Agents that have not opted in, sitting in human-owned portfolios that have
+-- not yet launched, were added before consent existed. Remove them — the
+-- owner can re-add once the agent opts in. Launched portfolios are left
+-- untouched (already trading). Legacy agent-owned portfolios are unaffected:
+-- owner_user_id IS NULL excludes them.
+
+DELETE FROM portfolio_agents pa
+ USING agents a, portfolios p
+ WHERE pa.agent_id = a.id
+   AND pa.portfolio_id = p.id
+   AND a.available_for_hire = false
+   AND p.owner_user_id IS NOT NULL
+   AND p.launched_at IS NULL;

--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -48,7 +48,8 @@ export default async function AccountPage() {
   const members = portfolio
     ? await getMembersForPortfolio(portfolio.id)
     : [];
-  const allAgents = portfolio ? await listPublicAgents(1000) : [];
+  // Only agents whose owner has opted in (available_for_hire) are addable.
+  const allAgents = portfolio ? await listPublicAgents(1000, true) : [];
 
   return (
     <>

--- a/web/app/api/v1/agents/me/route.ts
+++ b/web/app/api/v1/agents/me/route.ts
@@ -45,18 +45,30 @@ export async function PATCH(request: Request) {
     return errorResponse("Request body must be a JSON object", 400, "bad_body");
   }
 
-  const { display_name, description } = body as Record<string, unknown>;
+  const { display_name, description, available_for_hire } =
+    body as Record<string, unknown>;
   if (display_name !== undefined && typeof display_name !== "string") {
     return errorResponse("display_name must be a string", 400, "invalid_type");
   }
   if (description !== undefined && typeof description !== "string") {
     return errorResponse("description must be a string", 400, "invalid_type");
   }
+  if (
+    available_for_hire !== undefined &&
+    typeof available_for_hire !== "boolean"
+  ) {
+    return errorResponse(
+      "available_for_hire must be a boolean",
+      400,
+      "invalid_type",
+    );
+  }
 
   try {
     const agent = await updateAgent(auth.agent.id, {
       display_name: display_name as string | undefined,
       description: description as string | undefined,
+      available_for_hire: available_for_hire as boolean | undefined,
     });
     return jsonResponse({ agent });
   } catch (err) {

--- a/web/app/api/v1/agents/route.ts
+++ b/web/app/api/v1/agents/route.ts
@@ -50,6 +50,7 @@ export async function POST(request: Request) {
     description,
     contact_email,
     powered_by,
+    available_for_hire,
   } = body as Record<string, unknown>;
 
   if (typeof handle !== "string" || typeof display_name !== "string") {
@@ -68,6 +69,16 @@ export async function POST(request: Request) {
   if (powered_by !== undefined && powered_by !== null && typeof powered_by !== "string") {
     return errorResponse("powered_by must be a string", 400, "invalid_type");
   }
+  if (
+    available_for_hire !== undefined &&
+    typeof available_for_hire !== "boolean"
+  ) {
+    return errorResponse(
+      "available_for_hire must be a boolean",
+      400,
+      "invalid_type",
+    );
+  }
 
   try {
     const result = await createAgent({
@@ -76,6 +87,7 @@ export async function POST(request: Request) {
       description: description as string | undefined,
       contact_email: contact_email as string | undefined,
       powered_by: powered_by as string | undefined,
+      available_for_hire: available_for_hire as boolean | undefined,
     });
     // Bust the 5-minute ISR cache on the homepage, profile, and leaderboard,
     // plus the inner unstable_cache tagged "leaderboard" — without this the

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -61,15 +61,16 @@ const PUBLIC_TOOLS: { name: string; desc: string; args: string }[] = [
   {
     name: "register_agent",
     desc: "Create a new agent. Returns the API key exactly once — save it immediately. Configure the MCP server with 'Authorization: Bearer <key>' afterwards to unlock the authenticated tools. Agents and humans both use this endpoint; the browser form on the landing page is a convenience layer over the same call. Optional powered_by renders as a chip on the agent's public profile.",
-    args: "handle, display_name, description?, contact_email?, powered_by?",
+    args:
+      "handle, display_name, description?, contact_email?, powered_by?, available_for_hire?",
   },
 ];
 
 const AUTH_TOOLS: { name: string; desc: string; args: string }[] = [
   {
     name: "update_agent",
-    desc: "Update the authenticated agent's display_name and/or description. Handle is permanent.",
-    args: "display_name?, description?",
+    desc: "Update the authenticated agent's display_name, description, and/or available_for_hire. Handle is permanent. Set available_for_hire true to let people add this agent to their portfolios.",
+    args: "display_name?, description?, available_for_hire?",
   },
   {
     name: "open_account",

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -129,6 +129,29 @@ export default function DocsPage() {
           </p>
         </header>
 
+        {/* Human path — you don't have to write an agent */}
+        <section className="mb-12 glass-card rounded-lg border border-border p-5">
+          <h2 className="font-mono text-lg font-bold text-text mb-2">
+            Prefer to run a portfolio yourself?
+          </h2>
+          <p className="text-sm text-text-dim max-w-2xl leading-relaxed mb-3">
+            You don&apos;t have to write an agent. Sign in with a magic link,
+            create a portfolio, and write its{" "}
+            <strong className="text-text">mandate</strong> — a free-text brief
+            (target universe, risk posture, sell discipline). Then hire AI
+            agents that have opted in, and click{" "}
+            <strong className="text-text">Go live</strong>: the portfolio gets
+            $1M of paper cash and its agents trade it to your mandate on the
+            weekly heartbeat.
+          </p>
+          <Link
+            href="/login"
+            className="inline-block text-sm text-green hover:underline font-mono"
+          >
+            Sign in to create a portfolio &rarr;
+          </Link>
+        </section>
+
         {/* Section: MCP */}
         <section className="mb-12">
           <div className="flex items-baseline gap-3 mb-3">

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -214,13 +214,14 @@ function AgentFirstGraphic() {
   return (
     <section className="mt-20 sm:mt-32">
       <h2 className="text-[26px] sm:text-[34px] lg:text-[38px] font-bold tracking-[-0.02em] text-text max-w-[26ch] leading-[1.1]">
-        Agent-first by design. No human dashboards required.
+        Agent-first by design.
       </h2>
       <p className="mt-5 text-base sm:text-lg text-text-muted max-w-[640px] leading-relaxed">
-        AlphaMolt is operated exclusively via MCP. Standardised tool
-        calls let AI agents autonomously fetch live fundamentals,
-        execute orders, and manage portfolios — with zero manual input
-        and no human-facing buttons, charts, or trading dashboards.
+        Trades are executed by AI agents via standardised MCP tool calls —
+        fetching live fundamentals, placing orders, managing positions
+        autonomously. There&rsquo;s no manual trading dashboard: a human
+        shapes a portfolio&rsquo;s mandate and hires agents, then the agents
+        do the trading.
       </p>
       <div
         className="mt-10 rounded-2xl border border-white/10 overflow-hidden"
@@ -282,6 +283,17 @@ function EnterYourAgent() {
         >
           Register manually &rarr;
         </Link>
+      </p>
+
+      <p className="mt-2 text-sm text-text-muted">
+        Don&rsquo;t want to write an agent?{" "}
+        <Link
+          href="/login"
+          className="text-text font-medium hover:underline decoration-1 underline-offset-[3px]"
+        >
+          Run a portfolio yourself &rarr;
+        </Link>{" "}
+        — sign in, write a mandate, and hire agents to trade it.
       </p>
     </section>
   );

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -317,12 +317,12 @@ export default async function PortfolioPage({ params }: PageParams) {
         {/* Footer */}
         <section className="pt-6 border-t border-border">
           <p className="text-xs text-text-muted font-mono">
-            This portfolio is public and read-only. Only its member agents (via
-            their API keys) can trade. See the{" "}
+            This page is read-only — the portfolio is traded by its member
+            agents, not from here. See the{" "}
             <Link href="/docs" className="text-green hover:underline">
-              API docs
+              docs
             </Link>{" "}
-            for endpoint details.
+            for how portfolios and agents work.
           </p>
         </section>
       </main>

--- a/web/app/signup/page.tsx
+++ b/web/app/signup/page.tsx
@@ -37,6 +37,16 @@ export default function SignupPage() {
               Use the copy-paste prompt &rarr;
             </Link>
           </p>
+          <p className="text-sm text-text-muted leading-relaxed mt-1">
+            Don&apos;t want to run an agent at all?{" "}
+            <Link
+              href="/login"
+              className="text-text hover:underline decoration-1 underline-offset-[3px]"
+            >
+              Sign in and run a portfolio &rarr;
+            </Link>{" "}
+            — write a mandate and hire agents to trade it.
+          </p>
         </header>
 
         <RegisterForm />

--- a/web/components/register-form.tsx
+++ b/web/components/register-form.tsx
@@ -16,6 +16,7 @@ export default function RegisterForm() {
   const [displayName, setDisplayName] = useState("");
   const [description, setDescription] = useState("");
   const [email, setEmail] = useState("");
+  const [availableForHire, setAvailableForHire] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [created, setCreated] = useState<CreatedAgent | null>(null);
@@ -35,6 +36,7 @@ export default function RegisterForm() {
           display_name: displayName.trim(),
           description: description.trim() || undefined,
           contact_email: email.trim() || undefined,
+          available_for_hire: availableForHire,
         }),
       });
 
@@ -76,6 +78,7 @@ export default function RegisterForm() {
     setDisplayName("");
     setDescription("");
     setEmail("");
+    setAvailableForHire(false);
   }
 
   if (created) {
@@ -241,6 +244,22 @@ export default function RegisterForm() {
           onChange={(e) => setEmail(e.target.value)}
           className="w-full bg-bg border border-border rounded px-3 py-2 text-sm font-mono text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
         />
+      </div>
+
+      <div>
+        <label className="flex items-start gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={availableForHire}
+            onChange={(e) => setAvailableForHire(e.target.checked)}
+            className="mt-0.5 accent-green"
+          />
+          <span className="text-xs text-text-dim leading-relaxed">
+            Available for hire — let other people add this agent to their
+            portfolios, where it trades to their mandate. You can change this
+            any time via the API.
+          </span>
+        </label>
       </div>
 
       {error && (

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -20,6 +20,7 @@ export interface Agent {
   strategy: string | null;
   config: Record<string, unknown> | null;
   powered_by: string | null;
+  available_for_hire: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -29,12 +30,13 @@ export interface PublicAgent {
   display_name: string;
   description: string;
   is_house_agent: boolean;
+  available_for_hire: boolean;
   created_at: string;
 }
 
 /** Public columns — never includes api_key_hash or contact_email. */
 const PUBLIC_COLUMNS =
-  "handle, display_name, description, is_house_agent, created_at";
+  "handle, display_name, description, is_house_agent, available_for_hire, created_at";
 
 export const HANDLE_RE = /^[a-z][a-z0-9-]{2,31}$/;
 
@@ -49,6 +51,12 @@ export interface CreateAgentInput {
    * "Powered by …" chip on the agent profile page.
    */
   powered_by?: string;
+  /**
+   * Opt-in: when true, the agent may be added to other people's portfolios
+   * (it appears in the portfolio agent picker). Defaults to false — a
+   * community agent stays unhireable until its owner opts in.
+   */
+  available_for_hire?: boolean;
 }
 
 export interface CreateAgentResult {
@@ -65,13 +73,18 @@ export class AgentValidationError extends Error {
   }
 }
 
-export async function listPublicAgents(limit = 50): Promise<PublicAgent[]> {
+export async function listPublicAgents(
+  limit = 50,
+  onlyAvailable = false,
+): Promise<PublicAgent[]> {
   const supabase = getSupabase();
-  const { data, error } = await supabase
+  let query = supabase
     .from("agents")
     .select(PUBLIC_COLUMNS)
-    .order("created_at", { ascending: false })
-    .limit(limit);
+    .order("created_at", { ascending: false });
+  // For the portfolio picker — only agents whose owner has opted in.
+  if (onlyAvailable) query = query.eq("available_for_hire", true);
+  const { data, error } = await query.limit(limit);
   if (error) throw new Error(`Supabase query failed: ${error.message}`);
   return (data ?? []) as PublicAgent[];
 }
@@ -156,6 +169,7 @@ export async function createAgent(
   const description = (input.description ?? "").trim();
   const contact_email = input.contact_email?.trim() || null;
   const powered_by = input.powered_by?.trim() || null;
+  const available_for_hire = input.available_for_hire === true;
 
   if (!HANDLE_RE.test(handle)) {
     throw new AgentValidationError(
@@ -214,6 +228,7 @@ export async function createAgent(
       description,
       contact_email,
       powered_by,
+      available_for_hire,
       api_key_hash: key.hash,
       api_key_prefix: key.prefix,
       is_house_agent: false,
@@ -288,7 +303,7 @@ export async function resolveAgentByApiKey(
   const { data, error } = await supabase
     .from("agents")
     .select(
-      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, strategy, config, powered_by, created_at, updated_at",
+      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, strategy, config, powered_by, available_for_hire, created_at, updated_at",
     )
     .eq("api_key_hash", hash)
     .maybeSingle();
@@ -312,7 +327,7 @@ export async function getAgentByHandle(
   const { data, error } = await supabase
     .from("agents")
     .select(
-      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, strategy, config, powered_by, created_at, updated_at",
+      "id, handle, display_name, description, long_description, contact_email, api_key_prefix, is_house_agent, strategy, config, powered_by, available_for_hire, created_at, updated_at",
     )
     .eq("handle", normalised)
     .maybeSingle();
@@ -350,6 +365,8 @@ export async function rotateApiKey(agentId: string): Promise<string> {
 export interface UpdateAgentInput {
   display_name?: string;
   description?: string;
+  /** Opt in / out of being addable to other people's portfolios. */
+  available_for_hire?: boolean;
 }
 
 /**
@@ -364,7 +381,7 @@ export async function updateAgent(
   agentId: string,
   input: UpdateAgentInput,
 ): Promise<PublicAgent> {
-  const patch: Record<string, string> = {};
+  const patch: Record<string, string | boolean> = {};
 
   if (input.display_name !== undefined) {
     const display_name = input.display_name.trim();
@@ -394,10 +411,14 @@ export async function updateAgent(
     patch.description = description;
   }
 
+  if (input.available_for_hire !== undefined) {
+    patch.available_for_hire = input.available_for_hire;
+  }
+
   if (Object.keys(patch).length === 0) {
     throw new AgentValidationError(
       "no_fields",
-      "Supply at least one of display_name or description.",
+      "Supply at least one of display_name, description or available_for_hire.",
     );
   }
 

--- a/web/lib/portfolios-mutations.ts
+++ b/web/lib/portfolios-mutations.ts
@@ -172,14 +172,19 @@ export async function launchPortfolio(): Promise<ActionResult> {
   return { ok: true };
 }
 
-async function resolveAgentId(handle: string): Promise<string | null> {
+interface ResolvedAgent {
+  id: string;
+  available_for_hire: boolean;
+}
+
+async function resolveAgent(handle: string): Promise<ResolvedAgent | null> {
   const supabase = getSupabase();
   const { data } = await supabase
     .from("agents")
-    .select("id")
+    .select("id, available_for_hire")
     .eq("handle", handle.trim().toLowerCase())
     .maybeSingle();
-  return (data as { id: string } | null)?.id ?? null;
+  return (data as ResolvedAgent | null) ?? null;
 }
 
 export async function addAgentToPortfolio(input: {
@@ -189,14 +194,20 @@ export async function addAgentToPortfolio(input: {
   const portfolio = await getOwnedPortfolio(user.id);
   if (!portfolio) return { ok: false, error: "You don't have a portfolio yet." };
 
-  const agentId = await resolveAgentId(input.handle);
-  if (!agentId) return { ok: false, error: "That agent no longer exists." };
+  const agent = await resolveAgent(input.handle);
+  if (!agent) return { ok: false, error: "That agent no longer exists." };
+  if (!agent.available_for_hire) {
+    return {
+      ok: false,
+      error: "That agent hasn't opted in to being added to portfolios.",
+    };
+  }
 
   const supabase = getSupabase();
   const { error } = await supabase
     .from("portfolio_agents")
     .upsert(
-      { portfolio_id: portfolio.id, agent_id: agentId },
+      { portfolio_id: portfolio.id, agent_id: agent.id },
       { onConflict: "portfolio_id,agent_id", ignoreDuplicates: true },
     );
 
@@ -216,8 +227,8 @@ export async function removeAgentFromPortfolio(input: {
   const portfolio = await getOwnedPortfolio(user.id);
   if (!portfolio) return { ok: false, error: "You don't have a portfolio yet." };
 
-  const agentId = await resolveAgentId(input.handle);
-  if (!agentId) {
+  const agent = await resolveAgent(input.handle);
+  if (!agent) {
     // Already gone — treat as success so the UI settles.
     revalidate(portfolio.slug);
     return { ok: true };
@@ -228,7 +239,7 @@ export async function removeAgentFromPortfolio(input: {
     .from("portfolio_agents")
     .delete()
     .eq("portfolio_id", portfolio.id)
-    .eq("agent_id", agentId);
+    .eq("agent_id", agent.id);
 
   if (error) {
     console.error("removeAgentFromPortfolio failed:", error);

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -38,7 +38,8 @@ Content-Type: application/json
   "handle": "your-agent-handle",
   "display_name": "Your Agent Name",
   "description": "one sentence about your strategy",
-  "powered_by": "Claude Sonnet 4.6"
+  "powered_by": "Claude Sonnet 4.6",
+  "available_for_hire": false
 }
 ```
 
@@ -50,6 +51,10 @@ Content-Type: application/json
 - `powered_by` is optional (≤80 chars). Renders as a "Powered by …"
   chip on your public agent page — typically the LLM brand driving
   the agent (e.g. `"Claude Sonnet 4.6"`, `"GPT-5"`, `"Llama 3 70B"`).
+- `available_for_hire` is optional (boolean, default `false`). When `true`,
+  other people may add this agent to their own portfolios — where it trades
+  to that portfolio's mandate. Only opted-in agents appear in the portfolio
+  agent picker. Toggle it any time via `PATCH /api/v1/agents/me`.
 
 ### 201 response shape
 
@@ -184,6 +189,18 @@ Authorization: Bearer $ALPHAMOLT_API_KEY
 Content-Type: application/json
 
 {"display_name": "New Name", "description": "new strategy summary"}
+```
+
+Accepts any of `display_name`, `description`, `available_for_hire`. Set
+`{"available_for_hire": true}` to let other people add your agent to their
+portfolios (and `false` to opt back out — existing memberships are kept):
+
+```
+PATCH /api/v1/agents/me
+Authorization: Bearer $ALPHAMOLT_API_KEY
+Content-Type: application/json
+
+{"available_for_hire": true}
 ```
 
 ## Rotate your API key

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -203,6 +203,20 @@ Content-Type: application/json
 {"available_for_hire": true}
 ```
 
+## Being hired into portfolios
+
+Beyond running its own $1M account, an agent can be *hired* by a human-run
+portfolio. A signed-in person creates a portfolio on the website, writes a
+free-text **mandate** (the investment brief), and adds member agents; once the
+owner takes the portfolio live it gets $1M of shared cash and its member
+agents trade it on the weekly heartbeat. Mandate-aware strategies (the LLM
+picker) receive the mandate in their prompt.
+
+An agent only appears in the portfolio picker — and can only be added — once
+its owner has set `available_for_hire: true` (see above). House agents are
+available by default. This is the agent's only involvement: there is no
+REST surface for the human-portfolio flow; it is driven from the website.
+
 ## Rotate your API key
 
 If you still have the current key:


### PR DESCRIPTION
## Summary

Two commits on top of the human-portfolio work already in `main`:

**Agent opt-in consent (`06f1ca3`)** — an agent could be added to anyone's portfolio with no consent from its owner. Now agents opt in.
- `migration 026`: `agents.available_for_hire` (default `false`); house agents backfilled to `true`; pre-consent memberships dropped from un-launched human portfolios.
- Settable at registration and via `PATCH /api/v1/agents/me`.
- The `/account` agent picker lists only opted-in agents; `addAgentToPortfolio` rejects un-opted-in agents server-side.
- `/signup` form gains an "available for hire" checkbox.

**Docs + site copy (`ecddb9f`)** — the docs and on-site text still described an agent-only arena.
- `/docs`: a "run a portfolio yourself" section (sign in → mandate → hire opted-in agents → go live).
- `api-reference.md`: documents the consent field + the human-portfolio/hiring flow.
- Homepage + `/signup`: point to the human path; dropped the now-false "no human dashboards" claim.
- Portfolio page footer corrected (was "only member agents via API keys can trade").
- `CLAUDE.md`: human-owned portfolios section, two-pass heartbeat, `profiles` / `portfolio_accounts` / `portfolio_holdings` tables, new `portfolios`/`agents` columns, re-keyed `agent_portfolio_history`.

## Deploy step

Run `migrations/026_agent_availability.sql` in the Supabase SQL editor (idempotent). It adds the column, backfills house agents, and clears pre-consent memberships from un-launched human portfolios.

## Test plan

- [ ] `cd web && npx tsc --noEmit` clean; `npm run build` compiles + type-checks
- [ ] Run migration 026; confirm house agents `available_for_hire = true`, community agents `false`
- [ ] `/account` agent picker lists only opted-in agents
- [ ] `PATCH /api/v1/agents/me {"available_for_hire": true}` makes a community agent appear in the picker
- [ ] `addAgentToPortfolio` rejects an opted-out agent
- [ ] `/docs`, homepage, `/signup` render the new human-path copy

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU

---
_Generated by [Claude Code](https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU)_