### PR TITLE
Make the agent picker browsable (role chips, powered_by, descriptions)

### DIFF
--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -171,6 +171,8 @@ function PortfolioView({
     is_house_agent: m.is_house_agent,
     strategy: m.strategy,
     return30d: returns30d.get(m.handle) ?? null,
+    powered_by: m.powered_by,
+    description: m.description,
   }));
   const pickerAll = allAgents.map((a) => ({
     handle: a.handle,
@@ -179,6 +181,8 @@ function PortfolioView({
     is_house_agent: a.is_house_agent,
     strategy: a.strategy,
     return30d: returns30d.get(a.handle) ?? null,
+    powered_by: a.powered_by,
+    description: a.description,
   }));
 
   return (

--- a/web/components/portfolio/agent-picker.tsx
+++ b/web/components/portfolio/agent-picker.tsx
@@ -21,6 +21,78 @@ export interface PickerAgent {
   strategy: string | null;
   /** 30-day return %, or null when still warming up / unavailable. */
   return30d: number | null;
+  /** LLM brand label, e.g. "Claude Opus 4.7". Optional. */
+  powered_by: string | null;
+  /** One-line description from agents.description. Optional. */
+  description: string | null;
+}
+
+/**
+ * Role-chip categories for the candidate filter. `null` = "All".
+ * Other values match the `role` label produced by `roleFor(strategy).role`.
+ */
+type RoleFilter =
+  | null
+  | "Shortlist Builder"
+  | "Buying Agent"
+  | "Trader"
+  | "Manual";
+
+function PoweredByChip({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center rounded border border-border bg-bg px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase tracking-widest text-text-muted">
+      {label}
+    </span>
+  );
+}
+
+/**
+ * Single-select chip row above the search input. Cyan-accented active chip,
+ * matching the curate-phase accent used by the role pill.
+ */
+function RoleChipRow({
+  value,
+  onChange,
+  showManual,
+}: {
+  value: RoleFilter;
+  onChange: (v: RoleFilter) => void;
+  showManual: boolean;
+}) {
+  const chips: { label: string; value: RoleFilter }[] = [
+    { label: "All", value: null },
+    { label: "Shortlist Builders", value: "Shortlist Builder" },
+    { label: "Buying Agents", value: "Buying Agent" },
+    { label: "Traders", value: "Trader" },
+  ];
+  if (showManual) chips.push({ label: "Manual", value: "Manual" });
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Filter agents by role"
+      className="flex flex-wrap gap-1.5 mb-2"
+    >
+      {chips.map((c) => {
+        const active = value === c.value;
+        return (
+          <button
+            key={c.label}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(c.value)}
+            className={`rounded px-2 py-1 font-mono text-[10px] uppercase tracking-widest border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 ${
+              active
+                ? "border-cyan/40 bg-cyan/[0.10] text-cyan"
+                : "border-border bg-bg text-text-muted hover:text-text hover:border-white/20"
+            }`}
+          >
+            {c.label}
+          </button>
+        );
+      })}
+    </div>
+  );
 }
 
 function fmtReturn(v: number | null): { text: string; cls: string } {
@@ -105,6 +177,7 @@ export default function AgentPicker({
 }) {
   const router = useRouter();
   const [query, setQuery] = useState("");
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>(null);
   const [error, setError] = useState<string | null>(null);
   const [pendingHandle, setPendingHandle] = useState<string | null>(null);
   const [, startTransition] = useTransition();
@@ -121,18 +194,34 @@ export default function AgentPicker({
   const hasCurator = memberPhases.includes("curate");
   const hasBuyer = memberPhases.includes("trade");
 
+  // The non-member pool drives both the chip list (which chips to show)
+  // and the filtered candidate list. Computed once per render.
+  const addable = useMemo(
+    () => allAgents.filter((a) => !memberHandles.has(a.handle)),
+    [allAgents, memberHandles],
+  );
+
+  // Only show the Manual chip when at least one Manual agent exists in
+  // the addable pool — otherwise the chip is dead weight.
+  const hasManual = useMemo(
+    () => addable.some((a) => roleFor(a.strategy).role === "Manual"),
+    [addable],
+  );
+
   const candidates = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return allAgents
-      .filter((a) => !memberHandles.has(a.handle))
+    return addable
       .filter(
         (a) =>
           !q ||
           a.handle.toLowerCase().includes(q) ||
           a.display_name.toLowerCase().includes(q),
       )
+      .filter(
+        (a) => roleFilter == null || roleFor(a.strategy).role === roleFilter,
+      )
       .slice(0, 30);
-  }, [allAgents, memberHandles, query]);
+  }, [addable, query, roleFilter]);
 
   function runAction(handle: string, fn: () => Promise<ActionResult>) {
     setError(null);
@@ -182,6 +271,7 @@ export default function AgentPicker({
             {members.map((m) => {
               const { role, phase } = roleFor(m.strategy);
               const ret = fmtReturn(m.return30d);
+              const desc = (m.description ?? "").trim();
               return (
                 <li
                   key={m.handle}
@@ -193,12 +283,18 @@ export default function AgentPicker({
                         {m.display_name}
                       </span>
                       <RolePill phase={phase} role={role} />
+                      {m.powered_by && <PoweredByChip label={m.powered_by} />}
                       {m.is_house_agent && (
                         <span className="text-[9px] font-mono uppercase tracking-widest text-orange">
                           House
                         </span>
                       )}
                     </div>
+                    {desc && (
+                      <p className="mt-0.5 text-xs text-text-muted line-clamp-2">
+                        {desc}
+                      </p>
+                    )}
                     <span className="font-mono text-[11px] text-text-muted">
                       @{m.handle} ·{" "}
                       <span className={ret.cls}>{ret.text} 30d</span>
@@ -241,6 +337,11 @@ export default function AgentPicker({
         <p className="text-xs font-mono uppercase tracking-widest text-text-dim mb-2">
           Add an agent
         </p>
+        <RoleChipRow
+          value={roleFilter}
+          onChange={setRoleFilter}
+          showManual={hasManual}
+        />
         <input
           type="text"
           placeholder="Search agents…"
@@ -253,6 +354,7 @@ export default function AgentPicker({
           {candidates.map((a) => {
             const { role, phase } = roleFor(a.strategy);
             const ret = fmtReturn(a.return30d);
+            const desc = (a.description ?? "").trim();
             return (
               <li
                 key={a.handle}
@@ -264,12 +366,18 @@ export default function AgentPicker({
                       {a.display_name}
                     </span>
                     <RolePill phase={phase} role={role} />
+                    {a.powered_by && <PoweredByChip label={a.powered_by} />}
                     {a.is_house_agent && (
                       <span className="text-[9px] font-mono uppercase tracking-widest text-orange">
                         House
                       </span>
                     )}
                   </div>
+                  {desc && (
+                    <p className="mt-0.5 text-xs text-text-muted line-clamp-2">
+                      {desc}
+                    </p>
+                  )}
                   <span className="font-mono text-[11px] text-text-muted">
                     @{a.handle} · <span className={ret.cls}>{ret.text} 30d</span>
                   </span>

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -34,12 +34,14 @@ export interface PublicAgent {
   available_for_hire: boolean;
   /** Strategy key — drives the agent's role (see `agent-roles.ts`). */
   strategy: string | null;
+  /** Optional LLM brand label (e.g. "Claude Opus 4.7"). */
+  powered_by: string | null;
   created_at: string;
 }
 
 /** Public columns — never includes api_key_hash or contact_email. */
 const PUBLIC_COLUMNS =
-  "id, handle, display_name, description, is_house_agent, available_for_hire, strategy, created_at";
+  "id, handle, display_name, description, is_house_agent, available_for_hire, strategy, powered_by, created_at";
 
 export const HANDLE_RE = /^[a-z][a-z0-9-]{2,31}$/;
 


### PR DESCRIPTION
## Summary

Phase 1.3 of the agent-builder roadmap — makes the `/account` agent picker **browsable** instead of search-only. As the agent roster grows ("lots of agents users can add" is the explicit goal), users need filters + at-a-glance metadata, not just a search box.

**Stacked on top of [#1018](https://github.com/tobyrowland/update_ai_analysis/pull/1018)** — both PRs touch `agent-picker.tsx`. Merge ladder: #961 → #1018 → this.

## Changes

- **Role filter chips** above the search input: `All · Shortlist Builders · Buying Agents · Traders`. The `Manual` chip only renders when there's at least one Manual agent in the candidate pool. Single-select, cyan active accent (matching the curate-phase role pill palette). Search query and role filter are *combined* before the existing `.slice(0, 30)` cap.
- **`powered_by` chip** next to the role pill on both member rows and candidate rows — e.g. "Claude Opus 4.7". Skipped cleanly when null.
- **Description line** below the name (`line-clamp-2`, text-muted) on both member and candidate rows. Skipped cleanly when empty.

## Plumbing

- `web/lib/agents-query.ts` — `powered_by` added to `PUBLIC_COLUMNS` and to the `PublicAgent` interface.
- `web/components/portfolio/agent-picker.tsx` — extended `PickerAgent` with `powered_by` + `description`; new `RoleFilter` state, `RoleChipRow`, `PoweredByChip`; combined filter pipeline.
- `web/app/account/page.tsx` — `powered_by` + `description` threaded through both `pickerMembers` and `pickerAll`.

## Unchanged

The Run-now / Remove flow, the required-roles status component, the 30-day return display, the search behaviour, the 30-candidate cap, and the underlying server actions — all untouched.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `next build` exit 0 (21/21 routes)
- [ ] Eyeball with a real Supabase session: filter chips toggle correctly; `powered_by` + description render where present and skip cleanly otherwise; the candidate list still caps at 30 after both filters; Run-now / Remove still work.

https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4)_