### PR TITLE
nav: collapse email + Sign out into a click-to-open dropdown

### DIFF
--- a/web/components/nav-auth.tsx
+++ b/web/components/nav-auth.tsx
@@ -1,12 +1,17 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 
 // Auth chip at the end of the nav. The session lookup happens once in the
 // parent <Nav /> (so the link set can depend on it) and is passed in here
 // as props — keeps both nav-component renderings driven by a single
 // auth-state source. Renders nothing until the session has resolved to
 // avoid flashing the wrong state.
+//
+// When signed in, the chip is the email itself; clicking it opens a small
+// dropdown with "Sign out". The Dashboard link in the main nav covers the
+// "go to my account" affordance the email used to provide.
 export default function NavAuth({
   email,
   ready,
@@ -16,6 +21,30 @@ export default function NavAuth({
   ready: boolean;
   onNavigate?: () => void;
 }) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClickOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onClickOutside);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClickOutside);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
   if (!ready) {
     return null;
   }
@@ -33,23 +62,34 @@ export default function NavAuth({
   }
 
   return (
-    <span className="flex items-center gap-1">
-      <Link
-        href="/account"
-        onClick={onNavigate}
-        className="px-3 py-1.5 text-sm font-mono text-text-dim hover:text-text transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 truncate max-w-[180px]"
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={() => setOpen((v) => !v)}
         title={email}
+        className="px-3 py-1.5 text-sm font-mono text-text-dim hover:text-text transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 truncate max-w-[200px]"
       >
         {email}
-      </Link>
-      <form action="/auth/signout" method="post">
-        <button
-          type="submit"
-          className="px-3 py-1.5 text-sm text-text-dim hover:text-text transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 mt-1 min-w-[140px] rounded border border-border bg-bg-card shadow-lg py-1 z-50"
         >
-          Sign out
-        </button>
-      </form>
-    </span>
+          <form action="/auth/signout" method="post">
+            <button
+              type="submit"
+              role="menuitem"
+              onClick={onNavigate}
+              className="w-full text-left px-3 py-1.5 text-sm text-text-dim hover:text-text hover:bg-bg transition-colors focus:outline-none focus:bg-bg"
+            >
+              Sign out
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
   );
 }

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -33,9 +33,10 @@ export async function proxy(request: NextRequest) {
 
   // getUser() refreshes the access token when it's stale; the rotated
   // session cookie is propagated onto `response` by the setAll adapter
-  // above. Route gating is handled elsewhere: protected pages self-guard,
-  // and the "/" -> "/account" redirect for signed-in visitors lives in
-  // app/page.tsx (the cookie-backed getUser() there is the reliable path).
+  // above. Route gating is handled elsewhere: protected pages self-guard.
+  // The marketing homepage is reachable for everyone — signed-in users
+  // get there by clicking the logo; the post-login landing page (/account)
+  // is chosen by the auth callback's default `next` param.
   await supabase.auth.getUser();
 
   return response;


### PR DESCRIPTION
With the new "Dashboard" link in the main nav, the email chip's existing role as "link to /account" was a duplicate. The email is now a button: clicking it toggles a small dropdown menu containing the Sign out action. Same component renders in both the desktop nav and the mobile hamburger menu — closes on click-outside or Esc.

Also refresh the stale proxy.ts comment that still claimed the "/" → "/account" redirect lived in page.tsx (removed in 43e319f).

https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq