### PR TITLE
Add spam-folder guidance to magic-link sent screen

### DIFF
--- a/web/components/login-form.tsx
+++ b/web/components/login-form.tsx
@@ -50,6 +50,20 @@ export default function LoginForm() {
           for a one-time sign-in link. Open it in this browser to land back on
           your account — the link expires shortly.
         </p>
+
+        <div className="rounded-lg border border-white/10 bg-white/[0.02] px-3.5 py-3 mb-4">
+          <p className="text-[10px] font-mono uppercase tracking-widest text-text-muted mb-1.5">
+            Don&rsquo;t see it?
+          </p>
+          <p className="text-sm text-text-dim leading-relaxed">
+            AlphaMolt is a new domain, so our emails sometimes land in{" "}
+            <span className="text-text">Spam</span> or{" "}
+            <span className="text-text">Promotions</span>. Adding{" "}
+            <span className="text-text font-mono">hello@alphamolt.ai</span> to
+            your contacts gets future sign-ins straight to your inbox.
+          </p>
+        </div>
+
         <button
           type="button"
           onClick={() => {


### PR DESCRIPTION
## Summary

AlphaMolt is a new domain so magic-link emails frequently land in Spam or Promotions. Adds a nested "Don't see it?" sub-block to the post-send confirmation card on the login screen, explaining why and prompting the user to add the sender address to their contacts so future sign-ins reach the inbox directly.

## Changes

- `web/components/login-form.tsx` — new "Don't see it?" block inside the existing green "Magic link sent" card, sits between the main message and the "Use a different email" link.

## Notes

- Hardcoded example contact address: `hello@alphamolt.ai`. If your verified Resend sender uses a different local-part (e.g. `login@`, `auth@`), swap it in the one place in `login-form.tsx`.
- Complements (does not replace) the bigger deliverability levers: custom SMTP via Resend, SPF/DKIM/DMARC on `alphamolt.ai`, branded `From:` name, real reply-able sender address.

## Test plan

- [ ] Hit `/login`, submit a valid email, confirm the success card now shows the "Don't see it?" sub-block beneath the "Check &lt;email&gt; for a one-time sign-in link" message.
- [ ] Confirm the "Use a different email →" link still resets the form.
- [ ] Mobile view: sub-block reflows cleanly inside the parent card.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCFK3KhRr7GHgmWwnvzEhc)_