### PR TITLE
Add thesis-drift feature to homepage with live example

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Nav from "@/components/nav";
 import HeroChart from "@/components/hero-chart";
 import HomeConsensus from "@/components/home-consensus";
+import HomeThesisDrift from "@/components/home-thesis-drift";
 import WotBadge from "@/components/wot-badge";
 import HomePrompt from "@/components/home-prompt";
 import {
@@ -15,6 +16,10 @@ import {
   getLatestConsensus,
   type ConsensusResult,
 } from "@/lib/consensus-query";
+import {
+  getThesisDriftExample,
+  type ThesisDriftExample,
+} from "@/lib/thesis-drift-query";
 import { absoluteUrl } from "@/lib/site";
 import { redirect } from "next/navigation";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -87,6 +92,15 @@ export default async function HomePage() {
     console.error("homepage consensus fetch failed:", err);
   }
 
+  // One real `investment_theses` row to anchor the thesis-drift section.
+  // Returns null on a fresh DB; the component renders a static placeholder.
+  let driftExample: ThesisDriftExample | null = null;
+  try {
+    driftExample = await getThesisDriftExample();
+  } catch (err) {
+    console.error("homepage thesis drift fetch failed:", err);
+  }
+
   // JSON-LD: ItemList of the top 5 agents by 30d return (matches the
   // default period shown on the leaderboard). Structured data only sees
   // the SSR slice — crawlers don't execute the period toggle.
@@ -119,6 +133,7 @@ export default async function HomePage() {
           <Hero chart={chart} />
           <Workflow />
           <StrategyCard />
+          <HomeThesisDrift example={driftExample} />
           <section
             id="consensus"
             className="mt-20 sm:mt-28 scroll-mt-16"
@@ -129,6 +144,7 @@ export default async function HomePage() {
             />
           </section>
           <BuildYourAgent />
+          <FinalCta />
           <WotBadge />
         </div>
       </main>
@@ -478,6 +494,57 @@ function BuildYourAgent() {
             Run a portfolio yourself &rarr;
           </Link>
         </p>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Final CTA — closing nudge before the footer.
+// ---------------------------------------------------------------------------
+
+function FinalCta() {
+  return (
+    <section className="mt-20 sm:mt-28">
+      <div
+        className="rounded-2xl border border-white/10 p-8 sm:p-10 text-center"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(0,255,65,0.05), rgba(0,242,255,0.025) 60%, rgba(255,255,255,0.015))",
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+        }}
+      >
+        <h2 className="text-[26px] sm:text-[34px] font-bold tracking-[-0.025em] text-text leading-[1.12] max-w-[26ch] mx-auto">
+          No credit card. No locked features. Just build.
+        </h2>
+        <p className="mx-auto mt-4 text-base sm:text-lg text-text-muted max-w-[640px] leading-relaxed">
+          Try the new investing primitive: your strategy, your agents, your
+          public paper portfolio &mdash; marked to market daily.
+        </p>
+        <div className="mt-7 flex flex-wrap justify-center gap-3">
+          <Link
+            href="/login"
+            className="inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            style={{
+              boxShadow:
+                "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
+            }}
+          >
+            Run a portfolio &rarr;
+          </Link>
+          <Link
+            href="/leaderboard"
+            className="inline-flex items-center px-5 py-2.5 rounded-lg text-text text-sm font-semibold tracking-tight transition-colors hover:bg-white/[0.06] focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+            style={{
+              background:
+                "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+              border: "1px solid rgba(255,255,255,0.12)",
+              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+            }}
+          >
+            See the leaderboard &rarr;
+          </Link>
+        </div>
       </div>
     </section>
   );

--- a/web/components/home-thesis-drift.tsx
+++ b/web/components/home-thesis-drift.tsx
@@ -1,0 +1,449 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+import type {
+  DriftField,
+  ThesisDriftExample,
+  ThesisSignal,
+} from "@/lib/thesis-drift-query";
+
+interface Props {
+  example: ThesisDriftExample | null;
+}
+
+// Three-pillar explainer for the maintenance loop. Static — the
+// homepage doesn't have side-loaded data to wire here beyond the live
+// example panel on the right.
+const PILLARS: { glyph: PillarGlyph; title: string; body: string }[] = [
+  {
+    glyph: "freeze",
+    title: "Snapshot the buy case",
+    body: "Every buy freezes the fundamentals, valuation and narrative at purchase into investment_theses.",
+  },
+  {
+    glyph: "scan",
+    title: "Monitor drift",
+    body: "Maintenance agents compare today's evidence with the original snapshot and break-signal thresholds.",
+  },
+  {
+    glyph: "shield",
+    title: "Sell when it breaks",
+    body: "Positions exit when a recorded break signal triggers — not when the holder forgets why they bought.",
+  },
+];
+
+export default function HomeThesisDrift({ example }: Props) {
+  return (
+    <section id="thesis-drift" className="mt-20 sm:mt-28 scroll-mt-16">
+      <div className="grid gap-6 xl:gap-8 xl:grid-cols-[0.95fr_1.05fr]">
+        <ExplainerCard />
+        {example ? (
+          <ExampleCard example={example} />
+        ) : (
+          <PlaceholderCard />
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Left card — explainer
+// ---------------------------------------------------------------------------
+
+function ExplainerCard() {
+  return (
+    <div
+      className="rounded-2xl border border-white/10 p-6 sm:p-8"
+      style={{
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+      }}
+    >
+      <SectionBadge>Portfolio maintenance</SectionBadge>
+      <h2 className="mt-4 text-[24px] sm:text-[30px] font-bold tracking-[-0.02em] text-text leading-[1.14] max-w-[24ch]">
+        Most investors forget why they bought.
+      </h2>
+      <p className="mt-4 text-base sm:text-[17px] text-text-muted max-w-[560px] leading-relaxed">
+        AlphaMolt doesn&rsquo;t. Every paper buy stores the metrics,
+        valuation, narrative and signal thresholds that justified it.
+        Maintenance agents re-check the thesis on every heartbeat and sell
+        when the original case no longer holds.
+      </p>
+
+      <div className="mt-7 grid gap-3 sm:grid-cols-3">
+        {PILLARS.map((p) => (
+          <div
+            key={p.title}
+            className="rounded-xl border border-white/10 bg-white/[0.02] p-5"
+          >
+            <PillarGlyph
+              name={p.glyph}
+              className="w-[22px] h-[22px] text-[var(--color-cyan)]"
+            />
+            <h3 className="mt-3.5 text-sm font-semibold text-text">
+              {p.title}
+            </h3>
+            <p className="mt-1.5 text-sm leading-relaxed text-text-muted">
+              {p.body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Right card — live example pulled from investment_theses
+// ---------------------------------------------------------------------------
+
+function ExampleCard({ example }: { example: ThesisDriftExample }) {
+  return (
+    <div
+      className="rounded-2xl border border-white/10 p-6 sm:p-8"
+      style={{
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+      }}
+    >
+      <ExampleHeader example={example} />
+
+      <div className="mt-5 grid gap-3 md:grid-cols-2">
+        <SubCard label="Original buy thesis">
+          {example.thesis_text ? (
+            <p className="text-sm leading-relaxed text-text-dim">
+              &ldquo;{trimExcerpt(example.thesis_text, 280)}&rdquo;
+            </p>
+          ) : (
+            <p className="text-sm leading-relaxed text-text-muted font-mono">
+              No agent narrative — snapshot-only thesis. Maintenance is
+              driven by drift in the recorded fundamentals.
+            </p>
+          )}
+          <p className="mt-3 text-[11px] uppercase tracking-[0.14em] text-text-muted font-mono">
+            Opened {formatDate(example.opened_at)}
+          </p>
+        </SubCard>
+        <SubCard label="Current evidence">
+          <DriftTable drift={example.drift} />
+        </SubCard>
+      </div>
+
+      {example.break_signal_checks.length > 0 && (
+        <div className="mt-3">
+          <SignalsCard checks={example.break_signal_checks} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ExampleHeader({ example }: { example: ThesisDriftExample }) {
+  return (
+    <div className="flex items-start justify-between gap-3 flex-wrap">
+      <div className="min-w-0">
+        <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)] mb-2">
+          Live example
+        </div>
+        <h3 className="text-[22px] sm:text-[26px] font-bold tracking-[-0.02em] text-text leading-tight">
+          <Link
+            href={`/company/${encodeURIComponent(example.ticker)}`}
+            className="hover:underline decoration-1 underline-offset-[3px]"
+          >
+            {example.ticker}
+          </Link>{" "}
+          <span className="text-text-muted font-semibold text-[15px] sm:text-base">
+            · {example.company_name}
+          </span>
+        </h3>
+        <p className="mt-1 text-sm text-text-muted">
+          Recorded by{" "}
+          <Link
+            href={`/portfolios/${example.agent_handle}`}
+            className="text-text font-semibold hover:underline decoration-1 underline-offset-[3px]"
+          >
+            {example.agent_display_name}
+          </Link>
+        </p>
+      </div>
+      <VerdictPill verdict={example.verdict} />
+    </div>
+  );
+}
+
+function VerdictPill({ verdict }: { verdict: ThesisDriftExample["verdict"] }) {
+  const styles =
+    verdict === "broken"
+      ? {
+          border: "rgba(255,51,51,0.30)",
+          bg: "rgba(255,51,51,0.10)",
+          color: "var(--color-red)",
+          label: "Broken",
+        }
+      : verdict === "improved"
+      ? {
+          border: "rgba(0,255,65,0.30)",
+          bg: "rgba(0,255,65,0.08)",
+          color: "var(--color-green)",
+          label: "Improved",
+        }
+      : {
+          border: "rgba(0,242,255,0.30)",
+          bg: "rgba(0,242,255,0.08)",
+          color: "var(--color-cyan)",
+          label: "Active",
+        };
+  return (
+    <span
+      className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-bold uppercase tracking-[0.14em]"
+      style={{
+        border: `1px solid ${styles.border}`,
+        background: styles.bg,
+        color: styles.color,
+      }}
+    >
+      <span
+        aria-hidden
+        className="h-1.5 w-1.5 rounded-full"
+        style={{
+          background: styles.color,
+          boxShadow: `0 0 6px ${styles.color}`,
+        }}
+      />
+      {styles.label}
+    </span>
+  );
+}
+
+function SubCard({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className="rounded-xl border border-white/10 p-5"
+      style={{ background: "rgba(10,10,10,0.45)" }}
+    >
+      <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-text-muted mb-3">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function DriftTable({ drift }: { drift: DriftField[] }) {
+  if (drift.length === 0) {
+    return (
+      <p className="text-sm text-text-muted font-mono">
+        No field-level drift recorded.
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-2.5">
+      {drift.map((d) => (
+        <div
+          key={d.field}
+          className="flex items-baseline justify-between gap-3 text-sm"
+        >
+          <span className="text-text-muted truncate">{d.label}</span>
+          <span className="flex items-baseline gap-1.5 font-mono tabular-nums text-text-dim shrink-0">
+            <span className="text-text-muted">
+              {formatValue(d.snapshot, d.format)}
+            </span>
+            <span className="text-text-muted text-xs" aria-hidden>
+              →
+            </span>
+            <span
+              style={{
+                color: deltaColor(d),
+              }}
+            >
+              {formatValue(d.current, d.format)}
+            </span>
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function deltaColor(d: DriftField): string {
+  if (d.delta == null) return "var(--color-text-dim)";
+  // For most fields a positive delta is good; for ps_now (cheaper is better)
+  // and price_pct_of_52w_high (lower can mean opportunity / weakness — we
+  // treat lower as a neutral red flag), invert. Keep this conservative.
+  const negativeIsGood = d.field === "ps_now";
+  const positive = negativeIsGood ? d.delta < 0 : d.delta > 0;
+  if (Math.abs(d.delta) < 0.5) return "var(--color-text-dim)";
+  return positive ? "var(--color-green)" : "var(--color-red)";
+}
+
+function SignalsCard({
+  checks,
+}: {
+  checks: { signal: ThesisSignal; triggered: boolean }[];
+}) {
+  return (
+    <SubCard label="Recorded break signals">
+      <ul className="space-y-2">
+        {checks.map((c, i) => (
+          <li
+            key={`${c.signal.field}-${i}`}
+            className="flex items-center justify-between gap-3 text-sm"
+          >
+            <code className="text-text-dim font-mono text-xs truncate">
+              {formatSignal(c.signal)}
+            </code>
+            <span
+              className="text-[10px] font-bold uppercase tracking-[0.14em] shrink-0 px-2 py-0.5 rounded-md"
+              style={
+                c.triggered
+                  ? {
+                      color: "var(--color-red)",
+                      border: "1px solid rgba(255,51,51,0.35)",
+                      background: "rgba(255,51,51,0.08)",
+                    }
+                  : {
+                      color: "var(--color-text-muted)",
+                      border: "1px solid rgba(255,255,255,0.10)",
+                      background: "rgba(255,255,255,0.02)",
+                    }
+              }
+            >
+              {c.triggered ? "Triggered" : "OK"}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </SubCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Placeholder when no thesis row is suitable yet (fresh DB)
+// ---------------------------------------------------------------------------
+
+function PlaceholderCard() {
+  return (
+    <div
+      className="rounded-2xl border border-white/10 p-6 sm:p-8 flex items-center justify-center text-center min-h-[260px]"
+      style={{
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+      }}
+    >
+      <p className="text-sm text-text-muted font-mono max-w-[40ch]">
+        No agent-authored theses yet — examples land here as soon as
+        an agent records its first thesis on a buy.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function SectionBadge({ children }: { children: ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-cyan)]/25 bg-[var(--color-cyan)]/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)]">
+      <span
+        aria-hidden
+        className="h-1.5 w-1.5 rounded-full bg-[var(--color-cyan)]"
+        style={{ boxShadow: "0 0 6px rgba(0,242,255,0.8)" }}
+      />
+      {children}
+    </span>
+  );
+}
+
+function formatValue(v: number | null, format: DriftField["format"]): string {
+  if (v == null) return "—";
+  if (format === "pct") return `${v.toFixed(1)}%`;
+  if (format === "ratio") return v.toFixed(2);
+  return v.toFixed(1);
+}
+
+function formatSignal(s: ThesisSignal): string {
+  return `${s.field} ${s.op} ${s.value}`;
+}
+
+function trimExcerpt(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleDateString("en-GB", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+      timeZone: "UTC",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+// Tiny inline-SVG glyph set scoped to this component (keeps the page
+// dependency-free, mirroring app/page.tsx's Glyph component).
+type PillarGlyph = "freeze" | "scan" | "shield";
+
+function PillarGlyph({
+  name,
+  className,
+}: {
+  name: PillarGlyph;
+  className?: string;
+}) {
+  const paths: Record<PillarGlyph, ReactNode> = {
+    freeze: (
+      <>
+        <path d="M12 2v20" />
+        <path d="M4 7l8 4 8-4" />
+        <path d="M4 17l8-4 8 4" />
+        <path d="M12 2 9 5l3-3 3 3" />
+        <path d="M12 22l-3-3 3 3 3-3" />
+      </>
+    ),
+    scan: (
+      <>
+        <circle cx="11" cy="11" r="6" />
+        <path d="m20 20-4.3-4.3" />
+        <path d="M7.5 11h7" />
+        <path d="M11 7.5v7" />
+      </>
+    ),
+    shield: (
+      <>
+        <path d="M12 3 4 6.2v5.9c0 4.8 3.3 7.8 8 9 4.7-1.2 8-4.2 8-9V6.2L12 3Z" />
+        <path d="m8.7 11.8 2.4 2.4 4.6-5" />
+      </>
+    ),
+  };
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      {paths[name]}
+    </svg>
+  );
+}

--- a/web/lib/thesis-drift-query.ts
+++ b/web/lib/thesis-drift-query.ts
@@ -1,0 +1,257 @@
+/**
+ * Picks one recent `investment_theses` row to showcase the thesis-drift
+ * feature on the logged-out homepage. Read-only — does not mutate.
+ *
+ * Strategy: prefer agent-authored theses with break signals (most telling
+ * example: original thesis + signal check vs current state). Fall back
+ * through agent-authored / snapshot-only rows so we still show *something*
+ * if the picky case isn't populated yet.
+ *
+ * Returns null when there isn't a usable row — caller renders a static
+ * explainer-only variant.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+
+export interface ThesisSignal {
+  field: string;
+  op: string;
+  value: number | string;
+  description?: string;
+}
+
+export interface DriftField {
+  field: string;
+  label: string;
+  snapshot: number | null;
+  current: number | null;
+  /** Percentage-point delta (current - snapshot). Null when either side is null. */
+  delta: number | null;
+  /** Pretty-formatter hint for the cell. */
+  format: "pct" | "ratio" | "score";
+}
+
+export interface ThesisDriftExample {
+  agent_handle: string;
+  agent_display_name: string;
+  ticker: string;
+  company_name: string;
+  opened_at: string;
+  status: "active" | "broken" | "improved" | "superseded" | "closed";
+  source: "agent" | "auto";
+  thesis_text: string | null;
+  /** Up to 3 break signals + whether each is currently triggered. */
+  break_signal_checks: { signal: ThesisSignal; triggered: boolean }[];
+  /** Up to ~4 headline fields with snapshot vs current. */
+  drift: DriftField[];
+  /** Verdict computed live from snapshot + companies row. */
+  verdict: "active" | "broken" | "improved";
+}
+
+// Fields we surface in the drift comparison, in priority order. Picks the
+// first ~4 that actually have both snapshot + current populated.
+const DRIFT_CANDIDATES: { field: string; label: string; format: DriftField["format"] }[] = [
+  { field: "composite_score", label: "Composite score", format: "score" },
+  { field: "rev_growth_ttm_pct", label: "Revenue growth TTM", format: "pct" },
+  { field: "gross_margin_pct", label: "Gross margin", format: "pct" },
+  { field: "rule_of_40", label: "Rule of 40", format: "score" },
+  { field: "ps_now", label: "P/S ratio", format: "ratio" },
+  { field: "price_pct_of_52w_high", label: "% of 52w high", format: "pct" },
+];
+
+interface RawThesisRow {
+  id: number;
+  agent_id: string;
+  ticker: string;
+  status: string;
+  source: string;
+  opened_at: string;
+  thesis_text: string | null;
+  snapshot: Record<string, unknown> | null;
+  break_signals: ThesisSignal[] | null;
+}
+
+export async function getThesisDriftExample(): Promise<ThesisDriftExample | null> {
+  const supabase = getSupabase();
+
+  // Three-tiered pull: best-case rows first, then progressively looser
+  // fallbacks. Stop as soon as one tier returns rows. Each query is
+  // bounded so the page stays fast even if the table grows.
+  const SELECT =
+    "id, agent_id, ticker, status, source, opened_at, thesis_text, snapshot, break_signals";
+
+  let candidates: RawThesisRow[] = [];
+  for (let tier = 0; tier < 3 && candidates.length === 0; tier++) {
+    let q = supabase
+      .from("investment_theses")
+      .select(SELECT)
+      .order("opened_at", { ascending: false })
+      .limit(20);
+    if (tier === 0) {
+      // Best case: agent-authored, active, has break_signals.
+      q = q
+        .eq("source", "agent")
+        .eq("status", "active")
+        .not("break_signals", "is", null);
+    } else if (tier === 1) {
+      // Next: any active agent-authored thesis.
+      q = q.eq("source", "agent").eq("status", "active");
+    } else {
+      // Last resort: any active thesis (snapshot-only is still useful).
+      q = q.eq("status", "active");
+    }
+    const { data, error } = await q;
+    if (error) {
+      console.error(`thesis drift tier ${tier} fetch failed:`, error);
+      continue;
+    }
+    candidates = (data ?? []) as unknown as RawThesisRow[];
+  }
+
+  if (candidates.length === 0) return null;
+
+  // Resolve agent handle/display_name + current companies row for each
+  // candidate in two bulk lookups, then pick the first one where both
+  // resolved successfully.
+  const agentIds = Array.from(new Set(candidates.map((c) => c.agent_id)));
+  const tickers = Array.from(new Set(candidates.map((c) => c.ticker)));
+
+  const { data: agentRows } = await supabase
+    .from("agents")
+    .select("id, handle, display_name, is_house_agent")
+    .in("id", agentIds);
+  const agentById = new Map<
+    string,
+    { handle: string; display_name: string; is_house_agent: boolean }
+  >();
+  for (const r of (agentRows ?? []) as {
+    id: string;
+    handle: string;
+    display_name: string;
+    is_house_agent: boolean;
+  }[]) {
+    agentById.set(r.id, {
+      handle: r.handle,
+      display_name: r.display_name,
+      is_house_agent: r.is_house_agent,
+    });
+  }
+
+  const { data: companyRows } = await supabase
+    .from("companies")
+    .select(
+      "ticker, company_name, composite_score, rev_growth_ttm_pct, gross_margin_pct, " +
+        "rule_of_40, ps_now, price_pct_of_52w_high",
+    )
+    .in("ticker", tickers);
+  const companyByTicker = new Map<string, Record<string, unknown>>();
+  for (const r of (companyRows ?? []) as unknown as (Record<string, unknown> & {
+    ticker: string;
+  })[]) {
+    companyByTicker.set(r.ticker, r);
+  }
+
+  for (const c of candidates) {
+    const agent = agentById.get(c.agent_id);
+    const company = companyByTicker.get(c.ticker);
+    if (!agent || !company) continue;
+
+    const snapshot = (c.snapshot ?? {}) as Record<string, unknown>;
+    const drift = buildDrift(snapshot, company);
+    // Need at least two comparable fields for the drift card to feel
+    // substantive — otherwise the panel looks empty.
+    if (drift.length < 2) continue;
+
+    const signals = (c.break_signals ?? []).slice(0, 3);
+    const break_signal_checks = signals.map((sig) => ({
+      signal: sig,
+      triggered: evaluateSignal(sig, snapshot, company),
+    }));
+
+    const triggeredBreaks = break_signal_checks.filter((s) => s.triggered);
+    const verdict: ThesisDriftExample["verdict"] =
+      triggeredBreaks.length > 0 ? "broken" : "active";
+
+    return {
+      agent_handle: agent.handle,
+      agent_display_name: agent.display_name,
+      ticker: c.ticker,
+      company_name: (company.company_name as string) ?? c.ticker,
+      opened_at: c.opened_at,
+      status: (c.status as ThesisDriftExample["status"]) ?? "active",
+      source: c.source === "agent" ? "agent" : "auto",
+      thesis_text: c.thesis_text,
+      break_signal_checks,
+      drift,
+      verdict,
+    };
+  }
+
+  return null;
+}
+
+function buildDrift(
+  snapshot: Record<string, unknown>,
+  current: Record<string, unknown>,
+): DriftField[] {
+  const out: DriftField[] = [];
+  for (const c of DRIFT_CANDIDATES) {
+    const s = toNum(snapshot[c.field]);
+    const cur = toNum(current[c.field]);
+    if (s == null && cur == null) continue;
+    // Skip cases where both sides are identical — no signal to show.
+    if (s != null && cur != null && Math.abs(s - cur) < 0.01) continue;
+    out.push({
+      field: c.field,
+      label: c.label,
+      snapshot: s,
+      current: cur,
+      delta: s != null && cur != null ? cur - s : null,
+      format: c.format,
+    });
+    if (out.length >= 4) break;
+  }
+  return out;
+}
+
+// Tiny port of theses.py `_evaluate_signal`. Same operators, same
+// "missing field returns false (conservative)" semantics.
+const STATIC_OPS: Record<string, (c: number, t: number) => boolean> = {
+  ">": (c, t) => c > t,
+  ">=": (c, t) => c >= t,
+  "<": (c, t) => c < t,
+  "<=": (c, t) => c <= t,
+  "==": (c, t) => c === t,
+  "!=": (c, t) => c !== t,
+};
+
+function evaluateSignal(
+  signal: ThesisSignal,
+  snapshot: Record<string, unknown>,
+  current: Record<string, unknown>,
+): boolean {
+  const { field, op, value } = signal;
+  if (!field || !op) return false;
+  const currentValue = toNum(current[field]);
+  if (currentValue == null) return false;
+
+  if (op in STATIC_OPS) {
+    const threshold = toNum(value);
+    if (threshold == null) return false;
+    return STATIC_OPS[op](currentValue, threshold);
+  }
+  if (op === "change_pct_lt" || op === "change_pct_gt") {
+    const snapshotValue = toNum(snapshot[field]);
+    const threshold = toNum(value);
+    if (snapshotValue == null || threshold == null) return false;
+    const deltaPp = currentValue - snapshotValue;
+    return op === "change_pct_lt" ? deltaPp < threshold : deltaPp > threshold;
+  }
+  return false;
+}
+
+function toNum(v: unknown): number | null {
+  if (v == null) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}


### PR DESCRIPTION
## Summary

Adds a new "Portfolio maintenance" section to the homepage that showcases the thesis-drift feature — demonstrating how AlphaMolt snapshots investment theses at purchase and monitors them for drift over time. Includes a live example pulled from the `investment_theses` table and a static three-pillar explainer.

## Changes

- **New component: `HomeThesisDrift`** (`web/components/home-thesis-drift.tsx`)
  - Left card: explainer with three-pillar breakdown (snapshot → monitor → sell)
  - Right card: live example from `investment_theses` with original thesis text, current drift metrics, and break-signal status
  - Verdict pill showing whether the thesis is "active", "broken", or "improved"
  - Placeholder card when no suitable thesis row exists (fresh DB)
  - Inline SVG glyphs (freeze, scan, shield) to keep dependencies minimal

- **New query module: `getThesisDriftExample()`** (`web/lib/thesis-drift-query.ts`)
  - Three-tiered fallback strategy: prefers agent-authored active theses with break signals, falls back to agent-authored snapshot-only, then any active thesis
  - Resolves agent metadata and current company metrics in bulk lookups
  - Builds drift comparison (up to 4 fields) from snapshot vs. current state
  - Evaluates break signals against current data to compute live verdict
  - Returns `null` on empty DB; caller renders static placeholder

- **Homepage integration** (`web/app/page.tsx`)
  - Fetches thesis-drift example during SSR
  - Renders `<HomeThesisDrift>` between strategy card and consensus section
  - Adds `<FinalCta>` closing section before footer with "Run a portfolio" and "View leaderboard" CTAs

## Implementation Details

- **Drift field selection**: Prioritizes composite_score, revenue growth, gross margin, Rule of 40, P/S, and 52w high percentage; picks first ~4 with both snapshot and current values populated
- **Signal evaluation**: Supports static operators (`>`, `>=`, `<`, `<=`, `==`, `!=`) and change-based operators (`change_pct_lt`, `change_pct_gt`); mirrors backend `theses.py` logic
- **Verdict logic**: "broken" if any break signal is triggered, otherwise "active"
- **Delta coloring**: Green for positive deltas (except P/S where lower is better), red for negative; muted for <0.5pp changes
- **Date formatting**: ISO → "DD Mon YYYY" (UTC) with fallback to raw ISO on parse error
- **Styling**: Matches existing homepage aesthetic with gradient backgrounds, cyan accents, and responsive grid layout

https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq