### PR TITLE
auth: branded magic-link email template for Supabase + Resend

### DIFF
--- a/supabase/email-templates/README.md
+++ b/supabase/email-templates/README.md
@@ -1,0 +1,31 @@
+# Supabase Auth email templates
+
+Source of truth for the HTML used by Supabase Auth's transactional emails.
+
+Supabase stores these templates **only in the project dashboard** — they
+are not picked up from this directory automatically. These files exist so
+the templates are version-controlled, reviewable, and recoverable. When a
+template here changes, paste the new HTML into the dashboard by hand.
+
+## Deploy
+
+Supabase dashboard → **Authentication → Email Templates** → select the
+template → replace the body with the file's contents → **Save**.
+
+| File | Dashboard template | Supabase variables used |
+|---|---|---|
+| `magic-link.html` | Magic Link | `{{ .ConfirmationURL }}` |
+
+Only the **Magic Link** template is in use — the app's sole auth path is
+`signInWithOtp` (`web/components/login-form.tsx`). The other templates
+(Confirm signup, Reset password, etc.) are left on Supabase defaults.
+
+## Notes
+
+- All CSS is inline and the layout is table-based — email clients strip
+  `<style>` blocks and don't support modern CSS layout.
+- The design is dark to match the site (`web/app/opengraph-image.tsx`
+  palette: `#0A0A0A` background, `#EDEDED` text, `#00FF41` accent).
+- `{{ .ConfirmationURL }}` is substituted by Supabase with the one-time
+  sign-in link; it appears both as the CTA button and as a copy-pasteable
+  fallback link.

--- a/supabase/email-templates/magic-link.html
+++ b/supabase/email-templates/magic-link.html
@@ -1,0 +1,106 @@
+<!--
+  AlphaMolt — magic-link sign-in email.
+  Source of truth for the Supabase Auth "Magic Link" template.
+  Paste into: Supabase dashboard -> Authentication -> Email Templates -> Magic Link.
+  Supabase substitutes {{ .ConfirmationURL }} with the one-time sign-in link.
+  All CSS is inline (email clients drop <style> blocks); table-based layout.
+-->
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark">
+  <meta name="supported-color-schemes" content="dark">
+  <title>Sign in to AlphaMolt</title>
+</head>
+<body style="margin:0; padding:0; background-color:#0A0A0A; -webkit-text-size-adjust:100%;">
+  <!-- preheader: shown in inbox preview, hidden in the body -->
+  <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:#0A0A0A;">
+    Your one-time sign-in link for AlphaMolt. It works once and expires shortly.
+  </div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#0A0A0A" style="background-color:#0A0A0A;">
+    <tr>
+      <td align="center" style="padding:32px 16px;">
+
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="width:600px; max-width:600px;">
+
+          <!-- wordmark -->
+          <tr>
+            <td style="padding:8px 8px 24px 8px; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">
+              <span style="font-size:20px; font-weight:700; letter-spacing:0.5px; color:#EDEDED;">AlphaMolt</span>
+              <span style="font-size:20px; font-weight:700; color:#00FF41;">.</span>
+            </td>
+          </tr>
+
+          <!-- card -->
+          <tr>
+            <td bgcolor="#0D0F0D" style="background-color:#0D0F0D; border:1px solid #1F2622; border-radius:10px; padding:40px 40px 36px 40px;">
+
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">
+
+                    <h1 style="margin:0 0 16px 0; font-size:22px; line-height:1.3; font-weight:700; color:#EDEDED;">
+                      Sign in to AlphaMolt
+                    </h1>
+
+                    <p style="margin:0 0 28px 0; font-size:15px; line-height:1.6; color:#A1A1AA;">
+                      Click the button below to sign in. This link works once and
+                      expires shortly &mdash; no password needed.
+                    </p>
+
+                    <!-- CTA button -->
+                    <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 28px 0;">
+                      <tr>
+                        <td align="center" bgcolor="#00FF41" style="background-color:#00FF41; border-radius:6px;">
+                          <a href="{{ .ConfirmationURL }}" target="_blank"
+                             style="display:inline-block; padding:14px 34px; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:6px;">
+                            Sign in to AlphaMolt
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <p style="margin:0 0 8px 0; font-size:13px; line-height:1.5; color:#A1A1AA;">
+                      Button not working? Paste this link into your browser:
+                    </p>
+                    <p style="margin:0 0 4px 0; font-size:13px; line-height:1.5; word-break:break-all;">
+                      <a href="{{ .ConfirmationURL }}" target="_blank" style="color:#00CC33; text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                    </p>
+
+                  </td>
+                </tr>
+              </table>
+
+            </td>
+          </tr>
+
+          <!-- security note -->
+          <tr>
+            <td style="padding:24px 8px 8px 8px; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">
+              <p style="margin:0; font-size:13px; line-height:1.6; color:#A1A1AA;">
+                If you didn&rsquo;t request this email, you can safely ignore it &mdash;
+                someone may have typed your address by mistake.
+              </p>
+            </td>
+          </tr>
+
+          <!-- footer -->
+          <tr>
+            <td style="padding:16px 8px 8px 8px; border-top:1px solid #1F2622; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">
+              <p style="margin:0; font-size:12px; line-height:1.6; color:#A1A1AA;">
+                AlphaMolt &mdash; the hardening layer for stock-picking AI.<br>
+                <a href="https://www.alphamolt.ai" target="_blank" style="color:#A1A1AA; text-decoration:underline;">alphamolt.ai</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Moving Supabase Auth off its built-in email sender (test-grade — low
hourly cap, no deliverability guarantee) onto **Resend** custom SMTP.
Email in this repo is *only* auth magic-links (`signInWithOtp` in
`web/components/login-form.tsx`) — no other transactional mail anywhere.

Most of that migration is dashboard + DNS work with no repo footprint.
This PR adds the **one repo artifact** it needs: a branded HTML template
for the magic-link sign-in email, replacing Supabase's plain default.

### Files

- **`supabase/email-templates/magic-link.html`** — self-contained email:
  table-based layout, all CSS inline (email clients strip `<style>`).
  Dark palette matched to the OG card (`web/app/opengraph-image.tsx`):
  `#0A0A0A` background, `#EDEDED` text, `#00FF41` terminal-green accent.
  CTA button + copy-pasteable fallback link both wired to the Supabase Go
  variable `{{ .ConfirmationURL }}`.
- **`supabase/email-templates/README.md`** — Supabase stores templates
  only in the dashboard; these files are the version-controlled source of
  truth, pasted in by hand. Documents the deploy path and the template
  variables used.

No application code changes — `login-form.tsx`, `auth/callback/route.ts`,
and the Supabase clients are untouched.

## Deploying this (after merge)

The template only takes effect once pasted into the dashboard:

1. Supabase → **Authentication → Email Templates → "Magic Link"**.
2. Replace the body with the contents of `magic-link.html` → **Save**.

This is part of the larger Resend migration (full runbook in the plan):
Resend account → verify `alphamolt.ai` via DNS → Supabase
**Authentication → SMTP Settings** points at `smtp.resend.com` with
sender `login@alphamolt.ai` → raise the auth email rate limit.

## Test plan

- [x] HTML is well-formed (no unclosed tags)
- [x] `{{ .ConfirmationURL }}` present in CTA href, fallback href, and
      fallback link text
- [ ] Render check: open `magic-link.html` in a browser — dark layout,
      green CTA, readable on a phone width
- [ ] After dashboard paste + Resend SMTP live: request a magic link from
      `/login`, confirm the branded email arrives from
      `login@alphamolt.ai` and the link signs you in via `/auth/callback`

https://claude.ai/code/session_01V6nV9bpWsLwUfHQHi52h8S

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6nV9bpWsLwUfHQHi52h8S)_