### PR TITLE
Drop launch concept; Public/Private hysteresis + curator token fix

### DIFF
--- a/agent_strategies.py
+++ b/agent_strategies.py
@@ -824,7 +824,12 @@ def rebalance_momentum(ctx: RebalanceContext) -> RebalanceResult:
 
 WATCHLIST_CURATOR_DEFAULTS = {
     "watchlist_size": 20,        # target shortlist length (~15-25)
-    "max_tokens": 16384,
+    # 65536 = Gemini 2.5 Flash's hard output ceiling. Set this high because
+    # 2.5 Flash's "thinking" tokens count toward max_output_tokens — a small
+    # budget (e.g. 16384) leaves ~600 tokens of actual output after thinking,
+    # which truncates a 40-name JSON array mid-stream. Other providers
+    # ignore tokens they don't need; only the actual output is billed.
+    "max_tokens": 65536,
     "temperature": 0.2,
 }
 


### PR DESCRIPTION
## Summary

Replaces the "launch" lifecycle on portfolios with a Private/Public state gated on equity count (hysteresis 10/15), fixes the curator's token-budget bug that was producing empty shortlists, and lands the supporting web + docs changes.

Three commits, in order:

1. **`acd5040` — drop launch concept; replace with Public/Private hysteresis gate.** Migration 031 + supporting code. Portfolios are always live and funded with $1M from creation (no draft / Go live). The only public state is Private (default) vs Public, gated on `portfolio_holdings` count:
   - Flip Private → Public requires ≥ 15 distinct equities (DB trigger `enforce_portfolio_public_threshold`).
   - If a Public portfolio drops below 10 equities, it auto-reverts to Private (DB trigger `enforce_portfolio_public_floor`) and stays locked until equities climb back to ≥ 15.
   - `agent_leaderboard` view rewritten with islands-and-gaps SQL: performance is tracked only during the current consecutive run of snapshots with `num_positions ≥ 10`. A drop below 10 invalidates the prior period; on recovery, a brand-new qualifying period starts with a fresh baseline.
   - New atomic `create_portfolio_funded(...)` RPC: inserts the portfolios row + seeds `portfolio_accounts` with $1M in one transaction.
   - Backfills `portfolio_accounts` for every existing draft human portfolio (anchored to `created_at`).
   - `launched_at` column and `launch_portfolio()` RPC stay on the schema for back-compat; nothing reads them. A later cleanup migration can drop them.
   - Web: deletes `LaunchControl`, simplifies `RunNowButton` (always enabled modulo cooldown), rebuilds `/account` as 2-step setup + visibility status panel, extends `VisibilityToggle` with a holdings-count-aware locked state, threads `holdings_count` through `/portfolios/[slug]`.
   - Docs: CLAUDE.md, `web/app/docs/page.tsx`, `web/public/skill.md`, `web/public/api-reference.md` rewritten for the new model.

2. **`77d8b4d` — scope leaderboard qualifying-period rule to human portfolios only.** First cut of the rewritten view applied the ≥ 10 gate to every portfolio, which would have silently hidden any legacy agent-owned portfolio holding fewer than 10 names. Per the design (and the user's explicit answer in plan mode), agent-owned portfolios are exempt — they keep today's always-public, no-gate behaviour. Fix: thread `is_human` into the islands computation so agent portfolios always have `prior_breaks = 0` and stay in a single qualifying island spanning every snapshot since inception.

3. **`042be76` — curator: raise `max_tokens` default to 65536 for Gemini 2.5 Flash thinking.** The previous default (16384) silently truncated 40-name shortlists mid-array. Gemini 2.5 Flash's thinking tokens are billed against `max_output_tokens`, so on a 40-name curation the reasoning step consumed ~15.5k of the 16.4k budget — leaving ~640 tokens for actual JSON output, which cut off around the 13th ticker. Parser correctly rejected the malformed JSON, retry produced an empty `{"watchlist": []}`, and the heartbeat journalled `"curator LLM returned an empty shortlist"`. 65536 is Gemini 2.5 Flash's hard output ceiling — other providers ignore the headroom (billing is on actual output, not the cap).

## Migration order

1. Apply `migrations/031_drop_launch_for_visibility_gate.sql` in the Supabase SQL editor.
2. Merge this PR (web build + heartbeat workflow auto-deploy).

## Test plan

- [ ] Apply migration 031; verify every human portfolio has a `portfolio_accounts` row.
- [ ] Trigger smoke test: human portfolio with <15 holdings — attempt `UPDATE portfolios SET is_public = true` → expect `RAISE EXCEPTION`. Add 15 dummy holdings → retry → expect success.
- [ ] Auto-revert smoke test: public human portfolio with 11 holdings → delete 2 → expect `is_public` flips to false.
- [ ] Leaderboard view: confirm a legacy agent-owned portfolio with <10 holdings still appears (with its full history). Confirm a synthetic break in a human portfolio's history resets `pnl_pct` to the post-break baseline.
- [ ] Curator: Run-now on `alphamolt-shortlist` → confirm `portfolio_watchlist` populates with ~40 rows and `agent_heartbeats` shows `status='ok'`.
- [ ] /account UI: no Go live CTA, Run-now buttons always enabled, VisibilityToggle reads `Private · 8/15` while below threshold and unlocks at 15.

https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A)_