### PR TITLE
User-driven Portfolio Review Agent (sell mandate) + nav restore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,23 +215,31 @@ Two trade-phase strategies share the buyer slot:
 Both are no-ops on a legacy 1:1 agent portfolio.
 
 `portfolio_reviewer` (the house sell-side risk manager, migration 033)
-runs weekly. For each held position it calls Gemini 2.5 Pro with the
-recorded thesis (text + extend/break signals + snapshot at buy), a
-machine-check of which break signals are currently firing
-(`theses.check_thesis`), and the full current company data. Returns
-`{verdict: HOLD|SELL, conviction 1-5, rationale, what_changed}`. Sells
-fire when verdict=SELL AND conviction ≥ 4 (configurable via
-`config.sell_conviction_threshold`). Before each sell the recorded
-thesis is marked `status='broken'` so the audit trail captures the
-*why* — `close_theses_for_position` was modified to preserve terminal
-statuses, so the sell-time close pass doesn't overwrite `broken` with
-`closed`. Full-position sells only; doesn't trim. Skips legacy 1:1
-agent portfolios. Also no-op on portfolios with no holdings.
+runs weekly. **User-driven, not opinionated**: the reviewer follows the
+owner's `portfolios.sell_mandate` (migration 034) — a free-text brief
+describing when the agent should exit a position. If `sell_mandate`
+is empty, the reviewer is a no-op (it doesn't carry a sell discipline
+of its own; `notes.reason='no sell mandate set'`).
+
+For each held position it calls Gemini 2.5 Pro with the sell mandate
+(the primary directive), the main mandate, the recorded buy thesis
+(text + extend/break signals + snapshot at buy), a machine-check of
+which break signals are currently firing (`theses.check_thesis`), and
+the full current company data. Returns `{verdict: HOLD|SELL, conviction
+1-5, rationale, what_changed}`. Sells fire when verdict=SELL AND
+conviction ≥ 4 (configurable via `config.sell_conviction_threshold`).
+Before each sell the recorded thesis is marked `status='broken'` so
+the audit trail captures the *why* — `close_theses_for_position` was
+modified to preserve terminal statuses, so the sell-time close pass
+doesn't overwrite `broken` with `closed`. Full-position sells only;
+doesn't trim. Skips legacy 1:1 agent portfolios. Also no-op on
+portfolios with no holdings.
 
 The house agents `alphamolt-shortlist` (curator, `gemini-2.5-flash`,
 24h cadence, ~40-name target), `buying-agent` (buyer, `gemini-2.5-pro`,
 24h cadence) and `portfolio-reviewer` (reviewer, `gemini-2.5-pro`,
-weekly) — migrations 028, 030, 032, and 033 — drive the pipeline.
+weekly, user-mandate-driven) — migrations 028, 030, 032, 033, and 034
+— drive the pipeline.
 
 Supports `--handle`, `--force` (ignore interval guard), and `--dry-run`.
 

--- a/migrations/034_portfolio_sell_mandate.sql
+++ b/migrations/034_portfolio_sell_mandate.sql
@@ -1,0 +1,17 @@
+-- Migration 034: per-portfolio sell-decisions mandate.
+--
+-- Mirrors `portfolios.buy_mandate` (migration 032) on the sell side: the
+-- owner writes a free-text brief telling the Portfolio Review Agent
+-- (`portfolio-reviewer`, migration 033) HOW to decide when to exit a
+-- position. The reviewer no longer carries a baked-in 'sell discipline'
+-- in its prompt — it follows whatever the owner writes here.
+--
+-- If sell_mandate is NULL/empty, the reviewer is a no-op for that
+-- portfolio (the strategy bails before any LLM call, journals
+-- `reason='no sell mandate'`). This is intentional — without a mandate
+-- the agent has no opinion to act on.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+ALTER TABLE portfolios
+    ADD COLUMN IF NOT EXISTS sell_mandate TEXT;

--- a/portfolio_reviewer.py
+++ b/portfolio_reviewer.py
@@ -54,10 +54,11 @@ PORTFOLIO_REVIEWER_DEFAULTS: dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 REVIEWER_SYSTEM_PROMPT = """\
-You are a portfolio risk manager reviewing each held equity for THESIS DRIFT.
+You are a portfolio risk manager reviewing each held equity against the owner's SELL-DECISIONS MANDATE.
 
-Your job per call: look at ONE position the portfolio currently holds. You have:
-- The portfolio's investment mandate (what the book should be).
+Your job per call: look at ONE position the portfolio currently holds and decide whether the OWNER'S rules say to exit it. You have:
+- The portfolio's main mandate (what the book is meant to be).
+- The owner's sell-decisions mandate (the rules they want applied — this is the PRIMARY directive for your verdict).
 - The position (ticker, quantity, average cost, current price, P/L).
 - The buy thesis recorded when the position was opened (text + explicit break/extend signals), if any.
 - A machine-check of the recorded break signals against current data — which ones are firing right now.
@@ -65,25 +66,20 @@ Your job per call: look at ONE position the portfolio currently holds. You have:
 
 Render a verdict: HOLD (do nothing) or SELL (close the position at the next available price).
 
-Discipline:
-- Conviction 1-5 only meaningful when verdict="SELL". SELL at conviction >= 4 actually triggers a trade; lower convictions are journal-only.
-- A SELL needs HARD evidence of material deterioration vs the recorded thesis (or vs the portfolio mandate if no thesis on file). Conviction 5 = "the thesis is definitively broken; selling at any cost". Conviction 4 = "high-confidence material deterioration; sell now". 1-3 = noise / temporary moves / valuation concerns alone.
-- Do NOT sell on:
-  * short-term price moves alone (price is not the thesis)
-  * a single missed quarter unless the recorded thesis hinged on that metric
-  * minor margin compression unless the thesis was a margin-expansion story
-- DO sell on:
-  * a recorded break_signal firing on the data
-  * the company changing fundamentally (acquired, segment-divested, business model pivot away from the thesis)
-  * the portfolio mandate now disqualifying this name
-  * sustained, year-on-year deterioration in the metrics the thesis was built on
-- If there is no recorded thesis (source='none' in the payload), judge on current data + mandate only.
+Your job is NOT to apply your own opinion of when to sell. Apply the OWNER'S sell mandate. If the mandate is loose ("only sell on broken thesis"), be conservative. If it's vigilant ("sell on any meaningful deterioration"), be more willing to exit. If the mandate contradicts the recorded buy thesis, follow the SELL mandate — it's the active instruction.
+
+Conviction 1-5 only meaningful when verdict="SELL":
+  5 = the sell mandate is unambiguously triggered; no judgement call
+  4 = the sell mandate is clearly triggered, with one minor qualification
+  3 = the sell mandate is arguably triggered; reasonable people might disagree
+  1-2 = drift exists but doesn't meet the mandate's bar
+SELL at conviction >= 4 actually triggers a trade; lower convictions are journal-only.
 
 Output strict JSON only — no prose, no markdown fences."""
 
 
 REVIEWER_USER_TEMPLATE = """\
-{portfolio_mandate_block}{buy_mandate_block}PORTFOLIO STATE:
+{sell_mandate_block}{portfolio_mandate_block}PORTFOLIO STATE:
 - Total value: ${total_value_usd:,.0f}
 - Cash available: ${cash_usd:,.0f}
 - Number of holdings: {num_holdings}
@@ -126,18 +122,18 @@ Output JSON only."""
 # ---------------------------------------------------------------------------
 
 
-def _buy_mandate_block(buy_mandate: str | None) -> str:
-    """Render the per-portfolio buy-decisions mandate (migration 032) as a
-    prompt preamble. Same shape as the buyer reads — gives the reviewer a
-    coherent view of what 'broken' means relative to the owner's rules.
+def _sell_mandate_block(sell_mandate: str | None) -> str:
+    """Render the per-portfolio sell-decisions mandate (migration 034) as
+    the prompt's primary directive. This is what the reviewer follows —
+    not its own opinion of when to sell.
     """
-    text = (buy_mandate or "").strip()
+    text = (sell_mandate or "").strip()
     if not text:
         return ""
     return (
-        "BUY-DECISIONS MANDATE (the human owner's rules for adds — also "
-        "the bar a position should clear to stay in the book; if a held "
-        "name no longer fits these, that's grounds for SELL):\n"
+        "SELL-DECISIONS MANDATE (the human owner's rules for when to "
+        "exit a position — THIS IS THE RULE YOU APPLY; do not substitute "
+        "your own judgment of when to sell):\n"
         f"{text}\n\n"
     )
 
@@ -218,7 +214,7 @@ def _evaluate_position(
     current_price: float,
     portfolio: dict,
     portfolio_mandate: str | None,
-    buy_mandate: str | None,
+    sell_mandate: str | None,
     thesis: dict | None,
     signal_check: dict | None,
     current_data: dict,
@@ -245,7 +241,7 @@ def _evaluate_position(
 
     user = REVIEWER_USER_TEMPLATE.format(
         portfolio_mandate_block=_mandate_block(portfolio_mandate),
-        buy_mandate_block=_buy_mandate_block(buy_mandate),
+        sell_mandate_block=_sell_mandate_block(sell_mandate),
         total_value_usd=float(portfolio.get("total_value_usd") or 0),
         cash_usd=float(portfolio.get("cash_usd") or 0),
         num_holdings=len(portfolio.get("holdings") or []),
@@ -378,12 +374,22 @@ def rebalance_portfolio_reviewer(ctx: RebalanceContext) -> RebalanceResult:
         result.notes["reason"] = "no holdings to review"
         return result
 
-    # Load both mandates from the portfolios row.
+    # Load mandates from the portfolios row. The sell_mandate is the
+    # PRIMARY directive — the reviewer is user-driven, not opinionated.
+    # If it's empty, the agent has nothing to act on; bail before any
+    # LLM work.
     portfolio_mandate = ctx.mandate
-    buy_mandate: str | None = None
+    sell_mandate: str | None = None
     pf_row = ctx.db.get_portfolio_by_id(ctx.portfolio_id)
     if pf_row:
-        buy_mandate = pf_row.get("buy_mandate")
+        sell_mandate = pf_row.get("sell_mandate")
+    if not (sell_mandate or "").strip():
+        result.notes["reason"] = (
+            "no sell mandate set — the reviewer follows the owner's "
+            "sell rules. Set portfolios.sell_mandate via /account/settings "
+            "to enable."
+        )
+        return result
 
     # Theses for context (and to mark broken later).
     active_theses = _active_theses_by_ticker(ctx.db, ctx.portfolio_id)
@@ -488,7 +494,7 @@ def rebalance_portfolio_reviewer(ctx: RebalanceContext) -> RebalanceResult:
                 current_price=item["current_price"],
                 portfolio=portfolio,
                 portfolio_mandate=portfolio_mandate,
-                buy_mandate=buy_mandate,
+                sell_mandate=sell_mandate,
                 thesis=item["thesis"],
                 signal_check=item["signal_check"],
                 current_data=item["current_data"],

--- a/web/app/account/settings/page.tsx
+++ b/web/app/account/settings/page.tsx
@@ -15,6 +15,7 @@ import { listPublicAgents, getAgentReturns30d } from "@/lib/agents-query";
 import { roleFor } from "@/lib/agent-roles";
 import PortfolioDetailsEditor from "@/components/portfolio/portfolio-details-editor";
 import BuyMandateEditor from "@/components/portfolio/buy-mandate-editor";
+import SellMandateEditor from "@/components/portfolio/sell-mandate-editor";
 import AgentPicker from "@/components/portfolio/agent-picker";
 import VisibilityToggle from "@/components/portfolio/visibility-toggle";
 
@@ -199,6 +200,14 @@ function SettingsView({
         intro="A separate brief telling the buying agent HOW to evaluate adds — distinct from the main mandate, which says WHAT the portfolio should be. Leave empty to skip."
       >
         <BuyMandateEditor initialBuyMandate={portfolio.buy_mandate ?? ""} />
+      </SetupCard>
+
+      <SetupCard
+        glyph="clipboard"
+        title="Sell-decisions mandate (required for the reviewer)"
+        intro="When the Portfolio Review Agent should exit a position. This is the reviewer's primary directive — it doesn't carry its own sell discipline. Empty = the reviewer stays its hand."
+      >
+        <SellMandateEditor initialSellMandate={portfolio.sell_mandate ?? ""} />
       </SetupCard>
 
       <SetupCard

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -14,14 +14,14 @@ const PUBLIC_LINKS: { href: string; label: string }[] = [
 
 // Links injected only when the visitor is signed in. Slotted in front of
 // the public set so the user's own surfaces sit at the start of the nav
-// row. "Dashboard" lands on /account, which redirects to the user's
-// portfolio detail page (the actual overview). "Settings" hosts the
-// mandate / agent / visibility editors (moved off /account so the
-// dashboard isn't an interim signup-looking page).
+// row. Dashboard and Portfolio currently land on the same page (the
+// user's portfolio detail), via /account → /portfolios/<slug> and
+// /account/portfolio → /portfolios/<slug> respectively. Settings is
+// reachable from the chip on the portfolio header.
 const AUTHED_LINKS: { href: string; label: string }[] = [
   { href: "/account", label: "Dashboard" },
   { href: "/account/watchlist", label: "Watchlist" },
-  { href: "/account/settings", label: "Settings" },
+  { href: "/account/portfolio", label: "Portfolio" },
 ];
 
 export default function Nav() {

--- a/web/components/portfolio/sell-mandate-editor.tsx
+++ b/web/components/portfolio/sell-mandate-editor.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { updatePortfolioSellMandate } from "@/lib/portfolios-mutations";
+
+interface SellMandateExample {
+  id: string;
+  label: string;
+  summary: string;
+  text: string;
+}
+
+const EXAMPLES: SellMandateExample[] = [
+  {
+    id: "only-broken-thesis",
+    label: "Only on broken thesis",
+    summary: "Conservative — sell on hard signals only",
+    text:
+      "Only sell when the recorded buy thesis is clearly broken: at least one " +
+      "break_signal firing on current data, OR fundamental business change " +
+      "(acquisition, segment divestiture, business-model pivot away from " +
+      "the original thesis). Do NOT sell on short-term price moves, single " +
+      "missed quarters, or noisy valuation re-rating. If no thesis is recorded " +
+      "for the position, only sell on outright fraud / suspension / acquisition.",
+  },
+  {
+    id: "broken-or-decel",
+    label: "Broken thesis OR sustained decel",
+    summary: "Moderate — broken thesis or 2+ qtrs decel",
+    text:
+      "Sell when EITHER (a) the recorded buy thesis is broken via a firing " +
+      "break_signal, OR (b) the company has shown sustained year-on-year " +
+      "deterioration in the metric the thesis was built on (revenue growth, " +
+      "margins, FCF) for at least 2 consecutive quarters. Also sell if the " +
+      "portfolio's main mandate no longer applies — e.g. the company has " +
+      "drifted out of the target sector / size / quality bracket. Don't sell " +
+      "on short-term price moves alone.",
+  },
+  {
+    id: "vigilant",
+    label: "Vigilant",
+    summary: "Sell on any meaningful deterioration",
+    text:
+      "Sell on any meaningful deterioration in the company's quality, " +
+      "valuation discipline, or fit with the portfolio mandate. Specifically: " +
+      "R40 score dropped 10+ points from snapshot, gross margin compressed " +
+      "3+ percentage points, revenue growth decelerated by 1/3 or more YoY, " +
+      "or the prior in-house BEAR verdict has turned negative. Better to " +
+      "rotate the cash than hold a deteriorating name.",
+  },
+];
+
+/**
+ * Per-portfolio editor for the sell-decisions mandate (migration 034).
+ * This is the Portfolio Review Agent's PRIMARY directive — without it
+ * the reviewer is a no-op (the agent doesn't carry its own sell
+ * discipline). Empty = agent stays its hand.
+ */
+export default function SellMandateEditor({
+  initialSellMandate,
+}: {
+  initialSellMandate: string;
+}) {
+  const router = useRouter();
+  const [sellMandate, setSellMandate] = useState(initialSellMandate);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  const dirty = sellMandate !== initialSellMandate;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSaved(false);
+    startTransition(async () => {
+      const result = await updatePortfolioSellMandate({ sellMandate });
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setSaved(true);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[1.6fr_1fr]">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="portfolio-sell-mandate"
+            className="block text-xs font-mono uppercase tracking-widest text-text-dim mb-1"
+          >
+            Sell-decisions mandate
+          </label>
+          <p className="text-[10px] text-text-dim mb-1 font-mono">
+            How the Portfolio Review Agent should decide when to exit a
+            position. Empty means the agent stays its hand — it carries no
+            sell discipline of its own.
+          </p>
+          <textarea
+            id="portfolio-sell-mandate"
+            rows={7}
+            maxLength={2000}
+            placeholder="e.g. Only sell when a recorded break_signal fires or the company is acquired…"
+            value={sellMandate}
+            onChange={(e) => {
+              setSellMandate(e.target.value);
+              setSaved(false);
+            }}
+            className="w-full bg-bg border border-white/10 rounded px-3 py-2 text-sm text-text leading-relaxed focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 focus:border-cyan/50 placeholder:text-text-muted resize-none"
+          />
+          <p className="text-[10px] text-text-muted mt-1 font-mono">
+            {sellMandate.length} / 2000
+          </p>
+        </div>
+
+        {error && (
+          <div className="text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+            {error}
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={pending || !dirty}
+            className="px-4 py-2 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40 transition-colors"
+          >
+            {pending ? "Saving…" : "Save changes →"}
+          </button>
+          {saved && !dirty && (
+            <span className="text-xs font-mono text-green">✓ Saved</span>
+          )}
+        </div>
+      </form>
+
+      <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+        <p className="text-xs font-mono uppercase tracking-widest text-text-dim mb-1">
+          Example briefs
+        </p>
+        <p className="text-[11px] text-text-muted leading-relaxed mb-3">
+          Pick one and edit, or leave blank to keep the reviewer idle.
+        </p>
+        <ul className="space-y-2">
+          {EXAMPLES.map((ex) => (
+            <li key={ex.id}>
+              <button
+                type="button"
+                onClick={() => {
+                  setSellMandate(ex.text);
+                  setSaved(false);
+                }}
+                className="w-full text-left rounded-lg border border-white/10 bg-bg px-3 py-2.5 hover:border-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 transition-colors group"
+              >
+                <span className="block text-sm font-medium text-text group-hover:text-cyan transition-colors">
+                  {ex.label}
+                </span>
+                <span className="block text-[11px] font-mono text-text-muted mt-0.5">
+                  {ex.summary}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/web/lib/portfolios-mutations.ts
+++ b/web/lib/portfolios-mutations.ts
@@ -153,6 +153,37 @@ export async function updatePortfolioBuyMandate(input: {
   return { ok: true };
 }
 
+export async function updatePortfolioSellMandate(input: {
+  sellMandate: string;
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+  const sellMandate = input.sellMandate.trim();
+
+  if (sellMandate.length > MAX_MANDATE)
+    return {
+      ok: false,
+      error: `Sell mandate must be ${MAX_MANDATE} characters or fewer.`,
+    };
+
+  const portfolio = await getOwnedPortfolio(user.id);
+  if (!portfolio) return { ok: false, error: "You don't have a portfolio yet." };
+
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from("portfolios")
+    .update({ sell_mandate: sellMandate || null })
+    .eq("id", portfolio.id)
+    .eq("owner_user_id", user.id);
+
+  if (error) {
+    console.error("updatePortfolioSellMandate failed:", error);
+    return { ok: false, error: "Could not save changes. Try again." };
+  }
+
+  revalidate(portfolio.slug);
+  return { ok: true };
+}
+
 export async function setPortfolioVisibility(input: {
   isPublic: boolean;
 }): Promise<ActionResult> {

--- a/web/lib/portfolios-query.ts
+++ b/web/lib/portfolios-query.ts
@@ -28,6 +28,11 @@ export interface Portfolio {
    *  portfolio is meant to be). NULL = no per-buy rules; the buyer
    *  works to the main mandate alone. See migration 032. */
   buy_mandate: string | null;
+  /** Free-text brief on WHEN the reviewer agent should exit a position.
+   *  This is the reviewer's PRIMARY directive — without it the agent
+   *  is a no-op (it doesn't carry its own sell discipline). See
+   *  migration 034. */
+  sell_mandate: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -33,22 +33,11 @@ export async function proxy(request: NextRequest) {
 
   // getUser() refreshes the access token when it's stale; the rotated
   // session cookie is propagated onto `response` by the setAll adapter
-  // above. Most route gating is handled by the pages themselves —
-  // protected pages self-guard.
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  // Send signed-in visitors who land on `/` straight to the dashboard.
-  // The marketing homepage is for logged-out visitors; signed-in users
-  // came back to *use* the product, not read the pitch. /account
-  // handles the redirect to /portfolios/<slug> from there.
-  const pathname = request.nextUrl.pathname;
-  if (user && pathname === "/") {
-    const dest = request.nextUrl.clone();
-    dest.pathname = "/account";
-    return NextResponse.redirect(dest);
-  }
+  // above. Route gating is handled by the pages themselves — protected
+  // pages self-guard. The marketing homepage is reachable for everyone:
+  // signed-in users see it when they click the logo. First-login lands
+  // on the dashboard via the auth callback's default `next=/account`.
+  await supabase.auth.getUser();
 
   return response;
 }


### PR DESCRIPTION
## Summary

Two commits:

### 1. `93c3fc3` — Portfolio Review Agent is now user-driven

The reviewer's hardcoded "sell discipline" gets stripped from the prompt. The agent now follows the owner's `portfolios.sell_mandate` (new — migration 034) instead of inventing its own opinion. If the mandate is empty, the agent is a no-op — it bails before any LLM call and journals `notes.reason = 'no sell mandate set'`.

**Why**: the user's spec is that the reviewer shouldn't have its own opinion on when to sell. It should figure out what the OWNER wants to sell, then sell that. The previous prompt mixed the owner's intent with the agent's preset rules, making output unpredictable.

**Changes**:
- **Migration 034**: `ALTER TABLE portfolios ADD COLUMN IF NOT EXISTS sell_mandate TEXT`. Additive + idempotent.
- **`portfolio_reviewer.py`**: rewrites `REVIEWER_SYSTEM_PROMPT` ("Apply the OWNER's sell mandate. Do not substitute your own judgment"). Conviction 1-5 is now anchored to "how unambiguously the mandate is triggered". `_buy_mandate_block` helper → `_sell_mandate_block`. Strategy entrypoint reads `portfolios.sell_mandate`; bails if empty.
- **Web**: `Portfolio` type gains `sell_mandate`, new `updatePortfolioSellMandate` server action, new `SellMandateEditor` component with three starter briefs (Conservative / Moderate / Vigilant), new SetupCard on `/account/settings`.
- **CLAUDE.md**: reviewer description updated to call out the mandate-driven behaviour.

**Behaviour change**: existing portfolios with the reviewer agent already added will start no-op'ing on the next heartbeat until the owner writes a sell mandate. That's intended — the reviewer is now unambiguously the owner's tool rather than an opinionated house agent.

### 2. `25ce22f` — Nav cleanup (revert overshoot from the prior dashboard PR)

Three corrections to PR #1092:

- **Logo always goes to `/`**, signed in or out. The proxy redirect from `/` → `/account` broke that (clicking the logo while signed in bounced back to dashboard). Removed. First-login still lands on the dashboard via the auth callback's `next=/account` default — proxy redirect was redundant.
- **Top nav**: `Dashboard | Watchlist | Portfolio | Leaderboard | Docs`. The prior PR replaced Portfolio with Settings — that's not what was wanted. Settings comes off the top nav. Portfolio link restored.
- **Settings** stays reachable via the "Settings →" chip on the portfolio page header (owner-only), already added in PR #1092.

Dashboard and Portfolio currently land on the same destination. Intentional redundancy — Dashboard is the generic "my main page" affordance, Portfolio is the explicit name. If the dashboard concept later diverges (a summary across multiple portfolios), Dashboard becomes the natural slot.

## Deploy order

1. Apply `migrations/034_portfolio_sell_mandate.sql` in the Supabase SQL editor.
2. Merge the PR.
3. Visit `/account/settings`, write your sell mandate (or pick a starter brief), save.

## Test plan

- [ ] Migration 034: `SELECT column_name FROM information_schema.columns WHERE table_name='portfolios' AND column_name='sell_mandate';` returns one row.
- [ ] Reviewer with no sell_mandate: dry-run heartbeat → `notes.reason = 'no sell mandate set'`, zero trades.
- [ ] Reviewer with sell_mandate: dry-run → `notes.verdicts.sell_qualifying` lists positions matching the mandate's criteria.
- [ ] Logo click while signed in: lands on `/` marketing, not `/account`.
- [ ] First login (fresh tab): callback lands on `/account`, which redirects to `/portfolios/<slug>`.
- [ ] Top nav signed in: Dashboard, Watchlist, Portfolio, Leaderboard, Docs (no Settings).
- [ ] Portfolio page header: "Settings →" chip visible for the owner; click lands on `/account/settings` with all three editors (mandate, buy-mandate, sell-mandate).

https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A)_