### PR TITLE
/account = dashboard; setup moves to /account/settings; logged-in `/` → /account

### DIFF
--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -1,23 +1,10 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 import Nav from "@/components/nav";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
-import {
-  getPortfolioForUser,
-  getMembersForPortfolio,
-  getHoldingsCountForPortfolio,
-  type Portfolio,
-  type PortfolioMember,
-} from "@/lib/portfolios-query";
-import { listPublicAgents, getAgentReturns30d } from "@/lib/agents-query";
-import { roleFor } from "@/lib/agent-roles";
+import { getPortfolioForUser } from "@/lib/portfolios-query";
 import CreatePortfolioForm from "@/components/portfolio/create-portfolio-form";
-import PortfolioDetailsEditor from "@/components/portfolio/portfolio-details-editor";
-import BuyMandateEditor from "@/components/portfolio/buy-mandate-editor";
-import AgentPicker from "@/components/portfolio/agent-picker";
-import VisibilityToggle from "@/components/portfolio/visibility-toggle";
 
 export const metadata: Metadata = {
   title: "Your account — AlphaMolt",
@@ -26,10 +13,19 @@ export const metadata: Metadata = {
 
 export const dynamic = "force-dynamic";
 
-// Hysteresis thresholds for the Private/Public toggle (migration 031).
 const PUBLIC_ACTIVATE_THRESHOLD = 15;
-const PUBLIC_FLOOR_THRESHOLD = 10;
 
+/**
+ * Dashboard / onboarding gate. Three branches:
+ *
+ *   * Not signed in → /login
+ *   * Signed in, portfolio exists → /portfolios/<slug>
+ *     (the portfolio detail page IS the dashboard for the owner)
+ *   * Signed in, no portfolio yet → render the onboarding form here so
+ *     the user can create one
+ *
+ * Mandate / agent / visibility editing lives on /account/settings.
+ */
 export default async function AccountPage() {
   const supabase = await createSupabaseServerClient();
   const {
@@ -40,6 +36,19 @@ export default async function AccountPage() {
     redirect("/login?next=/account");
   }
 
+  let portfolio: { slug: string } | null = null;
+  try {
+    const p = await getPortfolioForUser(user.id);
+    portfolio = p ? { slug: p.slug } : null;
+  } catch {
+    portfolio = null;
+  }
+
+  if (portfolio) {
+    redirect(`/portfolios/${portfolio.slug}`);
+  }
+
+  // No portfolio yet — onboarding.
   let profile: { email: string | null; display_name: string | null } | null =
     null;
   try {
@@ -52,43 +61,8 @@ export default async function AccountPage() {
   } catch {
     profile = null;
   }
-
   const email = profile?.email ?? user.email ?? "";
   const displayName = profile?.display_name || email.split("@")[0] || "there";
-
-  let portfolio: Portfolio | null = null;
-  try {
-    portfolio = await getPortfolioForUser(user.id);
-  } catch {
-    portfolio = null;
-  }
-
-  let members: PortfolioMember[] = [];
-  let allAgents: Awaited<ReturnType<typeof listPublicAgents>> = [];
-  let returns30d = new Map<string, number | null>();
-  let holdingsCount = 0;
-  if (portfolio) {
-    try {
-      members = await getMembersForPortfolio(portfolio.id);
-    } catch {
-      members = [];
-    }
-    try {
-      allAgents = await listPublicAgents(1000, true);
-    } catch {
-      allAgents = [];
-    }
-    try {
-      returns30d = await getAgentReturns30d();
-    } catch {
-      returns30d = new Map();
-    }
-    try {
-      holdingsCount = await getHoldingsCountForPortfolio(portfolio.id);
-    } catch {
-      holdingsCount = 0;
-    }
-  }
 
   return (
     <>
@@ -102,390 +76,40 @@ export default async function AccountPage() {
               "radial-gradient(60% 65% at 16% 8%, rgba(0,255,65,0.05), transparent 70%), radial-gradient(48% 55% at 86% 4%, rgba(0,242,255,0.06), transparent 70%)",
           }}
         />
-        <div className="max-w-[820px] mx-auto w-full px-4 sm:px-6 py-10 sm:py-14">
-          {portfolio ? (
-            <PortfolioView
-              portfolio={portfolio}
-              members={members}
-              allAgents={allAgents}
-              returns30d={returns30d}
-              holdingsCount={holdingsCount}
-              email={email}
-            />
-          ) : (
-            <NoPortfolioView displayName={displayName} email={email} />
-          )}
+        <div className="max-w-[640px] mx-auto w-full px-4 sm:px-6 py-10 sm:py-14">
+          <SectionBadge>Get started</SectionBadge>
+          <h1 className="mt-4 text-[28px] sm:text-[34px] font-bold tracking-[-0.025em] text-text leading-[1.1]">
+            Welcome, {displayName}.
+          </h1>
+          <p className="mt-3 text-base text-text-muted leading-relaxed">
+            Create your portfolio: give it a name and write the mandate your
+            team of AI agents will trade a $1M paper account to. It starts
+            Private — flip it to Public once it holds{" "}
+            {PUBLIC_ACTIVATE_THRESHOLD}+ equities.
+          </p>
+          <div className="mt-7 rounded-2xl border border-white/10 bg-white/[0.02] p-5 sm:p-6">
+            <CreatePortfolioForm />
+          </div>
+          <form
+            action="/auth/signout"
+            method="post"
+            className="flex items-center justify-between gap-3 pt-6"
+          >
+            <span className="text-[11px] font-mono text-text-muted truncate">
+              Signed in as {email}
+            </span>
+            <button
+              type="submit"
+              className="text-[11px] font-mono text-text-muted hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 rounded px-1"
+            >
+              Sign out →
+            </button>
+          </form>
         </div>
       </main>
     </>
   );
 }
-
-function NoPortfolioView({
-  displayName,
-  email,
-}: {
-  displayName: string;
-  email: string;
-}) {
-  return (
-    <div className="max-w-[640px] mx-auto">
-      <SectionBadge>Get started</SectionBadge>
-      <h1 className="mt-4 text-[28px] sm:text-[34px] font-bold tracking-[-0.025em] text-text leading-[1.1]">
-        Welcome, {displayName}.
-      </h1>
-      <p className="mt-3 text-base text-text-muted leading-relaxed">
-        Create your portfolio: give it a name and write the mandate your team
-        of AI agents will trade a $1M paper account to. It starts Private —
-        flip it to Public once it holds {PUBLIC_ACTIVATE_THRESHOLD}+ equities.
-      </p>
-      <div className="mt-7 rounded-2xl border border-white/10 bg-white/[0.02] p-5 sm:p-6">
-        <CreatePortfolioForm />
-      </div>
-      <SignOutRow email={email} />
-    </div>
-  );
-}
-
-function PortfolioView({
-  portfolio,
-  members,
-  allAgents,
-  returns30d,
-  holdingsCount,
-  email,
-}: {
-  portfolio: Portfolio;
-  members: PortfolioMember[];
-  allAgents: Awaited<ReturnType<typeof listPublicAgents>>;
-  returns30d: Map<string, number | null>;
-  holdingsCount: number;
-  email: string;
-}) {
-  const phases = members.map((m) => roleFor(m.strategy).phase);
-  const hasCurator = phases.includes("curate");
-  const hasBuyer = phases.includes("trade");
-  const hasMandate = (portfolio.description ?? "").trim().length > 0;
-
-  const step1 = hasMandate;
-  const step2 = hasCurator && hasBuyer;
-
-  const pickerMembers = members.map((m) => ({
-    handle: m.handle,
-    agentId: m.agent_id,
-    display_name: m.display_name,
-    is_house_agent: m.is_house_agent,
-    strategy: m.strategy,
-    return30d: returns30d.get(m.handle) ?? null,
-    powered_by: m.powered_by,
-    description: m.description,
-  }));
-  const pickerAll = allAgents.map((a) => ({
-    handle: a.handle,
-    agentId: a.id,
-    display_name: a.display_name,
-    is_house_agent: a.is_house_agent,
-    strategy: a.strategy,
-    return30d: returns30d.get(a.handle) ?? null,
-    powered_by: a.powered_by,
-    description: a.description,
-  }));
-
-  return (
-    <div className="space-y-7 sm:space-y-9">
-      <header>
-        <div className="flex items-center gap-3 flex-wrap">
-          <VisibilityBadge isPublic={portfolio.is_public} />
-          <Link
-            href={`/portfolios/${portfolio.slug}`}
-            className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.02] px-3 py-1 text-[10px] font-mono uppercase tracking-[0.14em] text-text-dim hover:text-[var(--color-cyan)] hover:border-[var(--color-cyan)]/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/40 transition-colors"
-          >
-            View portfolio page →
-          </Link>
-        </div>
-        <h1 className="mt-4 text-[34px] sm:text-[44px] font-bold tracking-[-0.025em] text-text leading-[1.05]">
-          <span
-            className="bg-clip-text text-transparent"
-            style={{
-              backgroundImage:
-                "linear-gradient(110deg, var(--color-cyan) 0%, #6FF8A0 45%, var(--color-green) 100%)",
-            }}
-          >
-            {portfolio.display_name}
-          </span>
-        </h1>
-        <p className="mt-4 text-base sm:text-lg text-text-muted leading-relaxed max-w-[60ch]">
-          Your team of agents trades a $1M paper book to your mandate. Tune
-          mandate or membership any time. Hits public eligibility at{" "}
-          {PUBLIC_ACTIVATE_THRESHOLD} equities.
-        </p>
-        <ProgressSteps
-          steps={[
-            { label: "Write mandate", done: step1 },
-            { label: "Add agents", done: step2 },
-          ]}
-        />
-      </header>
-
-      <SetupCard
-        step={1}
-        glyph="clipboard"
-        title="Write the mandate"
-        intro="Your investment brief — the agents trade to it. Pick an example to start, then edit and save."
-      >
-        <PortfolioDetailsEditor
-          initialName={portfolio.display_name}
-          initialMandate={portfolio.description ?? ""}
-        />
-      </SetupCard>
-
-      <SetupCard
-        glyph="clipboard"
-        title="Buy-decisions mandate (optional)"
-        intro="A separate brief telling the buying agent HOW to evaluate adds — distinct from the main mandate, which says WHAT the portfolio should be. Leave empty to skip."
-      >
-        <BuyMandateEditor initialBuyMandate={portfolio.buy_mandate ?? ""} />
-      </SetupCard>
-
-      <SetupCard
-        step={2}
-        glyph="branch"
-        title="Add your agents"
-        intro="A portfolio needs a Shortlist Builder to curate the watchlist and a Buying Agent to trade it. The 30-day return is each agent's live track record."
-      >
-        <AgentPicker
-          members={pickerMembers}
-          allAgents={pickerAll}
-          portfolioId={portfolio.id}
-        />
-      </SetupCard>
-
-      <VisibilityPanel
-        isPublic={portfolio.is_public}
-        holdingsCount={holdingsCount}
-        publicPath={`/portfolios/${portfolio.slug}`}
-      />
-
-      <SignOutRow email={email} />
-    </div>
-  );
-}
-
-function VisibilityBadge({ isPublic }: { isPublic: boolean }) {
-  if (isPublic) {
-    return (
-      <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-green)]/30 bg-[var(--color-green)]/[0.08] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-green)]">
-        <span
-          aria-hidden
-          className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
-          style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
-        />
-        Public
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-cyan)]/30 bg-[var(--color-cyan)]/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)]">
-      <span
-        aria-hidden
-        className="h-1.5 w-1.5 rounded-full bg-[var(--color-cyan)]"
-        style={{ boxShadow: "0 0 6px rgba(0,242,255,0.8)" }}
-      />
-      Private
-    </span>
-  );
-}
-
-function VisibilityPanel({
-  isPublic,
-  holdingsCount,
-  publicPath,
-}: {
-  isPublic: boolean;
-  holdingsCount: number;
-  publicPath: string;
-}) {
-  const eligible = holdingsCount >= PUBLIC_ACTIVATE_THRESHOLD;
-
-  if (isPublic) {
-    return (
-      <div className="rounded-2xl border border-[var(--color-green)]/30 bg-[var(--color-green)]/[0.05] px-5 py-4 sm:px-6 sm:py-5">
-        <p className="text-[11px] font-mono uppercase tracking-[0.16em] text-[var(--color-green)] flex items-center gap-2">
-          <span
-            aria-hidden
-            className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
-            style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
-          />
-          Visible on the leaderboard
-        </p>
-        <p className="mt-2 text-sm text-text-dim leading-relaxed">
-          Holding {holdingsCount} equities. Drops to fewer than{" "}
-          {PUBLIC_FLOOR_THRESHOLD} → auto-reverts to Private, and
-          performance for the current period resets when it climbs back.
-        </p>
-        <div className="mt-3 flex items-center gap-3">
-          <VisibilityToggle
-            isPublic={isPublic}
-            holdingsCount={holdingsCount}
-          />
-          <Link
-            href={publicPath}
-            className="text-sm font-semibold text-[var(--color-cyan)] hover:brightness-110 transition-[filter] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/40 rounded"
-          >
-            View public page &rarr;
-          </Link>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      className="rounded-2xl border p-5 sm:p-6"
-      style={{
-        background: eligible
-          ? "linear-gradient(135deg, rgba(0,242,255,0.07), rgba(0,255,65,0.03) 48%, rgba(255,255,255,0.02))"
-          : "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
-        borderColor: eligible
-          ? "rgba(0,242,255,0.2)"
-          : "rgba(255,255,255,0.10)",
-        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
-      }}
-    >
-      <p className="text-[10px] font-mono font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)] mb-1">
-        {eligible ? "Ready to go public" : "Private"}
-      </p>
-      <p className="text-sm sm:text-[15px] text-text-dim leading-relaxed max-w-[480px]">
-        {eligible
-          ? `Holding ${holdingsCount} equities — eligible. Flip public to appear on the leaderboard.`
-          : `Holding ${holdingsCount} of ${PUBLIC_ACTIVATE_THRESHOLD} equities needed. Once the agents fill the book, you can flip the portfolio public.`}
-      </p>
-      <div className="mt-3 flex items-center gap-3 flex-wrap">
-        <VisibilityToggle
-          isPublic={isPublic}
-          holdingsCount={holdingsCount}
-        />
-        <Link
-          href={publicPath}
-          className="text-sm font-semibold text-[var(--color-cyan)] hover:brightness-110 transition-[filter] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/40 rounded"
-        >
-          View portfolio page &rarr;
-        </Link>
-      </div>
-    </div>
-  );
-}
-
-function ProgressSteps({
-  steps,
-}: {
-  steps: { label: string; done: boolean }[];
-}) {
-  return (
-    <ol className="mt-6 grid gap-2.5 sm:grid-cols-2">
-      {steps.map((s, i) => (
-        <li
-          key={s.label}
-          className={`flex items-center gap-2.5 rounded-xl border px-3.5 py-2.5 ${
-            s.done
-              ? "border-[var(--color-green)]/30 bg-[var(--color-green)]/[0.05]"
-              : "border-white/10 bg-white/[0.02]"
-          }`}
-        >
-          <span
-            aria-hidden
-            className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold font-mono ${
-              s.done
-                ? "bg-[var(--color-green)]/20 text-[var(--color-green)]"
-                : "border border-[var(--color-cyan)]/30 bg-[var(--color-cyan)]/[0.08] text-[var(--color-cyan)]"
-            }`}
-          >
-            {s.done ? "✓" : i + 1}
-          </span>
-          <span
-            className={`text-sm font-semibold ${
-              s.done ? "text-text" : "text-text-dim"
-            }`}
-          >
-            {s.label}
-          </span>
-        </li>
-      ))}
-    </ol>
-  );
-}
-
-function SetupCard({
-  step,
-  glyph,
-  title,
-  intro,
-  children,
-}: {
-  step?: number;
-  glyph: GlyphName;
-  title: string;
-  intro: string;
-  children: ReactNode;
-}) {
-  return (
-    <section
-      className="group rounded-2xl border border-white/10 p-5 sm:p-6 transition-colors hover:border-white/15"
-      style={{
-        background:
-          "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
-        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
-      }}
-    >
-      <div className="flex items-start gap-3 mb-4">
-        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-[var(--color-cyan)]/25 bg-[var(--color-cyan)]/[0.07]">
-          <Glyph
-            name={glyph}
-            className="w-[18px] h-[18px] text-[var(--color-cyan)]"
-          />
-        </span>
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            {step != null && (
-              <span className="text-[10px] font-mono font-bold uppercase tracking-[0.14em] text-[var(--color-cyan)]">
-                Step {step}
-              </span>
-            )}
-            <h2 className="text-base sm:text-lg font-bold tracking-[-0.01em] text-text">
-              {title}
-            </h2>
-          </div>
-          <p className="mt-1 text-[13px] text-text-muted leading-relaxed">
-            {intro}
-          </p>
-        </div>
-      </div>
-      {children}
-    </section>
-  );
-}
-
-function SignOutRow({ email }: { email: string }) {
-  return (
-    <form
-      action="/auth/signout"
-      method="post"
-      className="flex items-center justify-between gap-3 pt-2"
-    >
-      <span className="text-[11px] font-mono text-text-muted truncate">
-        Signed in as {email}
-      </span>
-      <button
-        type="submit"
-        className="text-[11px] font-mono text-text-muted hover:text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 rounded px-1"
-      >
-        Sign out →
-      </button>
-    </form>
-  );
-}
-
-type GlyphName = "clipboard" | "branch";
 
 function SectionBadge({ children }: { children: ReactNode }) {
   return (
@@ -497,46 +121,5 @@ function SectionBadge({ children }: { children: ReactNode }) {
       />
       {children}
     </span>
-  );
-}
-
-function Glyph({
-  name,
-  className,
-}: {
-  name: GlyphName;
-  className?: string;
-}) {
-  const paths: Record<GlyphName, ReactNode> = {
-    clipboard: (
-      <>
-        <rect x="8" y="2.5" width="8" height="4" rx="1.2" />
-        <path d="M8 4.5H6.2A1.2 1.2 0 0 0 5 5.7v14.6a1.2 1.2 0 0 0 1.2 1.2h11.6a1.2 1.2 0 0 0 1.2-1.2V5.7a1.2 1.2 0 0 0-1.2-1.2H16" />
-        <path d="m8.7 13.2 2.3 2.3 4.3-4.7" />
-      </>
-    ),
-    branch: (
-      <>
-        <circle cx="6.5" cy="6" r="2.6" />
-        <circle cx="6.5" cy="18" r="2.6" />
-        <circle cx="17.5" cy="8" r="2.6" />
-        <path d="M6.5 8.6v6.8" />
-        <path d="M17.5 10.6c0 5-11 1.7-11 5" />
-      </>
-    ),
-  };
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.6}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden
-    >
-      {paths[name]}
-    </svg>
   );
 }

--- a/web/app/account/settings/page.tsx
+++ b/web/app/account/settings/page.tsx
@@ -1,0 +1,465 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import Nav from "@/components/nav";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import {
+  getPortfolioForUser,
+  getMembersForPortfolio,
+  getHoldingsCountForPortfolio,
+  type Portfolio,
+  type PortfolioMember,
+} from "@/lib/portfolios-query";
+import { listPublicAgents, getAgentReturns30d } from "@/lib/agents-query";
+import { roleFor } from "@/lib/agent-roles";
+import PortfolioDetailsEditor from "@/components/portfolio/portfolio-details-editor";
+import BuyMandateEditor from "@/components/portfolio/buy-mandate-editor";
+import AgentPicker from "@/components/portfolio/agent-picker";
+import VisibilityToggle from "@/components/portfolio/visibility-toggle";
+
+export const metadata: Metadata = {
+  title: "Settings — AlphaMolt",
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = "force-dynamic";
+
+// Hysteresis thresholds for the Private/Public toggle (migration 031).
+const PUBLIC_ACTIVATE_THRESHOLD = 15;
+const PUBLIC_FLOOR_THRESHOLD = 10;
+
+/**
+ * Portfolio configuration page. Owner-only — edit mandate, buy mandate,
+ * agent membership, and visibility. The /account route is now the
+ * dashboard (redirects to /portfolios/<slug>); this page hosts the
+ * settings forms previously rendered inline there.
+ */
+export default async function SettingsPage() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login?next=/account/settings");
+  }
+
+  let portfolio: Portfolio | null = null;
+  try {
+    portfolio = await getPortfolioForUser(user.id);
+  } catch {
+    portfolio = null;
+  }
+
+  // No portfolio yet? Settings doesn't apply — bounce back to /account
+  // which will show the create-portfolio form.
+  if (!portfolio) {
+    redirect("/account");
+  }
+
+  let members: PortfolioMember[] = [];
+  let allAgents: Awaited<ReturnType<typeof listPublicAgents>> = [];
+  let returns30d = new Map<string, number | null>();
+  let holdingsCount = 0;
+  try {
+    members = await getMembersForPortfolio(portfolio.id);
+  } catch {
+    members = [];
+  }
+  try {
+    allAgents = await listPublicAgents(1000, true);
+  } catch {
+    allAgents = [];
+  }
+  try {
+    returns30d = await getAgentReturns30d();
+  } catch {
+    returns30d = new Map();
+  }
+  try {
+    holdingsCount = await getHoldingsCountForPortfolio(portfolio.id);
+  } catch {
+    holdingsCount = 0;
+  }
+
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 w-full relative">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-[440px] -z-10 opacity-80"
+          style={{
+            background:
+              "radial-gradient(60% 65% at 16% 8%, rgba(0,255,65,0.05), transparent 70%), radial-gradient(48% 55% at 86% 4%, rgba(0,242,255,0.06), transparent 70%)",
+          }}
+        />
+        <div className="max-w-[820px] mx-auto w-full px-4 sm:px-6 py-10 sm:py-14">
+          <SettingsView
+            portfolio={portfolio}
+            members={members}
+            allAgents={allAgents}
+            returns30d={returns30d}
+            holdingsCount={holdingsCount}
+          />
+        </div>
+      </main>
+    </>
+  );
+}
+
+function SettingsView({
+  portfolio,
+  members,
+  allAgents,
+  returns30d,
+  holdingsCount,
+}: {
+  portfolio: Portfolio;
+  members: PortfolioMember[];
+  allAgents: Awaited<ReturnType<typeof listPublicAgents>>;
+  returns30d: Map<string, number | null>;
+  holdingsCount: number;
+}) {
+  const phases = members.map((m) => roleFor(m.strategy).phase);
+  const hasCurator = phases.includes("curate");
+  const hasBuyer = phases.includes("trade");
+  const hasMandate = (portfolio.description ?? "").trim().length > 0;
+
+  const step1 = hasMandate;
+  const step2 = hasCurator && hasBuyer;
+
+  const pickerMembers = members.map((m) => ({
+    handle: m.handle,
+    agentId: m.agent_id,
+    display_name: m.display_name,
+    is_house_agent: m.is_house_agent,
+    strategy: m.strategy,
+    return30d: returns30d.get(m.handle) ?? null,
+    powered_by: m.powered_by,
+    description: m.description,
+  }));
+  const pickerAll = allAgents.map((a) => ({
+    handle: a.handle,
+    agentId: a.id,
+    display_name: a.display_name,
+    is_house_agent: a.is_house_agent,
+    strategy: a.strategy,
+    return30d: returns30d.get(a.handle) ?? null,
+    powered_by: a.powered_by,
+    description: a.description,
+  }));
+
+  return (
+    <div className="space-y-7 sm:space-y-9">
+      <header>
+        <div className="flex items-center gap-3 flex-wrap">
+          <VisibilityBadge isPublic={portfolio.is_public} />
+          <Link
+            href={`/portfolios/${portfolio.slug}`}
+            className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.02] px-3 py-1 text-[10px] font-mono uppercase tracking-[0.14em] text-text-dim hover:text-[var(--color-cyan)] hover:border-[var(--color-cyan)]/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/40 transition-colors"
+          >
+            ← Back to dashboard
+          </Link>
+        </div>
+        <h1 className="mt-4 text-[34px] sm:text-[44px] font-bold tracking-[-0.025em] text-text leading-[1.05]">
+          Settings
+        </h1>
+        <p className="mt-4 text-base sm:text-lg text-text-muted leading-relaxed max-w-[60ch]">
+          Tune the mandate, agent membership and visibility for{" "}
+          <span className="font-semibold text-text">
+            {portfolio.display_name}
+          </span>
+          . Hits public eligibility at {PUBLIC_ACTIVATE_THRESHOLD} equities.
+        </p>
+        <ProgressSteps
+          steps={[
+            { label: "Write mandate", done: step1 },
+            { label: "Add agents", done: step2 },
+          ]}
+        />
+      </header>
+
+      <SetupCard
+        step={1}
+        glyph="clipboard"
+        title="Write the mandate"
+        intro="Your investment brief — the agents trade to it. Pick an example to start, then edit and save."
+      >
+        <PortfolioDetailsEditor
+          initialName={portfolio.display_name}
+          initialMandate={portfolio.description ?? ""}
+        />
+      </SetupCard>
+
+      <SetupCard
+        glyph="clipboard"
+        title="Buy-decisions mandate (optional)"
+        intro="A separate brief telling the buying agent HOW to evaluate adds — distinct from the main mandate, which says WHAT the portfolio should be. Leave empty to skip."
+      >
+        <BuyMandateEditor initialBuyMandate={portfolio.buy_mandate ?? ""} />
+      </SetupCard>
+
+      <SetupCard
+        step={2}
+        glyph="branch"
+        title="Add your agents"
+        intro="A portfolio needs a Shortlist Builder to curate the watchlist and a Buying Agent to trade it. The 30-day return is each agent's live track record."
+      >
+        <AgentPicker
+          members={pickerMembers}
+          allAgents={pickerAll}
+          portfolioId={portfolio.id}
+        />
+      </SetupCard>
+
+      <VisibilityPanel
+        isPublic={portfolio.is_public}
+        holdingsCount={holdingsCount}
+        publicPath={`/portfolios/${portfolio.slug}`}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reused presentational helpers
+// ---------------------------------------------------------------------------
+
+function VisibilityBadge({ isPublic }: { isPublic: boolean }) {
+  if (isPublic) {
+    return (
+      <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-green)]/30 bg-[var(--color-green)]/[0.08] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-green)]">
+        <span
+          aria-hidden
+          className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
+          style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+        />
+        Public
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-cyan)]/30 bg-[var(--color-cyan)]/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)]">
+      <span
+        aria-hidden
+        className="h-1.5 w-1.5 rounded-full bg-[var(--color-cyan)]"
+        style={{ boxShadow: "0 0 6px rgba(0,242,255,0.8)" }}
+      />
+      Private
+    </span>
+  );
+}
+
+function VisibilityPanel({
+  isPublic,
+  holdingsCount,
+  publicPath,
+}: {
+  isPublic: boolean;
+  holdingsCount: number;
+  publicPath: string;
+}) {
+  const eligible = holdingsCount >= PUBLIC_ACTIVATE_THRESHOLD;
+
+  if (isPublic) {
+    return (
+      <div className="rounded-2xl border border-[var(--color-green)]/30 bg-[var(--color-green)]/[0.05] px-5 py-4 sm:px-6 sm:py-5">
+        <p className="text-[11px] font-mono uppercase tracking-[0.16em] text-[var(--color-green)] flex items-center gap-2">
+          <span
+            aria-hidden
+            className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
+            style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+          />
+          Visible on the leaderboard
+        </p>
+        <p className="mt-2 text-sm text-text-dim leading-relaxed">
+          Holding {holdingsCount} equities. Drops to fewer than{" "}
+          {PUBLIC_FLOOR_THRESHOLD} → auto-reverts to Private, and
+          performance for the current period resets when it climbs back.
+        </p>
+        <div className="mt-3 flex items-center gap-3 flex-wrap">
+          <VisibilityToggle
+            isPublic={isPublic}
+            holdingsCount={holdingsCount}
+          />
+          <Link
+            href={publicPath}
+            className="text-sm font-semibold text-[var(--color-cyan)] hover:brightness-110 transition-[filter] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/40 rounded"
+          >
+            View public page &rarr;
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="rounded-2xl border p-5 sm:p-6"
+      style={{
+        background: eligible
+          ? "linear-gradient(135deg, rgba(0,242,255,0.07), rgba(0,255,65,0.03) 48%, rgba(255,255,255,0.02))"
+          : "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
+        borderColor: eligible
+          ? "rgba(0,242,255,0.2)"
+          : "rgba(255,255,255,0.10)",
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+      }}
+    >
+      <p className="text-[10px] font-mono font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)] mb-1">
+        {eligible ? "Ready to go public" : "Private"}
+      </p>
+      <p className="text-sm sm:text-[15px] text-text-dim leading-relaxed max-w-[480px]">
+        {eligible
+          ? `Holding ${holdingsCount} equities — eligible. Flip public to appear on the leaderboard.`
+          : `Holding ${holdingsCount} of ${PUBLIC_ACTIVATE_THRESHOLD} equities needed. Once the agents fill the book, you can flip the portfolio public.`}
+      </p>
+      <div className="mt-3 flex items-center gap-3 flex-wrap">
+        <VisibilityToggle
+          isPublic={isPublic}
+          holdingsCount={holdingsCount}
+        />
+        <Link
+          href={publicPath}
+          className="text-sm font-semibold text-[var(--color-cyan)] hover:brightness-110 transition-[filter] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/40 rounded"
+        >
+          View portfolio page &rarr;
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function ProgressSteps({
+  steps,
+}: {
+  steps: { label: string; done: boolean }[];
+}) {
+  return (
+    <ol className="mt-6 grid gap-2.5 sm:grid-cols-2">
+      {steps.map((s, i) => (
+        <li
+          key={s.label}
+          className={`flex items-center gap-2.5 rounded-xl border px-3.5 py-2.5 ${
+            s.done
+              ? "border-[var(--color-green)]/30 bg-[var(--color-green)]/[0.05]"
+              : "border-white/10 bg-white/[0.02]"
+          }`}
+        >
+          <span
+            aria-hidden
+            className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold font-mono ${
+              s.done
+                ? "bg-[var(--color-green)]/20 text-[var(--color-green)]"
+                : "border border-[var(--color-cyan)]/30 bg-[var(--color-cyan)]/[0.08] text-[var(--color-cyan)]"
+            }`}
+          >
+            {s.done ? "✓" : i + 1}
+          </span>
+          <span
+            className={`text-sm font-semibold ${
+              s.done ? "text-text" : "text-text-dim"
+            }`}
+          >
+            {s.label}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function SetupCard({
+  step,
+  glyph,
+  title,
+  intro,
+  children,
+}: {
+  step?: number;
+  glyph: GlyphName;
+  title: string;
+  intro: string;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      className="group rounded-2xl border border-white/10 p-5 sm:p-6 transition-colors hover:border-white/15"
+      style={{
+        background:
+          "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
+        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+      }}
+    >
+      <div className="flex items-start gap-3 mb-4">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-[var(--color-cyan)]/25 bg-[var(--color-cyan)]/[0.07]">
+          <Glyph
+            name={glyph}
+            className="w-[18px] h-[18px] text-[var(--color-cyan)]"
+          />
+        </span>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            {step != null && (
+              <span className="text-[10px] font-mono font-bold uppercase tracking-[0.14em] text-[var(--color-cyan)]">
+                Step {step}
+              </span>
+            )}
+            <h2 className="text-base sm:text-lg font-bold tracking-[-0.01em] text-text">
+              {title}
+            </h2>
+          </div>
+          <p className="mt-1 text-[13px] text-text-muted leading-relaxed">
+            {intro}
+          </p>
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+type GlyphName = "clipboard" | "branch";
+
+function Glyph({
+  name,
+  className,
+}: {
+  name: GlyphName;
+  className?: string;
+}) {
+  const paths: Record<GlyphName, ReactNode> = {
+    clipboard: (
+      <>
+        <rect x="8" y="2.5" width="8" height="4" rx="1.2" />
+        <path d="M8 4.5H6.2A1.2 1.2 0 0 0 5 5.7v14.6a1.2 1.2 0 0 0 1.2 1.2h11.6a1.2 1.2 0 0 0 1.2-1.2V5.7a1.2 1.2 0 0 0-1.2-1.2H16" />
+        <path d="m8.7 13.2 2.3 2.3 4.3-4.7" />
+      </>
+    ),
+    branch: (
+      <>
+        <circle cx="6.5" cy="6" r="2.6" />
+        <circle cx="6.5" cy="18" r="2.6" />
+        <circle cx="17.5" cy="8" r="2.6" />
+        <path d="M6.5 8.6v6.8" />
+        <path d="M17.5 10.6c0 5-11 1.7-11 5" />
+      </>
+    ),
+  };
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      {paths[name]}
+    </svg>
+  );
+}

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -216,10 +216,18 @@ export default async function PortfolioPage({ params }: PageParams) {
                 Created {created}
               </p>
               {isOwner && (
-                <VisibilityToggle
-                  isPublic={portfolio.is_public}
-                  holdingsCount={holdingsCount}
-                />
+                <>
+                  <VisibilityToggle
+                    isPublic={portfolio.is_public}
+                    holdingsCount={holdingsCount}
+                  />
+                  <Link
+                    href="/account/settings"
+                    className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.02] px-3 py-1 text-[10px] font-mono uppercase tracking-[0.14em] text-text-dim hover:text-[var(--color-cyan)] hover:border-[var(--color-cyan)]/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/40 transition-colors"
+                  >
+                    Settings →
+                  </Link>
+                </>
               )}
             </div>
           </header>

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -13,14 +13,15 @@ const PUBLIC_LINKS: { href: string; label: string }[] = [
 ];
 
 // Links injected only when the visitor is signed in. Slotted in front of
-// the public set so the user's own surfaces ("Dashboard" / "Watchlist" /
-// "Portfolio") sit at the start of the nav row. "Portfolio" is a
-// server-side redirect to /portfolios/<owner's slug> via
-// /account/portfolio.
+// the public set so the user's own surfaces sit at the start of the nav
+// row. "Dashboard" lands on /account, which redirects to the user's
+// portfolio detail page (the actual overview). "Settings" hosts the
+// mandate / agent / visibility editors (moved off /account so the
+// dashboard isn't an interim signup-looking page).
 const AUTHED_LINKS: { href: string; label: string }[] = [
   { href: "/account", label: "Dashboard" },
   { href: "/account/watchlist", label: "Watchlist" },
-  { href: "/account/portfolio", label: "Portfolio" },
+  { href: "/account/settings", label: "Settings" },
 ];
 
 export default function Nav() {

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -33,11 +33,22 @@ export async function proxy(request: NextRequest) {
 
   // getUser() refreshes the access token when it's stale; the rotated
   // session cookie is propagated onto `response` by the setAll adapter
-  // above. Route gating is handled elsewhere: protected pages self-guard.
-  // The marketing homepage is reachable for everyone — signed-in users
-  // get there by clicking the logo; the post-login landing page (/account)
-  // is chosen by the auth callback's default `next` param.
-  await supabase.auth.getUser();
+  // above. Most route gating is handled by the pages themselves —
+  // protected pages self-guard.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Send signed-in visitors who land on `/` straight to the dashboard.
+  // The marketing homepage is for logged-out visitors; signed-in users
+  // came back to *use* the product, not read the pitch. /account
+  // handles the redirect to /portfolios/<slug> from there.
+  const pathname = request.nextUrl.pathname;
+  if (user && pathname === "/") {
+    const dest = request.nextUrl.clone();
+    dest.pathname = "/account";
+    return NextResponse.redirect(dest);
+  }
 
   return response;
 }


### PR DESCRIPTION
## Summary

Two related complaints, one consolidated fix:

1. **First login landed on the marketing homepage.** The auth callback already redirects to `/account`, but if anything bumped the user back to `/` (clicking the logo, opening a bookmark, etc.) they ended up on the logged-out-looking pitch page.
2. **Clicking "Dashboard" opened an interim-signup-looking setup page.** `/account` rendered a stack of setup cards (mandate, buy-mandate, agent picker, visibility) with no overview of the actual portfolio (cash, holdings, trades). For a user with a working portfolio it felt like a perpetual onboarding screen.

## The new model

- **`/account`** — pure router:
  - signed-out → `/login?next=/account`
  - has portfolio → `/portfolios/<slug>` (the actual dashboard)
  - no portfolio → onboarding (CreatePortfolioForm)
- **`/account/settings`** (new) — the mandate / buy-mandate / agent picker / visibility editors. Reachable from the top nav and from a new "Settings →" chip on the portfolio header (owner-only).
- **`/portfolios/<slug>`** — unchanged. It's now what "Dashboard" actually shows.
- **`proxy.ts`** — signed-in visitors hitting `/` get redirected to `/account` (which then redirects to the portfolio page). Marketing homepage stays public for logged-out users.
- **Nav (signed-in)**: `Dashboard | Watchlist | Settings | Leaderboard | Docs`. The redundant "Portfolio" link is gone since Dashboard now does the same job.
- **`/account/portfolio`** (the explicit redirect route added in a prior PR) stays in place for any bookmark / external link still pointing at it.

## Files

- `web/app/account/page.tsx` — slimmed to router + onboarding.
- `web/app/account/settings/page.tsx` — new; hosts the moved setup cards. Same presentational helpers as the old `/account` page (`VisibilityBadge`, `VisibilityPanel`, `ProgressSteps`, `SetupCard`, `Glyph`).
- `web/app/portfolios/[slug]/page.tsx` — adds a "Settings →" chip in the owner-only header row, alongside the existing `VisibilityToggle`.
- `web/components/nav.tsx` — replaces the "Portfolio" link with "Settings".
- `web/proxy.ts` — redirects signed-in `/` → `/account`.

## Test flow

- [ ] Sign out, hit `/` in incognito → marketing homepage renders.
- [ ] Sign in → callback lands at `/account` → redirects to `/portfolios/<slug>`. You're on your actual portfolio.
- [ ] Click "Dashboard" anywhere → same destination.
- [ ] Click "Settings" in the nav → mandate / buy-mandate / agent picker / visibility editors.
- [ ] Edit something, save, click "← Back to dashboard" → back on `/portfolios/<slug>`.
- [ ] On the portfolio detail page as owner, the "Settings →" chip is visible next to the visibility toggle.
- [ ] As a non-owner viewing a public portfolio, the "Settings →" chip is hidden.
- [ ] Bookmarked `/account/portfolio` still works (redirects via the route added in PR #1047).
- [ ] Brand-new user with no portfolio: signing in lands on `/account` showing the create-portfolio form (the redirect bails because `portfolio = null`).

https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A)_