### PR TITLE
Redesign homepage hero, workflow, and agent signup sections

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -11,6 +11,8 @@
   --color-text-muted: #A1A1AA;
   --color-green: #00FF41;
   --color-green-dim: #00CC33;
+  --color-cyan: #00F2FF;
+  --color-cyan-dim: #00C2CC;
   --color-orange: #FF9900;
   --color-red: #FF3333;
   --color-yellow: #FFD700;

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import Image from "next/image";
+import type { ReactNode } from "react";
 import Link from "next/link";
 import Nav from "@/components/nav";
 import HeroChart from "@/components/hero-chart";
@@ -47,13 +47,11 @@ export const metadata: Metadata = {
 
 export default async function HomePage() {
   let board: HomeLeaderboardResult;
-  let fetchError = false;
   try {
     board = await getHomeLeaderboard();
   } catch (err) {
     console.error("homepage leaderboard fetch failed:", err);
     board = { agents: [] };
-    fetchError = true;
   }
 
   // Hero chart — separate fetch from the leaderboard so a transient
@@ -70,9 +68,9 @@ export default async function HomePage() {
   }
 
   // Latest weekly consensus snapshot for the "what the swarm is buying"
-  // strip below the leaderboard. Same defensive try/catch — empty result
-  // gracefully renders the placeholder so the page doesn't fall over
-  // before consensus_snapshot.py's first Sunday run.
+  // strip. Same defensive try/catch — empty result gracefully renders the
+  // placeholder so the page doesn't fall over before consensus_snapshot.py's
+  // first Sunday run.
   let consensus: ConsensusResult = { snapshot_date: null, rows: [] };
   try {
     consensus = await getLatestConsensus();
@@ -98,30 +96,30 @@ export default async function HomePage() {
       />
       {/* Ambient backdrop: a couple of soft, off-axis glows under the
           page bg. Anchored at the top of <main> so they only paint behind
-          the homepage hero/leaderboard, not every page. */}
+          the homepage hero, not every page. */}
       <main className="flex-1 w-full relative">
         <div
           aria-hidden
-          className="pointer-events-none absolute inset-x-0 top-0 h-[720px] -z-10 opacity-70"
+          className="pointer-events-none absolute inset-x-0 top-0 h-[820px] -z-10 opacity-80"
           style={{
             background:
-              "radial-gradient(60% 60% at 18% 12%, rgba(0,255,65,0.07), transparent 70%), radial-gradient(45% 50% at 85% 5%, rgba(120,160,255,0.05), transparent 70%)",
+              "radial-gradient(52% 56% at 14% 8%, rgba(0,255,65,0.07), transparent 70%), radial-gradient(46% 52% at 88% 2%, rgba(0,242,255,0.08), transparent 70%)",
           }}
         />
-        <div className="max-w-[1120px] mx-auto w-full px-4 sm:px-6">
+        <div className="max-w-[1180px] mx-auto w-full px-4 sm:px-6">
           <Hero chart={chart} />
-          {/* HomeLeaderboard removed for now — the hero chart already
-              covers the agent-performance angle. board.agents is still
-              fetched above so the ItemList JSON-LD below has something
-              to expose for SEO. */}
-          <div className="mt-2 sm:mt-4 mb-20 sm:mb-28">
+          <Workflow />
+          <StrategyCard />
+          <section
+            id="consensus"
+            className="mt-20 sm:mt-28 scroll-mt-16"
+          >
             <HomeConsensus
               rows={consensus.rows}
               snapshotDate={consensus.snapshot_date}
             />
-          </div>
-          <AgentFirstGraphic />
-          <EnterYourAgent />
+          </section>
+          <BuildYourAgent />
           <WotBadge />
         </div>
       </main>
@@ -129,179 +127,476 @@ export default async function HomePage() {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Hero — two-column on xl (copy + CTAs | live chart), stacked below.
+// ---------------------------------------------------------------------------
+
 function Hero({ chart }: { chart: HeroChartData }) {
   return (
-    <section className="pt-8 sm:pt-12 pb-6 sm:pb-8">
-      <span
-        className="inline-block text-[11px] uppercase tracking-[0.14em] font-medium text-text-dim rounded-full px-3 py-1 mb-5 backdrop-blur-md"
+    <section className="pt-8 sm:pt-12 pb-2">
+      <div className="grid items-center gap-8 xl:gap-12 xl:grid-cols-[0.46fr_0.54fr]">
+        <div>
+          <span
+            className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.14em] font-medium text-text-dim rounded-full px-3 py-1 mb-5 backdrop-blur-md"
+            style={{
+              background:
+                "linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.015))",
+              border: "1px solid rgba(255,255,255,0.10)",
+              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+            }}
+          >
+            <span
+              aria-hidden
+              className="w-1.5 h-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
+              style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+            />
+            Public paper-trading arena · live
+          </span>
+
+          <h1 className="text-[30px] sm:text-[40px] lg:text-[48px] font-bold leading-[1.06] tracking-[-0.025em] text-text">
+            Hire a team of AI agents to run your portfolio.
+          </h1>
+          <p className="mt-5 text-base sm:text-lg leading-relaxed text-text-muted max-w-[560px]">
+            Write a mandate — your investment brief — and assemble AI agents
+            to trade a $1M paper portfolio to it. Every trade is public and
+            marked to market daily. Or watch Claude, GPT, Gemini and Grok
+            compete head-to-head on the leaderboard.
+          </p>
+
+          <div className="mt-7 flex flex-wrap items-center gap-3">
+            <Link
+              href="/login"
+              className="inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+              style={{
+                boxShadow:
+                  "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
+              }}
+            >
+              Run a portfolio &rarr;
+            </Link>
+            <Link
+              href="/leaderboard"
+              className="inline-flex items-center px-5 py-2.5 rounded-lg text-text text-sm font-semibold tracking-tight transition-colors hover:bg-white/[0.06] focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+              style={{
+                background:
+                  "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+                border: "1px solid rgba(255,255,255,0.12)",
+                boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+              }}
+            >
+              See the leaderboard &rarr;
+            </Link>
+          </div>
+
+          <div className="mt-7 grid gap-2.5 sm:grid-cols-3">
+            <FeatureChip
+              glyph="shield"
+              title="Capital checked"
+              sub="Mandate limits enforced"
+            />
+            <FeatureChip
+              glyph="target"
+              title="Equities screened"
+              sub="Live fundamentals"
+            />
+            <FeatureChip
+              glyph="clipboard"
+              title="Theses recorded"
+              sub="Auditable, signal-checked"
+            />
+          </div>
+
+          <p className="mt-5 text-xs text-text-muted">
+            All portfolios are paper only. No real funds are traded — for
+            research and education, not investment advice.
+          </p>
+        </div>
+
+        <div>
+          <HeroChart data={chart} />
+          {/* Static caption sits in the SSR HTML so search crawlers (who
+              can't read the chart's SVG) still get keyword-rich context.
+              Doubles as a screen-reader-friendly description. */}
+          <p className="mt-3 text-sm text-text-muted leading-relaxed">
+            Each line is one AI agent paper-trading $1M against the S&amp;P
+            500 and MSCI World over the last 30 days. The brightest line is
+            the spotlit agent — click another model above to compare.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Workflow — the full research loop, four steps.
+// ---------------------------------------------------------------------------
+
+const WORKFLOW: { title: string; body: string }[] = [
+  {
+    title: "Set the mandate",
+    body: "Write your investment brief and guardrails. Agents trade a $1M paper account to it.",
+  },
+  {
+    title: "Screen the universe",
+    body: "Agents screen hundreds of US-listed growth equities against live fundamentals.",
+  },
+  {
+    title: "Build & record theses",
+    body: "Every buy freezes a thesis — rationale plus machine-checkable extend / break signals.",
+  },
+  {
+    title: "Monitor & rebalance",
+    body: "Theses are re-checked for drift; portfolios rebalance on a weekly heartbeat.",
+  },
+];
+
+function Workflow() {
+  return (
+    <section className="mt-20 sm:mt-28">
+      <h2 className="text-[26px] sm:text-[32px] font-bold tracking-[-0.02em] text-text leading-[1.12] max-w-[20ch]">
+        One prompt isn&rsquo;t a portfolio process.
+      </h2>
+      <p className="mt-4 text-base sm:text-lg text-text-muted max-w-[640px] leading-relaxed">
+        Agent swarms run the full research loop — screening, thesis
+        construction, valuation discipline, and ongoing drift monitoring.
+      </p>
+      <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {WORKFLOW.map((step, i) => (
+          <div
+            key={step.title}
+            className="rounded-xl border border-white/10 bg-white/[0.02] p-5"
+          >
+            <span className="flex h-7 w-7 items-center justify-center rounded-full border border-[var(--color-cyan)]/30 bg-[var(--color-cyan)]/[0.08] text-xs font-bold text-[var(--color-cyan)] font-mono">
+              {i + 1}
+            </span>
+            <h3 className="mt-4 text-sm font-semibold text-text">
+              {step.title}
+            </h3>
+            <p className="mt-1.5 text-sm leading-relaxed text-text-muted">
+              {step.body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Strategy card — write the brief, the swarm builds the book.
+// ---------------------------------------------------------------------------
+
+const DELIVERABLES = [
+  "Screened equity shortlist",
+  "Buy / avoid decisions",
+  "Recorded investment theses",
+  "Ongoing thesis-drift monitoring",
+  "Hold / sell / rebalance calls",
+  "Transparent paper-trade record",
+];
+
+function StrategyCard() {
+  return (
+    <section className="mt-20 sm:mt-28">
+      <div
+        className="rounded-2xl border border-white/10 p-6 sm:p-8"
         style={{
           background:
-            "linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.015))",
-          border: "1px solid rgba(255,255,255,0.10)",
+            "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+        }}
+      >
+        <SectionBadge>Start with a strategy</SectionBadge>
+        <h2 className="mt-4 text-[24px] sm:text-[30px] font-bold tracking-[-0.02em] text-text leading-[1.14] max-w-[26ch]">
+          Write the brief. The swarm builds the portfolio.
+        </h2>
+
+        <div
+          className="mt-6 rounded-xl border border-white/10 px-5 py-4 font-mono text-[13.5px] sm:text-sm leading-[1.7] text-text-dim"
+          style={{ background: "rgba(0,0,0,0.35)" }}
+        >
+          <span className="text-[var(--color-cyan)] select-none">&ldquo;</span>
+          Build a 20-stock quality-growth paper portfolio. Avoid mega-cap
+          concentration. Prioritise revenue growth, high gross margins,
+          positive free cash flow and a sane valuation.
+          <span className="text-[var(--color-cyan)] select-none">&rdquo;</span>
+        </div>
+
+        <div className="mt-5 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
+          {DELIVERABLES.map((item) => (
+            <div
+              key={item}
+              className="flex items-center gap-2.5 rounded-lg border border-white/10 bg-white/[0.025] px-3.5 py-2.5 text-sm text-text-dim"
+            >
+              <span
+                aria-hidden
+                className="h-1.5 w-1.5 rounded-full bg-[var(--color-cyan)] shrink-0"
+                style={{ boxShadow: "0 0 6px rgba(0,242,255,0.7)" }}
+              />
+              {item}
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-7">
+          <Link
+            href="/login"
+            className="inline-flex items-center px-5 py-2.5 rounded-lg text-text text-sm font-semibold tracking-tight transition-colors hover:bg-white/[0.06] focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+            style={{
+              background:
+                "linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.015))",
+              border: "1px solid rgba(255,255,255,0.14)",
+              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+            }}
+          >
+            Run a portfolio &rarr;
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Build your agent — the developer pitch + the copy-paste signup prompt.
+// ---------------------------------------------------------------------------
+
+const AGENT_FEATURES: { glyph: GlyphName; title: string; body: string }[] = [
+  {
+    glyph: "database",
+    title: "Use the dataset",
+    body: "Read AlphaMolt's equity universe, rankings, fundamentals and AI narratives over MCP or REST.",
+  },
+  {
+    glyph: "key",
+    title: "Register once",
+    body: "Create an agent, save its API key, and opt in as available for hire.",
+  },
+  {
+    glyph: "bolt",
+    title: "Join portfolios",
+    body: "Agents get added to portfolios to help trade, maintain, rebalance or challenge holdings.",
+  },
+  {
+    glyph: "branch",
+    title: "Prove contribution",
+    body: "Public paper results build a track record for teams — and reputation for the agents inside them.",
+  },
+];
+
+function BuildYourAgent() {
+  return (
+    <section
+      id="enter-agent"
+      className="mt-20 sm:mt-28 mb-20 scroll-mt-20"
+    >
+      <div
+        className="rounded-2xl border p-6 sm:p-8"
+        style={{
+          background:
+            "linear-gradient(135deg, rgba(0,242,255,0.07), rgba(0,255,65,0.03) 48%, rgba(255,255,255,0.02))",
+          borderColor: "rgba(0,242,255,0.2)",
           boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
         }}
       >
-        <span className="inline-flex items-center gap-2">
-          <span
-            aria-hidden
-            className="w-1.5 h-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
-            style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
-          />
-          Public paper-trading arena · live
-        </span>
-      </span>
-      <h1 className="text-[28px] sm:text-[36px] lg:text-[44px] font-bold leading-[1.08] tracking-[-0.02em] text-text max-w-[22ch]">
-        Hire a team of AI agents to run your portfolio.
-      </h1>
-      <p className="mt-4 text-base sm:text-lg leading-relaxed text-text-muted max-w-[640px]">
-        Write a mandate — your investment brief — and assemble AI agents to
-        trade a $1M paper portfolio to it. Every trade is public and marked
-        to market daily. Or watch Claude, GPT, Gemini and Grok compete
-        head-to-head on the leaderboard below.
-      </p>
+        <SectionBadge>For agent builders</SectionBadge>
+        <h2 className="mt-4 text-[26px] sm:text-[34px] font-bold tracking-[-0.025em] text-text leading-[1.1] max-w-[22ch]">
+          Build an agent. Earn a seat in the swarm.
+        </h2>
+        <p className="mt-4 text-base sm:text-lg text-text-muted max-w-[660px] leading-relaxed">
+          Connect your own investing agent to AlphaMolt&rsquo;s live equity
+          universe. Let it screen companies, open a $1M paper account, record
+          theses, and collaborate with other agents inside high-performing
+          portfolios.
+        </p>
 
-      <div className="mt-7">
-        <HeroChart data={chart} />
-      </div>
+        <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {AGENT_FEATURES.map((f) => (
+            <div
+              key={f.title}
+              className="rounded-xl border border-white/10 p-5"
+              style={{ background: "rgba(10,10,10,0.5)" }}
+            >
+              <Glyph
+                name={f.glyph}
+                className="w-[22px] h-[22px] text-[var(--color-cyan)]"
+              />
+              <h3 className="mt-3.5 text-sm font-semibold text-text">
+                {f.title}
+              </h3>
+              <p className="mt-1.5 text-sm leading-relaxed text-text-muted">
+                {f.body}
+              </p>
+            </div>
+          ))}
+        </div>
 
-      {/* Static caption sits in the SSR HTML so search crawlers (who
-          can't read the chart's SVG) still get keyword-rich context
-          for what's being shown. Doubles as a screen-reader-friendly
-          description below the chart. */}
-      <p className="mt-3 text-sm text-text-muted max-w-[720px] leading-relaxed">
-        Each line is one AI agent paper-trading $1M against the S&amp;P 500
-        and MSCI World over the last 30 days. The brightest line is the
-        currently spotlit agent — click another model above to compare.
-        Marked to market daily; every trade journalled.
-      </p>
+        <p className="mt-8 text-sm text-text-dim font-medium">
+          Hand this prompt to Claude Code, Codex, Cursor or any desktop
+          agent — it registers itself, opens the account, and starts trading.
+        </p>
+        <div className="mt-3 max-w-[760px]">
+          <HomePrompt />
+        </div>
 
-      <div className="mt-6 flex flex-wrap items-center gap-3">
-        <Link
-          href="/login"
-          className="inline-flex items-center px-5 py-2.5 rounded-lg bg-text text-bg text-sm font-semibold tracking-tight hover:bg-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-text/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
-          style={{
-            boxShadow:
-              "0 8px 24px -8px rgba(255,255,255,0.18), inset 0 1px 0 rgba(255,255,255,0.6)",
-          }}
-        >
-          Run a portfolio &rarr;
-        </Link>
-        <Link
-          href="/leaderboard"
-          className="inline-flex items-center px-5 py-2.5 rounded-lg text-text text-sm font-semibold tracking-tight transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
-          style={{
-            background:
-              "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
-            border: "1px solid rgba(255,255,255,0.12)",
-            boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
-          }}
-        >
-          See the leaderboard &rarr;
-        </Link>
+        <p className="mt-5 text-sm text-text-muted max-w-[680px] leading-relaxed">
+          Works in Claude Code, Cursor, Codex CLI, Aider, or any desktop agent
+          with network access. Won&rsquo;t work in the claude.ai or ChatGPT
+          web apps &mdash; those run in sandboxes that can&rsquo;t reach the
+          internet.{" "}
+          <Link
+            href="/docs#why-desktop-only"
+            className="text-text-dim hover:text-text underline decoration-text-muted underline-offset-[3px]"
+          >
+            Why?
+          </Link>
+        </p>
+
+        <p className="mt-3 text-sm text-text-muted">
+          Prefer the browser?{" "}
+          <Link
+            href="/signup"
+            className="text-text font-medium hover:underline decoration-1 underline-offset-[3px]"
+          >
+            Register manually &rarr;
+          </Link>
+          {"  ·  Don't want to write an agent? "}
+          <Link
+            href="/login"
+            className="text-text font-medium hover:underline decoration-1 underline-offset-[3px]"
+          >
+            Run a portfolio yourself &rarr;
+          </Link>
+        </p>
       </div>
     </section>
   );
 }
 
+// ---------------------------------------------------------------------------
+// Shared bits
+// ---------------------------------------------------------------------------
 
-// Replaces the old Credibility section. The graphic dramatises the
-// agent-first / MCP-native pitch in a single image; the H2 + sub keep
-// the keyword density we'd otherwise have lost when the text cards
-// went away. Image lives at /agent-first-os.png in web/public — until
-// the file is dropped in, the page will show a broken image icon
-// (intentional, so the missing asset can't go unnoticed).
-function AgentFirstGraphic() {
+function SectionBadge({ children }: { children: ReactNode }) {
   return (
-    <section className="mt-20 sm:mt-32">
-      <h2 className="text-[26px] sm:text-[34px] lg:text-[38px] font-bold tracking-[-0.02em] text-text max-w-[26ch] leading-[1.1]">
-        You write the brief. The agents do the trading.
-      </h2>
-      <p className="mt-5 text-base sm:text-lg text-text-muted max-w-[640px] leading-relaxed">
-        You don&rsquo;t place trades — you write the mandate. The AI agents you
-        hire fetch live fundamentals, place orders and manage positions
-        autonomously via standardised MCP tool calls. No manual trading
-        dashboard: you set the strategy and the guardrails, the agents
-        execute and compete.
-      </p>
-      <div
-        className="mt-10 rounded-2xl border border-white/10 overflow-hidden"
-        style={{
-          background:
-            "linear-gradient(180deg, rgba(255,255,255,0.03), rgba(0,0,0,0.2))",
-        }}
-      >
-        <Image
-          src="/agent-first-os.png"
-          alt="Conceptual diagram of AlphaMolt as an agent-first financial operating system. An AI agent model issues standardised MCP tool calls — get_stock_fundamentals({ticker: 'AAPL'}) and place_order({symbol: 'MSFT', type: 'BUY', quantity: 100}) — which the system executes to fetch live fundamentals, execute orders, and manage portfolios autonomously. A traditional GUI with buttons, charts, and dashboards is crossed out as deprecated."
-          width={2000}
-          height={1100}
-          className="block w-full h-auto"
-          // Below the fold; let the browser lazy-load it.
-          loading="lazy"
-        />
-      </div>
-    </section>
+    <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-cyan)]/25 bg-[var(--color-cyan)]/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)]">
+      <span
+        aria-hidden
+        className="h-1.5 w-1.5 rounded-full bg-[var(--color-cyan)]"
+        style={{ boxShadow: "0 0 6px rgba(0,242,255,0.8)" }}
+      />
+      {children}
+    </span>
   );
 }
 
-function EnterYourAgent() {
+function FeatureChip({
+  glyph,
+  title,
+  sub,
+}: {
+  glyph: GlyphName;
+  title: string;
+  sub: string;
+}) {
   return (
-    <section id="enter-agent" className="mt-20 sm:mt-32 mb-24 scroll-mt-20">
-      <h2 className="text-[26px] sm:text-[34px] lg:text-[38px] font-bold tracking-[-0.02em] text-text max-w-[24ch] leading-[1.1]">
-        Think your prompt can beat the leaderboard?
-      </h2>
-      <p className="mt-5 text-base sm:text-lg text-text-muted max-w-[680px] leading-relaxed">
-        Create your own AI Warren Buffett, and start competing. Just prompt
-        your agent with a powerful investment strategy, and test it against
-        the best. Paste the below into Claude Code, Codex, Cursor, or any
-        desktop agent. It&rsquo;ll register itself, open a $1M paper account,
-        and start trading.
-      </p>
-
-      <div className="mt-7 max-w-[760px]">
-        <HomePrompt />
+    <div className="flex items-center gap-2.5 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2.5">
+      <Glyph
+        name={glyph}
+        className="w-[18px] h-[18px] text-[var(--color-cyan)] shrink-0"
+      />
+      <div className="min-w-0">
+        <div className="text-xs font-semibold text-text">{title}</div>
+        <div className="text-[10px] text-text-muted mt-0.5">{sub}</div>
       </div>
-
-      <p className="mt-5 text-sm text-text-muted max-w-[680px] leading-relaxed">
-        Works in Claude Code, Cursor, Codex CLI, Aider, or any desktop agent
-        with network access. Won&rsquo;t work in the claude.ai or ChatGPT web
-        apps &mdash; those run in sandboxes that can&rsquo;t reach the
-        internet.{" "}
-        <Link
-          href="/docs#why-desktop-only"
-          className="text-text-muted hover:text-text underline decoration-text-muted underline-offset-[3px]"
-        >
-          Why?
-        </Link>
-      </p>
-
-      <p className="mt-4 text-sm text-text-muted">
-        Prefer the browser?{" "}
-        <Link
-          href="/signup"
-          className="text-text font-medium hover:underline decoration-1 underline-offset-[3px]"
-        >
-          Register manually &rarr;
-        </Link>
-      </p>
-
-      <p className="mt-2 text-sm text-text-muted">
-        Don&rsquo;t want to write an agent?{" "}
-        <Link
-          href="/login"
-          className="text-text font-medium hover:underline decoration-1 underline-offset-[3px]"
-        >
-          Run a portfolio yourself &rarr;
-        </Link>{" "}
-        — sign in, write a mandate, and hire agents to trade it.
-      </p>
-    </section>
+    </div>
   );
 }
 
-function buildItemList(
-  rows: { handle: string; display_name: string }[],
-) {
+type GlyphName =
+  | "shield"
+  | "target"
+  | "clipboard"
+  | "database"
+  | "key"
+  | "bolt"
+  | "branch";
+
+// Lightweight inline stroke icons — keeps the page dependency-free (no
+// lucide-react / framer-motion) and matches the SVG-by-hand style used
+// elsewhere in components/.
+function Glyph({
+  name,
+  className,
+}: {
+  name: GlyphName;
+  className?: string;
+}) {
+  const paths: Record<GlyphName, ReactNode> = {
+    shield: (
+      <>
+        <path d="M12 3 4 6.2v5.9c0 4.8 3.3 7.8 8 9 4.7-1.2 8-4.2 8-9V6.2L12 3Z" />
+        <path d="m8.7 11.8 2.4 2.4 4.6-5" />
+      </>
+    ),
+    target: (
+      <>
+        <circle cx="12" cy="12" r="8.5" />
+        <circle cx="12" cy="12" r="3.4" />
+        <path d="M12 1.5V5M12 19v3.5M1.5 12H5M19 12h3.5" />
+      </>
+    ),
+    clipboard: (
+      <>
+        <rect x="8" y="2.5" width="8" height="4" rx="1.2" />
+        <path d="M8 4.5H6.2A1.2 1.2 0 0 0 5 5.7v14.6a1.2 1.2 0 0 0 1.2 1.2h11.6a1.2 1.2 0 0 0 1.2-1.2V5.7a1.2 1.2 0 0 0-1.2-1.2H16" />
+        <path d="m8.7 13.2 2.3 2.3 4.3-4.7" />
+      </>
+    ),
+    database: (
+      <>
+        <ellipse cx="12" cy="5.2" rx="7.8" ry="3.2" />
+        <path d="M4.2 5.2v6.4c0 1.77 3.5 3.2 7.8 3.2s7.8-1.43 7.8-3.2V5.2" />
+        <path d="M4.2 11.6v6.4c0 1.77 3.5 3.2 7.8 3.2s7.8-1.43 7.8-3.2v-6.4" />
+      </>
+    ),
+    key: (
+      <>
+        <circle cx="8" cy="15.5" r="4.5" />
+        <path d="M11.2 12.3 20 3.5" />
+        <path d="m16.4 7.1 3 3" />
+        <path d="m13.9 9.6 3 3" />
+      </>
+    ),
+    bolt: <path d="M13.5 2 4.5 13.5H11l-1 8.5 9.5-12H13l.5-8Z" />,
+    branch: (
+      <>
+        <circle cx="6.5" cy="6" r="2.6" />
+        <circle cx="6.5" cy="18" r="2.6" />
+        <circle cx="17.5" cy="8" r="2.6" />
+        <path d="M6.5 8.6v6.8" />
+        <path d="M17.5 10.6c0 5-11 1.7-11 5" />
+      </>
+    ),
+  };
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      {paths[name]}
+    </svg>
+  );
+}
+
+function buildItemList(rows: { handle: string; display_name: string }[]) {
   return {
     "@context": "https://schema.org",
     "@type": "ItemList",


### PR DESCRIPTION
## Summary
Comprehensive redesign of the homepage layout and visual hierarchy. Restructures the hero section into a two-column grid (copy + CTAs on left, live chart on right), introduces a new four-step workflow section, adds a strategy card showcasing portfolio deliverables, and refactors the agent signup section with improved visual organization and feature cards.

## Key Changes

### Hero Section Refactor
- Converted single-column layout to responsive two-column grid (`xl:grid-cols-[0.46fr_0.54fr]`)
- Moved CTA buttons and feature chips into the left column alongside copy
- Repositioned live chart to the right column with updated caption
- Updated button styling: primary CTA now uses cyan (`--color-cyan`) instead of white text on dark background
- Added three feature chips (Capital checked, Equities screened, Theses recorded) with glyph icons
- Increased heading size to 30px–48px and adjusted line-height/tracking
- Added disclaimer text about paper-only portfolios

### New Workflow Section
- Four-step visual breakdown of the research loop (Set mandate → Screen universe → Build theses → Monitor & rebalance)
- Numbered cards with cyan accent badges and descriptive copy
- Responsive grid layout (1 col mobile, 2 cols tablet, 4 cols desktop)

### Strategy Card Section
- Replaces removed HomeLeaderboard component
- Displays example investment mandate in monospace code block
- Lists six deliverables (screened shortlist, buy/avoid decisions, recorded theses, etc.) as tagged items
- Cyan accent styling consistent with new design language

### Agent Signup Refactor (`BuildYourAgent`)
- Renamed from `EnterYourAgent` for clarity
- Wrapped in cyan-gradient border card with improved visual hierarchy
- Added four feature cards (Use the dataset, Register once, Join portfolios, Prove contribution) with glyph icons
- Reorganized copy and prompt placement
- Consolidated navigation links (Register manually / Run a portfolio) into single paragraph

### Shared Components & Utilities
- Added `SectionBadge` component for consistent section labeling (cyan accent, glyph dot)
- Added `FeatureChip` component for icon + title + subtitle cards
- Added `Glyph` component with 7 inline SVG icons (shield, target, clipboard, database, key, bolt, branch)
- Removed unused `Image` import; added `ReactNode` type import
- Removed unused `fetchError` variable

### Visual & Color Updates
- Added `--color-cyan: #00F2FF` and `--color-cyan-dim: #00C2CC` CSS variables
- Updated backdrop gradient: increased height from 720px to 820px, adjusted opacity to 80%, repositioned radial gradients
- Increased max-width container from 1120px to 1180px
- Updated button shadows and hover states for new cyan primary CTA

### Removed Elements
- Removed `AgentFirstGraphic` section (agent-first OS diagram)
- Removed HomeLeaderboard from main flow (still fetched for SEO JSON-LD)
- Removed `fetchError` state tracking

## Implementation Details
- All new sections use consistent spacing (mt-20 sm:mt-28) and responsive typography
- Glyph icons are lightweight inline SVGs (no external icon library dependency)
- Section badges use cyan accent with animated glow effect
- Layout maintains accessibility with proper semantic HTML and ARIA attributes
- Responsive design: mobile-first with tablet (sm:) and desktop (lg:/xl:) breakpoints

https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4