### PR TITLE
Add two-agent curator/buyer pipeline backend

### DIFF
--- a/.github/workflows/agent-heartbeat.yml
+++ b/.github/workflows/agent-heartbeat.yml
@@ -1,11 +1,14 @@
 name: Agent Heartbeat
 
-# Weekly rebalance loop. Every agent row with a non-null `strategy` and a
-# due `last_heartbeat_at` gets its portfolio re-evaluated against its
-# strategy (see agent_strategies.STRATEGIES).
+# Daily rebalance loop. Every agent row with a non-null `strategy` — and
+# every human-portfolio member — is re-evaluated against its strategy
+# (see agent_strategies.STRATEGIES), but only actually rebalances when its
+# own `heartbeat_interval_hours` cadence is due, so most daily runs are
+# cheap no-op skips. Running daily lets daily-cadence agents (e.g. the
+# watchlist curator) get a daily run alongside weekly ones.
 #
-# Sunday 07:00 UTC — runs at the end of the Sunday morning data block,
-# after every input the picker depends on has refreshed:
+# 07:00 UTC — runs at the end of the morning data block, after every
+# input the picker depends on has refreshed:
 #   04:00 bear-evaluation   (refreshes companies.bear_eval)
 #   04:30 bull-evaluation   (refreshes companies.bull_eval)
 #   05:00 score-ai-analysis (composite scores + sort_order)
@@ -15,7 +18,7 @@ name: Agent Heartbeat
 
 on:
   schedule:
-    - cron: "0 7 * * 0"
+    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       handle:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,9 @@ Daily (UTC):
 05:00           score_ai_analysis.py      Score, rank & assign sort_order
 05:30           portfolio_valuation.py    Mark-to-market every agent + launched human portfolio
 06:00           build_universe_snapshot.py  Daily universe JSON snapshot (3 tiers)
+07:00           agent_heartbeat.py        Rebalance loop — every agent / human-portfolio member that is due on its own heartbeat_interval_hours cadence
 
 Weekly (Sunday UTC):
-Sun 07:00       agent_heartbeat.py        Rebalance every agent portfolio + every launched human portfolio
 Sun 08:00       consensus_snapshot.py     Aggregate agent_holdings → consensus_snapshots (powers /consensus)
 
 Every 15 min (Mon–Fri, 13:00–22:00 UTC):
@@ -130,9 +130,11 @@ view). Two cadences share the same script:
 Supports `--dry-run` and `--agent HANDLE` flags. See `portfolio.py` for the
 trading layer.
 
-### agent_heartbeat.py (Sundays 07:00 UTC)
-Weekly rebalance loop — the reason portfolios aren't frozen after the initial
-build. Runs in **two passes**:
+### agent_heartbeat.py (07:00 UTC daily)
+Rebalance loop — the reason portfolios aren't frozen after the initial
+build. Runs **daily**, but each agent / member only rebalances when its own
+`heartbeat_interval_hours` cadence is due, so most daily runs are cheap
+no-op skips. Runs in **two passes**:
 
 1. **Agent pass** — for every row in `agents` with a non-null `strategy` whose
    `last_heartbeat_at` is older than `heartbeat_interval_hours` (default 168h),
@@ -145,9 +147,13 @@ build. Runs in **two passes**:
    `portfolio_holdings`) — sequential rebalance, so a later agent sees what
    earlier ones did. Members run **curate-phase strategies before trade-phase
    ones** (see `STRATEGY_PHASES` below), and within each phase in
-   `portfolio_agents.joined_at` order (stable sort). Mandate-aware strategies
-   receive `portfolios.description` as their brief. Gated on
-   `portfolios.last_heartbeat_at`.
+   `portfolio_agents.joined_at` order (stable sort). Each member is gated on
+   its **own cadence** — the per-membership clock `portfolio_agents.last_heartbeat_at`
+   (migration 029) plus the agent's `heartbeat_interval_hours` — so a daily
+   curator and a weekly buyer coexist in one portfolio. The per-membership
+   clock (not the shared `agents` row) is used because one agent can belong
+   to many portfolios. Mandate-aware strategies receive `portfolios.description`
+   as their brief.
 
 The Pass-1 agents loop skips `trading_agents` (own long-timeout workflow) and
 the pipeline strategies `watchlist_curator` / `watchlist_buyer` (only
@@ -171,22 +177,27 @@ the phase for any name, listed or not). A *curate* strategy produces inputs a
 members first so their output is visible to the buyers in the same run.
 
 **Two-agent pipeline (`watchlist_curator` → `watchlist_buyer`).** A pair of
-strategies for human portfolios. `watchlist_curator` (phase `curate`) is a
-mandate-aware LLM curator: it loads the daily compact universe snapshot,
-prompts an LLM with the snapshot + the portfolio's mandate, parses ~15-25
-`{ticker, rationale}` items (count via `config.watchlist_size`, default 20),
-validates each against `companies`, and replaces the portfolio's
-`source='agent'` `portfolio_watchlist` rows (the owner's `source='user'`
-picks are never touched). It reuses `llm_picker`'s snapshot loader and the
-shared `pick_shortlist_via_llm` LLM-call helper; provider/model come from
-`agents.config` like `llm_pick`. `watchlist_buyer` (phase `trade`) is a
-mechanical buyer modelled on `dual_positive`: it reads the *whole* watchlist
-(both sources), equal-weights it with a 2% cash reserve, diffs against the
-shared book, sells holdings no longer on the watchlist (before buys), and
-buys watchlist tickers — passing a `thesis` kwarg on each buy so an
+strategies for human portfolios, run on different per-agent cadences:
+specialist curators populate the shortlist often (the house curator runs
+daily), buyers trade it less often (the house buyer runs weekly).
+`watchlist_curator` (phase `curate`) is a mandate-aware LLM curator: it loads
+the daily compact universe snapshot, prompts an LLM with the snapshot + the
+portfolio's mandate, parses ~15-25 `{ticker, rationale}` items (count via
+`config.watchlist_size`, default 20), validates each against `companies`, and
+replaces **only its own** `source='agent'` `portfolio_watchlist` rows — keyed
+by `added_by_agent_id`, so several specialist curators can each maintain
+their own slice, and the owner's `source='user'` picks are never touched. It
+reuses `llm_picker`'s snapshot loader and the shared `pick_shortlist_via_llm`
+LLM-call helper; provider/model come from `agents.config` like `llm_pick`.
+`watchlist_buyer` (phase `trade`) is a mechanical buyer modelled on
+`dual_positive`: it reads the *whole* watchlist (every curator's rows + the
+owner's), equal-weights it with a 2% cash reserve, diffs against the shared
+book, sells holdings no longer on the watchlist (before buys), and buys
+watchlist tickers — passing a `thesis` kwarg on each buy so an
 `investment_theses` row is recorded (the watchlist `rationale` becomes the
 thesis text). Both are no-ops on a legacy 1:1 agent portfolio. The house
-agents `shortlist-builder` and `buying-agent` (migration 028) drive them.
+agents `shortlist-builder` (curator, `gemini-2.5-flash`, 24h cadence) and
+`buying-agent` (buyer, 168h cadence) — migration 028 — drive them.
 
 Supports `--handle`, `--force` (ignore interval guard), and `--dry-run`.
 
@@ -350,13 +361,17 @@ public surfaces. URL: `/portfolios/<slug>`.
 
 ### portfolio_agents (membership join — many-to-many)
 ```
-(portfolio_id, agent_id) PK, notes (TEXT), joined_at
+(portfolio_id, agent_id) PK, notes (TEXT), joined_at, last_heartbeat_at
 ```
-Permissive many-to-many: no role or capability fields. Any member
-can buy / sell / record theses on the portfolio. `notes` is a
-free-form description of what this agent does for this portfolio
-("Handles weekly thesis-driven sells", "Rebalancer", etc.) —
+Permissive many-to-many: no role or capability fields (a member's job is
+its `agents.strategy`). Any member can buy / sell / record theses on the
+portfolio. `notes` is a free-form description of what this agent does for
+this portfolio ("Handles weekly thesis-driven sells", "Rebalancer", etc.) —
 rendered on the agent profile page next to each portfolio.
+`last_heartbeat_at` (migration 029) is the per-membership rebalance clock:
+`agent_heartbeat.py` gates each member on it plus the agent's
+`heartbeat_interval_hours`, so the same agent runs on its own cadence
+independently in every portfolio it joins.
 
 ### portfolio_accounts / portfolio_holdings (shared-pot trading — migration 025)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,11 +141,17 @@ build. Runs in **two passes**:
    `agent_heartbeats`.
 2. **Human-portfolio pass** — for every launched human-owned portfolio
    (`portfolios.owner_user_id` set, `launched_at` set), runs each member agent's
-   strategy in `portfolio_agents.joined_at` order against the portfolio's
-   *shared* book (`portfolio_accounts` / `portfolio_holdings`) — sequential
-   rebalance, so a later agent sees what earlier ones did. Mandate-aware
-   strategies receive `portfolios.description` as their brief. Gated on
+   strategy against the portfolio's *shared* book (`portfolio_accounts` /
+   `portfolio_holdings`) — sequential rebalance, so a later agent sees what
+   earlier ones did. Members run **curate-phase strategies before trade-phase
+   ones** (see `STRATEGY_PHASES` below), and within each phase in
+   `portfolio_agents.joined_at` order (stable sort). Mandate-aware strategies
+   receive `portfolios.description` as their brief. Gated on
    `portfolios.last_heartbeat_at`.
+
+The Pass-1 agents loop skips `trading_agents` (own long-timeout workflow) and
+the pipeline strategies `watchlist_curator` / `watchlist_buyer` (only
+meaningful operating a shared human portfolio — they run in Pass 2).
 
 Reference strategy `dual_positive` (in `agent_strategies.py`) re-reads the
 `companies` table, picks the top-N tickers with both `bear` ✅ and `bull` ✅
@@ -157,6 +163,30 @@ safe to rerun on an unchanged universe.
 Strategies trade through an account-model-agnostic `ctx.buy/sell/get_book`
 facade on `RebalanceContext` — the same strategy code drives a legacy
 agent account or a shared human portfolio depending on `ctx.portfolio_id`.
+
+**Strategy phases.** `agent_strategies.STRATEGY_PHASES` maps a strategy name
+to `'curate'` or `'trade'` (default `'trade'` — `strategy_phase(name)` returns
+the phase for any name, listed or not). A *curate* strategy produces inputs a
+*trade* strategy consumes; the portfolio heartbeat runs all curate-phase
+members first so their output is visible to the buyers in the same run.
+
+**Two-agent pipeline (`watchlist_curator` → `watchlist_buyer`).** A pair of
+strategies for human portfolios. `watchlist_curator` (phase `curate`) is a
+mandate-aware LLM curator: it loads the daily compact universe snapshot,
+prompts an LLM with the snapshot + the portfolio's mandate, parses ~15-25
+`{ticker, rationale}` items (count via `config.watchlist_size`, default 20),
+validates each against `companies`, and replaces the portfolio's
+`source='agent'` `portfolio_watchlist` rows (the owner's `source='user'`
+picks are never touched). It reuses `llm_picker`'s snapshot loader and the
+shared `pick_shortlist_via_llm` LLM-call helper; provider/model come from
+`agents.config` like `llm_pick`. `watchlist_buyer` (phase `trade`) is a
+mechanical buyer modelled on `dual_positive`: it reads the *whole* watchlist
+(both sources), equal-weights it with a 2% cash reserve, diffs against the
+shared book, sells holdings no longer on the watchlist (before buys), and
+buys watchlist tickers — passing a `thesis` kwarg on each buy so an
+`investment_theses` row is recorded (the watchlist `rationale` becomes the
+thesis text). Both are no-ops on a legacy 1:1 agent portfolio. The house
+agents `shortlist-builder` and `buying-agent` (migration 028) drive them.
 
 Supports `--handle`, `--force` (ignore interval guard), and `--dry-run`.
 
@@ -286,8 +316,12 @@ created_at, updated_at
 `strategy` is a key into `agent_strategies.STRATEGIES` (NULL = manually
 managed, no heartbeat). `heartbeat_interval_hours` defaults to 168 (weekly).
 `config` is a JSONB bag for per-agent strategy parameters — the `llm_pick`
-strategy uses `{provider, model, picker_mode, snapshot_tier}`; mechanical
-strategies ignore it. `powered_by` is an optional human-readable LLM brand
+strategy uses `{provider, model, picker_mode, snapshot_tier}`, the
+`watchlist_curator` strategy uses `{provider, model, watchlist_size}`;
+mechanical strategies (`dual_positive`, `momentum`, `watchlist_buyer`) ignore
+it. House agents `shortlist-builder` (`watchlist_curator`) and `buying-agent`
+(`watchlist_buyer`) seeded by migration 028 drive the two-agent pipeline for
+human portfolios. `powered_by` is an optional human-readable LLM brand
 (e.g. "Claude Sonnet 4.6") rendered as a chip on the public agent profile
 page; community agents set it on registration. `available_for_hire` (BOOLEAN,
 default false; house agents backfilled true) is the owner's opt-in to the
@@ -349,9 +383,10 @@ it from `/account/watchlist` (server actions in `web/lib/watchlist-mutations.ts`
 reads via `web/lib/watchlist-query.ts`). The table is agent-ready by design:
 `source` distinguishes a manual owner pick from an agent pick,
 `added_by_agent_id` attributes the latter, and `rationale` carries the "why".
-Today only the owner writes (`source='user'`); the agent wiring — one agent
-populating the list, a second trading from it — is a later PR and needs no
-schema change.
+The owner writes `source='user'` rows from the website; the
+`watchlist_curator` strategy writes `source='agent'` rows (replacing only its
+own prior rows — see `db.replace_agent_watchlist`), and the
+`watchlist_buyer` strategy trades from the union of both sources.
 
 **Trading-shaped tables and `portfolio_id`.** Since migration 021,
 every trade-related row carries both `agent_id` and `portfolio_id`

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -10,9 +10,11 @@ Iterates over every row in the `agents` table. For each agent:
     4. Journal the run in `agent_heartbeats` and update
        `agents.last_heartbeat_at`.
 
-Designed to run weekly (Sundays 07:00 UTC) via
-``.github/workflows/agent-heartbeat.yml`` but safe to run ad-hoc for a
-single agent.
+Designed to run daily (07:00 UTC) via
+``.github/workflows/agent-heartbeat.yml``; each agent — and each human
+portfolio member — only rebalances when its own ``heartbeat_interval_hours``
+cadence is due, so a daily run is mostly cheap no-op skips. Safe to run
+ad-hoc for a single agent.
 
 Usage::
 
@@ -101,10 +103,10 @@ def _journal(
     # in effect after a permanent-failure attempt; transient errors back off
     # by the same interval as successful runs).
     #
-    # advance_agent is False for human-portfolio member runs: those rebalance
-    # on the *portfolio's* cadence (portfolios.last_heartbeat_at), and an
-    # agent may be a member of several portfolios, so its own clock must not
-    # be touched here.
+    # advance_agent is False for human-portfolio member runs: those track
+    # cadence per (portfolio, agent) membership via
+    # portfolio_agents.last_heartbeat_at (an agent can be a member of
+    # several portfolios), so the shared agents row is left untouched.
     if not dry_run and advance_agent:
         db.update_agent_last_heartbeat(agent_id, _now_utc().isoformat())
 
@@ -192,15 +194,20 @@ def _run_one(
     return status
 
 
-# Human portfolios rebalance weekly, matching the default agent cadence.
-PORTFOLIO_HEARTBEAT_INTERVAL_HOURS = 168
+def _member_is_due(agent: dict, member_last: str | None, now: datetime) -> bool:
+    """Whether a portfolio member is due to rebalance, on its own cadence.
 
-
-def _portfolio_is_due(portfolio: dict, now: datetime) -> bool:
-    last = _parse_ts(portfolio.get("last_heartbeat_at"))
+    Gates on the per-membership last-run (``portfolio_agents.last_heartbeat_at``,
+    passed as ``member_last``) and the agent's ``heartbeat_interval_hours``.
+    A NULL last-run (never run in this portfolio) or NULL interval is due.
+    """
+    last = _parse_ts(member_last)
     if last is None:
         return True
-    return now >= last + timedelta(hours=PORTFOLIO_HEARTBEAT_INTERVAL_HOURS)
+    interval = agent.get("heartbeat_interval_hours")
+    if interval is None:
+        return True
+    return now >= last + timedelta(hours=int(interval))
 
 
 def _run_portfolio(
@@ -214,34 +221,35 @@ def _run_portfolio(
 ) -> dict[str, int]:
     """Rebalance one launched human portfolio.
 
-    Each member agent runs its own strategy, in portfolio_agents.joined_at
-    order, against the *shared* portfolio book — so a later member sees the
-    trades earlier members already made. Returns a status-count dict.
+    Each member agent runs its own strategy against the *shared* portfolio
+    book — so a later member sees the trades earlier members made. Members
+    are gated individually on their own cadence (the per-membership clock
+    ``portfolio_agents.last_heartbeat_at`` plus the agent's
+    ``heartbeat_interval_hours``), so e.g. a daily curator and a weekly
+    buyer coexist in one portfolio. Curate-phase members run before
+    trade-phase ones, so on a day both are due the buyer sees the fresh
+    shortlist. Returns a status-count dict.
     """
     counts = {"ok": 0, "dry-run": 0, "skipped": 0, "error": 0}
     slug = portfolio.get("slug") or portfolio["id"][:8]
 
-    if not force and not _portfolio_is_due(portfolio, _now_utc()):
-        logger.info("  portfolio %-22s skip (not due)", slug)
-        counts["skipped"] += 1
-        return counts
-
-    members = [m["agent"] for m in db.get_portfolio_members(portfolio["id"])]
+    member_entries = db.get_portfolio_members(portfolio["id"])
     mandate = portfolio.get("description")
 
     # Run curate-phase members (e.g. watchlist_curator) before trade-phase
-    # ones so a curator's fresh shortlist is visible to the buyer in the
-    # same heartbeat. Stable sort by (phase_rank, original joined_at index)
-    # preserves joined_at order within each phase.
+    # ones. Stable sort preserves joined_at order within each phase.
     _phase_rank = {"curate": 0, "trade": 1}
-    members.sort(
-        key=lambda m: (
-            _phase_rank.get(strategy_phase(m.get("strategy")), 1),
+    member_entries.sort(
+        key=lambda e: _phase_rank.get(
+            strategy_phase(e["agent"].get("strategy")), 1
         ),
     )
-    logger.info("  portfolio %-22s %d member(s)", slug, len(members))
+    member_agents = [e["agent"] for e in member_entries]
+    logger.info("  portfolio %-22s %d member(s)", slug, len(member_entries))
 
-    for member in members:
+    ran_any = False
+    for entry in member_entries:
+        member = entry["agent"]
         handle = member.get("handle", member["id"][:8])
         strategy_name = member.get("strategy")
         started = _now_utc()
@@ -253,6 +261,19 @@ def _run_portfolio(
         # trading_agents runs from its own long-timeout workflow.
         if strategy_name == "trading_agents":
             logger.info("    %-22s skip (trading_agents)", handle)
+            counts["skipped"] += 1
+            continue
+        # Per-membership cadence guard (migration 029): a member only
+        # rebalances when its own heartbeat_interval_hours is due here.
+        if not force and not _member_is_due(
+            member, entry.get("member_last_heartbeat_at"), started
+        ):
+            logger.info(
+                "    %-22s skip (last=%s, interval=%sh)",
+                handle,
+                entry.get("member_last_heartbeat_at") or "never",
+                member.get("heartbeat_interval_hours"),
+            )
             counts["skipped"] += 1
             continue
 
@@ -268,14 +289,19 @@ def _run_portfolio(
                 portfolio_id=portfolio["id"], advance_agent=False,
                 dry_run=dry_run,
             )
+            if not dry_run:
+                db.update_portfolio_member_heartbeat(
+                    portfolio["id"], member["id"], _now_utc().isoformat()
+                )
             counts["error"] += 1
+            ran_any = True
             continue
 
         ctx = RebalanceContext(
             db=db, pm=pm, agent=member, dry_run=dry_run,
             params=dict(member.get("config") or {}),
             portfolio_id=portfolio["id"],
-            members=members,
+            members=member_agents,
             mandate=mandate,
         )
         try:
@@ -289,7 +315,12 @@ def _run_portfolio(
                 portfolio_id=portfolio["id"], advance_agent=False,
                 dry_run=dry_run,
             )
+            if not dry_run:
+                db.update_portfolio_member_heartbeat(
+                    portfolio["id"], member["id"], _now_utc().isoformat()
+                )
             counts["error"] += 1
+            ran_any = True
             continue
 
         status = (
@@ -305,10 +336,16 @@ def _run_portfolio(
             error_message="; ".join(result.errors) if result.errors else None,
             portfolio_id=portfolio["id"], advance_agent=False, dry_run=dry_run,
         )
+        if not dry_run:
+            db.update_portfolio_member_heartbeat(
+                portfolio["id"], member["id"], _now_utc().isoformat()
+            )
         counts[status] = counts.get(status, 0) + 1
+        ran_any = True
 
-    # Stamp the portfolio's heartbeat clock once, after every member ran.
-    if not dry_run:
+    # Stamp the portfolio's clock when at least one member actually ran —
+    # informational ("last activity"); the per-member clocks are the gate.
+    if not dry_run and ran_any:
         db.update_portfolio_last_heartbeat(
             portfolio["id"], _now_utc().isoformat()
         )

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -33,7 +33,12 @@ from datetime import datetime, timedelta, timezone
 
 from dotenv import load_dotenv
 
-from agent_strategies import RebalanceContext, RebalanceResult, get_strategy
+from agent_strategies import (
+    RebalanceContext,
+    RebalanceResult,
+    get_strategy,
+    strategy_phase,
+)
 from db import SupabaseDB
 from portfolio import PortfolioManager
 
@@ -223,6 +228,17 @@ def _run_portfolio(
 
     members = [m["agent"] for m in db.get_portfolio_members(portfolio["id"])]
     mandate = portfolio.get("description")
+
+    # Run curate-phase members (e.g. watchlist_curator) before trade-phase
+    # ones so a curator's fresh shortlist is visible to the buyer in the
+    # same heartbeat. Stable sort by (phase_rank, original joined_at index)
+    # preserves joined_at order within each phase.
+    _phase_rank = {"curate": 0, "trade": 1}
+    members.sort(
+        key=lambda m: (
+            _phase_rank.get(strategy_phase(m.get("strategy")), 1),
+        ),
+    )
     logger.info("  portfolio %-22s %d member(s)", slug, len(members))
 
     for member in members:
@@ -346,6 +362,14 @@ def main() -> int:
         # work because the filter is only applied to the bulk path.
         agents = [
             a for a in agents if a.get("strategy") != "trading_agents"
+        ]
+        # The pipeline strategies (watchlist_curator / watchlist_buyer) only
+        # make sense operating a shared human portfolio — their legacy 1:1
+        # agent account has no mandate and no watchlist, so they'd no-op.
+        # Skip them in Pass 1; they run in Pass 2 as portfolio members.
+        agents = [
+            a for a in agents
+            if a.get("strategy") not in ("watchlist_curator", "watchlist_buyer")
         ]
 
     logger.info(

--- a/agent_strategies.py
+++ b/agent_strategies.py
@@ -17,6 +17,20 @@ Current strategies:
     dual_positive  — equal-weight the top N tickers where `bear` and `bull`
                      are both ✅, deduped by company, favouring US listings.
                      This is the rebalance version of build_portfolio.py.
+    momentum       — low-churn momentum rebalance.
+    llm_pick       — two-stage LLM-driven portfolio picker (llm_picker.py).
+    trading_agents — TauricResearch/TradingAgents multi-agent framework.
+    watchlist_curator — mandate-aware LLM curator for human portfolios; writes
+                     a shortlist into portfolio_watchlist (source='agent').
+    watchlist_buyer — mechanical buyer that equal-weights a portfolio's
+                     watchlist and trades it, recording a thesis per buy.
+
+Strategy phases (``STRATEGY_PHASES`` / ``strategy_phase``): a strategy is
+either a ``'curate'`` strategy (it produces inputs other strategies consume —
+today only ``watchlist_curator``) or a ``'trade'`` strategy (the default — it
+places trades). The portfolio heartbeat runs all curate-phase members before
+any trade-phase member so the curator's fresh shortlist is visible to the
+buyer in the same heartbeat.
 """
 
 from __future__ import annotations
@@ -796,6 +810,418 @@ def rebalance_momentum(ctx: RebalanceContext) -> RebalanceResult:
 
 
 # ---------------------------------------------------------------------------
+# Strategy: watchlist_curator
+# ---------------------------------------------------------------------------
+#
+# The curator half of the two-agent pipeline for human-owned portfolios.
+# It screens the daily compact universe snapshot against the portfolio's
+# free-text mandate via an LLM, then writes the result into
+# portfolio_watchlist as the portfolio's source='agent' rows. The buyer
+# strategy (watchlist_buyer) trades from that list later in the same
+# heartbeat — the heartbeat runs curate-phase strategies before trade-phase
+# ones (see STRATEGY_PHASES below).
+
+
+WATCHLIST_CURATOR_DEFAULTS = {
+    "watchlist_size": 20,        # target shortlist length (~15-25)
+    "max_tokens": 16384,
+    "temperature": 0.2,
+}
+
+
+WATCHLIST_CURATOR_SYSTEM_PROMPT = """\
+You are an equity research analyst curating a watchlist for a $1M paper-money portfolio.
+
+You will be given:
+1. A universe of screened companies with their current fundamentals.
+2. The portfolio's investment mandate (the human owner's brief).
+
+Your task: pick the tickers that best fit the mandate — a focused shortlist a buyer agent will then equal-weight and trade. Be selective and mandate-driven; this is a shortlist, not the whole universe.
+
+Output strict JSON only. No prose, no markdown fences."""
+
+
+WATCHLIST_CURATOR_USER_TEMPLATE = """\
+{mandate_block}UNIVERSE (compact tier, snapshot {snapshot_date}):
+{universe_json}
+
+CURRENT PORTFOLIO:
+{portfolio_json}
+
+OUTPUT SCHEMA (strict JSON, no other text):
+{{
+  "shortlist": [
+    {{"ticker": "XXX", "rationale": "<10-20 word reason this fits the mandate>"}}
+  ]
+}}
+
+Pick {shortlist_max} tickers (fewer is fine if you can't justify {shortlist_max}).
+Only tickers from the universe above are valid. Output JSON only."""
+
+
+def rebalance_watchlist_curator(ctx: RebalanceContext) -> RebalanceResult:
+    """Mandate-aware LLM curator — writes portfolio_watchlist source='agent' rows.
+
+    Lazy-imports the llm_picker machinery (and through it the LLM SDKs) so
+    the dependency only matters for runs that actually curate — momentum /
+    dual_positive heartbeats stay independent.
+
+    Defensive by contract: a missing snapshot, an LLM/provider error, or a
+    parse failure are all captured into ``result.errors`` / ``result.notes``
+    — the function never raises, so the heartbeat cannot crash on it.
+    """
+    result = RebalanceResult()
+    params = {**WATCHLIST_CURATOR_DEFAULTS, **(ctx.params or {})}
+    handle = ctx.agent.get("handle", ctx.agent["id"][:8])
+
+    # Only meaningful for a shared human portfolio — there is no watchlist
+    # to curate for a legacy 1:1 agent account.
+    if not ctx.portfolio_id:
+        result.notes["reason"] = "watchlist_curator only runs on a human portfolio"
+        return result
+
+    # Reuse llm_picker's snapshot loader + provider/model + LLM-call code.
+    try:
+        from llm_picker import (
+            _filter_snapshot_us_only,
+            _load_latest_snapshot,
+            _mandate_block,
+            _us_listed_tickers,
+            pick_shortlist_via_llm,
+        )
+        from llm_providers import LLMProviderError, PROVIDERS
+    except ImportError as exc:  # pragma: no cover — defensive
+        result.errors.append(f"watchlist_curator import failed: {exc}")
+        return result
+
+    provider = params.get("provider")
+    model = params.get("model")
+    if not provider or provider not in PROVIDERS:
+        result.errors.append(
+            f"agents.config.provider missing or invalid (got {provider!r}). "
+            f"Expected one of: {', '.join(PROVIDERS)}"
+        )
+        return result
+    if not model:
+        result.errors.append("agents.config.model missing")
+        return result
+
+    # Load the compact universe snapshot, filtered to US-listed tickers
+    # (same currency caveat the llm_pick strategy guards against).
+    snap_row = _load_latest_snapshot(ctx.db, "compact")
+    if not snap_row:
+        result.errors.append(
+            "no compact universe snapshot. Build one via build_universe_snapshot.py."
+        )
+        return result
+    us_tickers = _us_listed_tickers(ctx.db)
+    snapshot_json = _filter_snapshot_us_only(snap_row["json"], us_tickers)
+    snapshot_date = snap_row["snapshot_date"]
+    universe_tickers = {
+        str(t.get("ticker") or "").upper()
+        for t in (snapshot_json.get("tickers") or [])
+        if t.get("ticker")
+    }
+    if not universe_tickers:
+        result.errors.append("compact snapshot has no US-listed tickers")
+        return result
+
+    portfolio = ctx.get_book()
+    portfolio_summary = {
+        "cash_usd": round(float(portfolio["cash_usd"]), 2),
+        "total_value_usd": round(float(portfolio["total_value_usd"]), 2),
+        "holdings": [
+            {"ticker": h["ticker"], "quantity": float(h["quantity"])}
+            for h in portfolio["holdings"]
+        ],
+    }
+
+    watchlist_size = int(params["watchlist_size"])
+    notes: dict[str, Any] = {
+        "snapshot_date": snapshot_date,
+        "provider": provider,
+        "model": model,
+        "watchlist_size": watchlist_size,
+        "has_mandate": bool(ctx.mandate),
+    }
+
+    # Call the LLM via the same reusable shortlist helper llm_pick stage 1
+    # uses — validates each ticker against the universe, dedupes, caps.
+    try:
+        raw_text, shortlist, dropped, usage, retry_text = pick_shortlist_via_llm(
+            provider=provider,
+            model=model,
+            snapshot=snapshot_json,
+            snapshot_date=snapshot_date,
+            portfolio=portfolio_summary,
+            universe_tickers=universe_tickers,
+            system_prompt=WATCHLIST_CURATOR_SYSTEM_PROMPT,
+            user_template=WATCHLIST_CURATOR_USER_TEMPLATE,
+            shortlist_max=watchlist_size,
+            max_tokens=int(params["max_tokens"]),
+            temperature=float(params["temperature"]),
+            mandate_block=_mandate_block(ctx.mandate),
+        )
+    except LLMProviderError as exc:
+        result.errors.append(f"curator LLM call failed: {exc}")
+        notes["llm_error"] = str(exc)
+        result.notes = notes
+        return result
+    except Exception as exc:  # noqa: BLE001 — never crash the heartbeat
+        result.errors.append(f"curator unexpected error: {exc}")
+        notes["error"] = str(exc)
+        result.notes = notes
+        return result
+
+    notes["shortlist"] = shortlist
+    notes["shortlist_count"] = len(shortlist)
+    notes["dropped_invalid_tickers"] = dropped
+    notes["raw_response"] = raw_text[:8000]
+    notes["raw_response_retry"] = retry_text[:8000] if retry_text else None
+    notes["input_tokens"] = usage[0]
+    notes["output_tokens"] = usage[1]
+
+    if not shortlist:
+        result.errors.append("curator LLM returned an empty shortlist")
+        result.notes = notes
+        return result
+
+    # Defence-in-depth: pick_shortlist_via_llm already filters to the
+    # snapshot's universe, but re-confirm each ticker exists in companies
+    # (the snapshot could lag a freshly-delisted name).
+    valid_tickers = ctx.db.get_all_tickers()
+    items = [
+        {"ticker": p["ticker"], "rationale": p.get("rationale") or ""}
+        for p in shortlist
+        if p["ticker"] in valid_tickers
+    ]
+    missing = [p["ticker"] for p in shortlist if p["ticker"] not in valid_tickers]
+    if missing:
+        notes["dropped_not_in_companies"] = missing
+    if not items:
+        result.errors.append("curator shortlist had no tickers in `companies`")
+        result.notes = notes
+        return result
+
+    if ctx.dry_run:
+        notes["dry_run_plan"] = {
+            "would_write": items,
+            "count": len(items),
+        }
+        logger.info(
+            "[dry-run] %s: curated %d watchlist tickers (%s)",
+            handle, len(items), provider,
+        )
+        result.notes = notes
+        return result
+
+    # Replace the portfolio's agent-sourced watchlist rows. The owner's
+    # manual source='user' rows are never touched.
+    try:
+        ctx.db.replace_agent_watchlist(ctx.portfolio_id, ctx.agent["id"], items)
+    except Exception as exc:  # noqa: BLE001 — never crash the heartbeat
+        result.errors.append(f"watchlist write failed: {exc}")
+        result.notes = notes
+        return result
+
+    notes["watchlist_written"] = len(items)
+    logger.info("%s: wrote %d watchlist tickers", handle, len(items))
+    result.notes = notes
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Strategy: watchlist_buyer
+# ---------------------------------------------------------------------------
+#
+# The buyer half of the pipeline. Closely modelled on rebalance_dual_positive
+# — equal-weight, diff vs book, sells-before-buys, dry-run plan, idempotent —
+# but the candidate set is the portfolio's watchlist (all rows, source
+# 'agent' AND 'user') rather than the dual-positive screen. Each buy passes a
+# thesis kwarg so an investment thesis is recorded.
+
+
+WATCHLIST_BUYER_DEFAULTS = {
+    "cash_reserve_pct": 0.02,  # keep 2% cash to absorb rounding / price drift
+    "min_trade_usd": 500.0,    # ignore rebalance deltas below this notional
+}
+
+
+def _format_watchlist_sell_note(ticker: str) -> str:
+    return f"Sold {ticker} — no longer on the portfolio watchlist."
+
+
+def _format_watchlist_buy_note(ticker: str, rationale: str | None) -> str:
+    if rationale:
+        return f"Bought {ticker} — watchlist pick: {rationale}"
+    return f"Bought {ticker} — equal-weight watchlist pick."
+
+
+def rebalance_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
+    """Equal-weight the portfolio's watchlist and trade towards it.
+
+    Candidate set is every ``portfolio_watchlist`` row for the portfolio —
+    both the owner's manual ``source='user'`` picks and the curator's
+    ``source='agent'`` picks. Algorithm mirrors ``rebalance_dual_positive``:
+
+        1. Read the watchlist; price every ticker, drop the unpriced.
+        2. Equal-weight: per-target = total * (1 - cash_reserve) / N.
+        3. Sell holdings no longer on the watchlist (and trim overweights).
+        4. Buy watchlist tickers up to their target qty.
+
+    Sells run before buys so cash is freed for rotations. Trades below
+    ``min_trade_usd`` are skipped as noise, which keeps a back-to-back rerun
+    on an unchanged watchlist a no-op modulo price drift. Each buy passes a
+    ``thesis`` kwarg so an ``investment_theses`` row is recorded — using the
+    watchlist row's ``rationale`` as the thesis text when present.
+    """
+    result = RebalanceResult()
+    params = {**WATCHLIST_BUYER_DEFAULTS, **(ctx.params or {})}
+    handle = ctx.agent.get("handle", ctx.agent["id"][:8])
+
+    if not ctx.portfolio_id:
+        result.notes["reason"] = "watchlist_buyer only runs on a human portfolio"
+        return result
+
+    watchlist = ctx.db.get_portfolio_watchlist(ctx.portfolio_id)
+    # Dedupe by ticker (a ticker could in principle appear once per source);
+    # the (portfolio_id, ticker) PK makes that impossible today, but keep the
+    # buyer robust. Prefer a row that carries a rationale.
+    rationale_for: dict[str, str | None] = {}
+    for row in watchlist:
+        ticker = str(row.get("ticker") or "").strip().upper()
+        if not ticker:
+            continue
+        rationale = (row.get("rationale") or "").strip() or None
+        if ticker not in rationale_for or (
+            rationale and not rationale_for.get(ticker)
+        ):
+            rationale_for[ticker] = rationale
+    watchlist_tickers = list(rationale_for.keys())
+
+    if not watchlist_tickers:
+        result.notes["reason"] = "portfolio watchlist is empty"
+        return result
+
+    # Price every candidate; skip unpriced ones rather than aborting.
+    priced: list[tuple[str, float]] = []
+    unpriced: list[str] = []
+    for ticker in watchlist_tickers:
+        try:
+            price = ctx.pm.get_price(ticker)
+        except PortfolioError:
+            unpriced.append(ticker)
+            continue
+        priced.append((ticker, price))
+    if unpriced:
+        result.notes["unpriced"] = unpriced
+    if not priced:
+        result.notes["reason"] = "no priced watchlist tickers"
+        return result
+
+    target_tickers = {t for t, _ in priced}
+    price_map = dict(priced)
+
+    portfolio = ctx.get_book()
+    total_value = portfolio["total_value_usd"]
+    if total_value <= 0:
+        result.errors.append(f"total_value_usd <= 0 for {handle}")
+        return result
+
+    cash_reserve = float(params["cash_reserve_pct"])
+    investable = total_value * (1.0 - cash_reserve)
+    per_target_usd = investable / len(priced)
+    min_trade = float(params["min_trade_usd"])
+
+    desired_qty: dict[str, int] = {
+        t: int(math.floor(per_target_usd / p)) for t, p in priced
+    }
+    current_qty: dict[str, float] = {
+        h["ticker"]: float(h["quantity"]) for h in portfolio["holdings"]
+    }
+
+    # --- Phase 1: sell positions no longer on the watchlist, trim overshoots.
+    sells: list[tuple[str, float, bool]] = []  # (ticker, qty, off_watchlist)
+    buys: list[tuple[str, int]] = []
+
+    for ticker, held in current_qty.items():
+        want = desired_qty.get(ticker, 0) if ticker in target_tickers else 0
+        delta = held - want  # positive → need to sell
+        if delta <= 0:
+            continue
+        px = price_map.get(ticker)
+        if px is None:
+            try:
+                px = ctx.pm.get_price(ticker)
+            except PortfolioError:
+                result.notes.setdefault("unpriced_holdings", []).append(ticker)
+                continue
+        # Skip noise trims within a still-targeted position; an off-watchlist
+        # exit always sells in full regardless of notional.
+        if ticker in target_tickers and delta * px < min_trade:
+            continue
+        sells.append((ticker, delta, ticker not in target_tickers))
+
+    for ticker, price in priced:
+        held = current_qty.get(ticker, 0.0)
+        delta = desired_qty[ticker] - held
+        if delta <= 0:
+            continue
+        if delta * price < min_trade:
+            continue
+        buys.append((ticker, int(delta)))
+
+    # --- Dry-run: serialise the plan and return.
+    if ctx.dry_run:
+        result.notes["dry_run_plan"] = {
+            "sells": [
+                {"ticker": t, "qty": q, "off_watchlist": off}
+                for (t, q, off) in sells
+            ],
+            "buys": [
+                {"ticker": t, "qty": q, "rationale": rationale_for.get(t)}
+                for (t, q) in buys
+            ],
+            "targets": len(priced),
+            "per_target_usd": round(per_target_usd, 2),
+            "total_value_usd": total_value,
+        }
+        logger.info(
+            "[dry-run] %s: %d sells, %d buys, watchlist=%d, total=$%.2f",
+            handle, len(sells), len(buys), len(priced), total_value,
+        )
+        return result
+
+    # --- Live: execute sells first, then buys.
+    for ticker, qty, _off in sells:
+        try:
+            ctx.sell(ticker, qty, note=_format_watchlist_sell_note(ticker))
+            result.sells += 1
+        except PortfolioError as exc:
+            result.errors.append(f"sell {ticker} x{qty}: {exc}")
+
+    for ticker, qty in buys:
+        rationale = rationale_for.get(ticker)
+        note = _format_watchlist_buy_note(ticker, rationale)
+        # Pass a thesis so an investment_theses row is recorded on the buy.
+        # The watchlist rationale becomes the thesis text when present;
+        # otherwise the buy is snapshot-only (source='auto').
+        thesis = {"thesis_text": rationale} if rationale else None
+        try:
+            ctx.buy(ticker, qty, note=note, thesis=thesis)
+            result.buys += 1
+        except PortfolioError as exc:
+            # Cash drift between plan and execution is the usual failure
+            # mode — a partial rebalance beats aborting.
+            result.errors.append(f"buy {ticker} x{qty}: {exc}")
+
+    result.notes["targets"] = len(priced)
+    result.notes["per_target_usd"] = round(per_target_usd, 2)
+    result.notes["total_value_usd"] = total_value
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 
@@ -821,7 +1247,36 @@ STRATEGIES: dict[str, Strategy] = {
     "momentum": rebalance_momentum,
     "llm_pick": _llm_pick_lazy,
     "trading_agents": _trading_agents_lazy,
+    "watchlist_curator": rebalance_watchlist_curator,
+    "watchlist_buyer": rebalance_watchlist_buyer,
 }
+
+
+# ---------------------------------------------------------------------------
+# Strategy phases — curate-before-trade ordering
+# ---------------------------------------------------------------------------
+#
+# A strategy is either a 'curate' strategy (it produces inputs other
+# strategies consume — today only watchlist_curator, which refreshes the
+# portfolio_watchlist) or a 'trade' strategy (the default — it places
+# trades). agent_heartbeat._run_portfolio runs all curate-phase members of
+# a portfolio before any trade-phase member, so the curator's fresh
+# shortlist is visible to the watchlist_buyer in the same heartbeat.
+
+DEFAULT_STRATEGY_PHASE = "trade"
+
+STRATEGY_PHASES: dict[str, str] = {
+    "watchlist_curator": "curate",
+}
+
+
+def strategy_phase(name: str | None) -> str:
+    """Return the phase ('curate' | 'trade') for a strategy name.
+
+    Anything not explicitly listed in ``STRATEGY_PHASES`` — including
+    ``None`` and unknown names — defaults to ``'trade'``.
+    """
+    return STRATEGY_PHASES.get(name or "", DEFAULT_STRATEGY_PHASE)
 
 
 def get_strategy(name: str) -> Strategy | None:

--- a/db.py
+++ b/db.py
@@ -282,6 +282,10 @@ class SupabaseDB:
                     "agent": agent.data[0],
                     "notes": m.get("notes"),
                     "joined_at": m.get("joined_at"),
+                    # Per-membership heartbeat clock (migration 029) — each
+                    # member rebalances on its own cadence in every
+                    # portfolio it joins.
+                    "member_last_heartbeat_at": m.get("last_heartbeat_at"),
                 })
         return out
 
@@ -344,6 +348,23 @@ class SupabaseDB:
             self.client.table("portfolios")
             .update({"last_heartbeat_at": ts})
             .eq("id", portfolio_id)
+            .execute()
+        )
+
+    def update_portfolio_member_heartbeat(
+        self, portfolio_id: str, agent_id: str, ts: str
+    ) -> None:
+        """Stamp a portfolio_agents membership's last_heartbeat_at (migration 029).
+
+        Tracks per-(portfolio, agent) cadence so a member rebalances on its
+        own heartbeat_interval_hours independently in every portfolio it
+        joins — a daily curator and a weekly buyer can share one portfolio.
+        """
+        (
+            self.client.table("portfolio_agents")
+            .update({"last_heartbeat_at": ts})
+            .eq("portfolio_id", portfolio_id)
+            .eq("agent_id", agent_id)
             .execute()
         )
 
@@ -615,18 +636,22 @@ class SupabaseDB:
         agent_id: str,
         items: list[dict],
     ) -> None:
-        """Replace the agent-sourced watchlist rows for a portfolio.
+        """Replace one curator's watchlist picks for a portfolio.
 
-        Deletes every existing ``source='agent'`` row for the portfolio,
-        then inserts ``items`` (each ``{ticker, rationale}``) as fresh
-        ``source='agent'`` rows attributed to ``agent_id``. The owner's
-        manual ``source='user'`` rows are never touched.
+        Deletes the rows this ``agent_id`` previously contributed
+        (``source='agent'`` AND ``added_by_agent_id=agent_id``), then
+        inserts ``items`` (each ``{ticker, rationale}``) as fresh
+        ``source='agent'`` rows attributed to ``agent_id``. Other curators'
+        picks and the owner's manual ``source='user'`` rows are never
+        touched — so several specialist curators can each maintain their
+        own slice of the same portfolio's watchlist.
         """
         (
             self.client.table("portfolio_watchlist")
             .delete()
             .eq("portfolio_id", portfolio_id)
             .eq("source", "agent")
+            .eq("added_by_agent_id", agent_id)
             .execute()
         )
         rows = [

--- a/db.py
+++ b/db.py
@@ -594,6 +594,58 @@ class SupabaseDB:
         self.client.table("agent_heartbeats").insert(data).execute()
 
     # ------------------------------------------------------------------
+    # Portfolio watchlist (migration 027) — curated per-portfolio shortlist.
+    # The owner writes source='user' rows; the watchlist_curator strategy
+    # writes source='agent' rows; the watchlist_buyer strategy reads both.
+    # ------------------------------------------------------------------
+
+    def get_portfolio_watchlist(self, portfolio_id: str) -> list[dict]:
+        """Return every portfolio_watchlist row for a portfolio."""
+        resp = (
+            self.client.table("portfolio_watchlist")
+            .select("*")
+            .eq("portfolio_id", portfolio_id)
+            .execute()
+        )
+        return resp.data or []
+
+    def replace_agent_watchlist(
+        self,
+        portfolio_id: str,
+        agent_id: str,
+        items: list[dict],
+    ) -> None:
+        """Replace the agent-sourced watchlist rows for a portfolio.
+
+        Deletes every existing ``source='agent'`` row for the portfolio,
+        then inserts ``items`` (each ``{ticker, rationale}``) as fresh
+        ``source='agent'`` rows attributed to ``agent_id``. The owner's
+        manual ``source='user'`` rows are never touched.
+        """
+        (
+            self.client.table("portfolio_watchlist")
+            .delete()
+            .eq("portfolio_id", portfolio_id)
+            .eq("source", "agent")
+            .execute()
+        )
+        rows = [
+            {
+                "portfolio_id": portfolio_id,
+                "ticker": it["ticker"],
+                "source": "agent",
+                "added_by_agent_id": agent_id,
+                "rationale": it.get("rationale"),
+            }
+            for it in items
+            if it.get("ticker")
+        ]
+        if rows:
+            for r in rows:
+                self._sanitize(r)
+            self.client.table("portfolio_watchlist").insert(rows).execute()
+
+    # ------------------------------------------------------------------
     # Run Logs
     # ------------------------------------------------------------------
 

--- a/migrations/028_pipeline_house_agents.sql
+++ b/migrations/028_pipeline_house_agents.sql
@@ -11,10 +11,11 @@
 --     Reads the portfolio's watchlist, equal-weights it, and places paper
 --     trades, recording an investment thesis on each buy.
 --
--- The heartbeat runs curate-phase strategies before trade-phase ones
--- (see agent_strategies.STRATEGY_PHASES), so within a single human
--- portfolio the curator refreshes the shortlist and the buyer trades from
--- the fresh list in the same heartbeat.
+-- Each member rebalances on its own cadence (agents.heartbeat_interval_hours
+-- + migration 029's per-membership clock): the curator runs daily (24h),
+-- the buyer weekly (168h). On a day both are due the heartbeat runs the
+-- curate-phase member before the trade-phase one (see
+-- agent_strategies.STRATEGY_PHASES) so the buyer sees the fresh shortlist.
 --
 -- Like every other agent, each gets a 1:1 portfolios row (id == agent id),
 -- a portfolio_agents self-membership, and an agent_accounts row — exactly
@@ -35,14 +36,14 @@
 
 INSERT INTO agents (
     handle, display_name, description, long_description,
-    is_house_agent, available_for_hire, strategy, config,
-    api_key_hash, api_key_prefix
+    is_house_agent, available_for_hire, strategy, heartbeat_interval_hours,
+    config, api_key_hash, api_key_prefix
 )
 VALUES
     (
         'shortlist-builder',
         'Shortlist Builder',
-        'Curator agent. Screens the daily equity universe against a portfolio''s mandate and writes a ~20-name shortlist into the portfolio watchlist for a buyer agent to trade from. Brain: claude-opus-4-7 (anthropic).',
+        'Curator agent. Screens the daily equity universe against a portfolio''s mandate and writes a ~20-name shortlist into the portfolio watchlist for a buyer agent to trade from. Runs daily. Brain: gemini-2.5-flash (google).',
         $md$# Strategy: watchlist_curator
 
 The curator half of the two-agent pipeline for human-owned portfolios.
@@ -52,11 +53,11 @@ prompt from that snapshot plus the portfolio's free-text **mandate**, and
 asks the model for ~15-25 tickers with a one-line rationale each. Every
 ticker is validated against the `companies` universe.
 
-The result fully replaces the portfolio's `source='agent'` watchlist rows
-(the owner's manual `source='user'` picks are never touched). A buyer agent
-(`watchlist_buyer`) then trades from that shortlist later in the same
-heartbeat — the heartbeat runs curate-phase strategies before trade-phase
-ones.
+It refreshes only its own `source='agent'` watchlist rows — other curators'
+picks and the owner's manual `source='user'` picks are never touched. A
+buyer agent (`watchlist_buyer`) trades from the shortlist on its own
+(weekly) cadence; the heartbeat orders curate-phase members before
+trade-phase ones so the buyer always sees the freshest list.
 
 Only meaningful for shared human portfolios; on a legacy 1:1 agent
 portfolio it is a no-op.
@@ -65,7 +66,8 @@ portfolio it is a no-op.
         TRUE,
         TRUE,
         'watchlist_curator',
-        '{"provider": "anthropic", "model": "claude-opus-4-7", "watchlist_size": 20}'::jsonb,
+        24,
+        '{"provider": "google", "model": "gemini-2.5-flash", "watchlist_size": 20}'::jsonb,
         'house-agent',
         'ak_house_sb'
     ),
@@ -95,6 +97,7 @@ portfolio, or with an empty watchlist, it is a no-op.
         TRUE,
         TRUE,
         'watchlist_buyer',
+        168,
         '{}'::jsonb,
         'house-agent',
         'ak_house_ba'

--- a/migrations/028_pipeline_house_agents.sql
+++ b/migrations/028_pipeline_house_agents.sql
@@ -1,0 +1,138 @@
+-- Migration 028: Two-agent pipeline house agents.
+--
+-- Adds the two house agents that drive the curator -> buyer pipeline for
+-- human-owned portfolios:
+--
+--   * shortlist-builder (strategy 'watchlist_curator') — a mandate-aware
+--     LLM curator. Screens the daily universe snapshot against the
+--     portfolio's mandate and writes a ~20-name shortlist into
+--     portfolio_watchlist (source='agent').
+--   * buying-agent (strategy 'watchlist_buyer') — a mechanical buyer.
+--     Reads the portfolio's watchlist, equal-weights it, and places paper
+--     trades, recording an investment thesis on each buy.
+--
+-- The heartbeat runs curate-phase strategies before trade-phase ones
+-- (see agent_strategies.STRATEGY_PHASES), so within a single human
+-- portfolio the curator refreshes the shortlist and the buyer trades from
+-- the fresh list in the same heartbeat.
+--
+-- Like every other agent, each gets a 1:1 portfolios row (id == agent id),
+-- a portfolio_agents self-membership, and an agent_accounts row — exactly
+-- the way migration 021 backfilled the existing agents. Those legacy 1:1
+-- portfolios are never traded by these strategies (both are no-ops without
+-- a shared human portfolio_id); they exist purely so the agents are fully
+-- consistent with the rest of the agents table and render on the arena.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+-- ============================================================
+-- 1. agents — the two house agents
+-- ============================================================
+-- api_key_hash = 'house-agent' sentinel (house agents can't authenticate
+-- writes), with a placeholder api_key_prefix for the profile page.
+-- shortlist-builder carries an LLM config bag mirroring llm_pick's
+-- provider/model handling — the curator reads agents.config for these.
+
+INSERT INTO agents (
+    handle, display_name, description, long_description,
+    is_house_agent, available_for_hire, strategy, config,
+    api_key_hash, api_key_prefix
+)
+VALUES
+    (
+        'shortlist-builder',
+        'Shortlist Builder',
+        'Curator agent. Screens the daily equity universe against a portfolio''s mandate and writes a ~20-name shortlist into the portfolio watchlist for a buyer agent to trade from. Brain: claude-opus-4-7 (anthropic).',
+        $md$# Strategy: watchlist_curator
+
+The curator half of the two-agent pipeline for human-owned portfolios.
+
+Each heartbeat it loads the daily compact universe snapshot, builds an LLM
+prompt from that snapshot plus the portfolio's free-text **mandate**, and
+asks the model for ~15-25 tickers with a one-line rationale each. Every
+ticker is validated against the `companies` universe.
+
+The result fully replaces the portfolio's `source='agent'` watchlist rows
+(the owner's manual `source='user'` picks are never touched). A buyer agent
+(`watchlist_buyer`) then trades from that shortlist later in the same
+heartbeat — the heartbeat runs curate-phase strategies before trade-phase
+ones.
+
+Only meaningful for shared human portfolios; on a legacy 1:1 agent
+portfolio it is a no-op.
+
+**Source code:** `agent_strategies.rebalance_watchlist_curator`.$md$,
+        TRUE,
+        TRUE,
+        'watchlist_curator',
+        '{"provider": "anthropic", "model": "claude-opus-4-7", "watchlist_size": 20}'::jsonb,
+        'house-agent',
+        'ak_house_sb'
+    ),
+    (
+        'buying-agent',
+        'Buying Agent',
+        'Buyer agent. Reads a portfolio''s watchlist, equal-weights the candidates with a small cash reserve, and places paper trades — recording an investment thesis on each buy.',
+        $md$# Strategy: watchlist_buyer
+
+The buyer half of the two-agent pipeline for human-owned portfolios.
+
+Each heartbeat it reads the portfolio's watchlist (both the owner's manual
+`source='user'` picks and the curator's `source='agent'` picks), prices the
+candidates, equal-weights them with a small cash reserve, and diffs against
+the shared portfolio book. Holdings no longer on the watchlist are sold
+first to free cash, then watchlist tickers are bought to their target
+weight. Trades smaller than a noise floor are skipped, so running it twice
+back-to-back on an unchanged watchlist is a no-op modulo price drift.
+
+On every buy it records an investment thesis, using the watchlist row's
+rationale as the thesis text when present.
+
+Only meaningful for shared human portfolios; on a legacy 1:1 agent
+portfolio, or with an empty watchlist, it is a no-op.
+
+**Source code:** `agent_strategies.rebalance_watchlist_buyer`.$md$,
+        TRUE,
+        TRUE,
+        'watchlist_buyer',
+        '{}'::jsonb,
+        'house-agent',
+        'ak_house_ba'
+    )
+ON CONFLICT (handle) DO NOTHING;
+
+
+-- ============================================================
+-- 2. portfolios — 1:1 portfolio row per new house agent
+-- ============================================================
+-- Mirrors migration 021's backfill: portfolios.id == agent_id, slug ==
+-- handle. Idempotent on the id.
+
+INSERT INTO portfolios (id, slug, display_name, description, owner_agent_id, created_at)
+SELECT a.id, a.handle, a.display_name, a.description, a.id, NOW()
+  FROM agents a
+ WHERE a.handle IN ('shortlist-builder', 'buying-agent')
+  ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================
+-- 3. portfolio_agents — self-membership
+-- ============================================================
+
+INSERT INTO portfolio_agents (portfolio_id, agent_id, joined_at)
+SELECT p.id, p.owner_agent_id, p.created_at
+  FROM portfolios p
+ WHERE p.slug IN ('shortlist-builder', 'buying-agent')
+  ON CONFLICT (portfolio_id, agent_id) DO NOTHING;
+
+
+-- ============================================================
+-- 4. agent_accounts — $1M starting cash
+-- ============================================================
+-- portfolio_id == agent_id during the 1:1 shim (migration 021).
+
+INSERT INTO agent_accounts (agent_id, portfolio_id, starting_cash, cash_usd)
+SELECT a.id, a.id, 1000000.00, 1000000.00
+  FROM agents a
+ WHERE a.handle IN ('shortlist-builder', 'buying-agent')
+  ON CONFLICT (agent_id) DO NOTHING;

--- a/migrations/029_portfolio_member_cadence.sql
+++ b/migrations/029_portfolio_member_cadence.sql
@@ -1,0 +1,22 @@
+-- Migration 029: Per-membership heartbeat cadence.
+--
+-- A human portfolio's member agents each rebalance on their OWN cadence
+-- (agents.heartbeat_interval_hours) rather than all together on the
+-- portfolio's clock — e.g. a daily shortlist curator alongside a weekly
+-- buyer in the same portfolio.
+--
+-- Because one agent (notably the house shortlist-builder / buying-agent,
+-- and any available-for-hire community agent) can be a member of many
+-- portfolios, the "last run" timestamp must be tracked per
+-- (portfolio, agent) membership, not on the shared agents row — otherwise
+-- running an agent for one portfolio would mark it not-due for the rest.
+--
+-- This adds that column. agent_heartbeat.py gates each member on
+-- portfolio_agents.last_heartbeat_at + agents.heartbeat_interval_hours,
+-- and the heartbeat workflow now runs daily so daily-cadence members
+-- actually get a daily run.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+ALTER TABLE portfolio_agents
+    ADD COLUMN IF NOT EXISTS last_heartbeat_at TIMESTAMPTZ;


### PR DESCRIPTION
## Summary

Phase 1 of the agent-pipeline work — the backend for a **two-agent pipeline** on human-owned portfolios. A *curator* agent screens the universe against the portfolio mandate and writes a shortlist into `portfolio_watchlist`; a *buyer* agent trades from that shortlist. This is what makes the ChatGPT `/account` mock real; the `/account` redesign itself is Phase 2.

## Changes

### New strategies (`agent_strategies.py`)
- **`watchlist_curator`** — mandate-aware LLM curator. Loads the daily compact universe snapshot, prompts an LLM with snapshot + the portfolio's mandate (reusing `llm_picker`'s `pick_shortlist_via_llm` helper, snapshot loader, and provider/model handling), validates tickers against `companies`, and **replaces only the portfolio's `source='agent'` watchlist rows** — the owner's manual `source='user'` picks are never touched. Fully defensive: a missing snapshot, LLM/provider error, or parse failure is captured into the result, never raised, so the heartbeat can't crash.
- **`watchlist_buyer`** — mechanical buyer modelled on `dual_positive`. Equal-weights the *whole* watchlist (agent + user rows) with a 2% cash reserve, diffs against the shared book, sells off-watchlist holdings before buying, and passes a `thesis` kwarg on each buy so an `investment_theses` row is recorded.

### Strategy phases
`STRATEGY_PHASES` / `strategy_phase()` mark `watchlist_curator` as `'curate'` (everything else defaults `'trade'`). `agent_heartbeat.py` now runs a portfolio's curate-phase members before trade-phase ones (stable sort preserves `joined_at` within a phase), so the curator's fresh shortlist is visible to the buyer in the same heartbeat. The legacy agent pass skips both pipeline strategies.

### `db.py`
`get_portfolio_watchlist()` + `replace_agent_watchlist()`.

### Migration 028
Seeds two house agents — `shortlist-builder` (`watchlist_curator`) and `buying-agent` (`watchlist_buyer`) — each with a 1:1 portfolio/account exactly as migration 021 backfilled all agents. Idempotent.

## Verification

- [x] `python -c "import agent_strategies, agent_heartbeat, db"` — clean
- [x] `py_compile` clean; both strategies registered, phases correct
- [x] `pick_shortlist_via_llm` call signature, the `llm_picker` helpers, `db.get_all_tickers`, and `agent_accounts.portfolio_id` all verified against source
- [x] Confirmed the heartbeat workflow supplies `ANTHROPIC_API_KEY` (the curator house agent's configured provider)
- [ ] End-to-end heartbeat run — needs Supabase + an LLM key; not runnable in this environment

## Notes

- Migration 028 must be applied to Supabase before the pipeline runs.
- The `shortlist-builder` house agent is configured for `anthropic` / `claude-opus-4-7`; that's a per-agent `config` row and easy to retune (e.g. to a cheaper model) without code changes.
- Phase 2 = the `/account` redesign onto this backend.

https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4)_