### PR TITLE
Run-now buttons + browsable agent picker on /account

### DIFF
--- a/.github/workflows/agent-heartbeat.yml
+++ b/.github/workflows/agent-heartbeat.yml
@@ -1,14 +1,11 @@
 name: Agent Heartbeat
 
-# Daily rebalance loop. Every agent row with a non-null `strategy` — and
-# every human-portfolio member — is re-evaluated against its strategy
-# (see agent_strategies.STRATEGIES), but only actually rebalances when its
-# own `heartbeat_interval_hours` cadence is due, so most daily runs are
-# cheap no-op skips. Running daily lets daily-cadence agents (e.g. the
-# watchlist curator) get a daily run alongside weekly ones.
+# Weekly rebalance loop. Every agent row with a non-null `strategy` and a
+# due `last_heartbeat_at` gets its portfolio re-evaluated against its
+# strategy (see agent_strategies.STRATEGIES).
 #
-# 07:00 UTC — runs at the end of the morning data block, after every
-# input the picker depends on has refreshed:
+# Sunday 07:00 UTC — runs at the end of the Sunday morning data block,
+# after every input the picker depends on has refreshed:
 #   04:00 bear-evaluation   (refreshes companies.bear_eval)
 #   04:30 bull-evaluation   (refreshes companies.bull_eval)
 #   05:00 score-ai-analysis (composite scores + sort_order)
@@ -18,11 +15,15 @@ name: Agent Heartbeat
 
 on:
   schedule:
-    - cron: "0 7 * * *"
+    - cron: "0 7 * * 0"
   workflow_dispatch:
     inputs:
       handle:
         description: "Run only this agent handle (optional)"
+        required: false
+        type: string
+      portfolio:
+        description: "Run only this portfolio (id or slug, optional)"
         required: false
         type: string
       dry_run:
@@ -74,13 +75,19 @@ jobs:
           # whitespace / shell metacharacters can't break the arg list.
           # On scheduled runs these are empty strings — flags below skip.
           HEARTBEAT_HANDLE: ${{ inputs.handle }}
+          HEARTBEAT_PORTFOLIO: ${{ inputs.portfolio }}
           HEARTBEAT_DRY_RUN: ${{ inputs.dry_run }}
           HEARTBEAT_FORCE: ${{ inputs.force }}
+          # Manual (workflow_dispatch) runs always tag the journal so the
+          # /account "Run now" UI can distinguish them from scheduled runs.
+          HEARTBEAT_MANUAL: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           set -u
           echo "DEBUG: raw HEARTBEAT_HANDLE='${HEARTBEAT_HANDLE}' (length=${#HEARTBEAT_HANDLE})"
+          echo "DEBUG: raw HEARTBEAT_PORTFOLIO='${HEARTBEAT_PORTFOLIO}'"
           echo "DEBUG: raw HEARTBEAT_DRY_RUN='${HEARTBEAT_DRY_RUN}'"
           echo "DEBUG: raw HEARTBEAT_FORCE='${HEARTBEAT_FORCE}'"
+          echo "DEBUG: raw HEARTBEAT_MANUAL='${HEARTBEAT_MANUAL}'"
           ARGS=()
           # Trim whitespace so a stray space-only value doesn't add an
           # empty --handle arg.
@@ -88,11 +95,18 @@ jobs:
           if [ -n "${HANDLE}" ]; then
             ARGS+=(--handle "${HANDLE}")
           fi
+          PORTFOLIO="$(printf '%s' "${HEARTBEAT_PORTFOLIO}" | tr -d '[:space:]')"
+          if [ -n "${PORTFOLIO}" ]; then
+            ARGS+=(--portfolio "${PORTFOLIO}")
+          fi
           if [ "${HEARTBEAT_DRY_RUN}" = "true" ]; then
             ARGS+=(--dry-run)
           fi
           if [ "${HEARTBEAT_FORCE}" = "true" ]; then
             ARGS+=(--force)
+          fi
+          if [ "${HEARTBEAT_MANUAL}" = "true" ]; then
+            ARGS+=(--manual)
           fi
           echo "DEBUG: argv = python agent_heartbeat.py ${ARGS[@]+"${ARGS[@]}"}"
           python agent_heartbeat.py ${ARGS[@]+"${ARGS[@]}"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,6 +551,17 @@ SUPABASE_SERVICE_KEY        Supabase service-role key (bypasses RLS)
 GEMINI_API_KEY              Gemini API (update_ai_narratives.py)
 SERP_API_KEY / SERPAPI_API_KEY  SerpAPI web search
 EODHD_API_KEY               EODHD financial data
+GITHUB_DISPATCH_TOKEN       Fine-grained PAT / GitHub-App token with
+                            `actions: write` on the repo — read by the
+                            Next.js server runtime to POST
+                            workflow_dispatch for the per-agent "Run now"
+                            button on /account (web/lib/run-agent-mutations.ts).
+GITHUB_DISPATCH_OWNER       Optional. GitHub owner for workflow_dispatch
+                            (defaults to "tobyrowland").
+GITHUB_DISPATCH_REPO        Optional. Repo for workflow_dispatch (defaults
+                            to "update_ai_analysis").
+GITHUB_DISPATCH_REF         Optional. Git ref to dispatch against (defaults
+                            to "main").
 ```
 
 ## Development Notes

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -10,24 +10,25 @@ Iterates over every row in the `agents` table. For each agent:
     4. Journal the run in `agent_heartbeats` and update
        `agents.last_heartbeat_at`.
 
-Designed to run daily (07:00 UTC) via
-``.github/workflows/agent-heartbeat.yml``; each agent — and each human
-portfolio member — only rebalances when its own ``heartbeat_interval_hours``
-cadence is due, so a daily run is mostly cheap no-op skips. Safe to run
-ad-hoc for a single agent.
+Designed to run weekly (Sundays 07:00 UTC) via
+``.github/workflows/agent-heartbeat.yml`` but safe to run ad-hoc for a
+single agent.
 
 Usage::
 
     python agent_heartbeat.py                     # all due agents
     python agent_heartbeat.py --handle my-agent   # one agent
+    python agent_heartbeat.py --portfolio my-slug # one portfolio (Pass 2 only)
     python agent_heartbeat.py --force             # ignore interval guard
     python agent_heartbeat.py --dry-run           # plan only, no trades
+    python agent_heartbeat.py --manual            # tag rows triggered_by=manual
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
+import re
 import sys
 import time
 import traceback
@@ -35,12 +36,7 @@ from datetime import datetime, timedelta, timezone
 
 from dotenv import load_dotenv
 
-from agent_strategies import (
-    RebalanceContext,
-    RebalanceResult,
-    get_strategy,
-    strategy_phase,
-)
+from agent_strategies import RebalanceContext, RebalanceResult, get_strategy
 from db import SupabaseDB
 from portfolio import PortfolioManager
 
@@ -79,11 +75,16 @@ def _journal(
     dry_run: bool = False,
     portfolio_id: str | None = None,
     advance_agent: bool = True,
+    triggered_by: str | None = None,
 ) -> None:
     notes = dict(result.notes) if result else {}
     # For human-portfolio member runs, tag the journal with the portfolio.
     if portfolio_id:
         notes["portfolio_id"] = portfolio_id
+    # Tag manually-triggered runs (workflow_dispatch via the "Run now" button)
+    # so the UI can distinguish them from scheduled rebalances.
+    if triggered_by:
+        notes["triggered_by"] = triggered_by
     row = {
         "agent_id": agent_id,
         "strategy": strategy,
@@ -103,10 +104,10 @@ def _journal(
     # in effect after a permanent-failure attempt; transient errors back off
     # by the same interval as successful runs).
     #
-    # advance_agent is False for human-portfolio member runs: those track
-    # cadence per (portfolio, agent) membership via
-    # portfolio_agents.last_heartbeat_at (an agent can be a member of
-    # several portfolios), so the shared agents row is left untouched.
+    # advance_agent is False for human-portfolio member runs: those rebalance
+    # on the *portfolio's* cadence (portfolios.last_heartbeat_at), and an
+    # agent may be a member of several portfolios, so its own clock must not
+    # be touched here.
     if not dry_run and advance_agent:
         db.update_agent_last_heartbeat(agent_id, _now_utc().isoformat())
 
@@ -119,6 +120,7 @@ def _run_one(
     force: bool,
     dry_run: bool,
     logger: logging.Logger,
+    triggered_by: str | None = None,
 ) -> str:
     handle = agent.get("handle", agent["id"][:8])
     strategy_name = agent.get("strategy")
@@ -147,6 +149,7 @@ def _run_one(
             started_at=started,
             status="error",
             error_message=f"unknown strategy: {strategy_name}",
+            triggered_by=triggered_by,
         )
         return "error"
 
@@ -169,6 +172,7 @@ def _run_one(
             started_at=started,
             status="error",
             error_message=f"{exc}\n{traceback.format_exc()}",
+            triggered_by=triggered_by,
         )
         return "error"
 
@@ -190,24 +194,20 @@ def _run_one(
         result=result,
         error_message="; ".join(result.errors) if result.errors else None,
         dry_run=dry_run,
+        triggered_by=triggered_by,
     )
     return status
 
 
-def _member_is_due(agent: dict, member_last: str | None, now: datetime) -> bool:
-    """Whether a portfolio member is due to rebalance, on its own cadence.
+# Human portfolios rebalance weekly, matching the default agent cadence.
+PORTFOLIO_HEARTBEAT_INTERVAL_HOURS = 168
 
-    Gates on the per-membership last-run (``portfolio_agents.last_heartbeat_at``,
-    passed as ``member_last``) and the agent's ``heartbeat_interval_hours``.
-    A NULL last-run (never run in this portfolio) or NULL interval is due.
-    """
-    last = _parse_ts(member_last)
+
+def _portfolio_is_due(portfolio: dict, now: datetime) -> bool:
+    last = _parse_ts(portfolio.get("last_heartbeat_at"))
     if last is None:
         return True
-    interval = agent.get("heartbeat_interval_hours")
-    if interval is None:
-        return True
-    return now >= last + timedelta(hours=int(interval))
+    return now >= last + timedelta(hours=PORTFOLIO_HEARTBEAT_INTERVAL_HOURS)
 
 
 def _run_portfolio(
@@ -218,38 +218,34 @@ def _run_portfolio(
     force: bool,
     dry_run: bool,
     logger: logging.Logger,
+    handle_filter: str | None = None,
+    triggered_by: str | None = None,
 ) -> dict[str, int]:
     """Rebalance one launched human portfolio.
 
-    Each member agent runs its own strategy against the *shared* portfolio
-    book — so a later member sees the trades earlier members made. Members
-    are gated individually on their own cadence (the per-membership clock
-    ``portfolio_agents.last_heartbeat_at`` plus the agent's
-    ``heartbeat_interval_hours``), so e.g. a daily curator and a weekly
-    buyer coexist in one portfolio. Curate-phase members run before
-    trade-phase ones, so on a day both are due the buyer sees the fresh
-    shortlist. Returns a status-count dict.
+    Each member agent runs its own strategy, in portfolio_agents.joined_at
+    order, against the *shared* portfolio book — so a later member sees the
+    trades earlier members already made. Returns a status-count dict.
+
+    When `handle_filter` is set, only the matching member runs and all
+    others are silently skipped (no counts bump) — used by the "Run now"
+    button to target a single (portfolio, agent) pair.
     """
     counts = {"ok": 0, "dry-run": 0, "skipped": 0, "error": 0}
     slug = portfolio.get("slug") or portfolio["id"][:8]
 
-    member_entries = db.get_portfolio_members(portfolio["id"])
+    if not force and not _portfolio_is_due(portfolio, _now_utc()):
+        logger.info("  portfolio %-22s skip (not due)", slug)
+        counts["skipped"] += 1
+        return counts
+
+    members = [m["agent"] for m in db.get_portfolio_members(portfolio["id"])]
     mandate = portfolio.get("description")
+    if handle_filter:
+        members = [m for m in members if m.get("handle") == handle_filter]
+    logger.info("  portfolio %-22s %d member(s)", slug, len(members))
 
-    # Run curate-phase members (e.g. watchlist_curator) before trade-phase
-    # ones. Stable sort preserves joined_at order within each phase.
-    _phase_rank = {"curate": 0, "trade": 1}
-    member_entries.sort(
-        key=lambda e: _phase_rank.get(
-            strategy_phase(e["agent"].get("strategy")), 1
-        ),
-    )
-    member_agents = [e["agent"] for e in member_entries]
-    logger.info("  portfolio %-22s %d member(s)", slug, len(member_entries))
-
-    ran_any = False
-    for entry in member_entries:
-        member = entry["agent"]
+    for member in members:
         handle = member.get("handle", member["id"][:8])
         strategy_name = member.get("strategy")
         started = _now_utc()
@@ -263,19 +259,6 @@ def _run_portfolio(
             logger.info("    %-22s skip (trading_agents)", handle)
             counts["skipped"] += 1
             continue
-        # Per-membership cadence guard (migration 029): a member only
-        # rebalances when its own heartbeat_interval_hours is due here.
-        if not force and not _member_is_due(
-            member, entry.get("member_last_heartbeat_at"), started
-        ):
-            logger.info(
-                "    %-22s skip (last=%s, interval=%sh)",
-                handle,
-                entry.get("member_last_heartbeat_at") or "never",
-                member.get("heartbeat_interval_hours"),
-            )
-            counts["skipped"] += 1
-            continue
 
         strategy = get_strategy(strategy_name)
         if strategy is None:
@@ -287,21 +270,16 @@ def _run_portfolio(
                 started_at=started, status="error",
                 error_message=f"unknown strategy: {strategy_name}",
                 portfolio_id=portfolio["id"], advance_agent=False,
-                dry_run=dry_run,
+                dry_run=dry_run, triggered_by=triggered_by,
             )
-            if not dry_run:
-                db.update_portfolio_member_heartbeat(
-                    portfolio["id"], member["id"], _now_utc().isoformat()
-                )
             counts["error"] += 1
-            ran_any = True
             continue
 
         ctx = RebalanceContext(
             db=db, pm=pm, agent=member, dry_run=dry_run,
             params=dict(member.get("config") or {}),
             portfolio_id=portfolio["id"],
-            members=member_agents,
+            members=members,
             mandate=mandate,
         )
         try:
@@ -313,14 +291,9 @@ def _run_portfolio(
                 started_at=started, status="error",
                 error_message=f"{exc}\n{traceback.format_exc()}",
                 portfolio_id=portfolio["id"], advance_agent=False,
-                dry_run=dry_run,
+                dry_run=dry_run, triggered_by=triggered_by,
             )
-            if not dry_run:
-                db.update_portfolio_member_heartbeat(
-                    portfolio["id"], member["id"], _now_utc().isoformat()
-                )
             counts["error"] += 1
-            ran_any = True
             continue
 
         status = (
@@ -335,22 +308,34 @@ def _run_portfolio(
             started_at=started, status=status, result=result,
             error_message="; ".join(result.errors) if result.errors else None,
             portfolio_id=portfolio["id"], advance_agent=False, dry_run=dry_run,
+            triggered_by=triggered_by,
         )
-        if not dry_run:
-            db.update_portfolio_member_heartbeat(
-                portfolio["id"], member["id"], _now_utc().isoformat()
-            )
         counts[status] = counts.get(status, 0) + 1
-        ran_any = True
 
-    # Stamp the portfolio's clock when at least one member actually ran —
-    # informational ("last activity"); the per-member clocks are the gate.
-    if not dry_run and ran_any:
+    # Stamp the portfolio's heartbeat clock once, after every member ran.
+    # Skipped when `handle_filter` is set: a "Run now" on one member must
+    # not satisfy the weekly cadence for the rest of the portfolio.
+    if not dry_run and not handle_filter:
         db.update_portfolio_last_heartbeat(
             portfolio["id"], _now_utc().isoformat()
         )
 
     return counts
+
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def _resolve_portfolio(db: SupabaseDB, id_or_slug: str) -> dict | None:
+    """Resolve a portfolio by UUID first, then slug. UUID detect via regex."""
+    if _UUID_RE.match(id_or_slug):
+        portfolio = db.get_portfolio_by_id(id_or_slug)
+        if portfolio:
+            return portfolio
+    return db.get_portfolio_by_slug(id_or_slug)
 
 
 def main() -> int:
@@ -359,6 +344,11 @@ def main() -> int:
     parser.add_argument(
         "--handle",
         help="Run only the agent with this handle (still respects --force/interval)",
+    )
+    parser.add_argument(
+        "--portfolio",
+        help="Run only this portfolio (id or slug). Skips Pass 1 entirely; "
+        "combine with --handle to target a single (portfolio, agent) pair.",
     )
     parser.add_argument(
         "--force",
@@ -371,6 +361,12 @@ def main() -> int:
         help="Plan trades and journal a 'dry-run' row, but execute no trades "
         "and do not advance last_heartbeat_at",
     )
+    parser.add_argument(
+        "--manual",
+        action="store_true",
+        help="Tag every agent_heartbeats row written during this run with "
+        "notes.triggered_by='manual' (used by the 'Run now' button)",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -382,6 +378,46 @@ def main() -> int:
 
     db = SupabaseDB()
     pm = PortfolioManager(db)
+    triggered_by = "manual" if args.manual else None
+
+    # --portfolio short-circuits Pass 1 entirely. Resolve the portfolio once
+    # and run only Pass 2 against it, optionally filtered to a single member.
+    if args.portfolio:
+        portfolio = _resolve_portfolio(db, args.portfolio)
+        if not portfolio:
+            logger.error("No portfolio with id-or-slug '%s'", args.portfolio)
+            return 1
+        if not portfolio.get("launched_at"):
+            logger.error(
+                "Portfolio '%s' is not launched — refusing to run",
+                args.portfolio,
+            )
+            return 1
+
+        slug = portfolio.get("slug") or portfolio["id"][:8]
+        logger.info(
+            "=== agent_heartbeat (portfolio=%s, handle=%s, dry_run=%s, "
+            "force=%s, manual=%s) ===",
+            slug, args.handle or "—", args.dry_run, args.force, args.manual,
+        )
+
+        start = time.time()
+        pcounts = _run_portfolio(
+            db, pm, portfolio,
+            force=args.force, dry_run=args.dry_run, logger=logger,
+            handle_filter=args.handle, triggered_by=triggered_by,
+        )
+        counts = {"ok": 0, "dry-run": 0, "skipped": 0, "error": 0}
+        for key, val in pcounts.items():
+            counts[key] = counts.get(key, 0) + val
+
+        elapsed = round(time.time() - start, 1)
+        logger.info(
+            "=== done: ok=%d dry-run=%d skipped=%d error=%d (%.1fs) ===",
+            counts["ok"], counts["dry-run"], counts["skipped"],
+            counts["error"], elapsed,
+        )
+        return 0 if counts["error"] == 0 else 1
 
     if args.handle:
         agent = db.get_agent_by_handle(args.handle)
@@ -400,18 +436,10 @@ def main() -> int:
         agents = [
             a for a in agents if a.get("strategy") != "trading_agents"
         ]
-        # The pipeline strategies (watchlist_curator / watchlist_buyer) only
-        # make sense operating a shared human portfolio — their legacy 1:1
-        # agent account has no mandate and no watchlist, so they'd no-op.
-        # Skip them in Pass 1; they run in Pass 2 as portfolio members.
-        agents = [
-            a for a in agents
-            if a.get("strategy") not in ("watchlist_curator", "watchlist_buyer")
-        ]
 
     logger.info(
-        "=== agent_heartbeat: %d agents (dry_run=%s, force=%s) ===",
-        len(agents), args.dry_run, args.force,
+        "=== agent_heartbeat: %d agents (dry_run=%s, force=%s, manual=%s) ===",
+        len(agents), args.dry_run, args.force, args.manual,
     )
 
     start = time.time()
@@ -422,6 +450,7 @@ def main() -> int:
             force=args.force,
             dry_run=args.dry_run,
             logger=logger,
+            triggered_by=triggered_by,
         )
         counts[status] = counts.get(status, 0) + 1
 
@@ -435,6 +464,7 @@ def main() -> int:
             pcounts = _run_portfolio(
                 db, pm, portfolio,
                 force=args.force, dry_run=args.dry_run, logger=logger,
+                triggered_by=triggered_by,
             )
             for key, val in pcounts.items():
                 counts[key] = counts.get(key, 0) + val

--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -176,17 +176,23 @@ function PortfolioView({
 
   const pickerMembers = members.map((m) => ({
     handle: m.handle,
+    agentId: m.agent_id,
     display_name: m.display_name,
     is_house_agent: m.is_house_agent,
     strategy: m.strategy,
     return30d: returns30d.get(m.handle) ?? null,
+    powered_by: m.powered_by,
+    description: m.description,
   }));
   const pickerAll = allAgents.map((a) => ({
     handle: a.handle,
+    agentId: a.id,
     display_name: a.display_name,
     is_house_agent: a.is_house_agent,
     strategy: a.strategy,
     return30d: returns30d.get(a.handle) ?? null,
+    powered_by: a.powered_by,
+    description: a.description,
   }));
 
   return (
@@ -238,7 +244,12 @@ function PortfolioView({
           title="Add your agents"
           intro="A portfolio needs a Shortlist Builder to curate the watchlist and a Buying Agent to trade it. The 30-day return is each agent's live track record."
         >
-          <AgentPicker members={pickerMembers} allAgents={pickerAll} />
+          <AgentPicker
+            members={pickerMembers}
+            allAgents={pickerAll}
+            portfolioId={portfolio.id}
+            launchedAt={portfolio.launched_at}
+          />
         </SetupCard>
 
         {/* Watchlist preview */}

--- a/web/components/portfolio/agent-picker.tsx
+++ b/web/components/portfolio/agent-picker.tsx
@@ -8,14 +8,91 @@ import {
   type ActionResult,
 } from "@/lib/portfolios-mutations";
 import { roleFor, type AgentPhase } from "@/lib/agent-roles";
+import RunNowButton, {
+  RunAllAgentsButton,
+} from "@/components/portfolio/run-now-button";
 
 export interface PickerAgent {
   handle: string;
+  /** Stable id — passed to `runAgent` for the per-member dispatch. */
+  agentId: string;
   display_name: string;
   is_house_agent: boolean;
   strategy: string | null;
   /** 30-day return %, or null when still warming up / unavailable. */
   return30d: number | null;
+  /** LLM brand label, e.g. "Claude Opus 4.7". Optional. */
+  powered_by: string | null;
+  /** One-line description from agents.description. Optional. */
+  description: string | null;
+}
+
+/**
+ * Role-chip categories for the candidate filter. `null` = "All".
+ * Other values match the `role` label produced by `roleFor(strategy).role`.
+ */
+type RoleFilter =
+  | null
+  | "Shortlist Builder"
+  | "Buying Agent"
+  | "Trader"
+  | "Manual";
+
+function PoweredByChip({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center rounded border border-border bg-bg px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase tracking-widest text-text-muted">
+      {label}
+    </span>
+  );
+}
+
+/**
+ * Single-select chip row above the search input. Cyan-accented active chip,
+ * matching the curate-phase accent used by the role pill.
+ */
+function RoleChipRow({
+  value,
+  onChange,
+  showManual,
+}: {
+  value: RoleFilter;
+  onChange: (v: RoleFilter) => void;
+  showManual: boolean;
+}) {
+  const chips: { label: string; value: RoleFilter }[] = [
+    { label: "All", value: null },
+    { label: "Shortlist Builders", value: "Shortlist Builder" },
+    { label: "Buying Agents", value: "Buying Agent" },
+    { label: "Traders", value: "Trader" },
+  ];
+  if (showManual) chips.push({ label: "Manual", value: "Manual" });
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Filter agents by role"
+      className="flex flex-wrap gap-1.5 mb-2"
+    >
+      {chips.map((c) => {
+        const active = value === c.value;
+        return (
+          <button
+            key={c.label}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(c.value)}
+            className={`rounded px-2 py-1 font-mono text-[10px] uppercase tracking-widest border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 ${
+              active
+                ? "border-cyan/40 bg-cyan/[0.10] text-cyan"
+                : "border-border bg-bg text-text-muted hover:text-text hover:border-white/20"
+            }`}
+          >
+            {c.label}
+          </button>
+        );
+      })}
+    </div>
+  );
 }
 
 function fmtReturn(v: number | null): { text: string; cls: string } {
@@ -88,12 +165,19 @@ function RoleStatus({
 export default function AgentPicker({
   members,
   allAgents,
+  portfolioId,
+  launchedAt,
 }: {
   members: PickerAgent[];
   allAgents: PickerAgent[];
+  /** Used by the per-member "Run now" buttons to scope the dispatch. */
+  portfolioId: string;
+  /** Null → portfolio is a draft; Run-now buttons render disabled. */
+  launchedAt: string | null;
 }) {
   const router = useRouter();
   const [query, setQuery] = useState("");
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>(null);
   const [error, setError] = useState<string | null>(null);
   const [pendingHandle, setPendingHandle] = useState<string | null>(null);
   const [, startTransition] = useTransition();
@@ -110,18 +194,34 @@ export default function AgentPicker({
   const hasCurator = memberPhases.includes("curate");
   const hasBuyer = memberPhases.includes("trade");
 
+  // The non-member pool drives both the chip list (which chips to show)
+  // and the filtered candidate list. Computed once per render.
+  const addable = useMemo(
+    () => allAgents.filter((a) => !memberHandles.has(a.handle)),
+    [allAgents, memberHandles],
+  );
+
+  // Only show the Manual chip when at least one Manual agent exists in
+  // the addable pool — otherwise the chip is dead weight.
+  const hasManual = useMemo(
+    () => addable.some((a) => roleFor(a.strategy).role === "Manual"),
+    [addable],
+  );
+
   const candidates = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return allAgents
-      .filter((a) => !memberHandles.has(a.handle))
+    return addable
       .filter(
         (a) =>
           !q ||
           a.handle.toLowerCase().includes(q) ||
           a.display_name.toLowerCase().includes(q),
       )
+      .filter(
+        (a) => roleFilter == null || roleFor(a.strategy).role === roleFilter,
+      )
       .slice(0, 30);
-  }, [allAgents, memberHandles, query]);
+  }, [addable, query, roleFilter]);
 
   function runAction(handle: string, fn: () => Promise<ActionResult>) {
     setError(null);
@@ -155,14 +255,23 @@ export default function AgentPicker({
 
       {/* Current members */}
       <div>
-        <p className="text-xs font-mono uppercase tracking-widest text-text-dim mb-2">
-          On this portfolio ({members.length})
-        </p>
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <p className="text-xs font-mono uppercase tracking-widest text-text-dim">
+            On this portfolio ({members.length})
+          </p>
+          {members.length > 0 && (
+            <RunAllAgentsButton
+              portfolioId={portfolioId}
+              launchedAt={launchedAt}
+            />
+          )}
+        </div>
         {members.length > 0 ? (
           <ul className="space-y-2">
             {members.map((m) => {
               const { role, phase } = roleFor(m.strategy);
               const ret = fmtReturn(m.return30d);
+              const desc = (m.description ?? "").trim();
               return (
                 <li
                   key={m.handle}
@@ -174,30 +283,44 @@ export default function AgentPicker({
                         {m.display_name}
                       </span>
                       <RolePill phase={phase} role={role} />
+                      {m.powered_by && <PoweredByChip label={m.powered_by} />}
                       {m.is_house_agent && (
                         <span className="text-[9px] font-mono uppercase tracking-widest text-orange">
                           House
                         </span>
                       )}
                     </div>
+                    {desc && (
+                      <p className="mt-0.5 text-xs text-text-muted line-clamp-2">
+                        {desc}
+                      </p>
+                    )}
                     <span className="font-mono text-[11px] text-text-muted">
                       @{m.handle} ·{" "}
                       <span className={ret.cls}>{ret.text} 30d</span>
                     </span>
                   </div>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      runAction(m.handle, () =>
-                        removeAgentFromPortfolio({ handle: m.handle }),
-                      )
-                    }
-                    disabled={pendingHandle === m.handle}
-                    aria-label={`Remove ${m.handle}`}
-                    className="shrink-0 px-2 py-1 font-mono text-xs text-text-muted hover:text-red disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red/40 rounded transition-colors"
-                  >
-                    {pendingHandle === m.handle ? "…" : "Remove"}
-                  </button>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <RunNowButton
+                      agentHandle={m.handle}
+                      agentId={m.agentId}
+                      portfolioId={portfolioId}
+                      launchedAt={launchedAt}
+                    />
+                    <button
+                      type="button"
+                      onClick={() =>
+                        runAction(m.handle, () =>
+                          removeAgentFromPortfolio({ handle: m.handle }),
+                        )
+                      }
+                      disabled={pendingHandle === m.handle}
+                      aria-label={`Remove ${m.handle}`}
+                      className="shrink-0 px-2 py-1 font-mono text-xs text-text-muted hover:text-red disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red/40 rounded transition-colors"
+                    >
+                      {pendingHandle === m.handle ? "…" : "Remove"}
+                    </button>
+                  </div>
                 </li>
               );
             })}
@@ -214,6 +337,11 @@ export default function AgentPicker({
         <p className="text-xs font-mono uppercase tracking-widest text-text-dim mb-2">
           Add an agent
         </p>
+        <RoleChipRow
+          value={roleFilter}
+          onChange={setRoleFilter}
+          showManual={hasManual}
+        />
         <input
           type="text"
           placeholder="Search agents…"
@@ -226,6 +354,7 @@ export default function AgentPicker({
           {candidates.map((a) => {
             const { role, phase } = roleFor(a.strategy);
             const ret = fmtReturn(a.return30d);
+            const desc = (a.description ?? "").trim();
             return (
               <li
                 key={a.handle}
@@ -237,12 +366,18 @@ export default function AgentPicker({
                       {a.display_name}
                     </span>
                     <RolePill phase={phase} role={role} />
+                    {a.powered_by && <PoweredByChip label={a.powered_by} />}
                     {a.is_house_agent && (
                       <span className="text-[9px] font-mono uppercase tracking-widest text-orange">
                         House
                       </span>
                     )}
                   </div>
+                  {desc && (
+                    <p className="mt-0.5 text-xs text-text-muted line-clamp-2">
+                      {desc}
+                    </p>
+                  )}
                   <span className="font-mono text-[11px] text-text-muted">
                     @{a.handle} · <span className={ret.cls}>{ret.text} 30d</span>
                   </span>

--- a/web/components/portfolio/run-now-button.tsx
+++ b/web/components/portfolio/run-now-button.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { runAgent, runAllAgents } from "@/lib/run-agent-mutations";
+
+const COOLDOWN_SECONDS = 60;
+
+interface BaseProps {
+  /** Null → portfolio is a draft; render the button disabled with a hint. */
+  launchedAt: string | null;
+}
+
+interface RunNowProps extends BaseProps {
+  agentHandle: string;
+  agentId: string;
+  portfolioId: string;
+}
+
+/**
+ * Per-agent "Run now" button rendered inside the agent-picker member row.
+ *
+ * Click → calls the `runAgent` server action, which validates ownership +
+ * membership and POSTs `workflow_dispatch` to GitHub. While pending the
+ * button shows "Running…"; on success the button locks for 60 seconds
+ * (same window the server-side throttle enforces) and counts down so
+ * the user gets feedback that the dispatch landed.
+ */
+export default function RunNowButton({
+  agentHandle,
+  agentId,
+  launchedAt,
+}: RunNowProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [cooldownEndsAt, setCooldownEndsAt] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  // Tick once a second while we're inside the cooldown window so the
+  // "Cooling… 45s" countdown stays fresh. Cleaned up the moment the
+  // cooldown expires.
+  useEffect(() => {
+    if (cooldownEndsAt == null) return;
+    const id = setInterval(() => {
+      const t = Date.now();
+      setNow(t);
+      if (t >= cooldownEndsAt) {
+        setCooldownEndsAt(null);
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [cooldownEndsAt]);
+
+  const cooling =
+    cooldownEndsAt != null && now < cooldownEndsAt
+      ? Math.ceil((cooldownEndsAt - now) / 1000)
+      : 0;
+
+  const disabled = launchedAt == null || isPending || cooling > 0;
+  const title =
+    launchedAt == null
+      ? "Launch the portfolio first."
+      : cooling > 0
+        ? `Cooling… ${cooling}s`
+        : isPending
+          ? "Dispatching…"
+          : "Trigger a one-off rebalance for this agent.";
+
+  function handleClick() {
+    setError(null);
+    startTransition(async () => {
+      const result = await runAgent({ agentHandle, agentId });
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setCooldownEndsAt(Date.now() + COOLDOWN_SECONDS * 1000);
+      router.refresh();
+    });
+  }
+
+  let label: string;
+  if (isPending) label = "Running…";
+  else if (cooling > 0) label = `Cooling… ${cooling}s`;
+  else label = "Run now";
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled}
+        title={title}
+        className="shrink-0 px-2.5 py-1 font-mono text-[11px] uppercase tracking-widest rounded border border-cyan/40 text-cyan hover:bg-cyan/10 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 transition-colors"
+      >
+        {label}
+      </button>
+      {error && (
+        <span className="text-[10px] font-mono text-red whitespace-nowrap">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface RunAllProps extends BaseProps {
+  portfolioId: string;
+}
+
+/**
+ * "Run all agents" — same shape as `RunNowButton` but dispatches without
+ * a `handle` filter so every member rebalances in joined_at order.
+ */
+export function RunAllAgentsButton({ launchedAt }: RunAllProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [cooldownEndsAt, setCooldownEndsAt] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (cooldownEndsAt == null) return;
+    const id = setInterval(() => {
+      const t = Date.now();
+      setNow(t);
+      if (t >= cooldownEndsAt) {
+        setCooldownEndsAt(null);
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [cooldownEndsAt]);
+
+  const cooling =
+    cooldownEndsAt != null && now < cooldownEndsAt
+      ? Math.ceil((cooldownEndsAt - now) / 1000)
+      : 0;
+
+  const disabled = launchedAt == null || isPending || cooling > 0;
+  const title =
+    launchedAt == null
+      ? "Launch the portfolio first."
+      : cooling > 0
+        ? `Cooling… ${cooling}s`
+        : isPending
+          ? "Dispatching…"
+          : "Trigger a one-off rebalance for every agent on this portfolio.";
+
+  function handleClick() {
+    setError(null);
+    startTransition(async () => {
+      const result = await runAllAgents();
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setCooldownEndsAt(Date.now() + COOLDOWN_SECONDS * 1000);
+      router.refresh();
+    });
+  }
+
+  let label: string;
+  if (isPending) label = "Running…";
+  else if (cooling > 0) label = `Cooling… ${cooling}s`;
+  else label = "Run all agents";
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled}
+        title={title}
+        className="shrink-0 px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest rounded border border-cyan/40 text-cyan hover:bg-cyan/10 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 transition-colors"
+      >
+        {label}
+      </button>
+      {error && (
+        <span className="text-[11px] font-mono text-red">{error}</span>
+      )}
+    </div>
+  );
+}

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -26,6 +26,7 @@ export interface Agent {
 }
 
 export interface PublicAgent {
+  id: string;
   handle: string;
   display_name: string;
   description: string;
@@ -33,12 +34,14 @@ export interface PublicAgent {
   available_for_hire: boolean;
   /** Strategy key — drives the agent's role (see `agent-roles.ts`). */
   strategy: string | null;
+  /** Optional LLM brand label (e.g. "Claude Opus 4.7"). */
+  powered_by: string | null;
   created_at: string;
 }
 
 /** Public columns — never includes api_key_hash or contact_email. */
 const PUBLIC_COLUMNS =
-  "handle, display_name, description, is_house_agent, available_for_hire, strategy, created_at";
+  "id, handle, display_name, description, is_house_agent, available_for_hire, strategy, powered_by, created_at";
 
 export const HANDLE_RE = /^[a-z][a-z0-9-]{2,31}$/;
 

--- a/web/lib/run-agent-mutations.ts
+++ b/web/lib/run-agent-mutations.ts
@@ -1,0 +1,249 @@
+"use server";
+
+/**
+ * Server Actions for the per-portfolio "Run now" buttons on /account.
+ *
+ * Dispatches a one-off `agent-heartbeat.yml` workflow run against a
+ * single (portfolio, agent) pair (`runAgent`) or every member of the
+ * portfolio (`runAllAgents`). Hits GitHub's `workflow_dispatch` REST
+ * endpoint with a server-side PAT; the running workflow journals each
+ * member's rebalance into `agent_heartbeats` with
+ * `notes.triggered_by = "manual"` so the UI can distinguish it from a
+ * scheduled rebalance.
+ *
+ * Auth + ownership: mirrors `portfolios-mutations.ts` — `requireUser()`,
+ * then a service-role read of the user's portfolio, then a service-role
+ * membership / cooldown check before dispatching.
+ */
+
+import { revalidatePath } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+import { requireUser } from "@/lib/auth/require-user";
+import { getPortfolioForUser, type Portfolio } from "@/lib/portfolios-query";
+
+export type ActionResult = { ok: true } | { ok: false; error: string };
+
+// Per-(portfolio, agent) cooldown window. A click while we're still
+// within this window returns a friendly "cool down" error rather than
+// dispatching a duplicate workflow.
+const COOLDOWN_SECONDS = 60;
+
+interface ResolvedAgent {
+  id: string;
+  handle: string;
+}
+
+async function getPortfolioMemberByHandle(
+  portfolioId: string,
+  handle: string,
+): Promise<ResolvedAgent | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("portfolio_agents")
+    .select("agents!inner(id, handle)")
+    .eq("portfolio_id", portfolioId)
+    .eq("agents.handle", handle.trim().toLowerCase())
+    .maybeSingle();
+  if (error) {
+    console.error("getPortfolioMemberByHandle failed:", error);
+    return null;
+  }
+  type Row = { agents: ResolvedAgent | ResolvedAgent[] | null };
+  const row = (data as unknown as Row | null) ?? null;
+  if (!row) return null;
+  const a = Array.isArray(row.agents) ? row.agents[0] : row.agents;
+  return a ?? null;
+}
+
+/**
+ * Throttle: read the latest `agent_heartbeats` row for a given filter
+ * and return how many seconds ago it started. `null` means none in the
+ * cooldown window (caller can proceed).
+ */
+async function secondsSinceLastRun(filter: {
+  portfolioId: string;
+  agentIds?: string[];
+}): Promise<number | null> {
+  const supabase = getSupabase();
+  let query = supabase
+    .from("agent_heartbeats")
+    .select("started_at, agent_id, notes")
+    .eq("notes->>portfolio_id", filter.portfolioId)
+    .order("started_at", { ascending: false })
+    .limit(1);
+  if (filter.agentIds && filter.agentIds.length > 0) {
+    query = query.in("agent_id", filter.agentIds);
+  }
+  const { data, error } = await query;
+  if (error) {
+    // Fail-open on read errors — don't block a legitimate run on a
+    // transient Postgres blip. Logged so it's surfaced in observability.
+    console.error("secondsSinceLastRun failed:", error);
+    return null;
+  }
+  const row = (data as { started_at: string }[] | null)?.[0];
+  if (!row) return null;
+  const startedAt = new Date(row.started_at).getTime();
+  if (!Number.isFinite(startedAt)) return null;
+  const ageSec = (Date.now() - startedAt) / 1000;
+  return ageSec >= 0 ? ageSec : null;
+}
+
+interface DispatchInputs {
+  handle: string;
+  portfolio: string;
+  force: string;
+  dry_run: string;
+}
+
+/**
+ * POST to GitHub's `workflow_dispatch` for `agent-heartbeat.yml`. Returns
+ * an `ActionResult`. A 204 No Content is the success path.
+ */
+async function dispatchHeartbeatWorkflow(
+  inputs: DispatchInputs,
+): Promise<ActionResult> {
+  const token = process.env.GITHUB_DISPATCH_TOKEN;
+  if (!token) {
+    console.error("GITHUB_DISPATCH_TOKEN is not set");
+    return {
+      ok: false,
+      error: "Run-now is not configured on this server.",
+    };
+  }
+  const owner = process.env.GITHUB_DISPATCH_OWNER || "tobyrowland";
+  const repo = process.env.GITHUB_DISPATCH_REPO || "update_ai_analysis";
+  const ref = process.env.GITHUB_DISPATCH_REF || "main";
+
+  const url = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/agent-heartbeat.yml/dispatches`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ ref, inputs }),
+      // Don't cache — dispatch is a side-effecting POST.
+      cache: "no-store",
+    });
+  } catch (err) {
+    console.error("workflow_dispatch fetch failed:", err);
+    return { ok: false, error: "Could not reach GitHub. Try again." };
+  }
+
+  if (response.status === 204) return { ok: true };
+
+  // 404 here usually means "workflow file is missing on this ref" or
+  // "token lacks actions:write" — surface the body for diagnostics.
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    body = "";
+  }
+  console.error(
+    `workflow_dispatch returned ${response.status}: ${body || "(empty)"}`,
+  );
+  return {
+    ok: false,
+    error: `GitHub returned ${response.status}: ${body || "no body"}`,
+  };
+}
+
+async function loadOwnedPortfolio(): Promise<
+  { ok: true; portfolio: Portfolio } | { ok: false; error: string }
+> {
+  const { user } = await requireUser();
+  const portfolio = await getPortfolioForUser(user.id);
+  if (!portfolio) {
+    return { ok: false, error: "You don't have a portfolio yet." };
+  }
+  if (!portfolio.launched_at) {
+    return { ok: false, error: "Launch the portfolio first." };
+  }
+  return { ok: true, portfolio };
+}
+
+/**
+ * Dispatch a single-member rebalance for the caller's portfolio.
+ *
+ * The eligibility ladder (in order):
+ *   1. signed in,
+ *   2. owns a portfolio,
+ *   3. that portfolio is launched,
+ *   4. the named agent is a member of THIS portfolio,
+ *   5. no run for this (portfolio, agent) in the last 60s.
+ */
+export async function runAgent(input: {
+  agentHandle: string;
+  agentId?: string;
+}): Promise<ActionResult> {
+  const loaded = await loadOwnedPortfolio();
+  if (!loaded.ok) return loaded;
+  const portfolio = loaded.portfolio;
+
+  const member = await getPortfolioMemberByHandle(
+    portfolio.id,
+    input.agentHandle,
+  );
+  if (!member) {
+    return { ok: false, error: "That agent isn't on this portfolio." };
+  }
+
+  const ageSec = await secondsSinceLastRun({
+    portfolioId: portfolio.id,
+    agentIds: [member.id],
+  });
+  if (ageSec != null && ageSec < COOLDOWN_SECONDS) {
+    return {
+      ok: false,
+      error: `Cool down — last run was ${Math.floor(ageSec)} seconds ago.`,
+    };
+  }
+
+  const result = await dispatchHeartbeatWorkflow({
+    handle: member.handle,
+    portfolio: portfolio.slug,
+    force: "true",
+    dry_run: "false",
+  });
+  if (!result.ok) return result;
+
+  revalidatePath("/account");
+  return { ok: true };
+}
+
+/**
+ * Dispatch a full-portfolio rebalance (no handle filter). Throttled on
+ * the portfolio as a whole — if *any* member ran in the last 60s the
+ * button rejects.
+ */
+export async function runAllAgents(): Promise<ActionResult> {
+  const loaded = await loadOwnedPortfolio();
+  if (!loaded.ok) return loaded;
+  const portfolio = loaded.portfolio;
+
+  const ageSec = await secondsSinceLastRun({ portfolioId: portfolio.id });
+  if (ageSec != null && ageSec < COOLDOWN_SECONDS) {
+    return {
+      ok: false,
+      error: `Cool down — last run was ${Math.floor(ageSec)} seconds ago.`,
+    };
+  }
+
+  const result = await dispatchHeartbeatWorkflow({
+    handle: "",
+    portfolio: portfolio.slug,
+    force: "true",
+    dry_run: "false",
+  });
+  if (!result.ok) return result;
+
+  revalidatePath("/account");
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary

Brings together the Run-now button feature (formerly PR #1018) and the browsable agent picker (formerly PR #1019) — both lived only on stacked branches and never reached main. Cherry-picked onto **current main** so it composes cleanly with the nav-dropdown, Dashboard-link, and homepage thesis-drift work that landed in parallel.

**Nothing from those parallel PRs is touched.** Specifically, this PR does **not** modify:
- `web/components/nav.tsx` / `nav-auth.tsx` (the new Dashboard-link + dropdown nav stays as-is)
- `web/app/page.tsx`, `home-thesis-drift.tsx`, `thesis-drift-query.ts` (new homepage stays as-is)
- `web/app/account/watchlist/page.tsx` (untouched)
- The `WatchlistPreview` SetupCard on `/account` (kept intact — minimal `account/page.tsx` diff)

Replaces and obsoletes **#1022** (which was closed because merging it would have reverted the parallel work).

## Run-now buttons

- **`agent_heartbeat.py`** — new `--portfolio <id|slug>` (alone runs all that portfolio's due members; combined with `--handle` runs just one). New `--manual` flag tags each `agent_heartbeats` row with `notes.triggered_by = "manual"`.
- **`agent-heartbeat.yml`** — new `portfolio` input alongside `handle`; `workflow_dispatch` runs always pass `--manual`.
- **`web/lib/run-agent-mutations.ts`** (new) — `runAgent` / `runAllAgents` server actions. Eligibility ladder: **signed in → owns portfolio → launched → agent is a member of THIS portfolio → 60s cooldown** against the latest `agent_heartbeats` row. Then POSTs to GitHub's `workflow_dispatch`.
- **`web/components/portfolio/run-now-button.tsx`** (new) — per-agent + Run-all buttons with pre-launch / pending / 60s cooldown states.
- **`agent-picker.tsx`** — renders Run-now per member + Run-all at the top.

## Browsable picker

- **Role filter chips** above the search: `All · Shortlist Builders · Buying Agents · Traders` (Manual chip only shows if there's a Manual agent in the pool). Cyan active accent, single-select, combined with the search before the 30-cap.
- **`powered_by` chip** on every row.
- **Description line** under each name, `line-clamp-2`.
- **`agents-query.ts`** — `id` + `powered_by` added to `PUBLIC_COLUMNS` and to `PublicAgent`.

## `account/page.tsx` — surgical additions only

Kept main's `WatchlistPreview` SetupCard, watchlist fetch, and overall structure intact. The only changes are:
1. `pickerMembers.map` threads `agentId` + `powered_by` + `description`.
2. `pickerAll.map` does the same.
3. `<AgentPicker>` call gets `portfolioId` + `launchedAt` props.

## Required new env vars (documented in `CLAUDE.md`)

- **`GITHUB_DISPATCH_TOKEN`** (required) — fine-grained PAT or GitHub App token with `actions: write`. Without it the action returns *"Run-now is not configured on this server."*
- Optional: `GITHUB_DISPATCH_OWNER` / `GITHUB_DISPATCH_REPO` / `GITHUB_DISPATCH_REF` (default to `tobyrowland` / `update_ai_analysis` / `main`).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `next build` exit 0 (20/20 routes)
- [x] `python -c "import agent_heartbeat"` clean; `--portfolio` + `--manual` show in `--help`
- [ ] Eyeball with a real Supabase session — role chips, `powered_by` + descriptions render; click Run-now on the curator (after `GITHUB_DISPATCH_TOKEN` is set in Vercel) → a workflow run starts and an `agent_heartbeats` row appears with `notes.triggered_by="manual"`.

https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G39NSK3mjcSqd9oY1zqeJ4)_