### PR TITLE
Redesign /account as a guided pipeline setup

### DIFF
--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import Nav from "@/components/nav";
@@ -6,8 +7,12 @@ import { createSupabaseServerClient } from "@/lib/supabase/server";
 import {
   getPortfolioForUser,
   getMembersForPortfolio,
+  type Portfolio,
+  type PortfolioMember,
 } from "@/lib/portfolios-query";
-import { listPublicAgents } from "@/lib/agents-query";
+import { listPublicAgents, getAgentReturns30d } from "@/lib/agents-query";
+import { getWatchlistForPortfolio, type WatchlistItem } from "@/lib/watchlist-query";
+import { roleFor } from "@/lib/agent-roles";
 import CreatePortfolioForm from "@/components/portfolio/create-portfolio-form";
 import PortfolioDetailsEditor from "@/components/portfolio/portfolio-details-editor";
 import VisibilityToggle from "@/components/portfolio/visibility-toggle";
@@ -21,9 +26,6 @@ export const metadata: Metadata = {
 
 export const dynamic = "force-dynamic";
 
-const SECTION_HEADING =
-  "font-mono text-sm font-bold text-text-dim uppercase tracking-widest mb-3";
-
 export default async function AccountPage() {
   const supabase = await createSupabaseServerClient();
   const {
@@ -35,123 +37,587 @@ export default async function AccountPage() {
   }
 
   // RLS scopes this to the signed-in user's own row.
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("email, display_name")
-    .eq("id", user.id)
-    .maybeSingle();
+  let profile: { email: string | null; display_name: string | null } | null =
+    null;
+  try {
+    const { data } = await supabase
+      .from("profiles")
+      .select("email, display_name")
+      .eq("id", user.id)
+      .maybeSingle();
+    profile = data ?? null;
+  } catch {
+    profile = null;
+  }
 
   const email = profile?.email ?? user.email ?? "";
   const displayName = profile?.display_name || email.split("@")[0] || "there";
 
-  const portfolio = await getPortfolioForUser(user.id);
-  const members = portfolio
-    ? await getMembersForPortfolio(portfolio.id)
-    : [];
-  // Only agents whose owner has opted in (available_for_hire) are addable.
-  const allAgents = portfolio ? await listPublicAgents(1000, true) : [];
+  // Defensive fetches — the page degrades gracefully if Supabase is
+  // unreachable (e.g. placeholder env at build time).
+  let portfolio: Portfolio | null = null;
+  try {
+    portfolio = await getPortfolioForUser(user.id);
+  } catch {
+    portfolio = null;
+  }
+
+  let members: PortfolioMember[] = [];
+  let allAgents: Awaited<ReturnType<typeof listPublicAgents>> = [];
+  let returns30d = new Map<string, number | null>();
+  let watchlist: WatchlistItem[] = [];
+  if (portfolio) {
+    try {
+      members = await getMembersForPortfolio(portfolio.id);
+    } catch {
+      members = [];
+    }
+    try {
+      // Only agents whose owner has opted in (available_for_hire) are addable.
+      allAgents = await listPublicAgents(1000, true);
+    } catch {
+      allAgents = [];
+    }
+    try {
+      returns30d = await getAgentReturns30d();
+    } catch {
+      returns30d = new Map();
+    }
+    try {
+      watchlist = await getWatchlistForPortfolio(portfolio.id);
+    } catch {
+      watchlist = [];
+    }
+  }
 
   return (
     <>
       <Nav />
-      <main className="flex-1 max-w-[760px] mx-auto w-full px-4 py-10 font-sans">
-        <header className="mb-8">
-          <p className="text-xs font-mono uppercase tracking-widest text-text-muted mb-2">
-            Account
-          </p>
-          <h1 className="font-mono text-3xl font-bold text-green mb-3">
-            Welcome, {displayName}
-          </h1>
-          <p className="text-text-dim leading-relaxed">
-            You&apos;re signed in as{" "}
-            <span className="text-text font-mono">{email}</span>.
-          </p>
-        </header>
-
-        {portfolio ? (
-          <div className="space-y-8">
-            <LaunchControl
-              launchedAt={portfolio.launched_at}
-              memberCount={members.length}
+      <main className="flex-1 w-full">
+        <div className="max-w-[1180px] mx-auto w-full px-4 sm:px-6 py-8 sm:py-12">
+          {portfolio ? (
+            <PortfolioView
+              portfolio={portfolio}
+              members={members}
+              allAgents={allAgents}
+              returns30d={returns30d}
+              watchlist={watchlist}
+              email={email}
             />
-
-            <section>
-              <h2 className={SECTION_HEADING}>Portfolio</h2>
-              <PortfolioDetailsEditor
-                initialName={portfolio.display_name}
-                initialMandate={portfolio.description ?? ""}
-              />
-            </section>
-
-            <section>
-              <h2 className={SECTION_HEADING}>Agents</h2>
-              <p className="text-[11px] font-mono text-text-muted mb-3 -mt-1">
-                The agents that will operate this portfolio, working to your
-                mandate.
-              </p>
-              <AgentPicker
-                members={members.map((m) => ({
-                  handle: m.handle,
-                  display_name: m.display_name,
-                  is_house_agent: m.is_house_agent,
-                }))}
-                allAgents={allAgents.map((a) => ({
-                  handle: a.handle,
-                  display_name: a.display_name,
-                  is_house_agent: a.is_house_agent,
-                }))}
-              />
-            </section>
-
-            <section>
-              <h2 className={SECTION_HEADING}>Watchlist</h2>
-              <p className="text-[11px] font-mono text-text-muted mb-3 -mt-1">
-                A shortlist of equities for the agents on this portfolio to
-                populate and trade from.
-              </p>
-              <Link
-                href="/account/watchlist"
-                className="inline-flex items-center gap-1.5 rounded border border-border bg-bg px-3 py-2 font-mono text-sm text-text hover:border-green/40 hover:text-green transition-colors"
-              >
-                Manage watchlist &rarr;
-              </Link>
-            </section>
-
-            <section>
-              <h2 className={SECTION_HEADING}>Visibility</h2>
-              <VisibilityToggle isPublic={portfolio.is_public} />
-            </section>
-
-            <p className="text-xs font-mono text-text-muted">
-              Public page:{" "}
-              <Link
-                href={`/portfolios/${portfolio.slug}`}
-                className="text-green hover:underline"
-              >
-                /portfolios/{portfolio.slug}
-              </Link>
-            </p>
-          </div>
-        ) : (
-          <section>
-            <h2 className={SECTION_HEADING}>Create your portfolio</h2>
-            <p className="text-sm text-text-dim mb-4 leading-relaxed -mt-1">
-              Give it a name and write the mandate your agents will work to.
-              You can add agents and adjust everything afterwards.
-            </p>
-            <CreatePortfolioForm />
-          </section>
-        )}
-
-        <form action="/auth/signout" method="post" className="mt-10">
-          <button
-            type="submit"
-            className="text-xs font-mono text-text-muted hover:text-text"
-          >
-            Sign out &rarr;
-          </button>
-        </form>
+          ) : (
+            <NoPortfolioView displayName={displayName} email={email} />
+          )}
+        </div>
       </main>
     </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// No portfolio yet — onboarding into CreatePortfolioForm.
+// ---------------------------------------------------------------------------
+
+function NoPortfolioView({
+  displayName,
+  email,
+}: {
+  displayName: string;
+  email: string;
+}) {
+  return (
+    <div className="max-w-[640px] mx-auto">
+      <SectionBadge>Get started</SectionBadge>
+      <h1 className="mt-4 text-[28px] sm:text-[34px] font-bold tracking-[-0.025em] text-text leading-[1.1]">
+        Welcome, {displayName}.
+      </h1>
+      <p className="mt-3 text-base text-text-muted leading-relaxed">
+        Create your portfolio: give it a name and write the mandate your team
+        of AI agents will trade a $1M paper account to. You can add agents and
+        adjust everything before going live.
+      </p>
+      <div className="mt-7 rounded-2xl border border-white/10 bg-white/[0.02] p-5 sm:p-6">
+        <CreatePortfolioForm />
+      </div>
+      <SignOutRow email={email} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Portfolio exists — the two-column guided-setup layout.
+// ---------------------------------------------------------------------------
+
+function PortfolioView({
+  portfolio,
+  members,
+  allAgents,
+  returns30d,
+  watchlist,
+  email,
+}: {
+  portfolio: Portfolio;
+  members: PortfolioMember[];
+  allAgents: Awaited<ReturnType<typeof listPublicAgents>>;
+  returns30d: Map<string, number | null>;
+  watchlist: WatchlistItem[];
+  email: string;
+}) {
+  const live = portfolio.launched_at != null;
+  const phases = members.map((m) => roleFor(m.strategy).phase);
+  const hasCurator = phases.includes("curate");
+  const hasBuyer = phases.includes("trade");
+  const hasMandate = (portfolio.description ?? "").trim().length > 0;
+
+  // 3-step progress: mandate → agents (both roles) → live.
+  const step1 = hasMandate;
+  const step2 = hasCurator && hasBuyer;
+  const step3 = live;
+  const completed = [step1, step2, step3].filter(Boolean).length;
+
+  const pickerMembers = members.map((m) => ({
+    handle: m.handle,
+    display_name: m.display_name,
+    is_house_agent: m.is_house_agent,
+    strategy: m.strategy,
+    return30d: returns30d.get(m.handle) ?? null,
+  }));
+  const pickerAll = allAgents.map((a) => ({
+    handle: a.handle,
+    display_name: a.display_name,
+    is_house_agent: a.is_house_agent,
+    strategy: a.strategy,
+    return30d: returns30d.get(a.handle) ?? null,
+  }));
+
+  return (
+    <div className="grid gap-6 xl:gap-8 xl:grid-cols-[1fr_320px]">
+      {/* ---- Main column ---- */}
+      <div className="space-y-6">
+        {/* Header + progress */}
+        <header>
+          <div className="flex items-center gap-3">
+            <StateBadge live={live} />
+            <span className="text-[11px] font-mono uppercase tracking-widest text-text-muted">
+              {completed} / 3 steps done
+            </span>
+          </div>
+          <h1 className="mt-3 text-[26px] sm:text-[32px] font-bold tracking-[-0.025em] text-text leading-[1.12]">
+            {portfolio.display_name}
+          </h1>
+          <p className="mt-2 text-base text-text-muted leading-relaxed max-w-[60ch]">
+            {live
+              ? "Your team of agents is trading the shared $1M paper book to your mandate. Tune the setup below at any time."
+              : "Set up your portfolio in three steps, then go live to trade a $1M paper account."}
+          </p>
+          <ProgressSteps
+            steps={[
+              { label: "Write mandate", done: step1 },
+              { label: "Add agents", done: step2 },
+              { label: "Go live", done: step3 },
+            ]}
+          />
+        </header>
+
+        {/* 1. Mandate */}
+        <SetupCard
+          step={1}
+          glyph="clipboard"
+          title="Write the mandate"
+          intro="Your investment brief — the agents trade to it. Pick an example to start, then edit and save."
+        >
+          <PortfolioDetailsEditor
+            initialName={portfolio.display_name}
+            initialMandate={portfolio.description ?? ""}
+          />
+        </SetupCard>
+
+        {/* 2. Agents */}
+        <SetupCard
+          step={2}
+          glyph="branch"
+          title="Add your agents"
+          intro="A portfolio needs a Shortlist Builder to curate the watchlist and a Buying Agent to trade it. The 30-day return is each agent's live track record."
+        >
+          <AgentPicker members={pickerMembers} allAgents={pickerAll} />
+        </SetupCard>
+
+        {/* Watchlist preview */}
+        <SetupCard
+          glyph="target"
+          title="Watchlist"
+          intro="The shortlist of equities your agents populate and trade from."
+        >
+          <WatchlistPreview items={watchlist} />
+        </SetupCard>
+
+        {/* 3. Go live */}
+        <SetupCard
+          step={3}
+          glyph="bolt"
+          title={live ? "Live" : "Go live"}
+          intro={
+            live
+              ? "Your portfolio is trading."
+              : "Grant the $1M paper account and start trading."
+          }
+        >
+          <LaunchControl
+            launchedAt={portfolio.launched_at}
+            hasCurator={hasCurator}
+            hasBuyer={hasBuyer}
+          />
+        </SetupCard>
+
+        <SignOutRow email={email} />
+      </div>
+
+      {/* ---- Status rail ---- */}
+      <aside className="space-y-4 xl:sticky xl:top-20 xl:self-start">
+        <RailCard title="Portfolio status">
+          <div className="mb-3">
+            <StateBadge live={live} />
+          </div>
+          <ul className="space-y-2">
+            <ChecklistRow label="Mandate written" done={hasMandate} />
+            <ChecklistRow label="Shortlist Builder added" done={hasCurator} />
+            <ChecklistRow label="Buying Agent added" done={hasBuyer} />
+            <ChecklistRow label="Paper account live" done={live} />
+          </ul>
+        </RailCard>
+
+        <RailCard title="Benchmark goal" accent="cyan">
+          <p className="text-sm font-bold text-text">Beat the S&amp;P 500.</p>
+          <p className="mt-1.5 text-[12px] text-text-muted leading-relaxed">
+            Your portfolio is marked to market every day and charted against
+            the S&amp;P 500 (SPY) and MSCI World (URTH) on the public
+            leaderboard.
+          </p>
+        </RailCard>
+
+        <RailCard title="Visibility">
+          <VisibilityToggle isPublic={portfolio.is_public} />
+          <p className="mt-3 text-[11px] font-mono text-text-muted">
+            Public page:{" "}
+            <Link
+              href={`/portfolios/${portfolio.slug}`}
+              className="text-green hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40 rounded"
+            >
+              /portfolios/{portfolio.slug}
+            </Link>
+          </p>
+        </RailCard>
+      </aside>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Watchlist preview
+// ---------------------------------------------------------------------------
+
+function WatchlistPreview({ items }: { items: WatchlistItem[] }) {
+  const top = items.slice(0, 5);
+  return (
+    <div>
+      {top.length > 0 ? (
+        <ul className="divide-y divide-border rounded-lg border border-white/10 overflow-hidden">
+          {top.map((it) => (
+            <li
+              key={it.ticker}
+              className="flex items-center justify-between gap-3 bg-white/[0.02] px-3 py-2.5"
+            >
+              <div className="min-w-0">
+                <span className="font-mono text-sm font-bold text-text">
+                  {it.ticker}
+                </span>
+                {it.company_name && (
+                  <span className="ml-2 text-[12px] text-text-muted truncate">
+                    {it.company_name}
+                  </span>
+                )}
+              </div>
+              <span
+                className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] font-mono font-bold uppercase tracking-widest border ${
+                  it.source === "agent"
+                    ? "border-cyan/30 bg-cyan/[0.08] text-cyan"
+                    : "border-border bg-bg text-text-muted"
+                }`}
+              >
+                {it.source === "agent" ? "Agent" : "You"}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-text-muted italic">
+          No equities on the watchlist yet.
+        </p>
+      )}
+      <Link
+        href="/account/watchlist"
+        className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-border bg-bg px-3 py-2 font-mono text-sm text-text hover:border-cyan/40 hover:text-cyan focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 transition-colors"
+      >
+        {items.length > top.length
+          ? `Manage all ${items.length} watchlist items →`
+          : "Manage watchlist →"}
+      </Link>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared layout bits — match the homepage's visual language.
+// ---------------------------------------------------------------------------
+
+function StateBadge({ live }: { live: boolean }) {
+  if (live) {
+    return (
+      <span className="inline-flex items-center gap-2 rounded-full border border-green/30 bg-green/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-green">
+        <span
+          aria-hidden
+          className="h-1.5 w-1.5 rounded-full bg-green animate-pulse"
+          style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+        />
+        Live
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full border border-orange/30 bg-orange/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-orange">
+      <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-orange" />
+      Draft — not live yet
+    </span>
+  );
+}
+
+function ProgressSteps({
+  steps,
+}: {
+  steps: { label: string; done: boolean }[];
+}) {
+  return (
+    <ol className="mt-5 grid gap-2.5 sm:grid-cols-3">
+      {steps.map((s, i) => (
+        <li
+          key={s.label}
+          className={`flex items-center gap-2.5 rounded-xl border px-3.5 py-2.5 ${
+            s.done
+              ? "border-green/30 bg-green/[0.05]"
+              : "border-white/10 bg-white/[0.02]"
+          }`}
+        >
+          <span
+            aria-hidden
+            className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold font-mono ${
+              s.done
+                ? "bg-green/20 text-green"
+                : "border border-cyan/30 bg-cyan/[0.08] text-cyan"
+            }`}
+          >
+            {s.done ? "✓" : i + 1}
+          </span>
+          <span
+            className={`text-sm font-semibold ${
+              s.done ? "text-text" : "text-text-dim"
+            }`}
+          >
+            {s.label}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function SetupCard({
+  step,
+  glyph,
+  title,
+  intro,
+  children,
+}: {
+  step?: number;
+  glyph: GlyphName;
+  title: string;
+  intro: string;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      className="rounded-2xl border border-white/10 p-5 sm:p-6"
+      style={{
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+      }}
+    >
+      <div className="flex items-start gap-3 mb-4">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-cyan/25 bg-cyan/[0.07]">
+          <Glyph name={glyph} className="w-[18px] h-[18px] text-cyan" />
+        </span>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            {step != null && (
+              <span className="text-[10px] font-mono font-bold uppercase tracking-widest text-cyan">
+                Step {step}
+              </span>
+            )}
+            <h2 className="text-base sm:text-lg font-bold tracking-[-0.01em] text-text">
+              {title}
+            </h2>
+          </div>
+          <p className="mt-1 text-[13px] text-text-muted leading-relaxed">
+            {intro}
+          </p>
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function RailCard({
+  title,
+  accent,
+  children,
+}: {
+  title: string;
+  accent?: "cyan";
+  children: ReactNode;
+}) {
+  return (
+    <section
+      className="rounded-2xl border p-5"
+      style={
+        accent === "cyan"
+          ? {
+              background:
+                "linear-gradient(135deg, rgba(0,242,255,0.07), rgba(0,255,65,0.03) 48%, rgba(255,255,255,0.02))",
+              borderColor: "rgba(0,242,255,0.2)",
+              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+            }
+          : {
+              background:
+                "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
+              borderColor: "rgba(255,255,255,0.1)",
+              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+            }
+      }
+    >
+      <p className="text-[10px] font-mono font-bold uppercase tracking-[0.16em] text-text-dim mb-3">
+        {title}
+      </p>
+      {children}
+    </section>
+  );
+}
+
+function ChecklistRow({ label, done }: { label: string; done: boolean }) {
+  return (
+    <li className="flex items-center gap-2.5">
+      <span
+        aria-hidden
+        className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[10px] font-bold ${
+          done
+            ? "bg-green/20 text-green"
+            : "border border-text-muted/40 text-transparent"
+        }`}
+      >
+        ✓
+      </span>
+      <span
+        className={`text-[13px] ${done ? "text-text" : "text-text-muted"}`}
+      >
+        {label}
+      </span>
+    </li>
+  );
+}
+
+function SignOutRow({ email }: { email: string }) {
+  return (
+    <form
+      action="/auth/signout"
+      method="post"
+      className="flex items-center justify-between gap-3 pt-2"
+    >
+      <span className="text-[11px] font-mono text-text-muted truncate">
+        Signed in as {email}
+      </span>
+      <button
+        type="submit"
+        className="text-[11px] font-mono text-text-muted hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 rounded px-1"
+      >
+        Sign out →
+      </button>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline icons — matches the homepage's dependency-free SVG glyph style.
+// ---------------------------------------------------------------------------
+
+type GlyphName = "clipboard" | "branch" | "target" | "bolt";
+
+function SectionBadge({ children }: { children: ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full border border-cyan/25 bg-cyan/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-cyan">
+      <span
+        aria-hidden
+        className="h-1.5 w-1.5 rounded-full bg-cyan"
+        style={{ boxShadow: "0 0 6px rgba(0,242,255,0.8)" }}
+      />
+      {children}
+    </span>
+  );
+}
+
+function Glyph({
+  name,
+  className,
+}: {
+  name: GlyphName;
+  className?: string;
+}) {
+  const paths: Record<GlyphName, ReactNode> = {
+    clipboard: (
+      <>
+        <rect x="8" y="2.5" width="8" height="4" rx="1.2" />
+        <path d="M8 4.5H6.2A1.2 1.2 0 0 0 5 5.7v14.6a1.2 1.2 0 0 0 1.2 1.2h11.6a1.2 1.2 0 0 0 1.2-1.2V5.7a1.2 1.2 0 0 0-1.2-1.2H16" />
+        <path d="m8.7 13.2 2.3 2.3 4.3-4.7" />
+      </>
+    ),
+    branch: (
+      <>
+        <circle cx="6.5" cy="6" r="2.6" />
+        <circle cx="6.5" cy="18" r="2.6" />
+        <circle cx="17.5" cy="8" r="2.6" />
+        <path d="M6.5 8.6v6.8" />
+        <path d="M17.5 10.6c0 5-11 1.7-11 5" />
+      </>
+    ),
+    target: (
+      <>
+        <circle cx="12" cy="12" r="8.5" />
+        <circle cx="12" cy="12" r="3.4" />
+        <path d="M12 1.5V5M12 19v3.5M1.5 12H5M19 12h3.5" />
+      </>
+    ),
+    bolt: <path d="M13.5 2 4.5 13.5H11l-1 8.5 9.5-12H13l.5-8Z" />,
+  };
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      {paths[name]}
+    </svg>
   );
 }

--- a/web/components/portfolio/agent-picker.tsx
+++ b/web/components/portfolio/agent-picker.tsx
@@ -7,11 +7,82 @@ import {
   removeAgentFromPortfolio,
   type ActionResult,
 } from "@/lib/portfolios-mutations";
+import { roleFor, type AgentPhase } from "@/lib/agent-roles";
 
 export interface PickerAgent {
   handle: string;
   display_name: string;
   is_house_agent: boolean;
+  strategy: string | null;
+  /** 30-day return %, or null when still warming up / unavailable. */
+  return30d: number | null;
+}
+
+function fmtReturn(v: number | null): { text: string; cls: string } {
+  if (v == null) return { text: "—", cls: "text-text-muted" };
+  const sign = v > 0 ? "+" : "";
+  const cls = v > 0 ? "text-green" : v < 0 ? "text-red" : "text-text-dim";
+  return { text: `${sign}${v.toFixed(1)}%`, cls };
+}
+
+function RolePill({ phase, role }: { phase: AgentPhase; role: string }) {
+  const cls =
+    phase === "curate"
+      ? "border-cyan/30 bg-cyan/[0.08] text-cyan"
+      : phase === "trade"
+        ? "border-green/30 bg-green/[0.08] text-green"
+        : "border-border bg-bg text-text-muted";
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-mono font-bold uppercase tracking-widest border ${cls}`}
+    >
+      {role}
+    </span>
+  );
+}
+
+function RoleStatus({
+  label,
+  hint,
+  satisfied,
+}: {
+  label: string;
+  hint: string;
+  satisfied: boolean;
+}) {
+  return (
+    <div
+      className={`flex items-start gap-2.5 rounded-lg border px-3 py-2.5 ${
+        satisfied
+          ? "border-green/30 bg-green/[0.05]"
+          : "border-white/10 bg-white/[0.02]"
+      }`}
+    >
+      <span
+        aria-hidden
+        className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[10px] font-bold ${
+          satisfied
+            ? "bg-green/20 text-green"
+            : "border border-text-muted/40 text-text-muted"
+        }`}
+      >
+        {satisfied ? "✓" : ""}
+      </span>
+      <div className="min-w-0">
+        <p className="text-xs font-mono font-bold text-text">
+          {label}{" "}
+          <span
+            className={`font-normal ${satisfied ? "text-green" : "text-orange"}`}
+          >
+            {satisfied ? "added" : "still needed"}
+          </span>
+        </p>
+        <p className="mt-0.5 text-[11px] leading-relaxed text-text-muted">
+          {hint}
+        </p>
+      </div>
+    </div>
+  );
 }
 
 export default function AgentPicker({
@@ -31,6 +102,13 @@ export default function AgentPicker({
     () => new Set(members.map((m) => m.handle)),
     [members],
   );
+
+  const memberPhases = useMemo(
+    () => members.map((m) => roleFor(m.strategy).phase),
+    [members],
+  );
+  const hasCurator = memberPhases.includes("curate");
+  const hasBuyer = memberPhases.includes("trade");
 
   const candidates = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -60,35 +138,70 @@ export default function AgentPicker({
   }
 
   return (
-    <div className="glass-card rounded-lg border border-border p-5 space-y-5">
+    <div className="space-y-5">
+      {/* Required-roles status */}
+      <div className="grid gap-2.5 sm:grid-cols-2">
+        <RoleStatus
+          label="Shortlist Builder"
+          hint="Curates the watchlist of equities to consider."
+          satisfied={hasCurator}
+        />
+        <RoleStatus
+          label="Buying Agent"
+          hint="Trades the $1M book from the watchlist."
+          satisfied={hasBuyer}
+        />
+      </div>
+
+      {/* Current members */}
       <div>
         <p className="text-xs font-mono uppercase tracking-widest text-text-dim mb-2">
           On this portfolio ({members.length})
         </p>
         {members.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
-            {members.map((m) => (
-              <span
-                key={m.handle}
-                className="inline-flex items-center gap-1.5 rounded border border-border bg-bg px-2 py-1 font-mono text-xs text-text"
-              >
-                @{m.handle}
-                <button
-                  type="button"
-                  onClick={() =>
-                    runAction(m.handle, () =>
-                      removeAgentFromPortfolio({ handle: m.handle }),
-                    )
-                  }
-                  disabled={pendingHandle === m.handle}
-                  aria-label={`Remove ${m.handle}`}
-                  className="text-text-muted hover:text-red disabled:opacity-50"
+          <ul className="space-y-2">
+            {members.map((m) => {
+              const { role, phase } = roleFor(m.strategy);
+              const ret = fmtReturn(m.return30d);
+              return (
+                <li
+                  key={m.handle}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2.5"
                 >
-                  ×
-                </button>
-              </span>
-            ))}
-          </div>
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-mono text-sm text-text truncate">
+                        {m.display_name}
+                      </span>
+                      <RolePill phase={phase} role={role} />
+                      {m.is_house_agent && (
+                        <span className="text-[9px] font-mono uppercase tracking-widest text-orange">
+                          House
+                        </span>
+                      )}
+                    </div>
+                    <span className="font-mono text-[11px] text-text-muted">
+                      @{m.handle} ·{" "}
+                      <span className={ret.cls}>{ret.text} 30d</span>
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      runAction(m.handle, () =>
+                        removeAgentFromPortfolio({ handle: m.handle }),
+                      )
+                    }
+                    disabled={pendingHandle === m.handle}
+                    aria-label={`Remove ${m.handle}`}
+                    className="shrink-0 px-2 py-1 font-mono text-xs text-text-muted hover:text-red disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red/40 rounded transition-colors"
+                  >
+                    {pendingHandle === m.handle ? "…" : "Remove"}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
         ) : (
           <p className="text-sm text-text-muted italic">
             No agents added yet.
@@ -96,6 +209,7 @@ export default function AgentPicker({
         )}
       </div>
 
+      {/* Add an agent */}
       <div>
         <p className="text-xs font-mono uppercase tracking-widest text-text-dim mb-2">
           Add an agent
@@ -103,43 +217,51 @@ export default function AgentPicker({
         <input
           type="text"
           placeholder="Search agents…"
+          aria-label="Search agents"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted mb-2"
+          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 focus:border-cyan/50 placeholder:text-text-muted mb-2"
         />
         <ul className="divide-y divide-border max-h-72 overflow-y-auto">
-          {candidates.map((a) => (
-            <li
-              key={a.handle}
-              className="flex items-center justify-between gap-3 py-2"
-            >
-              <div className="min-w-0">
-                <span className="font-mono text-sm text-text">
-                  {a.display_name}
-                </span>
-                <span className="font-mono text-xs text-text-muted ml-2">
-                  @{a.handle}
-                </span>
-                {a.is_house_agent && (
-                  <span className="ml-2 text-[9px] font-mono uppercase tracking-widest text-orange">
-                    House
-                  </span>
-                )}
-              </div>
-              <button
-                type="button"
-                onClick={() =>
-                  runAction(a.handle, () =>
-                    addAgentToPortfolio({ handle: a.handle }),
-                  )
-                }
-                disabled={pendingHandle === a.handle}
-                className="shrink-0 px-2.5 py-1 font-mono text-[11px] uppercase tracking-widest rounded border border-green/40 text-green hover:bg-green/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          {candidates.map((a) => {
+            const { role, phase } = roleFor(a.strategy);
+            const ret = fmtReturn(a.return30d);
+            return (
+              <li
+                key={a.handle}
+                className="flex items-center justify-between gap-3 py-2.5"
               >
-                {pendingHandle === a.handle ? "…" : "Add"}
-              </button>
-            </li>
-          ))}
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-mono text-sm text-text truncate">
+                      {a.display_name}
+                    </span>
+                    <RolePill phase={phase} role={role} />
+                    {a.is_house_agent && (
+                      <span className="text-[9px] font-mono uppercase tracking-widest text-orange">
+                        House
+                      </span>
+                    )}
+                  </div>
+                  <span className="font-mono text-[11px] text-text-muted">
+                    @{a.handle} · <span className={ret.cls}>{ret.text} 30d</span>
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() =>
+                    runAction(a.handle, () =>
+                      addAgentToPortfolio({ handle: a.handle }),
+                    )
+                  }
+                  disabled={pendingHandle === a.handle}
+                  className="shrink-0 px-2.5 py-1 font-mono text-[11px] uppercase tracking-widest rounded border border-green/40 text-green hover:bg-green/10 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40 transition-colors"
+                >
+                  {pendingHandle === a.handle ? "…" : "Add"}
+                </button>
+              </li>
+            );
+          })}
           {candidates.length === 0 && (
             <li className="py-2 text-sm text-text-muted italic">
               No matching agents.

--- a/web/components/portfolio/launch-control.tsx
+++ b/web/components/portfolio/launch-control.tsx
@@ -6,10 +6,14 @@ import { launchPortfolio } from "@/lib/portfolios-mutations";
 
 export default function LaunchControl({
   launchedAt,
-  memberCount,
+  hasCurator,
+  hasBuyer,
 }: {
   launchedAt: string | null;
-  memberCount: number;
+  /** A curate-phase member (Shortlist Builder) is on the portfolio. */
+  hasCurator: boolean;
+  /** A trade-phase member (Buying Agent) is on the portfolio. */
+  hasBuyer: boolean;
 }) {
   const router = useRouter();
   const [confirming, setConfirming] = useState(false);
@@ -35,6 +39,8 @@ export default function LaunchControl({
     );
   }
 
+  const ready = hasCurator && hasBuyer;
+
   function launch() {
     setError(null);
     startTransition(async () => {
@@ -49,25 +55,34 @@ export default function LaunchControl({
   }
 
   return (
-    <div className="rounded-lg border border-border bg-bg px-4 py-3">
-      <p className="text-[11px] font-mono text-orange uppercase tracking-widest mb-1">
-        Draft — not trading yet
-      </p>
+    <div>
       <p className="text-sm text-text-dim leading-relaxed mb-3">
-        Shape the mandate and assemble your agents below. When you&apos;re
-        ready, go live: this grants the portfolio $1M of paper cash and its
-        agents start trading at the next heartbeat.
+        When you&apos;re ready, go live: this grants the portfolio $1M of paper
+        cash and its agents start trading at the next heartbeat.
       </p>
 
-      {memberCount === 0 ? (
-        <p className="text-xs font-mono text-text-muted">
-          Add at least one agent before you can go live.
-        </p>
+      {!ready ? (
+        <div className="rounded-lg border border-orange/30 bg-orange/[0.05] px-3 py-2.5">
+          <p className="text-xs font-mono font-bold text-orange uppercase tracking-widest mb-1.5">
+            Not ready to launch
+          </p>
+          <ul className="space-y-1 text-[12px] text-text-dim font-mono">
+            <li className={hasCurator ? "text-text-muted" : ""}>
+              {hasCurator ? "✓" : "○"} Shortlist Builder added
+            </li>
+            <li className={hasBuyer ? "text-text-muted" : ""}>
+              {hasBuyer ? "✓" : "○"} Buying Agent added
+            </li>
+          </ul>
+          <p className="text-[11px] text-text-muted mt-2 leading-relaxed">
+            Add a Shortlist Builder and a Buying Agent above before going live.
+          </p>
+        </div>
       ) : !confirming ? (
         <button
           type="button"
           onClick={() => setConfirming(true)}
-          className="px-4 py-2 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green transition-colors"
+          className="px-4 py-2 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40 transition-colors"
         >
           Go live →
         </button>
@@ -81,7 +96,7 @@ export default function LaunchControl({
               type="button"
               onClick={launch}
               disabled={pending}
-              className="px-4 py-2 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-4 py-2 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40 transition-colors"
             >
               {pending ? "Launching…" : "Confirm — go live"}
             </button>
@@ -89,7 +104,7 @@ export default function LaunchControl({
               type="button"
               onClick={() => setConfirming(false)}
               disabled={pending}
-              className="text-xs font-mono text-text-muted hover:text-text"
+              className="text-xs font-mono text-text-muted hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 rounded px-1"
             >
               Cancel
             </button>

--- a/web/components/portfolio/portfolio-details-editor.tsx
+++ b/web/components/portfolio/portfolio-details-editor.tsx
@@ -4,6 +4,56 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { updatePortfolioDetails } from "@/lib/portfolios-mutations";
 
+export interface MandateExample {
+  id: string;
+  label: string;
+  summary: string;
+  text: string;
+}
+
+/**
+ * Three structured, agent-executable starter mandates. Picking one fills the
+ * textarea — the owner then edits and saves as normal.
+ */
+export const MANDATE_EXAMPLES: MandateExample[] = [
+  {
+    id: "quality-growth",
+    label: "Quality growth",
+    summary: "20 names · revenue growth + margins + FCF",
+    text:
+      "Build a 20-stock quality-growth paper portfolio of US-listed companies. " +
+      "Universe: market cap $2B-$200B, revenue growth >15% TTM, gross margin >50%, " +
+      "positive free cash flow. Equal-weight, 2% cash reserve, max 8% per position. " +
+      "Avoid mega-cap concentration. Prefer companies with a Rule-of-40 score above 40. " +
+      "Sell discipline: exit if revenue growth falls below 8% for two consecutive quarters " +
+      "or if the broken-thesis signal fires. Rebalance weekly.",
+  },
+  {
+    id: "ai-infrastructure",
+    label: "AI infrastructure",
+    summary: "12 names · compute, networking, data picks",
+    text:
+      "Build a focused 12-stock AI-infrastructure portfolio of US-listed companies " +
+      "supplying the AI build-out: compute and accelerators, high-speed networking, " +
+      "data-center power and cooling, and data platforms. Universe: market cap $5B-$500B, " +
+      "revenue growth >20% TTM. Conviction-weight the top 5 at 12% each, the rest equal-weight, " +
+      "5% cash reserve. Sell discipline: trim any position above 15% on strength; exit on a " +
+      "broken thesis. Rebalance weekly.",
+  },
+  {
+    id: "lower-risk-compounders",
+    label: "Lower-risk compounders",
+    summary: "25 names · steady, profitable, defensive",
+    text:
+      "Build a 25-stock lower-risk compounder portfolio of US-listed companies. " +
+      "Universe: market cap >$20B, GAAP-profitable, net margin >12%, revenue growth 6-25% TTM, " +
+      "free-cash-flow margin >10%. Equal-weight with a 5% cash reserve, max 6% per position. " +
+      "Diversify across at least 6 sectors; cap any single sector at 25%. Avoid unprofitable " +
+      "high-multiple names. Sell discipline: exit if net margin turns negative or the thesis breaks. " +
+      "Rebalance weekly.",
+  },
+];
+
 export default function PortfolioDetailsEditor({
   initialName,
   initialMandate,
@@ -36,65 +86,106 @@ export default function PortfolioDetailsEditor({
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="glass-card rounded-lg border border-border p-5 space-y-4"
-    >
-      <div>
-        <label className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
-          Portfolio name
-        </label>
-        <input
-          type="text"
-          required
-          maxLength={80}
-          value={name}
-          onChange={(e) => {
-            setName(e.target.value);
-            setSaved(false);
-          }}
-          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
-        />
-      </div>
-
-      <div>
-        <label className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
-          Mandate
-        </label>
-        <p className="text-[10px] text-text-dim mb-1 font-mono">
-          The brief your agents will work to once execution is live.
-        </p>
-        <textarea
-          rows={6}
-          maxLength={2000}
-          placeholder="Target universe, position limits, risk posture, sell discipline…"
-          value={mandate}
-          onChange={(e) => {
-            setMandate(e.target.value);
-            setSaved(false);
-          }}
-          className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted resize-none"
-        />
-      </div>
-
-      {error && (
-        <div className="text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
-          {error}
+    <div className="grid gap-4 lg:grid-cols-[1.6fr_1fr]">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="portfolio-name"
+            className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1"
+          >
+            Portfolio name
+          </label>
+          <input
+            id="portfolio-name"
+            type="text"
+            required
+            maxLength={80}
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              setSaved(false);
+            }}
+            className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 focus:border-cyan/50 placeholder:text-text-muted"
+          />
         </div>
-      )}
 
-      <div className="flex items-center gap-3">
-        <button
-          type="submit"
-          disabled={pending || !dirty}
-          className="px-4 py-2 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        >
-          {pending ? "Saving…" : "Save changes →"}
-        </button>
-        {saved && !dirty && (
-          <span className="text-xs font-mono text-green">✓ Saved</span>
+        <div>
+          <label
+            htmlFor="portfolio-mandate"
+            className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1"
+          >
+            Mandate
+          </label>
+          <p className="text-[10px] text-text-dim mb-1 font-mono">
+            The brief your agents will work to once execution is live.
+          </p>
+          <textarea
+            id="portfolio-mandate"
+            rows={9}
+            maxLength={2000}
+            placeholder="Target universe, position limits, risk posture, sell discipline…"
+            value={mandate}
+            onChange={(e) => {
+              setMandate(e.target.value);
+              setSaved(false);
+            }}
+            className="w-full bg-bg border border-border rounded px-3 py-2 text-sm text-text leading-relaxed focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 focus:border-cyan/50 placeholder:text-text-muted resize-none"
+          />
+          <p className="text-[10px] text-text-muted mt-1 font-mono">
+            {mandate.length} / 2000
+          </p>
+        </div>
+
+        {error && (
+          <div className="text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+            {error}
+          </div>
         )}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={pending || !dirty}
+            className="px-4 py-2 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40 transition-colors"
+          >
+            {pending ? "Saving…" : "Save changes →"}
+          </button>
+          {saved && !dirty && (
+            <span className="text-xs font-mono text-green">✓ Saved</span>
+          )}
+        </div>
+      </form>
+
+      {/* Example mandates — clicking one fills the textarea. */}
+      <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+        <p className="text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
+          Example mandates
+        </p>
+        <p className="text-[11px] text-text-muted leading-relaxed mb-3">
+          Start from a structured brief, then edit it to your taste.
+        </p>
+        <ul className="space-y-2">
+          {MANDATE_EXAMPLES.map((ex) => (
+            <li key={ex.id}>
+              <button
+                type="button"
+                onClick={() => {
+                  setMandate(ex.text);
+                  setSaved(false);
+                }}
+                className="w-full text-left rounded-lg border border-white/10 bg-bg px-3 py-2.5 hover:border-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 transition-colors group"
+              >
+                <span className="block text-sm font-medium text-text group-hover:text-cyan transition-colors">
+                  {ex.label}
+                </span>
+                <span className="block text-[11px] font-mono text-text-muted mt-0.5">
+                  {ex.summary}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
       </div>
-    </form>
+    </div>
   );
 }

--- a/web/lib/agent-roles.ts
+++ b/web/lib/agent-roles.ts
@@ -1,0 +1,37 @@
+/**
+ * Agent role mapping (account-redesign).
+ *
+ * The two-agent pipeline introduces named *roles* per agent strategy: a
+ * curator (`watchlist_curator`) populates a portfolio's shortlist, a buyer
+ * (`watchlist_buyer`) trades from it. Other strategies are generic traders;
+ * a null/unknown strategy is a manually-driven agent with no role.
+ *
+ * `phase` is the coarse grouping the go-live gate checks — a portfolio needs
+ * one `curate`-phase member and one `trade`-phase member before launching.
+ */
+
+export type AgentPhase = "curate" | "trade" | null;
+
+export interface AgentRole {
+  /** Human-readable role label rendered on chips. */
+  role: string;
+  /** Coarse pipeline phase, or null for manual agents. */
+  phase: AgentPhase;
+}
+
+const ROLES: Record<string, AgentRole> = {
+  watchlist_curator: { role: "Shortlist Builder", phase: "curate" },
+  watchlist_buyer: { role: "Buying Agent", phase: "trade" },
+  dual_positive: { role: "Trader", phase: "trade" },
+  momentum: { role: "Trader", phase: "trade" },
+  llm_pick: { role: "Trader", phase: "trade" },
+  trading_agents: { role: "Trader", phase: "trade" },
+};
+
+const MANUAL: AgentRole = { role: "Manual", phase: null };
+
+/** Resolve a `agents.strategy` value to its role + pipeline phase. */
+export function roleFor(strategy: string | null | undefined): AgentRole {
+  if (!strategy) return MANUAL;
+  return ROLES[strategy] ?? MANUAL;
+}

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -31,12 +31,14 @@ export interface PublicAgent {
   description: string;
   is_house_agent: boolean;
   available_for_hire: boolean;
+  /** Strategy key — drives the agent's role (see `agent-roles.ts`). */
+  strategy: string | null;
   created_at: string;
 }
 
 /** Public columns — never includes api_key_hash or contact_email. */
 const PUBLIC_COLUMNS =
-  "handle, display_name, description, is_house_agent, available_for_hire, created_at";
+  "handle, display_name, description, is_house_agent, available_for_hire, strategy, created_at";
 
 export const HANDLE_RE = /^[a-z][a-z0-9-]{2,31}$/;
 
@@ -450,4 +452,32 @@ export async function deleteAgent(agentId: string): Promise<void> {
   if (error) {
     throw new Error(`Supabase agent delete failed: ${error.message}`);
   }
+}
+
+/**
+ * Map every agent handle to its 30-day return (`pnl_pct_30d`) from the
+ * `agent_leaderboard` view. The view is small (one row per portfolio) so a
+ * single unfiltered fetch is fine — the `/account` page uses this to show a
+ * real track record next to each agent in the picker. Returns an empty Map
+ * on error so callers degrade gracefully.
+ */
+export async function getAgentReturns30d(): Promise<Map<string, number | null>> {
+  const out = new Map<string, number | null>();
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agent_leaderboard")
+    .select("handle, pnl_pct_30d");
+  if (error) {
+    console.error("getAgentReturns30d failed:", error);
+    return out;
+  }
+  for (const row of (data ?? []) as {
+    handle: string | null;
+    pnl_pct_30d: number | string | null;
+  }[]) {
+    if (!row.handle) continue;
+    const n = row.pnl_pct_30d == null ? null : Number(row.pnl_pct_30d);
+    out.set(row.handle, n != null && Number.isFinite(n) ? n : null);
+  }
+  return out;
 }

--- a/web/lib/portfolios-mutations.ts
+++ b/web/lib/portfolios-mutations.ts
@@ -13,6 +13,7 @@ import { revalidatePath } from "next/cache";
 import { getSupabase } from "@/lib/supabase";
 import { requireUser } from "@/lib/auth/require-user";
 import { uniquePortfolioSlug } from "@/lib/slug";
+import { roleFor } from "@/lib/agent-roles";
 
 export type ActionResult = { ok: true } | { ok: false; error: string };
 
@@ -150,6 +151,28 @@ export async function launchPortfolio(): Promise<ActionResult> {
   if (!portfolio) return { ok: false, error: "You don't have a portfolio yet." };
 
   const supabase = getSupabase();
+
+  // Role gate: a launchable portfolio needs both a shortlist builder
+  // (curate phase) and a buying agent (trade phase). Resolve the members'
+  // strategies and check before spending the launch RPC.
+  const { data: memberRows } = await supabase
+    .from("portfolio_agents")
+    .select("agents (strategy)")
+    .eq("portfolio_id", portfolio.id);
+  type StratRow = { agents: { strategy: string | null } | { strategy: string | null }[] | null };
+  const phases = ((memberRows as unknown as StratRow[] | null) ?? []).map((r) => {
+    const a = Array.isArray(r.agents) ? r.agents[0] : r.agents;
+    return roleFor(a?.strategy ?? null).phase;
+  });
+  const hasCurator = phases.includes("curate");
+  const hasBuyer = phases.includes("trade");
+  if (!hasCurator || !hasBuyer) {
+    return {
+      ok: false,
+      error: "Add a Shortlist Builder and a Buying Agent before going live.",
+    };
+  }
+
   const { data, error } = await supabase.rpc("launch_portfolio", {
     p_portfolio_id: portfolio.id,
   });

--- a/web/lib/portfolios-query.ts
+++ b/web/lib/portfolios-query.ts
@@ -36,6 +36,8 @@ export interface PortfolioMember {
   description: string | null;
   is_house_agent: boolean;
   powered_by: string | null;
+  /** Strategy key — drives the agent's role (see `agent-roles.ts`). */
+  strategy: string | null;
   notes: string | null;
   joined_at: string;
 }
@@ -169,7 +171,7 @@ export async function getMembersForPortfolio(
   const { data, error } = await supabase
     .from("portfolio_agents")
     .select(
-      "agent_id, notes, joined_at, agents (handle, display_name, description, is_house_agent, powered_by)",
+      "agent_id, notes, joined_at, agents (handle, display_name, description, is_house_agent, powered_by, strategy)",
     )
     .eq("portfolio_id", portfolioId)
     .order("joined_at", { ascending: true });
@@ -186,6 +188,7 @@ export async function getMembersForPortfolio(
     description: string | null;
     is_house_agent: boolean;
     powered_by: string | null;
+    strategy: string | null;
   };
   type Row = {
     agent_id: string;
@@ -205,6 +208,7 @@ export async function getMembersForPortfolio(
         description: a.description,
         is_house_agent: a.is_house_agent,
         powered_by: a.powered_by,
+        strategy: a.strategy,
         notes: r.notes,
         joined_at: r.joined_at,
       };


### PR DESCRIPTION
## Summary

Phase 2 of the agent-pipeline work — rebuilds the signed-in `/account` area into a guided two-agent-pipeline setup, the real-data counterpart to the ChatGPT mock. Matches the homepage's visual language (green/cyan theme, inline SVG icons, gradient cards) with **no new dependencies** (no framer-motion, no lucide-react).

## The account area is now tabbed

`/account` and `/account/watchlist` are sibling tabs (new `AccountTabs` component — underline bar, cyan active accent, active tab from the route). A populated watchlist is ~40 equities, too big to live inline on the setup page, so it gets its own tab/page.

### Portfolio tab (`/account`)
Two-column layout (`xl:`), stacked below:
- **Main column** — header with draft/live badge + a 3-step progress indicator (Write mandate → Add agents → Go live), then cards: **Mandate**, **Agents**, and **Go live**.
- **Status rail** — portfolio-status checklist, draft/live state, a static "Beat SPY" benchmark card, and the visibility toggle.
- Unauthenticated → `/login`; no-portfolio → `CreatePortfolioForm`. All data fetches wrapped in try/catch for graceful degradation.

### Watchlist tab (`/account/watchlist`)
The full `WatchlistManager` editor, page chrome restyled to match the Portfolio tab (container width, header).

## Components

- **`account-tabs.tsx`** (new) — the tab bar.
- **`agent-picker.tsx`** — restyled; shows each agent's **role** (cyan curate / green trade pills) and real **30-day return**, plus a required-roles status (Shortlist Builder / Buying Agent — added ✓ or still needed). Same server-action wiring.
- **`portfolio-details-editor.tsx`** — restyled into a card; adds an **Example mandates** panel — 3 structured, agent-executable briefs that fill the textarea on click.
- **`launch-control.tsx`** — takes `hasCurator` / `hasBuyer`; renders a "not ready" panel naming the missing role.

## Data plumbing

- **`agent-roles.ts`** (new) — `roleFor(strategy)` → `{ role, phase }`.
- `strategy` added to `listPublicAgents` and `getMembersForPortfolio`.
- `getAgentReturns30d()` — maps handle → `pnl_pct_30d` from the `agent_leaderboard` view.

## Go-live gating

`launchPortfolio` resolves the members' strategies and **blocks launch until the portfolio has both a curate-phase and a trade-phase member** — matching the mock's "Required" framing. (Soft-warning instead is a one-line change.)

## Notes

- **Merge order:** this branch is off `main`; merge **#960 (pipeline backend) first**, then this. The web code references the `watchlist_curator` / `watchlist_buyer` strategies that #960 + migration 028 introduce.
- "Improve with AI" and fit scores stay out (Phase 3 / dropped, as agreed).
- `WatchlistManager`'s internal styling is still the older green-mono look — functional, a small re-skin is a possible follow-up.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `next build` succeeds (exit 0); `/account` + `/account/watchlist` are dynamic
- [ ] Eyeball with a real Supabase session — tabs, guided layout, role pills + 30d returns, go-live gating, example-mandate clicks (needs live data; not runnable here)

https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4