### PR TITLE
/account: link to portfolio page in private state too

### DIFF
--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -194,7 +194,15 @@ function PortfolioView({
   return (
     <div className="space-y-7 sm:space-y-9">
       <header>
-        <VisibilityBadge isPublic={portfolio.is_public} />
+        <div className="flex items-center gap-3 flex-wrap">
+          <VisibilityBadge isPublic={portfolio.is_public} />
+          <Link
+            href={`/portfolios/${portfolio.slug}`}
+            className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.02] px-3 py-1 text-[10px] font-mono uppercase tracking-[0.14em] text-text-dim hover:text-[var(--color-cyan)] hover:border-[var(--color-cyan)]/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/40 transition-colors"
+          >
+            View portfolio page →
+          </Link>
+        </div>
         <h1 className="mt-4 text-[34px] sm:text-[44px] font-bold tracking-[-0.025em] text-text leading-[1.05]">
           <span
             className="bg-clip-text text-transparent"
@@ -352,11 +360,17 @@ function VisibilityPanel({
           ? `Holding ${holdingsCount} equities — eligible. Flip public to appear on the leaderboard.`
           : `Holding ${holdingsCount} of ${PUBLIC_ACTIVATE_THRESHOLD} equities needed. Once the agents fill the book, you can flip the portfolio public.`}
       </p>
-      <div className="mt-3">
+      <div className="mt-3 flex items-center gap-3 flex-wrap">
         <VisibilityToggle
           isPublic={isPublic}
           holdingsCount={holdingsCount}
         />
+        <Link
+          href={publicPath}
+          className="text-sm font-semibold text-[var(--color-cyan)] hover:brightness-110 transition-[filter] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/40 rounded"
+        >
+          View portfolio page &rarr;
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Surfaces a "View portfolio page →" link on /account regardless of the portfolio's Public/Private state.

The previous /account dashboard only rendered the link to the portfolio's own detail page (`/portfolios/[slug]`) when the portfolio was already Public. The owner can always view their own portfolio though — the `portfolios` RLS policy is `is_public OR owner_user_id = auth.uid()` — so hiding the link when private was a discoverability bug. New private portfolios in particular had no obvious way to reach their own detail page from /account, where they'd actually see the watchlist the curator is building and the trade tape.

Two link surfaces now:

1. **Header chip** next to the Private/Public badge — small, monospaced, always visible. Most discoverable spot.
2. **Visibility-panel CTA** at the bottom — was already there for Public; now also renders in the Private state. Renamed from "View public page" to "View portfolio page" since it's owner-only when private.

## Test plan

- [ ] On a Private portfolio: confirm both the header chip and the bottom-panel link render, and that clicking either lands on `/portfolios/<slug>` for the owner.
- [ ] On a Public portfolio: same; copy reads "View portfolio page" in both spots.
- [ ] Signed out (or signed in as someone else): the chip lives on /account behind auth, so this is moot for non-owners.

https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A)_