### PR TITLE
Add per-portfolio watchlist framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,21 @@ agent portfolios keep using `agent_accounts` / `agent_holdings` — the two
 models run side by side. Atomic RPCs: `execute_portfolio_buy` /
 `execute_portfolio_sell`.
 
+### portfolio_watchlist (per-portfolio shortlist — migration 027)
+```
+(portfolio_id, ticker) PK, source ('user' | 'agent'),
+added_by_agent_id (FK → agents, nullable), rationale,
+created_at, updated_at
+```
+A curated shortlist of equities attached to a portfolio. The owner manages
+it from `/account/watchlist` (server actions in `web/lib/watchlist-mutations.ts`,
+reads via `web/lib/watchlist-query.ts`). The table is agent-ready by design:
+`source` distinguishes a manual owner pick from an agent pick,
+`added_by_agent_id` attributes the latter, and `rationale` carries the "why".
+Today only the owner writes (`source='user'`); the agent wiring — one agent
+populating the list, a second trading from it — is a later PR and needs no
+schema change.
+
 **Trading-shaped tables and `portfolio_id`.** Since migration 021,
 every trade-related row carries both `agent_id` and `portfolio_id`
 (NOT NULL on both). The 1:1 shim has them equal today; multi-agent

--- a/migrations/027_portfolio_watchlist.sql
+++ b/migrations/027_portfolio_watchlist.sql
@@ -1,0 +1,53 @@
+-- Migration 027: Per-portfolio watchlist (shortlist).
+--
+-- A watchlist is a curated shortlist of equities attached to a portfolio.
+-- The portfolio owner manages it from /account/watchlist.
+--
+-- The table is also agent-ready by design: `source` distinguishes a manual
+-- owner pick from an agent pick, `added_by_agent_id` attributes the latter,
+-- and `rationale` carries the "why". Today only the owner writes to it
+-- (source = 'user'); the agent wiring — one agent populating the list, a
+-- second trading from it — lands in a later PR and needs no schema change.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+-- ============================================================
+-- portfolio_watchlist — one row per (portfolio, ticker)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS portfolio_watchlist (
+    portfolio_id      UUID NOT NULL REFERENCES portfolios(id) ON DELETE CASCADE,
+    ticker            TEXT NOT NULL REFERENCES companies(ticker),
+    source            TEXT NOT NULL DEFAULT 'user'
+                          CHECK (source IN ('user', 'agent')),
+    added_by_agent_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+    rationale         TEXT,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (portfolio_id, ticker)
+);
+
+-- The (portfolio_id, ticker) PK already indexes the "watchlist for a
+-- portfolio" lookup, so no extra index is needed.
+
+DROP TRIGGER IF EXISTS portfolio_watchlist_updated_at ON portfolio_watchlist;
+CREATE TRIGGER portfolio_watchlist_updated_at
+    BEFORE UPDATE ON portfolio_watchlist
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ============================================================
+-- RLS — defense-in-depth (the website reads/writes via service-role
+-- after verifying portfolio ownership). A watchlist is visible to the
+-- portfolio owner, and to everyone when the portfolio is public —
+-- mirrors the portfolio_holdings policy from migration 025.
+-- ============================================================
+
+ALTER TABLE portfolio_watchlist ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "portfolio watchlist read" ON portfolio_watchlist;
+CREATE POLICY "portfolio watchlist read" ON portfolio_watchlist FOR SELECT
+    USING (EXISTS (
+        SELECT 1 FROM portfolios p
+         WHERE p.id = portfolio_watchlist.portfolio_id
+           AND (p.is_public OR p.owner_user_id = auth.uid())
+    ));

--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -104,6 +104,20 @@ export default async function AccountPage() {
             </section>
 
             <section>
+              <h2 className={SECTION_HEADING}>Watchlist</h2>
+              <p className="text-[11px] font-mono text-text-muted mb-3 -mt-1">
+                A shortlist of equities for the agents on this portfolio to
+                populate and trade from.
+              </p>
+              <Link
+                href="/account/watchlist"
+                className="inline-flex items-center gap-1.5 rounded border border-border bg-bg px-3 py-2 font-mono text-sm text-text hover:border-green/40 hover:text-green transition-colors"
+              >
+                Manage watchlist &rarr;
+              </Link>
+            </section>
+
+            <section>
               <h2 className={SECTION_HEADING}>Visibility</h2>
               <VisibilityToggle isPublic={portfolio.is_public} />
             </section>

--- a/web/app/account/watchlist/page.tsx
+++ b/web/app/account/watchlist/page.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import Nav from "@/components/nav";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { getPortfolioForUser } from "@/lib/portfolios-query";
+import { getWatchlistForPortfolio } from "@/lib/watchlist-query";
+import WatchlistManager from "@/components/portfolio/watchlist-manager";
+
+export const metadata: Metadata = {
+  title: "Watchlist — AlphaMolt",
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function WatchlistPage() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login?next=/account/watchlist");
+  }
+
+  const portfolio = await getPortfolioForUser(user.id);
+  const items = portfolio
+    ? await getWatchlistForPortfolio(portfolio.id)
+    : [];
+
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 max-w-[760px] mx-auto w-full px-4 py-10 font-sans">
+        <header className="mb-8">
+          <p className="text-xs font-mono uppercase tracking-widest text-text-muted mb-2">
+            <Link href="/account" className="hover:text-text">
+              Account
+            </Link>
+            {" / Watchlist"}
+          </p>
+          <h1 className="font-mono text-3xl font-bold text-green mb-3">
+            Watchlist
+          </h1>
+          <p className="text-text-dim leading-relaxed">
+            A shortlist of equities for{" "}
+            {portfolio ? (
+              <span className="text-text font-mono">
+                {portfolio.display_name}
+              </span>
+            ) : (
+              "your portfolio"
+            )}
+            . Curate it here — agents on this portfolio can populate the list
+            and trade from it.
+          </p>
+        </header>
+
+        {portfolio ? (
+          <WatchlistManager items={items} />
+        ) : (
+          <div className="glass-card rounded-lg border border-border p-6">
+            <p className="text-sm text-text-dim leading-relaxed">
+              You don&apos;t have a portfolio yet.{" "}
+              <Link href="/account" className="text-green hover:underline">
+                Create one first &rarr;
+              </Link>
+            </p>
+          </div>
+        )}
+      </main>
+    </>
+  );
+}

--- a/web/components/portfolio/watchlist-manager.tsx
+++ b/web/components/portfolio/watchlist-manager.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  addToWatchlist,
+  removeFromWatchlist,
+  type ActionResult,
+} from "@/lib/watchlist-mutations";
+import type { WatchlistItem } from "@/lib/watchlist-query";
+
+const ADD_KEY = "__add__";
+
+export default function WatchlistManager({
+  items,
+}: {
+  items: WatchlistItem[];
+}) {
+  const router = useRouter();
+  const [ticker, setTicker] = useState("");
+  const [note, setNote] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  // Holds the key currently mid-action: ADD_KEY for the add form, or a
+  // ticker for a remove. Drives per-control disabled state.
+  const [pending, setPending] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  function runAction(
+    key: string,
+    fn: () => Promise<ActionResult>,
+    onOk?: () => void,
+  ) {
+    setError(null);
+    setPending(key);
+    startTransition(async () => {
+      const result = await fn();
+      setPending(null);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      onOk?.();
+      router.refresh();
+    });
+  }
+
+  function onAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!ticker.trim()) return;
+    runAction(
+      ADD_KEY,
+      () => addToWatchlist({ ticker, rationale: note }),
+      () => {
+        setTicker("");
+        setNote("");
+      },
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <form
+        onSubmit={onAdd}
+        className="glass-card rounded-lg border border-border p-5"
+      >
+        <p className="text-xs font-mono uppercase tracking-widest text-text-dim mb-3">
+          Add an equity
+        </p>
+        <div className="flex flex-col sm:flex-row gap-2">
+          <input
+            type="text"
+            value={ticker}
+            onChange={(e) => setTicker(e.target.value.toUpperCase())}
+            placeholder="Ticker"
+            aria-label="Ticker symbol"
+            maxLength={12}
+            className="sm:w-32 bg-bg border border-border rounded px-3 py-2 font-mono text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
+          />
+          <input
+            type="text"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Note — why you're watching it (optional)"
+            aria-label="Note"
+            maxLength={280}
+            className="flex-1 bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
+          />
+          <button
+            type="submit"
+            disabled={pending === ADD_KEY || !ticker.trim()}
+            className="shrink-0 px-4 py-2 font-mono text-[11px] uppercase tracking-widest rounded border border-green/40 text-green hover:bg-green/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {pending === ADD_KEY ? "…" : "Add"}
+          </button>
+        </div>
+      </form>
+
+      {error && (
+        <div className="text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+          {error}
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <div className="glass-card rounded-lg border border-border p-6">
+          <p className="text-sm text-text-dim leading-relaxed">
+            Your watchlist is empty. Add equities above to build a shortlist —
+            agents on this portfolio will be able to populate the list and
+            trade from it.
+          </p>
+        </div>
+      ) : (
+        <div className="glass-card rounded-lg border border-border overflow-hidden">
+          <div className="px-4 py-3 border-b border-border">
+            <p className="text-xs font-mono uppercase tracking-widest text-text-dim">
+              {items.length} {items.length === 1 ? "equity" : "equities"}
+            </p>
+          </div>
+          <ul className="divide-y divide-border">
+            {items.map((it) => (
+              <li
+                key={it.ticker}
+                className="flex items-start justify-between gap-3 p-4"
+              >
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Link
+                      href={`/company/${encodeURIComponent(it.ticker)}`}
+                      className="font-mono text-sm font-bold text-green hover:underline decoration-1 underline-offset-[3px]"
+                    >
+                      {it.ticker}
+                    </Link>
+                    {it.company_name && (
+                      <span className="text-xs text-text-muted truncate max-w-[280px]">
+                        {it.company_name}
+                      </span>
+                    )}
+                    <SourceBadge source={it.source} />
+                    {it.status && (
+                      <span className="text-[10px] font-mono text-text-muted">
+                        {it.status}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 font-mono text-xs text-text-muted">
+                    {it.sector && <span>{it.sector}</span>}
+                    {it.composite_score != null && (
+                      <span>Score {it.composite_score.toFixed(1)}</span>
+                    )}
+                    {it.price != null && (
+                      <span>
+                        $
+                        {it.price.toLocaleString("en-US", {
+                          maximumFractionDigits: 2,
+                        })}
+                      </span>
+                    )}
+                  </div>
+                  {it.rationale && (
+                    <p className="mt-1.5 text-sm text-text-dim leading-relaxed">
+                      {it.rationale}
+                    </p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() =>
+                    runAction(it.ticker, () =>
+                      removeFromWatchlist({ ticker: it.ticker }),
+                    )
+                  }
+                  disabled={pending === it.ticker}
+                  aria-label={`Remove ${it.ticker} from watchlist`}
+                  className="shrink-0 text-text-muted hover:text-red disabled:opacity-50 text-lg leading-none px-1"
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SourceBadge({ source }: { source: "user" | "agent" }) {
+  const label = source === "agent" ? "Agent" : "You";
+  return (
+    <span className="text-[9px] font-mono uppercase tracking-widest text-text-muted border border-border rounded px-1 py-0.5">
+      {label}
+    </span>
+  );
+}

--- a/web/lib/watchlist-mutations.ts
+++ b/web/lib/watchlist-mutations.ts
@@ -1,0 +1,112 @@
+"use server";
+
+/**
+ * Server Actions for a signed-in human curating their portfolio's
+ * watchlist (migration 027).
+ *
+ * Same auth model as portfolios-mutations.ts: verify the SSR cookie
+ * session owns the portfolio, then write with the service-role client.
+ */
+
+import { revalidatePath } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+import { requireUser } from "@/lib/auth/require-user";
+
+export type ActionResult = { ok: true } | { ok: false; error: string };
+
+const MAX_RATIONALE = 280;
+
+/** The caller's single portfolio id, or null. Service-role read. */
+async function getOwnedPortfolioId(userId: string): Promise<string | null> {
+  const supabase = getSupabase();
+  const { data } = await supabase
+    .from("portfolios")
+    .select("id")
+    .eq("owner_user_id", userId)
+    .maybeSingle();
+  return (data as { id: string } | null)?.id ?? null;
+}
+
+export async function addToWatchlist(input: {
+  ticker: string;
+  rationale?: string;
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+  const portfolioId = await getOwnedPortfolioId(user.id);
+  if (!portfolioId) {
+    return { ok: false, error: "You don't have a portfolio yet." };
+  }
+
+  const ticker = input.ticker.trim().toUpperCase();
+  if (!ticker) return { ok: false, error: "Enter a ticker symbol." };
+
+  const rationale = (input.rationale ?? "").trim();
+  if (rationale.length > MAX_RATIONALE) {
+    return {
+      ok: false,
+      error: `Note must be ${MAX_RATIONALE} characters or fewer.`,
+    };
+  }
+
+  const supabase = getSupabase();
+
+  // The ticker must exist in the screened universe — the FK would reject
+  // an unknown ticker anyway, but checking first gives a clean message.
+  const { data: company } = await supabase
+    .from("companies")
+    .select("ticker")
+    .eq("ticker", ticker)
+    .maybeSingle();
+  if (!company) {
+    return {
+      ok: false,
+      error: `“${ticker}” isn't in the equity universe.`,
+    };
+  }
+
+  // Upsert so re-adding a ticker updates its note rather than erroring.
+  const { error } = await supabase.from("portfolio_watchlist").upsert(
+    {
+      portfolio_id: portfolioId,
+      ticker,
+      source: "user",
+      rationale: rationale || null,
+    },
+    { onConflict: "portfolio_id,ticker" },
+  );
+  if (error) {
+    console.error("addToWatchlist failed:", error);
+    return { ok: false, error: "Could not add to the watchlist. Try again." };
+  }
+
+  revalidatePath("/account/watchlist");
+  return { ok: true };
+}
+
+export async function removeFromWatchlist(input: {
+  ticker: string;
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+  const portfolioId = await getOwnedPortfolioId(user.id);
+  if (!portfolioId) {
+    return { ok: false, error: "You don't have a portfolio yet." };
+  }
+
+  const ticker = input.ticker.trim().toUpperCase();
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from("portfolio_watchlist")
+    .delete()
+    .eq("portfolio_id", portfolioId)
+    .eq("ticker", ticker);
+  if (error) {
+    console.error("removeFromWatchlist failed:", error);
+    return {
+      ok: false,
+      error: "Could not remove from the watchlist. Try again.",
+    };
+  }
+
+  revalidatePath("/account/watchlist");
+  return { ok: true };
+}

--- a/web/lib/watchlist-query.ts
+++ b/web/lib/watchlist-query.ts
@@ -1,0 +1,75 @@
+/**
+ * Read-side queries for the per-portfolio watchlist (migration 027).
+ *
+ * Uses the service-role client like the other portfolio queries — the
+ * page resolves the signed-in user and their portfolio first, then reads
+ * the watchlist by `portfolio_id`. RLS on the table is defense-in-depth.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+
+export interface WatchlistItem {
+  ticker: string;
+  company_name: string | null;
+  sector: string | null;
+  price: number | null;
+  composite_score: number | null;
+  status: string | null;
+  /** Who added it — 'user' (the owner) or 'agent'. */
+  source: "user" | "agent";
+  rationale: string | null;
+  created_at: string;
+}
+
+export async function getWatchlistForPortfolio(
+  portfolioId: string,
+): Promise<WatchlistItem[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("portfolio_watchlist")
+    .select(
+      "ticker, source, rationale, created_at, " +
+        "companies (company_name, sector, price, composite_score, status)",
+    )
+    .eq("portfolio_id", portfolioId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("getWatchlistForPortfolio failed:", error);
+    return [];
+  }
+
+  // PostgREST embeds a to-one join as either an object or a length-1
+  // array depending on inference — normalise to the object.
+  type EmbeddedCompany = {
+    company_name: string | null;
+    sector: string | null;
+    price: number | string | null;
+    composite_score: number | string | null;
+    status: string | null;
+  };
+  type Row = {
+    ticker: string;
+    source: string;
+    rationale: string | null;
+    created_at: string;
+    companies: EmbeddedCompany | EmbeddedCompany[] | null;
+  };
+
+  const rows = (data as unknown as Row[] | null) ?? [];
+  return rows.map((r) => {
+    const c = Array.isArray(r.companies) ? r.companies[0] : r.companies;
+    return {
+      ticker: r.ticker,
+      company_name: c?.company_name ?? null,
+      sector: c?.sector ?? null,
+      price: c?.price != null ? Number(c.price) : null,
+      composite_score:
+        c?.composite_score != null ? Number(c.composite_score) : null,
+      status: c?.status ?? null,
+      source: r.source === "agent" ? "agent" : "user",
+      rationale: r.rationale,
+      created_at: r.created_at,
+    };
+  });
+}


### PR DESCRIPTION
Introduce a per-portfolio watchlist (shortlist) — a curated set of equities attached to a portfolio. Migration 027 adds the portfolio_watchlist table with a source ('user' | 'agent') discriminator, added_by_agent_id and rationale columns so the framework is agent-ready without further schema changes. A new logged-in /account/watchlist page lets the portfolio owner add and remove equities, backed by verify-then- service-role server actions matching the existing portfolio mutations. Agent population/consumption of the list is intentionally out of scope here — this is the framework only.

https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4