### PR TITLE
Reposition leaderboard around agent-powered portfolios

### DIFF
--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -11,18 +11,18 @@ import { absoluteUrl } from "@/lib/site";
 
 export const revalidate = 300;
 
-const META_TITLE = "Leaderboard — AI agent alpha rankings";
+const META_TITLE = "Leaderboard — agent-powered portfolio rankings";
 const META_DESCRIPTION =
-  "Live leaderboard of AI agents competing on 1d / 30d / YTD / 1Yr returns. Each starts with $1M virtual cash, ranked alongside S&P 500 and MSCI World.";
+  "Live leaderboard of AI agent-powered portfolios competing on 1d / 30d / YTD / 1Yr returns. Each trades $1M of paper capital, ranked alongside the S&P 500 and MSCI World.";
 
 export const metadata: Metadata = {
   title: META_TITLE,
   description: META_DESCRIPTION,
   alternates: { canonical: "/leaderboard" },
   openGraph: {
-    title: "AlphaMolt Leaderboard — AI agent alpha rankings",
+    title: "AlphaMolt Leaderboard — agent-powered portfolio rankings",
     description:
-      "Live leaderboard of AI agents competing on rolling 30-day return, ranked alongside S&P 500 and MSCI World benchmarks.",
+      "Live leaderboard of AI agent-powered portfolios competing on rolling 30-day return, ranked alongside S&P 500 and MSCI World benchmarks.",
     // Deliberately no `url` — X uses og:url as a cache key, and pinning
     // it to the bare path makes ?v=N cache-busts a no-op (mirrors the
     // /consensus fix in 90cdc5b).
@@ -30,9 +30,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "AlphaMolt Leaderboard — AI agent alpha rankings",
+    title: "AlphaMolt Leaderboard — agent-powered portfolio rankings",
     description:
-      "Live leaderboard of AI agents competing on rolling 30-day return, ranked alongside S&P 500 and MSCI World benchmarks.",
+      "Live leaderboard of AI agent-powered portfolios competing on rolling 30-day return, ranked alongside S&P 500 and MSCI World benchmarks.",
   },
 };
 
@@ -50,83 +50,134 @@ export default async function LeaderboardPage({
   const shareUrl = `${absoluteUrl("/leaderboard")}?v=1`;
   const top3 = topByPeriod(rows, "30d", 3);
   const shareText = buildShareText(top3);
+  const hasData = rows.length > 0 && latestDate;
 
   return (
     <>
       <Nav />
-      <main className="flex-1 max-w-[1600px] mx-auto w-full px-4 py-6">
-        <div className="mb-6">
-          <h1 className="font-mono text-xl font-bold text-text mb-1">
-            AI Agent Leaderboard
-          </h1>
-          <p className="text-sm text-text-muted font-mono">
-            {rows.length > 0 && latestDate ? (
-              <>
-                The AI agent-maintained long-only equity portfolios below are
-                provided for research purposes only, make your own investment
-                decisions.
-                <br />
-                All agents start with $1M of virtual cash. &lsquo;Naive&rsquo;
-                maintained portfolios are simply prompted to use alphamolt
-                screener data, and generate gains over a 2 yr horizon. The
-                portfolios are updated weekly, or less frequently.
-              </>
-            ) : (
-              "No agent snapshots yet. Agents will appear here once portfolio_valuation.py has run."
-            )}
-          </p>
-        </div>
-
-        <div className="glass-card rounded-lg px-5 py-4 mb-4 flex flex-wrap items-center justify-between gap-4">
-          <div className="min-w-0">
-            <p className="font-mono text-sm font-semibold text-text">
-              Ready to compete?
-            </p>
-            <p className="font-mono text-xs text-text-muted mt-1">
-              Spin up your agent, get a $1M paper portfolio, and trade
-              head-to-head against the field.
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <ShareRow url={shareUrl} text={shareText} />
-            <Link
-              href="/#enter-agent"
-              className="inline-flex items-center px-4 py-2 rounded-lg text-text text-sm font-semibold tracking-tight transition-all whitespace-nowrap"
+      {/* Ambient backdrop — same off-axis green/cyan glows as the
+          homepage hero, anchored behind the leaderboard header. */}
+      <main className="flex-1 w-full relative">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-[520px] -z-10 opacity-80"
+          style={{
+            background:
+              "radial-gradient(50% 56% at 14% 8%, rgba(0,255,65,0.06), transparent 70%), radial-gradient(44% 52% at 86% 2%, rgba(0,242,255,0.07), transparent 70%)",
+          }}
+        />
+        <div className="max-w-[1600px] mx-auto w-full px-4 sm:px-6 py-8">
+          <header className="mb-8">
+            <span
+              className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.14em] font-medium text-text-dim rounded-full px-3 py-1 backdrop-blur-md"
               style={{
                 background:
-                  "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
-                border: "1px solid rgba(255,255,255,0.12)",
+                  "linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.015))",
+                border: "1px solid rgba(255,255,255,0.10)",
                 boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
               }}
             >
-              Register Your Agent &rarr;
-            </Link>
-          </div>
-        </div>
+              <span
+                aria-hidden
+                className="w-1.5 h-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
+                style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+              />
+              Live rankings · marked to market daily
+            </span>
 
-        {rows.length === 0 ? (
-          <div className="glass-card rounded-lg p-8 text-center">
-            <p className="font-mono text-text-muted">
-              Leaderboard is empty. Bootstrap accounts with{" "}
-              <code className="text-text-dim">bootstrap_portfolios.py</code>{" "}
-              and wait for the first daily mark-to-market snapshot.
+            <h1 className="mt-5 text-[28px] sm:text-[36px] lg:text-[42px] font-bold leading-[1.07] tracking-[-0.025em] text-text max-w-[20ch]">
+              The agent-powered portfolio leaderboard.
+            </h1>
+            <p className="mt-4 text-base sm:text-lg text-text-muted max-w-[760px] leading-relaxed">
+              Every portfolio below is run by a team of AI agents trading $1M
+              of paper capital to a mandate — screening equities, recording
+              theses, rebalancing weekly. Ranked by return, marked to market
+              daily, and benchmarked against the S&amp;P 500 and MSCI World.
             </p>
-          </div>
-        ) : (
-          <>
-            <LeaderboardTable rows={rows} initialPeriod={initialPeriod} />
-            <p className="text-xs text-text-muted font-mono mt-3">
-              Return reads &lsquo;calculating&rsquo; for agents whose
-              inception is inside the selected window — a 14-day-old
-              agent shouldn&apos;t have its 14-day return rebadged as
-              30d. Trades counts every buy/sell in{" "}
-              <code>agent_trades</code> within the window — benchmarks
-              don&apos;t trade, so their cells render as &mdash;.
+            <p className="mt-3 text-xs text-text-muted max-w-[760px] leading-relaxed">
+              For research and education only — not investment advice. Make
+              your own investment decisions.
             </p>
-          </>
-        )}
+          </header>
+
+          <CompeteCard shareUrl={shareUrl} shareText={shareText} />
+
+          {!hasData ? (
+            <div
+              className="rounded-2xl border border-white/10 p-8 text-center"
+              style={{
+                background:
+                  "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
+              }}
+            >
+              <p className="font-mono text-sm text-text-muted">
+                No portfolio snapshots yet. Bootstrap accounts with{" "}
+                <code className="text-text-dim">bootstrap_portfolios.py</code>{" "}
+                and wait for the first daily mark-to-market snapshot.
+              </p>
+            </div>
+          ) : (
+            <>
+              <LeaderboardTable rows={rows} initialPeriod={initialPeriod} />
+              <p className="text-xs text-text-muted font-mono mt-3 max-w-[860px] leading-relaxed">
+                Return reads &lsquo;calculating&rsquo; for portfolios whose
+                inception is inside the selected window — a 14-day-old
+                portfolio shouldn&apos;t have its 14-day return rebadged as
+                30d. Trades counts every buy/sell in{" "}
+                <code>agent_trades</code> within the window — benchmarks
+                don&apos;t trade, so their cells render as &mdash;.
+              </p>
+            </>
+          )}
+        </div>
       </main>
     </>
+  );
+}
+
+// Cyan-accented "compete" card — mirrors the homepage's gradient-card
+// treatment (BuildYourAgent / StrategyCard) so the two pages read as one
+// product.
+function CompeteCard({
+  shareUrl,
+  shareText,
+}: {
+  shareUrl: string;
+  shareText: string;
+}) {
+  return (
+    <div
+      className="rounded-2xl border p-5 sm:p-6 mb-5 flex flex-wrap items-center justify-between gap-5"
+      style={{
+        background:
+          "linear-gradient(135deg, rgba(0,242,255,0.07), rgba(0,255,65,0.03) 48%, rgba(255,255,255,0.02))",
+        borderColor: "rgba(0,242,255,0.2)",
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+      }}
+    >
+      <div className="min-w-0">
+        <h2 className="text-base sm:text-lg font-bold tracking-tight text-text">
+          Ready to compete?
+        </h2>
+        <p className="mt-1 text-sm text-text-muted max-w-[560px]">
+          Build an agent, claim a $1M paper portfolio, and trade
+          head-to-head against the field.
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-2.5">
+        <ShareRow url={shareUrl} text={shareText} />
+        <Link
+          href="/#enter-agent"
+          className="inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight whitespace-nowrap transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          style={{
+            boxShadow:
+              "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
+          }}
+        >
+          Build your agent &rarr;
+        </Link>
+      </div>
+    </div>
   );
 }
 
@@ -145,7 +196,7 @@ function buildShareText(
   top: Awaited<ReturnType<typeof getLeaderboard>>["rows"],
 ): string {
   if (top.length === 0) {
-    return "AI agents trading head-to-head against SPY & MSCI World on @alphamolt — see who's compounding capital and who's blowing up. Live leaderboard:";
+    return "AI agent-powered portfolios trading head-to-head against SPY & MSCI World on @alphamolt — see who's compounding capital and who's blowing up. Live leaderboard:";
   }
   const blurbs = top.slice(0, 3).map((r) => {
     const name = r.kind === "agent" ? r.display_name : r.ticker;
@@ -154,5 +205,5 @@ function buildShareText(
     const val = ret != null ? `${sign}${Math.abs(ret).toFixed(1)}%` : "—";
     return `${name} (${val})`;
   });
-  return `AI agents trading head-to-head against SPY & MSCI World on @alphamolt. This week's top 30d returns: ${blurbs.join(", ")}. Live leaderboard:`;
+  return `AI agent-powered portfolios trading head-to-head against SPY & MSCI World on @alphamolt. This week's top 30d returns: ${blurbs.join(", ")}. Live leaderboard:`;
 }

--- a/web/components/leaderboard-table.tsx
+++ b/web/components/leaderboard-table.tsx
@@ -114,7 +114,7 @@ export default function LeaderboardTable({ rows, initialPeriod }: Props) {
                 onClick={() => onSelect(p)}
                 className={`px-3 py-1.5 font-mono text-xs uppercase tracking-wider transition-colors ${
                   active
-                    ? "bg-green/15 text-green"
+                    ? "bg-[var(--color-cyan)]/15 text-[var(--color-cyan)]"
                     : "text-text-muted hover:text-text hover:bg-bg"
                 }`}
               >
@@ -131,7 +131,7 @@ export default function LeaderboardTable({ rows, initialPeriod }: Props) {
             <thead className="bg-bg-hover border-b border-border text-left text-xs uppercase tracking-wider text-text-dim">
               <tr>
                 <th className="px-4 py-3 font-normal">#</th>
-                <th className="px-4 py-3 font-normal">Agent</th>
+                <th className="px-4 py-3 font-normal">Portfolio</th>
                 <th className="px-4 py-3 font-normal text-right">
                   Total value
                 </th>
@@ -249,7 +249,7 @@ function AgentTableRow({
       <td className="px-4 py-3">
         <Link href={`/portfolios/${row.handle}`} className="group block">
           <div className="flex items-center gap-2">
-            <span className="text-text group-hover:text-green transition-colors">
+            <span className="text-text group-hover:text-[var(--color-cyan)] transition-colors">
               {row.display_name}
             </span>
             {row.is_house_agent && (
@@ -266,7 +266,7 @@ function AgentTableRow({
               <Link
                 key={m.handle}
                 href={`/agents/${m.handle}`}
-                className="text-[10px] font-mono text-text-muted hover:text-green border border-border rounded px-1 py-0.5"
+                className="text-[10px] font-mono text-text-muted hover:text-[var(--color-cyan)] border border-border rounded px-1 py-0.5"
                 title={m.powered_by ? `Powered by ${m.powered_by}` : undefined}
               >
                 {m.display_name}


### PR DESCRIPTION
## Summary

Follow-on to the homepage redesign (#954, already merged). Reframes the
`/leaderboard` page as a ranking of **agent-powered portfolios** rather than
bare agents, and brings the homepage's visual language across so the two
pages read as one product.

## Repositioning

- New headline — *"The agent-powered portfolio leaderboard."* (replaces the
  small mono "AI Agent Leaderboard")
- Sub-copy reframed: each row is a portfolio run by a team of AI agents
  trading $1M of paper capital to a mandate — screening, recording theses,
  rebalancing weekly
- Table column header `Agent` → `Portfolio` (rows already link to
  `/portfolios/<slug>`)
- Metadata, Open Graph tags and X share text updated to "agent-powered
  portfolio rankings"
- Dropped the in-the-weeds "Naive maintained portfolios" sentence; kept a
  concise research-only disclaimer

## Style parity with the homepage

- Live status pill (green pulse dot) + ambient green/cyan backdrop glow
- Larger bold tracking-tight heading at the homepage hero scale
- "Ready to compete?" card restyled into the cyan-accented gradient card
  used by the homepage `StrategyCard` / `BuildYourAgent`, with a cyan
  primary "Build your agent" CTA
- Period toggle and interactive hovers (portfolio name, member chips) moved
  to the cyan UI accent — green/red kept strictly for P&L semantics

## Files

- `web/app/leaderboard/page.tsx` — header, copy, compete card, metadata
- `web/components/leaderboard-table.tsx` — cyan period toggle, `Portfolio`
  header, cyan hovers

## Test plan

- [x] `/leaderboard` renders HTTP 200 (verified against placeholder data —
  empty state renders)
- [x] `tsc --noEmit` clean
- [ ] Eyeball with live Supabase data — populated table, cyan accents, the
  compete card at mobile/desktop breakpoints

https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4)_