### PR TITLE
dashboard: ultra-minimal single-column flow + graphical polish

### DIFF
--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -84,7 +84,18 @@ export default async function AccountPage() {
   return (
     <>
       <Nav />
-      <main className="flex-1 w-full">
+      <main className="flex-1 w-full relative">
+        {/* Ambient backdrop — same off-axis cyan/green glows as the
+            homepage hero, calmer opacity, scoped behind the header so
+            the form region below stays a clean dark canvas. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-[440px] -z-10 opacity-80"
+          style={{
+            background:
+              "radial-gradient(60% 65% at 16% 8%, rgba(0,255,65,0.05), transparent 70%), radial-gradient(48% 55% at 86% 4%, rgba(0,242,255,0.06), transparent 70%)",
+          }}
+        />
         <div className="max-w-[820px] mx-auto w-full px-4 sm:px-6 py-10 sm:py-14">
           {portfolio ? (
             <PortfolioView
@@ -181,13 +192,32 @@ function PortfolioView({
     description: a.description,
   }));
 
+  const daysLive = live
+    ? Math.max(
+        0,
+        Math.floor(
+          (Date.now() - new Date(portfolio.launched_at!).getTime()) /
+            86_400_000,
+        ),
+      )
+    : 0;
+
   return (
-    <div className="space-y-6 sm:space-y-8">
+    <div className="space-y-7 sm:space-y-9">
       <header>
-        <h1 className="text-[30px] sm:text-[36px] font-bold tracking-[-0.02em] text-text leading-[1.08]">
-          {portfolio.display_name}
+        <DashboardStateBadge live={live} daysLive={daysLive} />
+        <h1 className="mt-4 text-[34px] sm:text-[44px] font-bold tracking-[-0.025em] text-text leading-[1.05]">
+          <span
+            className="bg-clip-text text-transparent"
+            style={{
+              backgroundImage:
+                "linear-gradient(110deg, var(--color-cyan) 0%, #6FF8A0 45%, var(--color-green) 100%)",
+            }}
+          >
+            {portfolio.display_name}
+          </span>
         </h1>
-        <p className="mt-3 text-base text-text-muted leading-relaxed max-w-[60ch]">
+        <p className="mt-4 text-base sm:text-lg text-text-muted leading-relaxed max-w-[60ch]">
           {live
             ? "Your team of agents is trading the shared $1M paper book to your mandate. Tune the setup below at any time."
             : "Two steps, then go live. Write your mandate, add the agents, launch."}
@@ -243,6 +273,47 @@ function PortfolioView({
 // Shared layout bits — match the homepage's visual language.
 // ---------------------------------------------------------------------------
 
+function DashboardStateBadge({
+  live,
+  daysLive,
+}: {
+  live: boolean;
+  daysLive: number;
+}) {
+  if (live) {
+    return (
+      <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-green)]/30 bg-[var(--color-green)]/[0.08] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-green)]">
+        <span
+          aria-hidden
+          className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
+          style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+        />
+        Live
+        {daysLive > 0 && (
+          <>
+            <span aria-hidden className="text-[var(--color-green)]/40">
+              ·
+            </span>
+            <span className="font-mono">
+              {daysLive}d
+            </span>
+          </>
+        )}
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-cyan)]/30 bg-[var(--color-cyan)]/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)]">
+      <span
+        aria-hidden
+        className="h-1.5 w-1.5 rounded-full bg-[var(--color-cyan)]"
+        style={{ boxShadow: "0 0 6px rgba(0,242,255,0.8)" }}
+      />
+      Setup in progress
+    </span>
+  );
+}
+
 function ProgressSteps({
   steps,
 }: {
@@ -297,7 +368,7 @@ function SetupCard({
 }) {
   return (
     <section
-      className="rounded-2xl border border-white/10 p-5 sm:p-6"
+      className="group rounded-2xl border border-white/10 p-5 sm:p-6 transition-colors hover:border-white/15"
       style={{
         background:
           "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",

--- a/web/components/portfolio/launch-control.tsx
+++ b/web/components/portfolio/launch-control.tsx
@@ -95,11 +95,28 @@ export default function LaunchControl({
   return (
     <div>
       {!confirming ? (
-        <>
+        <div
+          className="rounded-2xl border p-5 sm:p-6 flex flex-wrap items-center justify-between gap-4"
+          style={{
+            background:
+              "linear-gradient(135deg, rgba(0,242,255,0.07), rgba(0,255,65,0.03) 48%, rgba(255,255,255,0.02))",
+            borderColor: "rgba(0,242,255,0.2)",
+            boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+          }}
+        >
+          <div className="min-w-0">
+            <p className="text-[10px] font-mono font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)] mb-1">
+              Ready to launch
+            </p>
+            <p className="text-sm sm:text-[15px] text-text-dim leading-relaxed max-w-[440px]">
+              Grants the portfolio $1M of paper cash. Agents start trading at
+              the next heartbeat.
+            </p>
+          </div>
           <button
             type="button"
             onClick={() => setConfirming(true)}
-            className="inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            className="shrink-0 inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
             style={{
               boxShadow:
                 "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
@@ -107,11 +124,7 @@ export default function LaunchControl({
           >
             Go live &rarr;
           </button>
-          <p className="mt-2 text-xs text-text-muted leading-relaxed">
-            Grants the portfolio $1M of paper cash; agents start trading at the
-            next heartbeat.
-          </p>
-        </>
+        </div>
       ) : (
         <div className="rounded-2xl border border-[var(--color-orange)]/30 bg-[var(--color-orange)]/[0.05] px-5 py-4">
           <p className="text-xs font-mono text-[var(--color-orange)] leading-relaxed">


### PR DESCRIPTION
## Summary

Two passes on `/account`:

**1. Ultra-minimal single-column flow (6e565fd)**
Stripped the dashboard down to mandate → agents → launch in one column. Dropped the right rail entirely (status checklist / benchmark / visibility), the duplicate state badge in the header, the "X/3 steps done" counter, the Watchlist preview block, and the Go-live SetupCard wrapper. Watchlist already lives in the top nav; visibility moved to `/portfolios/[slug]` as a compact inline pill (owner-only). `LaunchControl` gained a `publicPath` prop so the live state surfaces a "View public page →" link.

**2. Graphical love (073de17)**
Warmed up the simplified shell without re-introducing visual debt:
- Ambient cyan/green radial backdrop scoped to the header region (calmer opacity than the homepage, fades before the form region).
- State badge above the H1 — "Setup in progress" (cyan dot) when not live, pulsing green "Live · Nd" once launched.
- H1 scaled to 34→44px with the portfolio name rendered in the homepage's cyan→green gradient.
- SetupCard gains a subtle hover-border lift.
- LaunchControl's "ready" state upgrades from a bare button to a cyan-gradient call-out panel (eyebrow + body + button) — reads as the reward for finishing setup.

Includes a merge of `main` (03d8ed3) — the Run-now buttons + browsable agent picker (PR #1023) conflicted with the dashboard rewrite; resolution kept the ultra-minimal layout while passing through the new `AgentPicker` props (`portfolioId`, `launchedAt`).

## Test plan

- [ ] `/account` for a brand-new user — `NoPortfolioView` still renders the welcome + create-portfolio form
- [ ] `/account` with portfolio in setup — state badge reads "Setup in progress", progress strip shows 0–2 done, gradient name renders
- [ ] Add mandate + a curator + a buyer — Launch-ready cyan-gradient CTA panel appears
- [ ] Click Go live → confirm → portfolio launches; header flips to pulsing green "Live · 0d", LaunchControl shows live card with "View public page →" link
- [ ] Owner visits `/portfolios/<slug>` — sees the inline Public/Private toggle next to "Created" timestamp; non-owner viewers don't see it
- [ ] Watchlist still reachable via top nav (no preview on dashboard)
- [ ] AgentPicker Run-now buttons still work (preserved from main)

https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq

---
_Generated by [Claude Code](https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq)_