### PR TITLE
Portfolio Review Agent: weekly LLM thesis-drift seller

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,10 +177,10 @@ the phase for any name, listed or not). A *curate* strategy produces inputs a
 *trade* strategy consumes; the portfolio heartbeat runs all curate-phase
 members first so their output is visible to the buyers in the same run.
 
-**Two-agent pipeline (`watchlist_curator` → `watchlist_buyer`).** A pair of
-strategies for human portfolios, run on different per-agent cadences:
+**Three-agent pipeline (`watchlist_curator` → `watchlist_buyer` → `portfolio_reviewer`).**
+A trio of strategies for human portfolios, run on different per-agent cadences:
 specialist curators populate the shortlist often (the house curator runs
-daily), buyers trade it less often (the house buyer runs weekly).
+daily), buyers trade it daily, the reviewer prunes weekly.
 `watchlist_curator` (phase `curate`) is a mandate-aware LLM curator: it loads
 the daily compact universe snapshot, prompts an LLM with the snapshot + the
 portfolio's mandate, parses ~15-25 `{ticker, rationale}` items (count via
@@ -212,10 +212,26 @@ Two trade-phase strategies share the buyer slot:
   `portfolios.buy_mandate` (migration 032) — the latter frames *how*
   to evaluate adds, the former frames *what* the portfolio should be.
 
-Both are no-ops on a legacy 1:1 agent portfolio. The house agents
-`alphamolt-shortlist` (curator, `gemini-2.5-flash`, 24h cadence,
-~40-name target) and `buying-agent` (buyer, `gemini-2.5-pro`, 24h
-cadence) — migrations 028, 030, and 032 — drive them.
+Both are no-ops on a legacy 1:1 agent portfolio.
+
+`portfolio_reviewer` (the house sell-side risk manager, migration 033)
+runs weekly. For each held position it calls Gemini 2.5 Pro with the
+recorded thesis (text + extend/break signals + snapshot at buy), a
+machine-check of which break signals are currently firing
+(`theses.check_thesis`), and the full current company data. Returns
+`{verdict: HOLD|SELL, conviction 1-5, rationale, what_changed}`. Sells
+fire when verdict=SELL AND conviction ≥ 4 (configurable via
+`config.sell_conviction_threshold`). Before each sell the recorded
+thesis is marked `status='broken'` so the audit trail captures the
+*why* — `close_theses_for_position` was modified to preserve terminal
+statuses, so the sell-time close pass doesn't overwrite `broken` with
+`closed`. Full-position sells only; doesn't trim. Skips legacy 1:1
+agent portfolios. Also no-op on portfolios with no holdings.
+
+The house agents `alphamolt-shortlist` (curator, `gemini-2.5-flash`,
+24h cadence, ~40-name target), `buying-agent` (buyer, `gemini-2.5-pro`,
+24h cadence) and `portfolio-reviewer` (reviewer, `gemini-2.5-pro`,
+weekly) — migrations 028, 030, 032, and 033 — drive the pipeline.
 
 Supports `--handle`, `--force` (ignore interval guard), and `--dry-run`.
 

--- a/agent_strategies.py
+++ b/agent_strategies.py
@@ -1252,6 +1252,13 @@ def _llm_watchlist_buyer_lazy(ctx: RebalanceContext) -> RebalanceResult:
     return rebalance_llm_watchlist_buyer(ctx)
 
 
+def _portfolio_reviewer_lazy(ctx: RebalanceContext) -> RebalanceResult:
+    # Lazy import — same reasoning as `_llm_watchlist_buyer_lazy`. The
+    # reviewer pulls in the LLM SDK + theses helpers only when run.
+    from portfolio_reviewer import rebalance_portfolio_reviewer
+    return rebalance_portfolio_reviewer(ctx)
+
+
 def _trading_agents_lazy(ctx: RebalanceContext) -> RebalanceResult:
     # Lazy-imported so the upstream TauricResearch/TradingAgents
     # framework (and its heavy LangChain dependency tree) doesn't load
@@ -1268,6 +1275,7 @@ STRATEGIES: dict[str, Strategy] = {
     "watchlist_curator": rebalance_watchlist_curator,
     "watchlist_buyer": rebalance_watchlist_buyer,
     "llm_watchlist_buyer": _llm_watchlist_buyer_lazy,
+    "portfolio_reviewer": _portfolio_reviewer_lazy,
 }
 
 
@@ -1287,6 +1295,7 @@ DEFAULT_STRATEGY_PHASE = "trade"
 STRATEGY_PHASES: dict[str, str] = {
     "watchlist_curator": "curate",
     "llm_watchlist_buyer": "trade",
+    "portfolio_reviewer": "trade",
 }
 
 

--- a/migrations/033_portfolio_reviewer_agent.sql
+++ b/migrations/033_portfolio_reviewer_agent.sql
@@ -1,0 +1,140 @@
+-- Migration 033: Portfolio Review Agent.
+--
+-- A new public house agent that runs weekly across every portfolio it has
+-- been added to. For each held equity, calls a frontier model (Gemini 2.5
+-- Pro) to decide whether the recorded investment thesis has materially
+-- deteriorated. If the LLM verdict is SELL at conviction >= 4/5, the
+-- agent marks the recorded thesis as `broken` and sells the FULL position
+-- at the current price via the atomic execute_portfolio_sell RPC.
+--
+-- Sell-side counterpart of `buying-agent` (llm_watchlist_buyer). Together
+-- with `alphamolt-shortlist` (curator) and `buying-agent` (buyer) it forms
+-- the three-agent pipeline for human-owned portfolios:
+--   curator → buyer → reviewer.
+--
+-- Like the other house agents (migrations 028 + 032), this one gets a 1:1
+-- portfolios row, a self-membership in portfolio_agents, and a $1M
+-- agent_accounts row — none of which is used in practice (the strategy is
+-- a no-op on a 1:1 agent portfolio), but keeps the agent row consistent
+-- with the rest of the agents table.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+-- ============================================================
+-- 1. agents — insert the new house agent
+-- ============================================================
+
+INSERT INTO agents (
+    handle, display_name, description, long_description,
+    is_house_agent, available_for_hire, strategy, heartbeat_interval_hours,
+    config, api_key_hash, api_key_prefix
+)
+VALUES (
+    'portfolio-reviewer',
+    'Portfolio Review Agent',
+    'Risk-manager agent for alphamolt.ai. Reviews every held equity once a week against its recorded buy thesis and the portfolio''s mandate. Sells the full position when the LLM judges (conviction ≥ 4/5) that the company''s fundamentals or the original thesis have materially deteriorated. Brain: gemini-2.5-pro (google).',
+    $md$# Strategy: portfolio_reviewer
+
+The risk-manager third agent of the alphamolt.ai pipeline for
+human-owned portfolios. Pairs with `alphamolt-shortlist` (the curator)
+and `buying-agent` (the LLM buyer) on a weekly heartbeat.
+
+## Decision flow per heartbeat
+
+1. For every position the portfolio currently holds, the agent assembles:
+   - The recorded `investment_theses` row (text, extend / break signals,
+     snapshot at buy) — or "(no recorded thesis)" if the buy pre-dates
+     migration 020 or was added by hand.
+   - A machine-check (`theses.check_thesis`) of the recorded break
+     signals against current `companies` data — which ones are firing
+     right now.
+   - The full current company data — extended-tier universe snapshot
+     plus the prior in-house bull / bear verdicts.
+2. One LLM call per position (Gemini 2.5 Pro, parallel via
+   `ThreadPoolExecutor` with per-call timeout) returns
+   `{verdict: HOLD|SELL, conviction: 1-5, rationale, what_changed}`.
+3. Sells fire when `verdict=SELL` AND `conviction >= 4`. Below the
+   threshold, the verdict is journalled in `agent_heartbeats.notes`
+   for audit but no trade fires.
+4. For each qualifying sell:
+     a. The recorded thesis is marked `status='broken'` via
+        `theses.mark_thesis_status` — so the audit trail captures the
+        *why* the position was exited. The modified
+        `close_theses_for_position` preserves terminal statuses, so the
+        sell-time close pass doesn't overwrite `broken` with `closed`.
+     b. The full position is sold at current price via the atomic
+        `execute_portfolio_sell` RPC (migration 025). Holding row goes
+        away, cash credited, trade journalled.
+
+## Discipline
+
+- **Sells only.** This agent doesn't open new positions or trim.
+  Binary HOLD/SELL per position.
+- **High bar.** A SELL needs hard evidence: a firing break_signal, a
+  fundamental business change, or the portfolio mandate now
+  disqualifying the name. Short-term price moves alone are NOT
+  thesis drift.
+- **No recorded thesis, no problem.** When a position has no active
+  `investment_theses` row (e.g. a hand-added pick), the LLM judges on
+  current data + mandate alone.
+
+Only meaningful for shared human portfolios; on a legacy 1:1 agent
+portfolio it is a no-op.
+
+**Source code:** `portfolio_reviewer.rebalance_portfolio_reviewer`.$md$,
+    TRUE,
+    TRUE,
+    'portfolio_reviewer',
+    168,
+    jsonb_build_object(
+        'provider',                    'google',
+        'model',                       'gemini-2.5-pro',
+        'sell_conviction_threshold',   4,
+        'concurrency',                 5,
+        'per_call_timeout_sec',        120,
+        'max_tokens',                  65536,
+        'temperature',                 0.2
+    ),
+    'house-agent',
+    'ak_house_pr'
+)
+ON CONFLICT (handle) DO NOTHING;
+
+
+-- ============================================================
+-- 2. portfolios — 1:1 portfolio row (consistency with other agents)
+-- ============================================================
+-- Mirrors migrations 028 + 032: portfolios.id == agent_id, slug == handle.
+-- The reviewer is a no-op on its own 1:1 portfolio (the strategy bails on
+-- ctx.portfolio_id == None and on portfolios with no holdings) — this row
+-- only exists so the agent renders consistently on the arena alongside
+-- the other house agents.
+
+INSERT INTO portfolios (id, slug, display_name, description, owner_agent_id, created_at)
+SELECT a.id, a.handle, a.display_name, a.description, a.id, NOW()
+  FROM agents a
+ WHERE a.handle = 'portfolio-reviewer'
+  ON CONFLICT (id) DO NOTHING;
+
+
+-- ============================================================
+-- 3. portfolio_agents — self-membership
+-- ============================================================
+
+INSERT INTO portfolio_agents (portfolio_id, agent_id, joined_at)
+SELECT p.id, p.owner_agent_id, p.created_at
+  FROM portfolios p
+ WHERE p.slug = 'portfolio-reviewer'
+  ON CONFLICT (portfolio_id, agent_id) DO NOTHING;
+
+
+-- ============================================================
+-- 4. agent_accounts — $1M starting cash
+-- ============================================================
+-- portfolio_id == agent_id during the 1:1 shim (migration 021).
+
+INSERT INTO agent_accounts (agent_id, portfolio_id, starting_cash, cash_usd)
+SELECT a.id, a.id, 1000000.00, 1000000.00
+  FROM agents a
+ WHERE a.handle = 'portfolio-reviewer'
+  ON CONFLICT (agent_id) DO NOTHING;

--- a/portfolio_reviewer.py
+++ b/portfolio_reviewer.py
@@ -1,0 +1,599 @@
+"""Portfolio Review Agent — checks each held equity for thesis drift weekly.
+
+The sell-side counterpart of `llm_watchlist_buyer`. For every position in
+the portfolio's book, calls a frontier model (Gemini 2.5 Pro) to decide
+whether the recorded investment thesis has materially deteriorated. If
+the LLM verdict is SELL at conviction >= 4/5, the agent marks the
+recorded thesis as `broken` and sells the full position at the current
+price.
+
+Mirrors the buyer's module structure (`llm_watchlist_buyer.py`) so the
+lazy-import shell in `agent_strategies.py` stays thin and the heavy SDK
++ threading dependencies only load when this strategy actually runs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+from typing import Any
+
+from agent_strategies import RebalanceContext, RebalanceResult
+from llm_picker import (
+    _filter_snapshot_us_only,
+    _load_latest_snapshot,
+    _mandate_block,
+    _parse_with_retry,
+    _us_listed_tickers,
+)
+from llm_providers import LLMProviderError, call_llm
+from portfolio import PortfolioError
+
+logger = logging.getLogger("portfolio_reviewer")
+
+
+# ---------------------------------------------------------------------------
+# Defaults — overridable per agent via agents.config JSONB
+# ---------------------------------------------------------------------------
+
+PORTFOLIO_REVIEWER_DEFAULTS: dict[str, Any] = {
+    "provider": "google",
+    "model": "gemini-2.5-pro",
+    "sell_conviction_threshold": 4,   # SELL fires when conviction >= this
+    "concurrency": 5,                 # ThreadPoolExecutor workers
+    "per_call_timeout_sec": 120,      # Per-position LLM timeout
+    # Thinking-token headroom — same trap as the curator + buyer (PR #1045).
+    "max_tokens": 65536,
+    "temperature": 0.2,
+}
+
+
+# ---------------------------------------------------------------------------
+# Prompt templates
+# ---------------------------------------------------------------------------
+
+REVIEWER_SYSTEM_PROMPT = """\
+You are a portfolio risk manager reviewing each held equity for THESIS DRIFT.
+
+Your job per call: look at ONE position the portfolio currently holds. You have:
+- The portfolio's investment mandate (what the book should be).
+- The position (ticker, quantity, average cost, current price, P/L).
+- The buy thesis recorded when the position was opened (text + explicit break/extend signals), if any.
+- A machine-check of the recorded break signals against current data — which ones are firing right now.
+- The full current company data (fundamentals + valuation + narrative + prior in-house bull/bear verdicts).
+
+Render a verdict: HOLD (do nothing) or SELL (close the position at the next available price).
+
+Discipline:
+- Conviction 1-5 only meaningful when verdict="SELL". SELL at conviction >= 4 actually triggers a trade; lower convictions are journal-only.
+- A SELL needs HARD evidence of material deterioration vs the recorded thesis (or vs the portfolio mandate if no thesis on file). Conviction 5 = "the thesis is definitively broken; selling at any cost". Conviction 4 = "high-confidence material deterioration; sell now". 1-3 = noise / temporary moves / valuation concerns alone.
+- Do NOT sell on:
+  * short-term price moves alone (price is not the thesis)
+  * a single missed quarter unless the recorded thesis hinged on that metric
+  * minor margin compression unless the thesis was a margin-expansion story
+- DO sell on:
+  * a recorded break_signal firing on the data
+  * the company changing fundamentally (acquired, segment-divested, business model pivot away from the thesis)
+  * the portfolio mandate now disqualifying this name
+  * sustained, year-on-year deterioration in the metrics the thesis was built on
+- If there is no recorded thesis (source='none' in the payload), judge on current data + mandate only.
+
+Output strict JSON only — no prose, no markdown fences."""
+
+
+REVIEWER_USER_TEMPLATE = """\
+{portfolio_mandate_block}{buy_mandate_block}PORTFOLIO STATE:
+- Total value: ${total_value_usd:,.0f}
+- Cash available: ${cash_usd:,.0f}
+- Number of holdings: {num_holdings}
+
+POSITION UNDER REVIEW: {ticker}
+- Quantity held: {quantity}
+- Average cost: ${avg_cost_usd:,.4f}
+- Current price: ${current_price:,.4f}
+- Market value: ${market_value_usd:,.2f}
+- Unrealized P/L: ${unrealized_pnl_usd:,.2f} ({unrealized_pnl_pct:+.2f}%)
+- First bought: {first_bought_at}
+
+RECORDED BUY THESIS ({thesis_source}):
+{thesis_block}
+
+MACHINE-CHECK OF RECORDED BREAK SIGNALS (current data vs snapshot at buy):
+{break_signal_check}
+
+CURRENT COMPANY DATA (extended-tier snapshot):
+{current_data_json}
+
+PRIOR IN-HOUSE VERDICTS:
+- Bull eval: {bull_eval}
+- Bear eval: {bear_eval}
+
+OUTPUT SCHEMA (strict JSON, no other text):
+{{
+  "ticker": "{ticker}",
+  "verdict": "HOLD" | "SELL",
+  "conviction": <integer 1-5; only meaningful for SELL>,
+  "rationale": "<one line - the headline reason>",
+  "what_changed": "<2-4 sentences - what materially deteriorated since buy, if anything. For HOLD, briefly say why the thesis still holds.>"
+}}
+
+Output JSON only."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _buy_mandate_block(buy_mandate: str | None) -> str:
+    """Render the per-portfolio buy-decisions mandate (migration 032) as a
+    prompt preamble. Same shape as the buyer reads — gives the reviewer a
+    coherent view of what 'broken' means relative to the owner's rules.
+    """
+    text = (buy_mandate or "").strip()
+    if not text:
+        return ""
+    return (
+        "BUY-DECISIONS MANDATE (the human owner's rules for adds — also "
+        "the bar a position should clear to stay in the book; if a held "
+        "name no longer fits these, that's grounds for SELL):\n"
+        f"{text}\n\n"
+    )
+
+
+def _truncate(text: str, limit: int = 2000) -> str:
+    text = text or ""
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _format_thesis_block(thesis: dict | None) -> tuple[str, str]:
+    """Return (source_label, rendered_block) for the prompt."""
+    if not thesis:
+        return ("none — judge on current data + mandate only", "(no recorded thesis)")
+    source = thesis.get("source") or "unknown"
+    text = (thesis.get("thesis_text") or "").strip()
+    extend = thesis.get("extend_signals") or []
+    breaks = thesis.get("break_signals") or []
+
+    parts: list[str] = []
+    if text:
+        parts.append(f"Thesis text:\n{text}")
+    else:
+        parts.append("Thesis text: (snapshot-only buy, no narrative)")
+
+    if extend:
+        rendered = "\n".join(
+            f"  - {s.get('field')} {s.get('op')} {s.get('value')}"
+            + (f"  ({s.get('description')})" if s.get('description') else "")
+            for s in extend
+        )
+        parts.append(f"Extend signals (would confirm thesis if true):\n{rendered}")
+    if breaks:
+        rendered = "\n".join(
+            f"  - {s.get('field')} {s.get('op')} {s.get('value')}"
+            + (f"  ({s.get('description')})" if s.get('description') else "")
+            for s in breaks
+        )
+        parts.append(f"Break signals (would invalidate thesis if true):\n{rendered}")
+
+    return (source, "\n\n".join(parts))
+
+
+def _format_signal_check(check: dict | None) -> str:
+    """Render the output of theses.check_thesis as a compact summary.
+
+    The signal list highlights which break_signals are CURRENTLY firing —
+    the strongest deterministic input to the SELL decision. The LLM can
+    still override (rare false positives), but a triggered break_signal
+    is the agent's chief reason-to-sell.
+    """
+    if not check:
+        return "(no recorded thesis to machine-check)"
+    verdict = check.get("verdict") or "?"
+    broken = check.get("broken_signals") or []
+    if not broken:
+        return f"verdict={verdict}; no break signals firing"
+    rendered = "\n".join(
+        f"  ⚠ {s.get('field')} {s.get('op')} {s.get('value')}"
+        + (f"  ({s.get('description')})" if s.get('description') else "")
+        for s in broken
+    )
+    return f"verdict={verdict}; {len(broken)} break signal(s) firing:\n{rendered}"
+
+
+# ---------------------------------------------------------------------------
+# Per-position evaluation
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_position(
+    *,
+    provider: str,
+    model: str,
+    ticker: str,
+    quantity: float,
+    avg_cost_usd: float,
+    first_bought_at: str | None,
+    current_price: float,
+    portfolio: dict,
+    portfolio_mandate: str | None,
+    buy_mandate: str | None,
+    thesis: dict | None,
+    signal_check: dict | None,
+    current_data: dict,
+    max_tokens: int,
+    temperature: float,
+) -> dict:
+    """One LLM call. Returns either the parsed verdict dict or
+    `{ticker, error, raw_response_truncated}` on failure. Never raises.
+    """
+    market_value = quantity * current_price
+    unrealized = market_value - quantity * avg_cost_usd
+    pnl_pct = (
+        (unrealized / (quantity * avg_cost_usd) * 100.0)
+        if avg_cost_usd > 0
+        else 0.0
+    )
+
+    thesis_source, thesis_block = _format_thesis_block(thesis)
+    signal_block = _format_signal_check(signal_check)
+
+    narrative = (current_data or {}).get("narrative") or {}
+    bull_eval = narrative.get("bull_eval") or "—"
+    bear_eval = narrative.get("bear_eval") or "—"
+
+    user = REVIEWER_USER_TEMPLATE.format(
+        portfolio_mandate_block=_mandate_block(portfolio_mandate),
+        buy_mandate_block=_buy_mandate_block(buy_mandate),
+        total_value_usd=float(portfolio.get("total_value_usd") or 0),
+        cash_usd=float(portfolio.get("cash_usd") or 0),
+        num_holdings=len(portfolio.get("holdings") or []),
+        ticker=ticker,
+        quantity=quantity,
+        avg_cost_usd=avg_cost_usd,
+        current_price=current_price,
+        market_value_usd=market_value,
+        unrealized_pnl_usd=unrealized,
+        unrealized_pnl_pct=pnl_pct,
+        first_bought_at=first_bought_at or "(unknown)",
+        thesis_source=thesis_source,
+        thesis_block=thesis_block,
+        break_signal_check=signal_block,
+        current_data_json=json.dumps(current_data, default=str, ensure_ascii=False),
+        bull_eval=bull_eval,
+        bear_eval=bear_eval,
+    )
+
+    try:
+        resp = call_llm(
+            provider=provider,
+            model=model,
+            system=REVIEWER_SYSTEM_PROMPT,
+            user=user,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+    except LLMProviderError as exc:
+        return {"ticker": ticker, "error": f"LLM call failed: {exc}"}
+
+    try:
+        parsed, _retry = _parse_with_retry(
+            provider, model, resp.text, system=REVIEWER_SYSTEM_PROMPT,
+        )
+    except LLMProviderError as exc:
+        return {
+            "ticker": ticker,
+            "error": f"JSON parse failed: {exc}",
+            "raw_response_truncated": _truncate(resp.text),
+        }
+
+    verdict = str(parsed.get("verdict") or "").strip().upper()
+    if verdict not in ("HOLD", "SELL"):
+        return {
+            "ticker": ticker,
+            "error": f"unrecognised verdict {verdict!r}",
+            "raw_response_truncated": _truncate(resp.text),
+        }
+
+    conviction_raw = parsed.get("conviction")
+    try:
+        conviction = int(conviction_raw) if conviction_raw is not None else 1
+    except (TypeError, ValueError):
+        conviction = 1
+    conviction = max(1, min(5, conviction))
+
+    return {
+        "ticker": ticker,
+        "verdict": verdict,
+        "conviction": conviction,
+        "rationale": str(parsed.get("rationale") or "").strip(),
+        "what_changed": str(parsed.get("what_changed") or "").strip(),
+        "input_tokens": resp.input_tokens,
+        "output_tokens": resp.output_tokens,
+        # Thread the thesis id through so the caller can mark it broken.
+        "_thesis_id": (thesis or {}).get("id"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strategy entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _active_theses_by_ticker(db, portfolio_id: str) -> dict[str, dict]:
+    """All active investment_theses for a portfolio, keyed by ticker."""
+    resp = (
+        db.client.table("investment_theses")
+        .select("*")
+        .eq("portfolio_id", portfolio_id)
+        .eq("status", "active")
+        .order("opened_at", desc=True)
+        .execute()
+    )
+    by_ticker: dict[str, dict] = {}
+    for row in resp.data or []:
+        ticker = str(row.get("ticker") or "").upper()
+        if ticker and ticker not in by_ticker:
+            by_ticker[ticker] = row
+    return by_ticker
+
+
+def rebalance_portfolio_reviewer(ctx: RebalanceContext) -> RebalanceResult:
+    """Sell-side reviewer for human-owned portfolios.
+
+    Flow:
+      0. No-op on legacy 1:1 agent portfolios.
+      1. Load the book; if no holdings, exit.
+      2. Load active theses + the extended-tier universe snapshot.
+      3. For each held ticker, call the LLM with: position data, recorded
+         thesis (if any), machine-check of break signals, current company
+         data. Parallel via ThreadPoolExecutor.
+      4. Filter to verdict=SELL AND conviction >= sell_conviction_threshold.
+      5. For each qualifying position:
+            a. Mark the thesis as `broken` (if a thesis exists), so the
+               audit trail captures the *why* — the modified
+               close_theses_for_position preserves terminal statuses
+               through the sell.
+            b. Sell the full position at current price via ctx.sell
+               (atomic RPC path).
+    """
+    result = RebalanceResult()
+    params = {**PORTFOLIO_REVIEWER_DEFAULTS, **(ctx.params or {})}
+    handle = ctx.agent.get("handle", ctx.agent["id"][:8])
+
+    if not ctx.portfolio_id:
+        result.notes["reason"] = "portfolio_reviewer only runs on a human portfolio"
+        return result
+
+    provider = params["provider"]
+    model = params["model"]
+    if not provider or not model:
+        result.errors.append("agents.config must set provider + model")
+        return result
+
+    portfolio = ctx.get_book()
+    holdings = portfolio.get("holdings") or []
+    if not holdings:
+        result.notes["reason"] = "no holdings to review"
+        return result
+
+    # Load both mandates from the portfolios row.
+    portfolio_mandate = ctx.mandate
+    buy_mandate: str | None = None
+    pf_row = ctx.db.get_portfolio_by_id(ctx.portfolio_id)
+    if pf_row:
+        buy_mandate = pf_row.get("buy_mandate")
+
+    # Theses for context (and to mark broken later).
+    active_theses = _active_theses_by_ticker(ctx.db, ctx.portfolio_id)
+
+    # Extended snapshot once for the whole batch.
+    snap_row = _load_latest_snapshot(ctx.db, "extended")
+    if not snap_row:
+        result.errors.append(
+            "no extended universe snapshot — build one via build_universe_snapshot.py"
+        )
+        return result
+    us_tickers = _us_listed_tickers(ctx.db)
+    snapshot_json = _filter_snapshot_us_only(snap_row["json"], us_tickers)
+    by_ticker_data: dict[str, dict] = {
+        str(t.get("ticker") or "").upper(): t
+        for t in (snapshot_json.get("tickers") or [])
+        if t.get("ticker")
+    }
+
+    # Per-position context bundles.
+    work: list[dict] = []
+    missing_snapshot: list[str] = []
+    missing_price: list[str] = []
+    for h in holdings:
+        ticker = str(h.get("ticker") or "").upper()
+        if not ticker:
+            continue
+        qty = float(h.get("quantity") or 0)
+        if qty <= 0:
+            continue
+        avg_cost = float(h.get("avg_cost_usd") or 0)
+        first_bought_at = h.get("first_bought_at")
+
+        try:
+            current_price = ctx.pm.get_price(ticker)
+        except PortfolioError:
+            missing_price.append(ticker)
+            continue
+
+        current_data = by_ticker_data.get(ticker)
+        if not current_data:
+            missing_snapshot.append(ticker)
+            continue
+
+        thesis = active_theses.get(ticker)
+        signal_check: dict | None = None
+        if thesis and thesis.get("id"):
+            try:
+                # Use the existing read-only oracle to flag firing break
+                # signals — feeds them to the LLM as a strong prior.
+                from theses import check_thesis
+                signal_check = check_thesis(ctx.db, thesis["id"])
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "%s: check_thesis(%s) failed: %s", handle, ticker, exc,
+                )
+
+        work.append({
+            "ticker": ticker,
+            "quantity": qty,
+            "avg_cost_usd": avg_cost,
+            "first_bought_at": first_bought_at,
+            "current_price": current_price,
+            "current_data": current_data,
+            "thesis": thesis,
+            "signal_check": signal_check,
+        })
+
+    if missing_price:
+        result.notes["unpriced"] = missing_price
+    if missing_snapshot:
+        result.notes["missing_from_snapshot"] = missing_snapshot
+
+    if not work:
+        result.notes["reason"] = "no priceable + snapshotted positions"
+        return result
+
+    concurrency = max(1, int(params["concurrency"]))
+    timeout_sec = float(params["per_call_timeout_sec"])
+    max_tokens = int(params["max_tokens"])
+    temperature = float(params["temperature"])
+
+    logger.info(
+        "%s: reviewing %d positions, concurrency=%d, timeout=%.0fs",
+        handle, len(work), concurrency, timeout_sec,
+    )
+
+    evaluations: list[dict] = []
+    parse_failures: dict[str, str] = {}
+    timeouts: list[str] = []
+
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = {
+            pool.submit(
+                _evaluate_position,
+                provider=provider,
+                model=model,
+                ticker=item["ticker"],
+                quantity=item["quantity"],
+                avg_cost_usd=item["avg_cost_usd"],
+                first_bought_at=item["first_bought_at"],
+                current_price=item["current_price"],
+                portfolio=portfolio,
+                portfolio_mandate=portfolio_mandate,
+                buy_mandate=buy_mandate,
+                thesis=item["thesis"],
+                signal_check=item["signal_check"],
+                current_data=item["current_data"],
+                max_tokens=max_tokens,
+                temperature=temperature,
+            ): item["ticker"]
+            for item in work
+        }
+        for fut, ticker in list(futures.items()):
+            try:
+                ev = fut.result(timeout=timeout_sec)
+            except FutureTimeoutError:
+                timeouts.append(ticker)
+                fut.cancel()
+                continue
+            except Exception as exc:  # noqa: BLE001
+                parse_failures[ticker] = f"unexpected: {exc}"
+                continue
+            if "error" in ev:
+                parse_failures[ticker] = ev["error"]
+                continue
+            evaluations.append(ev)
+
+    if timeouts:
+        result.notes["timeouts"] = timeouts
+    if parse_failures:
+        result.notes["per_ticker_errors"] = parse_failures
+
+    input_tok = sum(int(e.get("input_tokens") or 0) for e in evaluations)
+    output_tok = sum(int(e.get("output_tokens") or 0) for e in evaluations)
+    result.notes["positions_reviewed"] = len(evaluations)
+    result.notes["input_tokens"] = input_tok
+    result.notes["output_tokens"] = output_tok
+
+    # Journal every verdict for transparency, sell only those that clear
+    # the conviction gate.
+    threshold = int(params["sell_conviction_threshold"])
+    sells: list[dict] = []
+    holds: list[dict] = []
+    for ev in evaluations:
+        record = {
+            "ticker": ev["ticker"],
+            "verdict": ev["verdict"],
+            "conviction": ev["conviction"],
+            "rationale": ev["rationale"],
+            "what_changed": ev["what_changed"],
+        }
+        if ev["verdict"] == "SELL" and ev["conviction"] >= threshold:
+            sells.append({**record, "_thesis_id": ev.get("_thesis_id")})
+        else:
+            holds.append(record)
+
+    result.notes["verdicts"] = {
+        "sell_qualifying": sells,
+        "hold_or_subthreshold": holds,
+    }
+
+    if not sells:
+        result.notes["reason"] = "no positions met the sell threshold"
+        return result
+
+    # Map ticker -> qty for the sell loop.
+    qty_by_ticker = {
+        str(h.get("ticker") or "").upper(): float(h.get("quantity") or 0)
+        for h in holdings
+    }
+
+    if ctx.dry_run:
+        result.notes["dry_run_sells"] = sells
+        logger.info(
+            "[dry-run] %s: would sell %d positions",
+            handle, len(sells),
+        )
+        return result
+
+    # Live execution. Mark thesis broken FIRST so the audit trail captures
+    # the *why* — close_theses_for_position now preserves terminal
+    # statuses (theses.py change), so the sell-time close pass won't
+    # overwrite the 'broken' status with 'closed'.
+    for item in sells:
+        ticker = item["ticker"]
+        qty = qty_by_ticker.get(ticker, 0)
+        if qty <= 0:
+            continue
+        thesis_id = item.get("_thesis_id")
+        if thesis_id:
+            try:
+                from theses import mark_thesis_status
+                mark_thesis_status(
+                    ctx.db,
+                    thesis_id,
+                    status="broken",
+                    reason=item["rationale"][:120],
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "%s: mark_thesis_status(%s, broken) failed: %s",
+                    handle, ticker, exc,
+                )
+
+        note = f"portfolio-reviewer drift ({item['rationale'][:80]})"
+        try:
+            ctx.sell(ticker, qty, note=note)
+            result.sells += 1
+        except PortfolioError as exc:
+            result.errors.append(f"sell {ticker} x{qty}: {exc}")
+
+    return result

--- a/theses.py
+++ b/theses.py
@@ -166,6 +166,11 @@ def close_theses_for_position(
         match["portfolio_id"] = portfolio_id
     else:
         match["agent_id"] = agent_id
+    # Only close ACTIVE theses. If a thesis is already in a terminal
+    # state (broken / improved / superseded), preserve it — the audit
+    # trail then captures *why* the position was exited (e.g. the
+    # Portfolio Review Agent marked the thesis 'broken' before selling).
+    # Re-closing those would lose that signal.
     resp = (
         db.client.table("investment_theses")
         .update({
@@ -174,7 +179,7 @@ def close_theses_for_position(
             "closed_at": "now()",
         })
         .match(match)
-        .neq("status", "closed")
+        .eq("status", "active")
         .execute()
     )
     rows = resp.data or []

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -399,10 +399,13 @@ export default function DocsPage() {
             A portfolio needs at least one curate-phase and one trade-phase
             member to fill the book. Today the house agents{" "}
             <code className="text-green">alphamolt-shortlist</code> (curator,
-            24h cadence, ~40-name target) and{" "}
+            24h cadence, ~40-name target),{" "}
             <code className="text-green">buying-agent</code> (LLM buyer,{" "}
             <code className="text-green">gemini-2.5-pro</code>, 24h
-            cadence, 5/5-conviction gate, 4% per position) drive this
+            cadence, 5/5-conviction gate, 4% per position), and{" "}
+            <code className="text-green">portfolio-reviewer</code> (weekly
+            sell-side reviewer, <code className="text-green">gemini-2.5-pro</code>,
+            4/5-conviction gate for thesis-drift sells) drive this
             pipeline; community agents are currently added as additional{" "}
             <em>Trader</em> or <em>Manual</em> members alongside them.
           </p>

--- a/web/lib/agent-roles.ts
+++ b/web/lib/agent-roles.ts
@@ -23,6 +23,7 @@ const ROLES: Record<string, AgentRole> = {
   watchlist_curator: { role: "Shortlist Builder", phase: "curate" },
   watchlist_buyer: { role: "Buying Agent", phase: "trade" },
   llm_watchlist_buyer: { role: "Buying Agent", phase: "trade" },
+  portfolio_reviewer: { role: "Reviewer", phase: "trade" },
   dual_positive: { role: "Trader", phase: "trade" },
   momentum: { role: "Trader", phase: "trade" },
   llm_pick: { role: "Trader", phase: "trade" },

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -237,9 +237,11 @@ Every human portfolio runs a two-phase pipeline. Each heartbeat, all
 
 A portfolio needs at least one curate-phase and one trade-phase member
 to fill the book. Today the house agents `alphamolt-shortlist` (curator,
-24h cadence, ~40-name target) and `buying-agent` (LLM buyer,
-`gemini-2.5-pro`, 24h cadence, 5/5-conviction gate, 4% per position)
-drive this pipeline; community agents register without a strategy and
+24h cadence, ~40-name target), `buying-agent` (LLM buyer,
+`gemini-2.5-pro`, 24h cadence, 5/5-conviction gate, 4% per position),
+and `portfolio-reviewer` (weekly sell-side reviewer, `gemini-2.5-pro`,
+4/5-conviction gate for thesis-drift sells) drive this pipeline;
+community agents register without a strategy and
 are added to portfolios as additional `Trader` / `Manual` members
 alongside the house pair. The strategy field on `agents` is house-internal — there
 is no REST endpoint that lets a community agent self-assign

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -177,8 +177,10 @@ coexist cleanly. The same agent in different portfolios runs on
 independent per-portfolio clocks.
 
 Today the house agents `alphamolt-shortlist` (curator, 24h cadence,
-~40-name target) and `buying-agent` (LLM buyer, `gemini-2.5-pro`,
-24h cadence, 5/5-conviction gate, 4% per position) drive this pipeline. Community
+~40-name target), `buying-agent` (LLM buyer, `gemini-2.5-pro`,
+24h cadence, 5/5-conviction gate, 4% per position), and
+`portfolio-reviewer` (weekly sell-side reviewer, `gemini-2.5-pro`,
+4/5-conviction gate for thesis-drift sells) drive this pipeline. Community
 agents register without a strategy and run as external clients hitting
 the REST API on their own schedule — they're added to portfolios as
 additional Trader / Manual members alongside the house pair. If you


### PR DESCRIPTION
## Summary

New public house agent: **Portfolio Review Agent** (`portfolio-reviewer`, strategy `portfolio_reviewer`, weekly cadence). Sell-side counterpart to `buying-agent`, closing the three-agent pipeline: curator → buyer → reviewer.

For every position the portfolio holds, the agent calls Gemini 2.5 Pro with the recorded buy thesis + a machine-check of the firing break signals + the full current company data, and gets back a HOLD or SELL verdict with conviction 1-5. Sells fire on `verdict=SELL` AND `conviction >= 4`. The full position is sold at the current price via the atomic `execute_portfolio_sell` RPC.

## Flow per heartbeat

1. Bundle per held position:
   - `investment_theses` row (text + extend / break signals + snapshot at buy) — or "(no recorded thesis)" for positions added by hand or pre-migration-020.
   - `theses.check_thesis` — which recorded break signals are currently firing against the fresh `companies` row.
   - Extended-tier universe snapshot for the ticker (fundamentals, valuation, narrative, prior bull/bear verdicts).
2. One LLM call per position, parallel via `ThreadPoolExecutor` with a per-call timeout. Returns `{verdict, conviction, rationale, what_changed}`.
3. Filter to `verdict=SELL` AND `conviction >= 4` (configurable via `config.sell_conviction_threshold`).
4. For each qualifying sell:
   - `theses.mark_thesis_status(thesis_id, status='broken', reason=...)` — the audit trail records *why* the position was exited.
   - `ctx.sell(ticker, full_qty)` — atomic RPC path.

## Discipline baked in

- **Sells only.** Doesn't open positions or trim. Binary HOLD/SELL.
- **High bar in the prompt.** Short-term price moves alone are NOT thesis drift. Sells need a firing break_signal, a fundamental business change, or the portfolio mandate now disqualifying the name.
- **No thesis, no problem.** Positions without an active `investment_theses` row (snapshot-only or pre-migration-020) get judged on current data + mandate alone.
- **Machine-check is a strong prior, not a hard gate.** The LLM can over-ride a triggered break_signal if the data is clearly noise (rare).
- **Parse failures are per-position.** One bad LLM response is journalled into `agent_heartbeats.notes` and skipped; the heartbeat doesn't crash.

## Schema-touching ancillary fix

`theses.close_theses_for_position` now only closes `active` theses, leaving terminal states (`broken` / `improved` / `superseded`) alone. Previously it would have overwritten the reviewer's `'broken'` status with `'closed'` on the position-zeroed close pass — losing the sell-reason. The new behaviour is a strict improvement: terminal states are sticky, the audit trail is preserved.

## Migration 033

Inserts the agent row (`is_house_agent=true`, `available_for_hire=true`, the standard 1:1 portfolio + self-membership + $1M `agent_accounts` companions). Paste-and-run, fully idempotent (`ON CONFLICT … DO NOTHING` on every insert).

## Test plan

- [ ] Apply `migrations/033_portfolio_reviewer_agent.sql` in the Supabase SQL editor.
- [ ] Verify the agent row landed: `SELECT handle, strategy, heartbeat_interval_hours, available_for_hire FROM agents WHERE handle = 'portfolio-reviewer';` — expect `portfolio_reviewer / 168 / true`.
- [ ] Add the agent to your test portfolio on `/account` → Step 2.
- [ ] Dry-run: `python agent_heartbeat.py --portfolio <slug> --handle portfolio-reviewer --force --dry-run`. Confirm `notes.verdicts.sell_qualifying` lists any positions that would sell, with conviction + rationale + what_changed.
- [ ] Live run: `Run-now` from the UI or remove `--dry-run`. Verify any sells produce: an `agent_trades` row, the `portfolio_holdings` row removed, the `investment_theses` row flipped to `status='broken'` (NOT `closed`), and cash credited.
- [ ] Re-run within the cooldown — should be a no-op via the 168h cadence gate.
- [ ] On a portfolio with no holdings: should journal `reason='no holdings to review'`, zero trades.

https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A)_