### PR TITLE
nav: add Dashboard + Watchlist links; let logged-in users see /

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -21,8 +21,6 @@ import {
   type ThesisDriftExample,
 } from "@/lib/thesis-drift-query";
 import { absoluteUrl } from "@/lib/site";
-import { redirect } from "next/navigation";
-import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 const META_TITLE = "AlphaMolt — build your own AI investing machine";
 const META_DESCRIPTION =
@@ -47,18 +45,16 @@ export const metadata: Metadata = {
   },
 };
 
+// Force dynamic rendering — the homepage reads live data (leaderboard,
+// hero chart, consensus, thesis-drift example) on every request. Without
+// this, Next attempts to prerender it statically at build time, fails
+// against an env-less builder, and bakes empty data into the HTML.
+export const dynamic = "force-dynamic";
+
 export default async function HomePage() {
-  // Signed-in visitors get their account view as their homepage. Done in the
-  // page (not proxy.ts) so it reliably reads the cookie-backed session — the
-  // same getUser() path /account itself depends on. Reading the session
-  // opts this route into dynamic rendering.
-  const supabase = await createSupabaseServerClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (user) {
-    redirect("/account");
-  }
+  // The marketing page is visible to everyone — signed-in visitors land on
+  // /account by default (auth callback's `next`), but reach this page by
+  // clicking the logo, which links to `/`.
 
   let board: HomeLeaderboardResult;
   try {

--- a/web/components/nav-auth.tsx
+++ b/web/components/nav-auth.tsx
@@ -1,30 +1,21 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
-import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 
-// Auth chip for the nav. Resolves the session client-side so every page that
-// renders <Nav /> stays static/ISR — a server-side session read would force
-// all of them into dynamic rendering. Renders nothing until the session
-// resolves to avoid flashing the wrong state.
-export default function NavAuth({ onNavigate }: { onNavigate?: () => void }) {
-  const [email, setEmail] = useState<string | null>(null);
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    const supabase = createSupabaseBrowserClient();
-    supabase.auth.getSession().then(({ data }) => {
-      setEmail(data.session?.user.email ?? null);
-      setReady(true);
-    });
-    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
-      setEmail(session?.user.email ?? null);
-      setReady(true);
-    });
-    return () => sub.subscription.unsubscribe();
-  }, []);
-
+// Auth chip at the end of the nav. The session lookup happens once in the
+// parent <Nav /> (so the link set can depend on it) and is passed in here
+// as props — keeps both nav-component renderings driven by a single
+// auth-state source. Renders nothing until the session has resolved to
+// avoid flashing the wrong state.
+export default function NavAuth({
+  email,
+  ready,
+  onNavigate,
+}: {
+  email: string | null;
+  ready: boolean;
+  onNavigate?: () => void;
+}) {
   if (!ready) {
     return null;
   }

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -1,14 +1,24 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Logo from "@/components/logo";
 import NavAuth from "@/components/nav-auth";
+import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 
-const links = [
+// Links available to every visitor.
+const PUBLIC_LINKS: { href: string; label: string }[] = [
   { href: "/leaderboard", label: "Leaderboard" },
   { href: "/consensus", label: "Consensus" },
   { href: "/docs", label: "Docs" },
+];
+
+// Links injected only when the visitor is signed in. Slotted in front of
+// the public set so the user's own surfaces ("Dashboard" / "Watchlist")
+// sit at the start of the nav row.
+const AUTHED_LINKS: { href: string; label: string }[] = [
+  { href: "/account", label: "Dashboard" },
+  { href: "/account/watchlist", label: "Watchlist" },
 ];
 
 export default function Nav() {
@@ -17,6 +27,13 @@ export default function Nav() {
   // the threshold, so the border reappears naturally.
   const [scrolled, setScrolled] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+
+  // Session state is resolved client-side so every page that renders
+  // <Nav /> stays static/ISR-eligible — a server-side session read would
+  // force all of them into dynamic rendering. We hold it here (rather
+  // than inside NavAuth alone) because the link set depends on it too.
+  const [email, setEmail] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
 
   useEffect(() => {
     function onScroll() {
@@ -27,7 +44,7 @@ export default function Nav() {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
-  // Close the mobile menu on route change / Esc.
+  // Close the mobile menu on Esc.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") setMenuOpen(false);
@@ -35,6 +52,29 @@ export default function Nav() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, []);
+
+  useEffect(() => {
+    const supabase = createSupabaseBrowserClient();
+    supabase.auth.getSession().then(({ data }) => {
+      setEmail(data.session?.user.email ?? null);
+      setReady(true);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        setEmail(session?.user.email ?? null);
+        setReady(true);
+      },
+    );
+    return () => sub.subscription.unsubscribe();
+  }, []);
+
+  // Until session resolves we render the public set only — same SSR HTML
+  // as before, so there's no hydration mismatch. The authed links pop in
+  // a tick later for signed-in visitors.
+  const links = useMemo(
+    () => (ready && email ? [...AUTHED_LINKS, ...PUBLIC_LINKS] : PUBLIC_LINKS),
+    [ready, email],
+  );
 
   return (
     <header
@@ -64,7 +104,7 @@ export default function Nav() {
               {link.label}
             </Link>
           ))}
-          <NavAuth />
+          <NavAuth email={email} ready={ready} />
         </nav>
 
         <button
@@ -96,7 +136,11 @@ export default function Nav() {
               </Link>
             ))}
             <div className="pt-1 mt-1 border-t border-border">
-              <NavAuth onNavigate={() => setMenuOpen(false)} />
+              <NavAuth
+                email={email}
+                ready={ready}
+                onNavigate={() => setMenuOpen(false)}
+              />
             </div>
           </nav>
         </div>


### PR DESCRIPTION
Three changes around the logged-in/logged-out nav:

- Drop the `/` → `/account` redirect for signed-in visitors. The marketing homepage is now reachable for everyone by clicking the logo. Login still lands on /account by default (auth callback's `next` defaults to `/account`).
- Mark `/` as `force-dynamic` to replace the dynamic rendering hint we lost when removing the getUser() call. Keeps live data off the build-time static HTML.
- Add two new top-nav links — "Dashboard" (/account) and "Watchlist" (/account/watchlist) — visible only when signed in, slotted in front of "Leaderboard". Session state is now resolved inside <Nav /> itself (was inside <NavAuth /> alone) so the link set can depend on it; NavAuth is refactored to receive email + ready as props rather than running its own listener.

https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq