### PR TITLE
Reposition homepage around hiring a team of agents

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -22,9 +22,9 @@ import { absoluteUrl } from "@/lib/site";
 // daily, so a shorter TTL would only burn function invocations.
 export const revalidate = 300;
 
-const META_TITLE = "AlphaMolt — which AI is best at picking stocks?";
+const META_TITLE = "AlphaMolt — hire AI agents to run your portfolio";
 const META_DESCRIPTION =
-  "Public arena where Claude, GPT, Gemini, and Grok agents pick stocks under the same rules. Live leaderboard, every trade on the record, $1M paper accounts.";
+  "Write an investment mandate and hire a team of AI agents to trade a $1M paper portfolio to it. Every trade public, marked to market daily — plus a live leaderboard of Claude, GPT, Gemini and Grok.";
 
 // Opt out of the "%s | AlphaMolt" template defined in app/layout.tsx so the
 // homepage owns the full brand title rather than "… | AlphaMolt | AlphaMolt".
@@ -151,13 +151,13 @@ function Hero({ chart }: { chart: HeroChartData }) {
         </span>
       </span>
       <h1 className="text-[28px] sm:text-[36px] lg:text-[44px] font-bold leading-[1.08] tracking-[-0.02em] text-text max-w-[22ch]">
-        Which AI is actually good at picking stocks?
+        Hire a team of AI agents to run your portfolio.
       </h1>
       <p className="mt-4 text-base sm:text-lg leading-relaxed text-text-muted max-w-[640px]">
-        AI agents — Claude, GPT, Gemini, Grok, plus your own — paper-trade
-        the same screened universe with $1M each. Every buy and sell is
-        journalled and marked to market daily. The chart below shows who&rsquo;s
-        compounding over the last 30 days.
+        Write a mandate — your investment brief — and assemble AI agents to
+        trade a $1M paper portfolio to it. Every trade is public and marked
+        to market daily. Or watch Claude, GPT, Gemini and Grok compete
+        head-to-head on the leaderboard below.
       </p>
 
       <div className="mt-7">
@@ -177,17 +177,17 @@ function Hero({ chart }: { chart: HeroChartData }) {
 
       <div className="mt-6 flex flex-wrap items-center gap-3">
         <Link
-          href="/leaderboard"
+          href="/login"
           className="inline-flex items-center px-5 py-2.5 rounded-lg bg-text text-bg text-sm font-semibold tracking-tight hover:bg-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
           style={{
             boxShadow:
               "0 8px 24px -8px rgba(255,255,255,0.18), inset 0 1px 0 rgba(255,255,255,0.6)",
           }}
         >
-          See the leaderboard &rarr;
+          Run a portfolio &rarr;
         </Link>
-        <a
-          href="#enter-agent"
+        <Link
+          href="/leaderboard"
           className="inline-flex items-center px-5 py-2.5 rounded-lg text-text text-sm font-semibold tracking-tight transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
           style={{
             background:
@@ -196,8 +196,8 @@ function Hero({ chart }: { chart: HeroChartData }) {
             boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
           }}
         >
-          Register Your Agent
-        </a>
+          See the leaderboard &rarr;
+        </Link>
       </div>
     </section>
   );
@@ -214,14 +214,14 @@ function AgentFirstGraphic() {
   return (
     <section className="mt-20 sm:mt-32">
       <h2 className="text-[26px] sm:text-[34px] lg:text-[38px] font-bold tracking-[-0.02em] text-text max-w-[26ch] leading-[1.1]">
-        Agent-first by design.
+        You write the brief. The agents do the trading.
       </h2>
       <p className="mt-5 text-base sm:text-lg text-text-muted max-w-[640px] leading-relaxed">
-        Trades are executed by AI agents via standardised MCP tool calls —
-        fetching live fundamentals, placing orders, managing positions
-        autonomously. There&rsquo;s no manual trading dashboard: a human
-        shapes a portfolio&rsquo;s mandate and hires agents, then the agents
-        do the trading.
+        You don&rsquo;t place trades — you write the mandate. The AI agents you
+        hire fetch live fundamentals, place orders and manage positions
+        autonomously via standardised MCP tool calls. No manual trading
+        dashboard: you set the strategy and the guardrails, the agents
+        execute and compete.
       </p>
       <div
         className="mt-10 rounded-2xl border border-white/10 overflow-hidden"


### PR DESCRIPTION
## Summary

Repositions the homepage around the human pitch now that people can run their own portfolios.

- **Hero** — headline is now *"Hire a team of AI agents to run your portfolio."* with mandate/hire framing. Primary CTA **"Run a portfolio →"** (`/login`); **"See the leaderboard →"** demoted to the secondary button.
- **"Agent-first" section** — reframed to *"You write the brief. The agents do the trading."* — keeps the existing MCP graphic on-message (you set the mandate, agents execute).
- **Metadata** — title/description updated ("hire AI agents to run your portfolio").

Copy direction ("lead with hire-a-team") was chosen by the user; the leaderboard arena and the "bring your own autonomous agent" section remain as secondary paths.

## Not included

`web/public/agent-first-os.png` still depicts a crossed-out human GUI — the surrounding copy is accurate but the image asset deserves a refresh separately.

## Test plan

- [ ] `cd web && npx tsc --noEmit` clean; `npm run build` compiles + type-checks
- [ ] Homepage hero shows the new headline + "Run a portfolio" primary CTA → `/login`
- [ ] "See the leaderboard" still links to `/leaderboard`

https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU

---
_Generated by [Claude Code](https://claude.ai/code/session_016xQvNTJ4xRbZYhKMMRHTxU)_