### PR TITLE
dashboard: ultra-minimal single-column flow

### DIFF
--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 import Nav from "@/components/nav";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -11,11 +10,9 @@ import {
   type PortfolioMember,
 } from "@/lib/portfolios-query";
 import { listPublicAgents, getAgentReturns30d } from "@/lib/agents-query";
-import { getWatchlistForPortfolio, type WatchlistItem } from "@/lib/watchlist-query";
 import { roleFor } from "@/lib/agent-roles";
 import CreatePortfolioForm from "@/components/portfolio/create-portfolio-form";
 import PortfolioDetailsEditor from "@/components/portfolio/portfolio-details-editor";
-import VisibilityToggle from "@/components/portfolio/visibility-toggle";
 import AgentPicker from "@/components/portfolio/agent-picker";
 import LaunchControl from "@/components/portfolio/launch-control";
 
@@ -65,7 +62,6 @@ export default async function AccountPage() {
   let members: PortfolioMember[] = [];
   let allAgents: Awaited<ReturnType<typeof listPublicAgents>> = [];
   let returns30d = new Map<string, number | null>();
-  let watchlist: WatchlistItem[] = [];
   if (portfolio) {
     try {
       members = await getMembersForPortfolio(portfolio.id);
@@ -83,25 +79,19 @@ export default async function AccountPage() {
     } catch {
       returns30d = new Map();
     }
-    try {
-      watchlist = await getWatchlistForPortfolio(portfolio.id);
-    } catch {
-      watchlist = [];
-    }
   }
 
   return (
     <>
       <Nav />
       <main className="flex-1 w-full">
-        <div className="max-w-[1180px] mx-auto w-full px-4 sm:px-6 py-8 sm:py-12">
+        <div className="max-w-[820px] mx-auto w-full px-4 sm:px-6 py-10 sm:py-14">
           {portfolio ? (
             <PortfolioView
               portfolio={portfolio}
               members={members}
               allAgents={allAgents}
               returns30d={returns30d}
-              watchlist={watchlist}
               email={email}
             />
           ) : (
@@ -144,7 +134,7 @@ function NoPortfolioView({
 }
 
 // ---------------------------------------------------------------------------
-// Portfolio exists — the two-column guided-setup layout.
+// Portfolio exists — ultra-minimal single-column path: mandate → agents → launch.
 // ---------------------------------------------------------------------------
 
 function PortfolioView({
@@ -152,14 +142,12 @@ function PortfolioView({
   members,
   allAgents,
   returns30d,
-  watchlist,
   email,
 }: {
   portfolio: Portfolio;
   members: PortfolioMember[];
   allAgents: Awaited<ReturnType<typeof listPublicAgents>>;
   returns30d: Map<string, number | null>;
-  watchlist: WatchlistItem[];
   email: string;
 }) {
   const live = portfolio.launched_at != null;
@@ -168,11 +156,9 @@ function PortfolioView({
   const hasBuyer = phases.includes("trade");
   const hasMandate = (portfolio.description ?? "").trim().length > 0;
 
-  // 3-step progress: mandate → agents (both roles) → live.
   const step1 = hasMandate;
   const step2 = hasCurator && hasBuyer;
   const step3 = live;
-  const completed = [step1, step2, step3].filter(Boolean).length;
 
   const pickerMembers = members.map((m) => ({
     handle: m.handle,
@@ -190,177 +176,54 @@ function PortfolioView({
   }));
 
   return (
-    <div className="grid gap-6 xl:gap-8 xl:grid-cols-[1fr_320px]">
-      {/* ---- Main column ---- */}
-      <div className="space-y-6">
-        {/* Header + progress */}
-        <header>
-          <div className="flex items-center gap-3">
-            <StateBadge live={live} />
-            <span className="text-[11px] font-mono uppercase tracking-widest text-text-muted">
-              {completed} / 3 steps done
-            </span>
-          </div>
-          <h1 className="mt-3 text-[26px] sm:text-[32px] font-bold tracking-[-0.025em] text-text leading-[1.12]">
-            {portfolio.display_name}
-          </h1>
-          <p className="mt-2 text-base text-text-muted leading-relaxed max-w-[60ch]">
-            {live
-              ? "Your team of agents is trading the shared $1M paper book to your mandate. Tune the setup below at any time."
-              : "Set up your portfolio in three steps, then go live to trade a $1M paper account."}
-          </p>
-          <ProgressSteps
-            steps={[
-              { label: "Write mandate", done: step1 },
-              { label: "Add agents", done: step2 },
-              { label: "Go live", done: step3 },
-            ]}
-          />
-        </header>
-
-        {/* 1. Mandate */}
-        <SetupCard
-          step={1}
-          glyph="clipboard"
-          title="Write the mandate"
-          intro="Your investment brief — the agents trade to it. Pick an example to start, then edit and save."
-        >
-          <PortfolioDetailsEditor
-            initialName={portfolio.display_name}
-            initialMandate={portfolio.description ?? ""}
-          />
-        </SetupCard>
-
-        {/* 2. Agents */}
-        <SetupCard
-          step={2}
-          glyph="branch"
-          title="Add your agents"
-          intro="A portfolio needs a Shortlist Builder to curate the watchlist and a Buying Agent to trade it. The 30-day return is each agent's live track record."
-        >
-          <AgentPicker members={pickerMembers} allAgents={pickerAll} />
-        </SetupCard>
-
-        {/* Watchlist preview */}
-        <SetupCard
-          glyph="target"
-          title="Watchlist"
-          intro="The shortlist of equities your agents populate and trade from."
-        >
-          <WatchlistPreview items={watchlist} />
-        </SetupCard>
-
-        {/* 3. Go live */}
-        <SetupCard
-          step={3}
-          glyph="bolt"
-          title={live ? "Live" : "Go live"}
-          intro={
-            live
-              ? "Your portfolio is trading."
-              : "Grant the $1M paper account and start trading."
-          }
-        >
-          <LaunchControl
-            launchedAt={portfolio.launched_at}
-            hasCurator={hasCurator}
-            hasBuyer={hasBuyer}
-          />
-        </SetupCard>
-
-        <SignOutRow email={email} />
-      </div>
-
-      {/* ---- Status rail ---- */}
-      <aside className="space-y-4 xl:sticky xl:top-20 xl:self-start">
-        <RailCard title="Portfolio status">
-          <div className="mb-3">
-            <StateBadge live={live} />
-          </div>
-          <ul className="space-y-2">
-            <ChecklistRow label="Mandate written" done={hasMandate} />
-            <ChecklistRow label="Shortlist Builder added" done={hasCurator} />
-            <ChecklistRow label="Buying Agent added" done={hasBuyer} />
-            <ChecklistRow label="Paper account live" done={live} />
-          </ul>
-        </RailCard>
-
-        <RailCard title="Benchmark goal" accent="cyan">
-          <p className="text-sm font-bold text-text">Beat the S&amp;P 500.</p>
-          <p className="mt-1.5 text-[12px] text-text-muted leading-relaxed">
-            Your portfolio is marked to market every day and charted against
-            the S&amp;P 500 (SPY) and MSCI World (URTH) on the public
-            leaderboard.
-          </p>
-        </RailCard>
-
-        <RailCard title="Visibility">
-          <VisibilityToggle isPublic={portfolio.is_public} />
-          <p className="mt-3 text-[11px] font-mono text-text-muted">
-            Public page:{" "}
-            <Link
-              href={`/portfolios/${portfolio.slug}`}
-              className="text-[var(--color-cyan)] hover:brightness-110 transition-[filter] focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 rounded"
-            >
-              /portfolios/{portfolio.slug}
-            </Link>
-          </p>
-        </RailCard>
-      </aside>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Watchlist preview
-// ---------------------------------------------------------------------------
-
-function WatchlistPreview({ items }: { items: WatchlistItem[] }) {
-  const top = items.slice(0, 5);
-  return (
-    <div>
-      {top.length > 0 ? (
-        <ul className="divide-y divide-white/[0.06] rounded-lg border border-white/10 overflow-hidden">
-          {top.map((it) => (
-            <li
-              key={it.ticker}
-              className="flex items-center justify-between gap-3 bg-white/[0.02] px-3 py-2.5"
-            >
-              <div className="min-w-0">
-                <span className="font-mono text-sm font-bold text-text">
-                  {it.ticker}
-                </span>
-                {it.company_name && (
-                  <span className="ml-2 text-[12px] text-text-muted truncate">
-                    {it.company_name}
-                  </span>
-                )}
-              </div>
-              <span
-                className={`shrink-0 rounded px-1.5 py-0.5 text-[9px] font-mono font-bold uppercase tracking-[0.14em] border ${
-                  it.source === "agent"
-                    ? "border-cyan/30 bg-cyan/[0.08] text-cyan"
-                    : "border-white/10 bg-white/[0.02] text-text-muted"
-                }`}
-              >
-                {it.source === "agent" ? "Agent" : "You"}
-              </span>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="text-sm text-text-muted italic">
-          No equities on the watchlist yet.
+    <div className="space-y-6 sm:space-y-8">
+      <header>
+        <h1 className="text-[30px] sm:text-[36px] font-bold tracking-[-0.02em] text-text leading-[1.08]">
+          {portfolio.display_name}
+        </h1>
+        <p className="mt-3 text-base text-text-muted leading-relaxed max-w-[60ch]">
+          {live
+            ? "Your team of agents is trading the shared $1M paper book to your mandate. Tune the setup below at any time."
+            : "Two steps, then go live. Write your mandate, add the agents, launch."}
         </p>
-      )}
-      <Link
-        href="/account/watchlist"
-        className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2 font-mono text-sm text-text hover:border-cyan/40 hover:text-cyan focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 transition-colors"
+        <ProgressSteps
+          steps={[
+            { label: "Write mandate", done: step1 },
+            { label: "Add agents", done: step2 },
+            { label: "Go live", done: step3 },
+          ]}
+        />
+      </header>
+
+      <SetupCard
+        step={1}
+        glyph="clipboard"
+        title="Write the mandate"
+        intro="Your investment brief — the agents trade to it. Pick an example to start, then edit and save."
       >
-        {items.length > top.length
-          ? `Manage all ${items.length} watchlist items →`
-          : "Manage watchlist →"}
-      </Link>
+        <PortfolioDetailsEditor
+          initialName={portfolio.display_name}
+          initialMandate={portfolio.description ?? ""}
+        />
+      </SetupCard>
+
+      <SetupCard
+        step={2}
+        glyph="branch"
+        title="Add your agents"
+        intro="A portfolio needs a Shortlist Builder to curate the watchlist and a Buying Agent to trade it. The 30-day return is each agent's live track record."
+      >
+        <AgentPicker members={pickerMembers} allAgents={pickerAll} />
+      </SetupCard>
+
+      <LaunchControl
+        launchedAt={portfolio.launched_at}
+        hasCurator={hasCurator}
+        hasBuyer={hasBuyer}
+        publicPath={`/portfolios/${portfolio.slug}`}
+      />
+
+      <SignOutRow email={email} />
     </div>
   );
 }
@@ -369,40 +232,19 @@ function WatchlistPreview({ items }: { items: WatchlistItem[] }) {
 // Shared layout bits — match the homepage's visual language.
 // ---------------------------------------------------------------------------
 
-function StateBadge({ live }: { live: boolean }) {
-  if (live) {
-    return (
-      <span className="inline-flex items-center gap-2 rounded-full border border-green/30 bg-green/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-green">
-        <span
-          aria-hidden
-          className="h-1.5 w-1.5 rounded-full bg-green animate-pulse"
-          style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
-        />
-        Live
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center gap-2 rounded-full border border-orange/30 bg-orange/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-orange">
-      <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-orange" />
-      Draft — not live yet
-    </span>
-  );
-}
-
 function ProgressSteps({
   steps,
 }: {
   steps: { label: string; done: boolean }[];
 }) {
   return (
-    <ol className="mt-5 grid gap-2.5 sm:grid-cols-3">
+    <ol className="mt-6 grid gap-2.5 sm:grid-cols-3">
       {steps.map((s, i) => (
         <li
           key={s.label}
           className={`flex items-center gap-2.5 rounded-xl border px-3.5 py-2.5 ${
             s.done
-              ? "border-green/30 bg-green/[0.05]"
+              ? "border-[var(--color-green)]/30 bg-[var(--color-green)]/[0.05]"
               : "border-white/10 bg-white/[0.02]"
           }`}
         >
@@ -410,8 +252,8 @@ function ProgressSteps({
             aria-hidden
             className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold font-mono ${
               s.done
-                ? "bg-green/20 text-green"
-                : "border border-cyan/30 bg-cyan/[0.08] text-cyan"
+                ? "bg-[var(--color-green)]/20 text-[var(--color-green)]"
+                : "border border-[var(--color-cyan)]/30 bg-[var(--color-cyan)]/[0.08] text-[var(--color-cyan)]"
             }`}
           >
             {s.done ? "✓" : i + 1}
@@ -452,13 +294,16 @@ function SetupCard({
       }}
     >
       <div className="flex items-start gap-3 mb-4">
-        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-cyan/25 bg-cyan/[0.07]">
-          <Glyph name={glyph} className="w-[18px] h-[18px] text-cyan" />
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-[var(--color-cyan)]/25 bg-[var(--color-cyan)]/[0.07]">
+          <Glyph
+            name={glyph}
+            className="w-[18px] h-[18px] text-[var(--color-cyan)]"
+          />
         </span>
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             {step != null && (
-              <span className="text-[10px] font-mono font-bold uppercase tracking-widest text-cyan">
+              <span className="text-[10px] font-mono font-bold uppercase tracking-[0.14em] text-[var(--color-cyan)]">
                 Step {step}
               </span>
             )}
@@ -473,64 +318,6 @@ function SetupCard({
       </div>
       {children}
     </section>
-  );
-}
-
-function RailCard({
-  title,
-  accent,
-  children,
-}: {
-  title: string;
-  accent?: "cyan";
-  children: ReactNode;
-}) {
-  return (
-    <section
-      className="rounded-2xl border p-5"
-      style={
-        accent === "cyan"
-          ? {
-              background:
-                "linear-gradient(135deg, rgba(0,242,255,0.07), rgba(0,255,65,0.03) 48%, rgba(255,255,255,0.02))",
-              borderColor: "rgba(0,242,255,0.2)",
-              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
-            }
-          : {
-              background:
-                "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
-              borderColor: "rgba(255,255,255,0.1)",
-              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
-            }
-      }
-    >
-      <p className="text-[10px] font-mono font-bold uppercase tracking-[0.16em] text-text-dim mb-3">
-        {title}
-      </p>
-      {children}
-    </section>
-  );
-}
-
-function ChecklistRow({ label, done }: { label: string; done: boolean }) {
-  return (
-    <li className="flex items-center gap-2.5">
-      <span
-        aria-hidden
-        className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[10px] font-bold ${
-          done
-            ? "bg-green/20 text-green"
-            : "border border-text-muted/40 text-transparent"
-        }`}
-      >
-        ✓
-      </span>
-      <span
-        className={`text-[13px] ${done ? "text-text" : "text-text-muted"}`}
-      >
-        {label}
-      </span>
-    </li>
   );
 }
 
@@ -558,14 +345,14 @@ function SignOutRow({ email }: { email: string }) {
 // Inline icons — matches the homepage's dependency-free SVG glyph style.
 // ---------------------------------------------------------------------------
 
-type GlyphName = "clipboard" | "branch" | "target" | "bolt";
+type GlyphName = "clipboard" | "branch";
 
 function SectionBadge({ children }: { children: ReactNode }) {
   return (
-    <span className="inline-flex items-center gap-2 rounded-full border border-cyan/25 bg-cyan/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-cyan">
+    <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-cyan)]/25 bg-[var(--color-cyan)]/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)]">
       <span
         aria-hidden
-        className="h-1.5 w-1.5 rounded-full bg-cyan"
+        className="h-1.5 w-1.5 rounded-full bg-[var(--color-cyan)]"
         style={{ boxShadow: "0 0 6px rgba(0,242,255,0.8)" }}
       />
       {children}
@@ -597,14 +384,6 @@ function Glyph({
         <path d="M17.5 10.6c0 5-11 1.7-11 5" />
       </>
     ),
-    target: (
-      <>
-        <circle cx="12" cy="12" r="8.5" />
-        <circle cx="12" cy="12" r="3.4" />
-        <path d="M12 1.5V5M12 19v3.5M1.5 12H5M19 12h3.5" />
-      </>
-    ),
-    bolt: <path d="M13.5 2 4.5 13.5H11l-1 8.5 9.5-12H13l.5-8Z" />,
   };
   return (
     <svg
@@ -621,3 +400,4 @@ function Glyph({
     </svg>
   );
 }
+

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Nav from "@/components/nav";
 import HoldingsList from "@/components/holdings-list";
 import { AgentMonogram } from "@/components/agent-monogram";
 import { TradeTape, type Trade } from "@/components/trade-tape";
+import VisibilityToggle from "@/components/portfolio/visibility-toggle";
 import { getPortfolio, type PortfolioSnapshot } from "@/lib/portfolio";
 import {
   getMembersForPortfolio,
@@ -48,6 +49,20 @@ async function resolveVisiblePortfolio(
   return null;
 }
 
+/**
+ * Did the current viewer create this portfolio? Used to gate owner-only
+ * controls (visibility toggle, future settings). Always returns false for
+ * agent-owned legacy portfolios since they have no human owner.
+ */
+async function isViewerOwner(portfolio: Portfolio): Promise<boolean> {
+  if (!portfolio.owner_user_id) return false;
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return !!user && user.id === portfolio.owner_user_id;
+}
+
 // ----- Metadata ------------------------------------------------------------
 
 export async function generateMetadata({
@@ -84,6 +99,7 @@ export async function generateMetadata({
 
 async function getPortfolioPageData(slug: string): Promise<{
   portfolio: Portfolio | null;
+  isOwner: boolean;
   snapshot: PortfolioSnapshot | null;
   members: PortfolioMember[];
   thesesByTicker: Record<string, InvestmentThesis>;
@@ -94,6 +110,7 @@ async function getPortfolioPageData(slug: string): Promise<{
   if (!portfolio) {
     return {
       portfolio: null,
+      isOwner: false,
       snapshot: null,
       members: [],
       thesesByTicker: {},
@@ -101,6 +118,7 @@ async function getPortfolioPageData(slug: string): Promise<{
       totalTrades: 0,
     };
   }
+  const isOwner = await isViewerOwner(portfolio);
 
   // Human-owned portfolios (owner_agent_id null, migration 024) don't trade
   // yet — no account, holdings or theses. The snapshot/theses helpers are
@@ -121,7 +139,15 @@ async function getPortfolioPageData(slug: string): Promise<{
     portfolio.id,
   );
 
-  return { portfolio, snapshot, members, thesesByTicker, trades, totalTrades };
+  return {
+    portfolio,
+    isOwner,
+    snapshot,
+    members,
+    thesesByTicker,
+    trades,
+    totalTrades,
+  };
 }
 
 // ----- Page ---------------------------------------------------------------
@@ -130,8 +156,15 @@ export default async function PortfolioPage({ params }: PageParams) {
   const { slug: rawSlug } = await params;
   const slug = decodeURIComponent(rawSlug).toLowerCase();
 
-  const { portfolio, snapshot, members, thesesByTicker, trades, totalTrades } =
-    await getPortfolioPageData(slug);
+  const {
+    portfolio,
+    isOwner,
+    snapshot,
+    members,
+    thesesByTicker,
+    trades,
+    totalTrades,
+  } = await getPortfolioPageData(slug);
   if (!portfolio) notFound();
 
   const created = new Date(portfolio.created_at).toLocaleDateString("en-US", {
@@ -158,9 +191,14 @@ export default async function PortfolioPage({ params }: PageParams) {
                 /{portfolio.slug}
               </code>
             </div>
-            <p className="mt-2 text-[11px] font-mono uppercase tracking-[0.14em] text-text-muted">
-              Created {created}
-            </p>
+            <div className="mt-3 flex flex-wrap items-center gap-3">
+              <p className="text-[11px] font-mono uppercase tracking-[0.14em] text-text-muted">
+                Created {created}
+              </p>
+              {isOwner && (
+                <VisibilityToggle isPublic={portfolio.is_public} />
+              )}
+            </div>
           </header>
 
           {/* Mandate — the brief agents work to */}

--- a/web/components/portfolio/launch-control.tsx
+++ b/web/components/portfolio/launch-control.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { launchPortfolio } from "@/lib/portfolios-mutations";
@@ -8,12 +9,15 @@ export default function LaunchControl({
   launchedAt,
   hasCurator,
   hasBuyer,
+  publicPath,
 }: {
   launchedAt: string | null;
   /** A curate-phase member (Shortlist Builder) is on the portfolio. */
   hasCurator: boolean;
   /** A trade-phase member (Buying Agent) is on the portfolio. */
   hasBuyer: boolean;
+  /** Path to the portfolio's public page, surfaced as a link in the live state. */
+  publicPath?: string;
 }) {
   const router = useRouter();
   const [confirming, setConfirming] = useState(false);
@@ -27,14 +31,27 @@ export default function LaunchControl({
       year: "numeric",
     });
     return (
-      <div className="rounded-lg border border-green/40 bg-green/5 px-4 py-3">
-        <p className="text-[11px] font-mono text-green uppercase tracking-widest mb-1">
-          ● Live since {since}
+      <div className="rounded-2xl border border-[var(--color-green)]/30 bg-[var(--color-green)]/[0.05] px-5 py-4 sm:px-6 sm:py-5">
+        <p className="text-[11px] font-mono uppercase tracking-[0.16em] text-[var(--color-green)] flex items-center gap-2">
+          <span
+            aria-hidden
+            className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
+            style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+          />
+          Live since {since}
         </p>
-        <p className="text-sm text-text-dim leading-relaxed">
+        <p className="mt-2 text-sm text-text-dim leading-relaxed">
           Your portfolio is trading. Its agents rebalance the shared $1M book
           each weekly heartbeat, working to your mandate.
         </p>
+        {publicPath && (
+          <Link
+            href={publicPath}
+            className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-[var(--color-cyan)] hover:brightness-110 transition-[filter] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/40 rounded"
+          >
+            View public page &rarr;
+          </Link>
+        )}
       </div>
     );
   }
@@ -54,49 +71,62 @@ export default function LaunchControl({
     });
   }
 
+  if (!ready) {
+    return (
+      <div className="rounded-2xl border border-[var(--color-orange)]/30 bg-[var(--color-orange)]/[0.05] px-5 py-4 sm:px-6 sm:py-5">
+        <p className="text-[11px] font-mono font-bold text-[var(--color-orange)] uppercase tracking-[0.14em] mb-2">
+          Not ready to launch
+        </p>
+        <ul className="space-y-1 text-[13px] text-text-dim font-mono">
+          <li className={hasCurator ? "text-text-muted" : ""}>
+            {hasCurator ? "✓" : "○"} Shortlist Builder added
+          </li>
+          <li className={hasBuyer ? "text-text-muted" : ""}>
+            {hasBuyer ? "✓" : "○"} Buying Agent added
+          </li>
+        </ul>
+        <p className="mt-3 text-xs text-text-muted leading-relaxed">
+          Add a Shortlist Builder and a Buying Agent above before going live.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <p className="text-sm text-text-dim leading-relaxed mb-3">
-        When you&apos;re ready, go live: this grants the portfolio $1M of paper
-        cash and its agents start trading at the next heartbeat.
-      </p>
-
-      {!ready ? (
-        <div className="rounded-lg border border-orange/30 bg-orange/[0.05] px-3 py-2.5">
-          <p className="text-xs font-mono font-bold text-orange uppercase tracking-widest mb-1.5">
-            Not ready to launch
+      {!confirming ? (
+        <>
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            style={{
+              boxShadow:
+                "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
+            }}
+          >
+            Go live &rarr;
+          </button>
+          <p className="mt-2 text-xs text-text-muted leading-relaxed">
+            Grants the portfolio $1M of paper cash; agents start trading at the
+            next heartbeat.
           </p>
-          <ul className="space-y-1 text-[12px] text-text-dim font-mono">
-            <li className={hasCurator ? "text-text-muted" : ""}>
-              {hasCurator ? "✓" : "○"} Shortlist Builder added
-            </li>
-            <li className={hasBuyer ? "text-text-muted" : ""}>
-              {hasBuyer ? "✓" : "○"} Buying Agent added
-            </li>
-          </ul>
-          <p className="text-[11px] text-text-muted mt-2 leading-relaxed">
-            Add a Shortlist Builder and a Buying Agent above before going live.
-          </p>
-        </div>
-      ) : !confirming ? (
-        <button
-          type="button"
-          onClick={() => setConfirming(true)}
-          className="px-4 py-2 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40 transition-colors"
-        >
-          Go live →
-        </button>
+        </>
       ) : (
-        <div className="space-y-2">
-          <p className="text-xs font-mono text-orange">
+        <div className="rounded-2xl border border-[var(--color-orange)]/30 bg-[var(--color-orange)]/[0.05] px-5 py-4">
+          <p className="text-xs font-mono text-[var(--color-orange)] leading-relaxed">
             Going live grants $1M and starts trading — this can&apos;t be undone.
           </p>
-          <div className="flex items-center gap-2">
+          <div className="mt-3 flex items-center gap-3">
             <button
               type="button"
               onClick={launch}
               disabled={pending}
-              className="px-4 py-2 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40 transition-colors"
+              className="inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:brightness-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+              style={{
+                boxShadow:
+                  "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
+              }}
             >
               {pending ? "Launching…" : "Confirm — go live"}
             </button>
@@ -104,7 +134,7 @@ export default function LaunchControl({
               type="button"
               onClick={() => setConfirming(false)}
               disabled={pending}
-              className="text-xs font-mono text-text-muted hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 rounded px-1"
+              className="text-xs font-mono text-text-muted hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 rounded px-1 transition-colors"
             >
               Cancel
             </button>
@@ -113,7 +143,7 @@ export default function LaunchControl({
       )}
 
       {error && (
-        <div className="mt-3 text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+        <div className="mt-3 text-sm text-[var(--color-red)] font-mono border-l-2 border-[var(--color-red)] pl-3 py-1">
           {error}
         </div>
       )}

--- a/web/components/portfolio/visibility-toggle.tsx
+++ b/web/components/portfolio/visibility-toggle.tsx
@@ -4,6 +4,11 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { setPortfolioVisibility } from "@/lib/portfolios-mutations";
 
+/**
+ * Compact inline pill — current visibility state + a single button to
+ * flip it. Designed to sit next to a page H1, not own a card. The owner
+ * sees this on the portfolio detail page header.
+ */
 export default function VisibilityToggle({ isPublic }: { isPublic: boolean }) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
@@ -22,31 +27,36 @@ export default function VisibilityToggle({ isPublic }: { isPublic: boolean }) {
   }
 
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <p className="font-mono text-sm text-text">
-            {isPublic ? "Public" : "Private"}
-          </p>
-          <p className="text-xs text-text-muted mt-1 leading-relaxed">
-            {isPublic
-              ? "Anyone can view this portfolio at its public URL."
-              : "Only you can view this portfolio. It's hidden from its public URL and the portfolio API."}
-          </p>
-        </div>
+    <div className="inline-flex flex-col gap-1">
+      <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.02] px-3 py-1 text-[11px] font-mono uppercase tracking-[0.14em]">
+        <span
+          aria-hidden
+          className={`h-1.5 w-1.5 rounded-full ${
+            isPublic ? "bg-[var(--color-green)]" : "bg-text-muted"
+          }`}
+          style={
+            isPublic ? { boxShadow: "0 0 6px rgba(0,255,65,0.5)" } : undefined
+          }
+        />
+        <span className={isPublic ? "text-[var(--color-green)]" : "text-text-muted"}>
+          {isPublic ? "Public" : "Private"}
+        </span>
+        <span aria-hidden className="text-text-muted/60">
+          ·
+        </span>
         <button
           type="button"
           onClick={toggle}
           disabled={pending}
-          className="shrink-0 px-3 py-1.5 font-mono text-xs uppercase tracking-widest rounded border border-white/10 text-text-dim hover:text-text hover:border-text/40 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="text-text-dim hover:text-text disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 rounded transition-colors"
         >
           {pending ? "…" : isPublic ? "Make private" : "Make public"}
         </button>
-      </div>
+      </span>
       {error && (
-        <div className="mt-3 text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+        <span className="text-xs text-[var(--color-red)] font-mono">
           {error}
-        </div>
+        </span>
       )}
     </div>
   );


### PR DESCRIPTION
Cuts the noise so the setup path is mandate → agents → launch, in one column. Everything else is gone or moved.

app/account/page.tsx — dropped:
- Right rail entirely (portfolio status checklist / benchmark goal card / visibility card).
- Duplicate state badge in the header + "X / 3 steps done" counter — the ProgressSteps strip is the single progress UI.
- Watchlist preview SetupCard (the top nav already has a Watchlist link; the preview was redundant).
- Go-live SetupCard wrapper — LaunchControl now renders bare at the bottom as a button + status row.
- Watchlist data fetch + WatchlistPreview component + RailCard / ChecklistRow / StateBadge / Glyph 'target' & 'bolt' (all unused after the rail drop). Page width drops to max-w-[820px] (centred) since there's no rail.

components/portfolio/launch-control.tsx — refreshed to match the unified style:
- "Go live" button now uses the cyan-glow primary CTA (was green- outline). Mirrors HP CTAs.
- Live-state card adds a "View public page →" link (new publicPath prop). Pulse-dot indicator stays green (semantic).
- Not-ready warning + confirmation step use rounded-2xl + colour tokens consistent with the rest of the app.

components/portfolio/visibility-toggle.tsx — collapsed from a full card to a compact inline pill: state dot + "Public/Private" label + "Make private/public" button. Designed to sit next to a page H1.

app/portfolios/[slug]/page.tsx — owner-only visibility toggle moves here. New isViewerOwner() helper + isOwner plumbed through getPortfolioPageData; toggle renders inline in the header next to the "Created" timestamp when the viewer owns the portfolio.

Net effect: /account shows only mandate, agents, and a launch button. Public/private control lives where it makes sense — on the public page itself.

https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq