### PR TITLE
Redirect signed-in users to /account; trim nav

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -16,11 +16,8 @@ import {
   type ConsensusResult,
 } from "@/lib/consensus-query";
 import { absoluteUrl } from "@/lib/site";
-
-// Re-fetch the leaderboard snapshot every 5 minutes. Matches the existing
-// /leaderboard page's ISR window — underlying data is marked to market
-// daily, so a shorter TTL would only burn function invocations.
-export const revalidate = 300;
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 const META_TITLE = "AlphaMolt — hire AI agents to run your portfolio";
 const META_DESCRIPTION =
@@ -46,6 +43,18 @@ export const metadata: Metadata = {
 };
 
 export default async function HomePage() {
+  // Signed-in visitors get their account view as their homepage. Done in the
+  // page (not proxy.ts) so it reliably reads the cookie-backed session — the
+  // same getUser() path /account itself depends on. Reading the session
+  // opts this route into dynamic rendering.
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (user) {
+    redirect("/account");
+  }
+
   let board: HomeLeaderboardResult;
   try {
     board = await getHomeLeaderboard();

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -8,8 +8,6 @@ import NavAuth from "@/components/nav-auth";
 const links = [
   { href: "/leaderboard", label: "Leaderboard" },
   { href: "/consensus", label: "Consensus" },
-  { href: "/screener", label: "Screener" },
-  { href: "/signup", label: "Sign up" },
   { href: "/docs", label: "Docs" },
 ];
 

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -31,21 +31,12 @@ export async function proxy(request: NextRequest) {
     },
   );
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  // Signed-in visitors get their account view as the homepage. "/" stays
-  // fully static for logged-out visitors — the redirect happens here in the
-  // proxy rather than in the page, so the public homepage keeps its caching.
-  if (user && request.nextUrl.pathname === "/") {
-    const url = request.nextUrl.clone();
-    url.pathname = "/account";
-    const redirect = NextResponse.redirect(url);
-    // Carry any refreshed session cookies onto the redirect response.
-    response.cookies.getAll().forEach((cookie) => redirect.cookies.set(cookie));
-    return redirect;
-  }
+  // getUser() refreshes the access token when it's stale; the rotated
+  // session cookie is propagated onto `response` by the setAll adapter
+  // above. Route gating is handled elsewhere: protected pages self-guard,
+  // and the "/" -> "/account" redirect for signed-in visitors lives in
+  // app/page.tsx (the cookie-backed getUser() there is the reliable path).
+  await supabase.auth.getUser();
 
   return response;
 }


### PR DESCRIPTION
## Summary

Fixes two issues reported by a signed-in user on the homepage.

### 1. Signed-in users land on `/account`
Previously a signed-in visitor still saw the public marketing homepage at
`/`. They now redirect to `/account` (their portfolio construction page).

- The redirect runs in `web/app/page.tsx` via the cookie-backed
  `createSupabaseServerClient()` + `auth.getUser()` path — the same one
  `/account` itself uses — rather than the proxy's equivalent block, which
  was not firing in practice.
- `web/proxy.ts` keeps its primary job (refreshing the Supabase session
  cookie); its redundant redirect block is removed so there's a single
  mechanism.
- **Tradeoff:** reading the session opts `/` into dynamic rendering, so the
  stale `revalidate = 300` ISR export is dropped. Confirmed in the build
  output — `/` is now `ƒ (Dynamic)`.

### 2. Trimmed top nav
Removed `Screener` and `Sign up` from the nav `links` array in
`web/components/nav.tsx`:
- `Sign up` is redundant once signed in (and human auth is the magic-link
  `/login` flow anyway).
- `Screener` is demoted as a primary destination.

The nav now reads `Leaderboard · Consensus · Docs` plus the auth chip
(`Sign in` when logged out; email + `Sign out` when logged in).

**Scope:** the `/screener` route, its SEO/sitemap entry, the equity count,
and the company-page deep links are intentionally left untouched — this is
a nav-only demotion.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `next build` succeeds; `/` is `ƒ (Dynamic)`, `/screener` still builds
- [x] Signed-out: `/` renders; nav shows `Leaderboard · Consensus · Docs`
- [x] `/screener` still loads directly
- [ ] Signed-in (needs a real Supabase session): `/` redirects to
  `/account`; nav shows no Screener / Sign up

https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4)_