### PR TITLE
Rebrand shortlist-builder → alphamolt-shortlist, widen to 40 names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,8 +196,9 @@ book, sells holdings no longer on the watchlist (before buys), and buys
 watchlist tickers — passing a `thesis` kwarg on each buy so an
 `investment_theses` row is recorded (the watchlist `rationale` becomes the
 thesis text). Both are no-ops on a legacy 1:1 agent portfolio. The house
-agents `shortlist-builder` (curator, `gemini-2.5-flash`, 24h cadence) and
-`buying-agent` (buyer, 168h cadence) — migration 028 — drive them.
+agents `alphamolt-shortlist` (curator, `gemini-2.5-flash`, 24h cadence,
+~40-name target) and `buying-agent` (buyer, 168h cadence) — migrations 028
+and 030 — drive them.
 
 Supports `--handle`, `--force` (ignore interval guard), and `--dry-run`.
 
@@ -330,9 +331,9 @@ managed, no heartbeat). `heartbeat_interval_hours` defaults to 168 (weekly).
 strategy uses `{provider, model, picker_mode, snapshot_tier}`, the
 `watchlist_curator` strategy uses `{provider, model, watchlist_size}`;
 mechanical strategies (`dual_positive`, `momentum`, `watchlist_buyer`) ignore
-it. House agents `shortlist-builder` (`watchlist_curator`) and `buying-agent`
-(`watchlist_buyer`) seeded by migration 028 drive the two-agent pipeline for
-human portfolios. `powered_by` is an optional human-readable LLM brand
+it. House agents `alphamolt-shortlist` (`watchlist_curator`, `watchlist_size=40`)
+and `buying-agent` (`watchlist_buyer`) seeded by migrations 028 + 030 drive the
+two-agent pipeline for human portfolios. `powered_by` is an optional human-readable LLM brand
 (e.g. "Claude Sonnet 4.6") rendered as a chip on the public agent profile
 page; community agents set it on registration. `available_for_hire` (BOOLEAN,
 default false; house agents backfilled true) is the owner's opt-in to the

--- a/migrations/030_alphamolt_shortlist_house_agent.sql
+++ b/migrations/030_alphamolt_shortlist_house_agent.sql
@@ -1,0 +1,65 @@
+-- Migration 030: Rebrand `shortlist-builder` → `alphamolt-shortlist`, target 40 names.
+--
+-- Background: migration 028 launched the curator half of the two-agent
+-- pipeline under the generic handle `shortlist-builder` with a 20-name target.
+-- We're rebranding it as the alphamolt.ai house curator and bumping the
+-- target shortlist to 40 — a wider list still flows through the existing
+-- `watchlist_buyer` (which equal-weights whatever it finds), so the only
+-- visible change for owners is more names + alphamolt branding.
+--
+-- The strategy dispatcher keys on `agents.strategy` (= 'watchlist_curator'),
+-- not handle, and every relation (portfolios.id, portfolio_agents.agent_id,
+-- agent_accounts.agent_id, portfolio_watchlist.added_by_agent_id) references
+-- the agent's UUID. Renaming the handle is therefore safe: existing
+-- portfolio memberships, the 1:1 portfolio row, the cash account, and any
+-- watchlist rows it has already authored all stay attached.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+-- ============================================================
+-- 1. agents — rebrand the curator + widen the shortlist target
+-- ============================================================
+
+UPDATE agents
+   SET handle = 'alphamolt-shortlist',
+       display_name = 'Alphamolt Shortlist',
+       description = 'House curator for alphamolt.ai. For every portfolio it joins, reads the owner''s mandate and picks a ~40-name shortlist from the daily equity universe. Runs daily. Brain: gemini-2.5-flash (google).',
+       long_description = $md$# Strategy: watchlist_curator
+
+The mandate-aware house curator for alphamolt.ai — the curator half of the
+two-agent pipeline for human-owned portfolios.
+
+Each heartbeat it loads the daily compact universe snapshot, builds an LLM
+prompt from that snapshot plus the portfolio's free-text **mandate**, and
+asks the model for ~40 tickers with a one-line rationale each. Every
+ticker is validated against the `companies` universe.
+
+It refreshes only its own `source='agent'` watchlist rows — other curators'
+picks and the owner's manual `source='user'` picks are never touched. A
+buyer agent (`watchlist_buyer`) trades from the shortlist on its own
+(weekly) cadence; the heartbeat orders curate-phase members before
+trade-phase ones so the buyer always sees the freshest list.
+
+Only meaningful for shared human portfolios; on a legacy 1:1 agent
+portfolio it is a no-op.
+
+**Source code:** `agent_strategies.rebalance_watchlist_curator`.$md$,
+       config = jsonb_set(COALESCE(config, '{}'::jsonb), '{watchlist_size}', '40'::jsonb, true),
+       updated_at = NOW()
+ WHERE handle = 'shortlist-builder';
+
+
+-- ============================================================
+-- 2. portfolios — re-slug the 1:1 portfolio row to match the new handle
+-- ============================================================
+-- portfolios.id == agent.id (migrations 021 + 028 1:1 shim), so we re-key
+-- by UUID and refresh the display strings from the renamed agent row.
+
+UPDATE portfolios p
+   SET slug = a.handle,
+       display_name = a.display_name,
+       description = a.description,
+       updated_at = NOW()
+  FROM agents a
+ WHERE a.handle = 'alphamolt-shortlist'
+   AND p.id = a.id;

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -395,11 +395,12 @@ export default function DocsPage() {
           <p className="text-xs text-text-muted mb-6 max-w-2xl leading-relaxed">
             The launch gate requires at least one curate-phase and one
             trade-phase member. Today the house agents{" "}
-            <code className="text-green">shortlist-builder</code> (curator,
-            24h cadence) and <code className="text-green">buying-agent</code>{" "}
-            (buyer, 168h cadence) drive this pipeline; community agents are
-            currently added as additional <em>Trader</em> or{" "}
-            <em>Manual</em> members alongside them.
+            <code className="text-green">alphamolt-shortlist</code> (curator,
+            24h cadence, ~40-name target) and{" "}
+            <code className="text-green">buying-agent</code> (buyer, 168h
+            cadence) drive this pipeline; community agents are currently
+            added as additional <em>Trader</em> or <em>Manual</em> members
+            alongside them.
           </p>
 
           <h3 className="font-mono text-xs font-bold uppercase tracking-widest text-green mb-2 mt-6">

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -236,9 +236,10 @@ Every human portfolio runs a two-phase pipeline. Each heartbeat, all
   watchlist's rationale as the thesis text.
 
 The portfolio's launch gate requires at least one curate-phase and one
-trade-phase member. Today the house agents `shortlist-builder`
-(curator, 24h cadence) and `buying-agent` (buyer, 168h cadence) drive
-this pipeline; community agents register without a strategy and are
+trade-phase member. Today the house agents `alphamolt-shortlist`
+(curator, 24h cadence, ~40-name target) and `buying-agent` (buyer,
+168h cadence) drive this pipeline; community agents register without a
+strategy and are
 added to portfolios as additional `Trader` / `Manual` members alongside
 the house pair. The strategy field on `agents` is house-internal — there
 is no REST endpoint that lets a community agent self-assign

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -176,8 +176,8 @@ fresh when the buyer trades it. Each membership has its **own cadence**
 coexist cleanly. The same agent in different portfolios runs on
 independent per-portfolio clocks.
 
-Today the house agents `shortlist-builder` (curator, 24h cadence) and
-`buying-agent` (buyer, 168h cadence) drive this pipeline. Community
+Today the house agents `alphamolt-shortlist` (curator, 24h cadence,
+~40-name target) and `buying-agent` (buyer, 168h cadence) drive this pipeline. Community
 agents register without a strategy and run as external clients hitting
 the REST API on their own schedule — they're added to portfolios as
 additional Trader / Manual members alongside the house pair. If you


### PR DESCRIPTION
## Summary
Rebrand the house curator agent from `shortlist-builder` to `alphamolt-shortlist` and increase its target shortlist size from 20 to 40 names. This is a pure rebranding + configuration change with no functional impact on the two-agent pipeline.

## Changes

**Migration 030** (`migrations/030_alphamolt_shortlist_house_agent.sql`):
- Updates `agents` table: rename handle to `alphamolt-shortlist`, refresh display name and descriptions to reflect alphamolt.ai branding
- Bumps `config.watchlist_size` from 20 to 40 in the curator agent's config
- Re-slugs the 1:1 portfolio row (`portfolios.id == agents.id`) to match the new handle and syncs display strings

**Documentation updates** across CLAUDE.md, web/app/docs/page.tsx, web/public/api-reference.md, and web/public/skill.md:
- Replace all references to `shortlist-builder` with `alphamolt-shortlist`
- Add `~40-name target` notation where the curator is mentioned
- Update migration references to include 030 alongside 028

## Implementation Details

- **Safe rename**: The strategy dispatcher keys on `agents.strategy` (= `'watchlist_curator'`), not handle. All existing portfolio memberships, cash accounts, and watchlist rows remain attached to the agent UUID and continue to work without interruption.
- **Additive & idempotent**: Migration can be pasted directly into Supabase SQL editor and re-run safely.
- **Wider shortlist flows through existing buyer**: The `watchlist_buyer` agent equal-weights whatever it finds, so the only visible change for portfolio owners is more curator picks + alphamolt branding.

https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A