### PR TITLE
Holdings on human-portfolio detail page + Portfolio link in nav

### DIFF
--- a/web/app/account/portfolio/page.tsx
+++ b/web/app/account/portfolio/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { getPortfolioForUser } from "@/lib/portfolios-query";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Server-side redirect to the signed-in user's own portfolio detail page
+ * (`/portfolios/<slug>`). The nav links here so visitors have a stable
+ * "Portfolio" entry that always resolves to whichever slug they own — no
+ * need for the nav to fetch the slug client-side.
+ *
+ *   * Not signed in → /login?next=/account/portfolio
+ *   * Signed in, no portfolio yet → /account (where they'd create one)
+ *   * Signed in with portfolio → /portfolios/<slug>
+ */
+export default async function PortfolioRedirect() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login?next=/account/portfolio");
+  }
+
+  const portfolio = await getPortfolioForUser(user.id);
+  if (!portfolio) {
+    redirect("/account");
+  }
+
+  redirect(`/portfolios/${portfolio.slug}`);
+}

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -6,7 +6,11 @@ import HoldingsList from "@/components/holdings-list";
 import { AgentMonogram } from "@/components/agent-monogram";
 import { TradeTape, type Trade } from "@/components/trade-tape";
 import VisibilityToggle from "@/components/portfolio/visibility-toggle";
-import { getPortfolio, type PortfolioSnapshot } from "@/lib/portfolio";
+import {
+  getPortfolio,
+  getPortfolioByPortfolioId,
+  type PortfolioSnapshot,
+} from "@/lib/portfolio";
 import {
   getHoldingsCountForPortfolio,
   getMembersForPortfolio,
@@ -17,6 +21,7 @@ import {
 } from "@/lib/portfolios-query";
 import {
   getActiveThesesForAgent,
+  getActiveThesesForPortfolio,
   type InvestmentThesis,
 } from "@/lib/theses-query";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -123,9 +128,11 @@ async function getPortfolioPageData(slug: string): Promise<{
   }
   const isOwner = await isViewerOwner(portfolio);
 
-  // Human-owned portfolios (owner_agent_id null, migration 024) don't trade
-  // yet — no account, holdings or theses. The snapshot/theses helpers are
-  // keyed on agent_id during the shim period, so skip them entirely.
+  // Two snapshot paths: legacy 1:1 agent portfolios are keyed on agent_id
+  // (the agent_accounts / agent_holdings tables); human-owned portfolios
+  // (migration 024) are keyed on portfolio_id (portfolio_accounts /
+  // portfolio_holdings, the shared-pot trading model from 025). The page
+  // renders the same way for both — only the loader differs.
   let snapshot: PortfolioSnapshot | null = null;
   let thesesByTicker: Record<string, InvestmentThesis> = {};
   if (portfolio.owner_agent_id) {
@@ -135,6 +142,13 @@ async function getPortfolioPageData(slug: string): Promise<{
       console.error("getPortfolio failed for", slug, err);
     }
     thesesByTicker = await getActiveThesesForAgent(portfolio.owner_agent_id);
+  } else if (portfolio.owner_user_id) {
+    try {
+      snapshot = await getPortfolioByPortfolioId(portfolio.id);
+    } catch (err) {
+      console.error("getPortfolioByPortfolioId failed for", slug, err);
+    }
+    thesesByTicker = await getActiveThesesForPortfolio(portfolio.id);
   }
 
   const members = await getMembersForPortfolio(portfolio.id);
@@ -338,8 +352,8 @@ export default async function PortfolioPage({ params }: PageParams) {
           ) : portfolio.owner_agent_id === null ? (
             <section className="mb-12 sm:mb-14">
               <p className="text-sm text-text-muted italic">
-                Not trading yet — this portfolio is being set up by its owner.
-                Agent execution is coming soon.
+                No account yet — the portfolio_accounts row should exist after
+                migration 031. Re-run portfolio_valuation.py or report this.
               </p>
             </section>
           ) : (

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -9,16 +9,18 @@ import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 // Links available to every visitor.
 const PUBLIC_LINKS: { href: string; label: string }[] = [
   { href: "/leaderboard", label: "Leaderboard" },
-  { href: "/consensus", label: "Consensus" },
   { href: "/docs", label: "Docs" },
 ];
 
 // Links injected only when the visitor is signed in. Slotted in front of
-// the public set so the user's own surfaces ("Dashboard" / "Watchlist")
-// sit at the start of the nav row.
+// the public set so the user's own surfaces ("Dashboard" / "Watchlist" /
+// "Portfolio") sit at the start of the nav row. "Portfolio" is a
+// server-side redirect to /portfolios/<owner's slug> via
+// /account/portfolio.
 const AUTHED_LINKS: { href: string; label: string }[] = [
   { href: "/account", label: "Dashboard" },
   { href: "/account/watchlist", label: "Watchlist" },
+  { href: "/account/portfolio", label: "Portfolio" },
 ];
 
 export default function Nav() {

--- a/web/lib/portfolio.ts
+++ b/web/lib/portfolio.ts
@@ -689,6 +689,109 @@ export async function getPortfolio(
   };
 }
 
+/**
+ * Mark-to-market snapshot of a *human-owned* portfolio (shared-pot
+ * trading model from migration 025 — keyed on `portfolio_id`, not
+ * `agent_id`). Mirrors `getPortfolio` but reads `portfolio_accounts` /
+ * `portfolio_holdings` instead of `agent_accounts` / `agent_holdings`,
+ * so the public detail page can render holdings + cash for human
+ * portfolios.
+ */
+export async function getPortfolioByPortfolioId(
+  portfolioId: string,
+): Promise<PortfolioSnapshot | null> {
+  const supabase = getSupabase();
+
+  const { data: accountData, error: accountError } = await supabase
+    .from("portfolio_accounts")
+    .select("portfolio_id, cash_usd, starting_cash")
+    .eq("portfolio_id", portfolioId)
+    .maybeSingle();
+  if (accountError) {
+    throw new PortfolioError(
+      "db_error",
+      `portfolio_accounts lookup failed: ${accountError.message}`,
+    );
+  }
+  if (!accountData) return null;
+  const account = accountData as {
+    portfolio_id: string;
+    cash_usd: string | number;
+    starting_cash: string | number;
+  };
+  const cash = Number(account.cash_usd);
+  const startingCash = Number(account.starting_cash);
+
+  const { data: holdingsData, error: holdingsError } = await supabase
+    .from("portfolio_holdings")
+    .select("ticker, quantity, avg_cost_usd")
+    .eq("portfolio_id", portfolioId);
+  if (holdingsError) {
+    throw new PortfolioError(
+      "db_error",
+      `portfolio_holdings lookup failed: ${holdingsError.message}`,
+    );
+  }
+  const holdings = (holdingsData ?? []).map((row) => {
+    const r = row as {
+      ticker: string;
+      quantity: string | number;
+      avg_cost_usd: string | number;
+    };
+    return {
+      ticker: r.ticker,
+      quantity: Number(r.quantity),
+      avg_cost_usd: Number(r.avg_cost_usd),
+    };
+  });
+
+  const meta = await getCompaniesMeta(holdings.map((h) => h.ticker));
+
+  const enriched: HoldingWithMtm[] = [];
+  let holdingsValue = 0;
+  for (const h of holdings) {
+    const row = meta.get(h.ticker);
+    const rawPrice = row?.price ?? null;
+    const price =
+      rawPrice != null && Number.isFinite(rawPrice) && rawPrice > 0
+        ? rawPrice
+        : h.avg_cost_usd;
+    const mv = round2(h.quantity * price);
+    holdingsValue += mv;
+    enriched.push({
+      ticker: h.ticker,
+      company_name: row?.company_name ?? null,
+      quantity: h.quantity,
+      avg_cost_usd: h.avg_cost_usd,
+      price_usd: round4(price),
+      market_value_usd: mv,
+      unrealized_pnl_usd: round2((price - h.avg_cost_usd) * h.quantity),
+    });
+  }
+
+  holdingsValue = round2(holdingsValue);
+  const total = round2(cash + holdingsValue);
+  const pnl = round2(total - startingCash);
+  const pnlPct =
+    startingCash > 0
+      ? Math.round((pnl / startingCash) * 1_000_000) / 10_000
+      : 0;
+
+  return {
+    // PortfolioSnapshot's agent_id field is a legacy of the 1:1 shim;
+    // human portfolios have no single agent. Use the portfolio_id so
+    // consumers that key on it (logging, debugging) get a useful value.
+    agent_id: portfolioId,
+    cash_usd: cash,
+    starting_cash: startingCash,
+    holdings: enriched,
+    holdings_value_usd: holdingsValue,
+    total_value_usd: total,
+    pnl_usd: pnl,
+    pnl_pct: pnlPct,
+  };
+}
+
 export async function getLeaderboard(): Promise<LeaderboardRow[]> {
   const supabase = getSupabase();
   const { data, error } = await supabase

--- a/web/lib/theses-query.ts
+++ b/web/lib/theses-query.ts
@@ -70,3 +70,34 @@ export async function getActiveThesesForAgent(
   }
   return byTicker;
 }
+
+/**
+ * Same as `getActiveThesesForAgent` but keyed on `portfolio_id` — for
+ * human-owned portfolios where there isn't a single owner agent. Every
+ * member agent's theses land on the shared book, so we want the union
+ * (one active per ticker, latest wins) for the portfolio's detail page.
+ */
+export async function getActiveThesesForPortfolio(
+  portfolioId: string,
+): Promise<Record<string, InvestmentThesis>> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("investment_theses")
+    .select("*")
+    .eq("portfolio_id", portfolioId)
+    .eq("status", "active")
+    .order("opened_at", { ascending: false });
+
+  if (error) {
+    console.error("getActiveThesesForPortfolio failed:", error);
+    return {};
+  }
+
+  const byTicker: Record<string, InvestmentThesis> = {};
+  for (const row of (data ?? []) as InvestmentThesis[]) {
+    if (!byTicker[row.ticker]) {
+      byTicker[row.ticker] = row;
+    }
+  }
+  return byTicker;
+}


### PR DESCRIPTION
## Summary

Two related fixes shipped together — both surfaced once the LLM buyer started landing real trades on `test-portfolio-toby`:

1. **Holdings render on `/portfolios/[slug]` for human portfolios.** The page's data loader was gated on `portfolio.owner_agent_id`, with a "Not trading yet" placeholder branch for human portfolios that hadn't been implemented yet. After migration 025 + 031 every human portfolio has a `portfolio_accounts` row from day one and `portfolio_holdings` rows as soon as the buyer fills them, so the placeholder was dead code.

   - New `getPortfolioByPortfolioId` in `web/lib/portfolio.ts` mirrors `getPortfolio` but reads from `portfolio_accounts` / `portfolio_holdings` (the shared-pot trading model from migration 025) instead of `agent_accounts` / `agent_holdings`. Same MTM math, same `PortfolioSnapshot` shape — drop-in for the existing render path.
   - New `getActiveThesesForPortfolio` in `web/lib/theses-query.ts` is the parallel for the thesis dropdown the holdings list shows on click — keyed on `portfolio_id` rather than `agent_id` so it captures every member agent's theses on the shared book.
   - The slug page loader now branches on owner: legacy 1:1 agent portfolios keep using `getPortfolio` + `getActiveThesesForAgent`; human portfolios use the new helpers. The stale "Not trading yet" copy is replaced with a diagnostic in case `portfolio_accounts` is somehow missing (shouldn't happen post-031).

2. **Nav: drop Consensus, add Portfolio.** Per request:
   - Consensus moves off the top nav. Still reachable at `/consensus` directly — just not first-class anymore.
   - New **Portfolio** link added to the signed-in-only nav set, after Watchlist. Points at `/account/portfolio`, a new server-side redirect route that resolves to `/portfolios/<owner's-slug>`. Means the nav stays static (no slug fetch client-side) and the redirect handles the not-signed-in (→ `/login?next=...`) and no-portfolio-yet (→ `/account`) edge cases inline.

## Test plan

- [ ] Visit your portfolio's public page (`/portfolios/<slug>`). Confirm the Holdings section now renders with cash + MTM, position rows, market values, and unrealized P/L for each position. Clicking a row should open the thesis chip if the buy recorded one.
- [ ] Empty-portfolio case: a brand-new account with no buys yet should render "No positions yet. All cash." — `HoldingsList` already handles this.
- [ ] Signed in, click "Portfolio" in the top nav. Should land on `/portfolios/<your-slug>`.
- [ ] Signed in with no portfolio (fresh user before they hit `/account`): clicking "Portfolio" should redirect to `/account`.
- [ ] Signed out, click "Portfolio" (only visible when signed in, but if accessed directly): should redirect to `/login?next=/account/portfolio`.
- [ ] Consensus is gone from the top nav. `/consensus` still loads if you navigate to it directly.
- [ ] Legacy 1:1 agent portfolios (`/portfolios/dual-positive-arena` etc.) still render correctly — the loader for them is unchanged.

https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A)_