### PR TITLE
ctx.buy/sell: use the atomic RPC path for human portfolios

### DIFF
--- a/agent_strategies.py
+++ b/agent_strategies.py
@@ -84,7 +84,13 @@ class RebalanceContext:
         thesis: dict | None = None,
     ) -> dict:
         if self.portfolio_id:
-            return self.pm.buy_portfolio(
+            # Atomic RPC: holding-upsert + cash-decrement + trade-journal in
+            # one Postgres transaction. The non-atomic `buy_portfolio` path
+            # leaves partial state on failure (holding written, cash debited,
+            # trade row never landed) — historically also seen tripping a
+            # spurious ON CONFLICT error from PostgREST on the agent_trades
+            # insert that has no easy reproduction.
+            return self.pm.buy_portfolio_atomic(
                 self.portfolio_id, self.agent["id"], ticker, quantity,
                 note=note, thesis=thesis,
             )
@@ -94,7 +100,7 @@ class RebalanceContext:
 
     def sell(self, ticker: str, quantity: float, note: str = "") -> dict:
         if self.portfolio_id:
-            return self.pm.sell_portfolio(
+            return self.pm.sell_portfolio_atomic(
                 self.portfolio_id, self.agent["id"], ticker, quantity,
                 note=note,
             )


### PR DESCRIPTION
## Summary

Routes `ctx.buy` and `ctx.sell` for human portfolios through the atomic `execute_portfolio_buy` / `execute_portfolio_sell` SQL RPCs from migration 025 (via the existing `buy_portfolio_atomic` / `sell_portfolio_atomic` helpers on `PortfolioManager`).

## Why

The non-atomic `buy_portfolio` path does three sequential PostgREST writes: holding upsert, cash upsert, agent_trades insert. If the third fails, the first two have already committed — the portfolio is left with a holding it didn't journal, cash it didn't account for, and no thesis to follow up on.

The LLM buying agent's first live run tripped this on a PostgREST 400 error during the `agent_trades` insert:

```
postgrest.exceptions.APIError: {'message': 'there is no unique or exclusion constraint matching the ON CONFLICT specification', 'code': '42P10'}
```

The two upserts before it had landed, so the portfolio ended up with a VRT holding worth $40k, $40k less cash, and no trade or thesis row.

I couldn't reproduce the `ON CONFLICT` cause through static inspection — `insert_agent_trade` is a plain `.insert(data)` (no `upsert=True`, no `on_conflict` query param), `agent_trades` has no triggers, no recent ALTERs added unique constraints, the postgrest-py library doesn't add `on_conflict` for plain inserts. Likely a Supabase server-side oddity. Switching to the atomic RPC sidesteps PostgREST entirely for the trade-journal write (the insert happens inside the SQL function via raw SQL), so whatever was upsetting it can't fire.

## The change

One file. The `RebalanceContext` facade's `buy` and `sell` methods now call `pm.buy_portfolio_atomic` / `pm.sell_portfolio_atomic` when `portfolio_id` is set. Legacy 1:1 agent portfolios (no `portfolio_id`) continue to use `pm.buy` / `pm.sell` unchanged — there's no atomic RPC variant for `agent_accounts` / `agent_holdings`.

The atomic RPCs already exist (migration 025), are already exercised elsewhere, and have the same signature as their non-atomic counterparts. Drop-in.

## Cleanup needed before merge

Any portfolio with partial-write residue from a pre-fix failed buy will need a manual reconcile — restore the cash, delete the orphan holding. For the test portfolio that triggered this, the SQL is:

```sql
BEGIN;
UPDATE portfolio_accounts
   SET cash_usd = cash_usd + (
     SELECT quantity * avg_cost_usd
       FROM portfolio_holdings
      WHERE portfolio_id = '<portfolio_id>' AND ticker = '<orphan_ticker>'
   )
 WHERE portfolio_id = '<portfolio_id>';
DELETE FROM portfolio_holdings
 WHERE portfolio_id = '<portfolio_id>' AND ticker = '<orphan_ticker>';
COMMIT;
```

After this PR ships, partial state of that shape can't happen — the RPC is all-or-nothing.

## Test plan

- [ ] Re-run Run-now on `buying-agent` for the test portfolio. Confirm the heartbeat completes ✓ with `agent_trades` + `portfolio_holdings` + `investment_theses` rows all landing for every buy.
- [ ] Confirm the `agent_heartbeats.notes` JSON shows `executed_plan` populated.
- [ ] Confirm cash ≈ $1M minus sum(qty × avg_cost) across all holdings (no drift from missing trade rows).

https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A)_