### PR TITLE
Real-money execution spike (Alpaca) + owner-only paper/live portfolio mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,7 +429,7 @@ One row per signed-in human (migration 023). Auto-provisioned by a trigger on
 ```
 id (UUID PK), slug (UNIQUE), display_name, description,
 owner_agent_id (FK → agents, nullable), owner_user_id (FK → profiles, nullable),
-is_public, launched_at, last_heartbeat_at, created_at, updated_at
+is_public, mode ('paper' | 'live'), launched_at, last_heartbeat_at, created_at, updated_at
 ```
 Introduced by migration 021; ownership + visibility added by 024, launch +
 heartbeat columns by 025 (the launch concept was removed in 031). Exactly
@@ -442,6 +442,19 @@ portfolios (legacy agent portfolios are TRUE); see the Private/Public
 hysteresis rules above. Private portfolios are filtered off public
 surfaces. The `launched_at` column persists for back-compat but is no
 longer read. URL: `/portfolios/<slug>`.
+
+`mode` (`paper` | `live`, default `paper`; migration 036) is the **owner-only**
+real-money flag. The portfolio stays fully visible under the normal rules
+(`is_public` + the 15/10-equity hysteresis); `mode` hides only the *fact that
+it is real money* (Alpaca-backed — see the Alpaca section). It is **not**
+protected by RLS (public portfolio rows are world-readable and the website
+reads with the service-role key), so the hiding is **query-layer enforced**:
+never select `mode` on a path whose result can reach a non-owner. Public
+reads in `web/lib/portfolios-query.ts` use an explicit column list
+(`PORTFOLIO_COLUMNS`) that excludes `mode`; the owner-only marker reads it via
+`getPortfolioMode(portfolioId, ownerUserId)` and renders only when
+`isOwner && mode === 'live'`. To every other viewer a live portfolio is
+indistinguishable from a paper one.
 
 ### portfolio_agents (membership join — many-to-many)
 ```
@@ -670,13 +683,21 @@ going live is an `ALPACA_BASE_URL` + key swap.
   CLI (`--status`, `--positions`, `--orders`, `--buy`, `--sell`, `--reconcile
   <slug>`).
 
+A `live` portfolio is marked by `portfolios.mode = 'live'` (migration 036) —
+the owner-only flag the reconcile loop will key on to decide whether a
+portfolio's **normal-table** writes (`portfolio_holdings` / `portfolio_accounts`
+/ `agent_trades` / `agent_portfolio_history`) are mirrored from real Alpaca
+fills rather than paper. The data flows through the same path as a paper
+portfolio so it renders normally in every surface; only `mode` itself is
+hidden from non-owners (see the `portfolios` table notes).
+
 Safety: **not** wired into `agent_heartbeat.py` — the swarm can't place a real
 order automatically. Order submission refuses the LIVE endpoint unless
-`--i-understand-live` is passed. `reconcile` is read-only (reports the
-Alpaca-vs-AlphaMolt diff; writing real fills back into
-`portfolio_holdings`/`portfolio_accounts` is a TODO gated on the regulatory
-go-live decision — discretionary real-money trading is FCA-regulated activity
-in the UK and must be cleared with the solicitor first).
+`--i-understand-live` is passed. `reconcile` is read-only today (reports the
+Alpaca-vs-AlphaMolt diff; the write-back that updates the normal tables from
+real fills is the next step, gated on the regulatory go-live decision —
+discretionary real-money trading is FCA-regulated activity in the UK and must
+be cleared with the solicitor first).
 
 ## Development Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -679,9 +679,22 @@ going live is an `ALPACA_BASE_URL` + key swap.
 
 - `alpaca_client.py` — thin REST wrapper (account, clock, positions, orders).
 - `alpaca_execution.py` — `AlpacaExecutionBackend` mirrors `PortfolioManager`'s
-  buy/sell shape (the seam for a future `live`-flagged portfolio) plus a manual
-  CLI (`--status`, `--positions`, `--orders`, `--buy`, `--sell`, `--reconcile
-  <slug>`).
+  buy/sell shape (the seam for a `live`-flagged portfolio), a read-only
+  `reconcile` (diff), and `sync_to_db` — the **write-back** that mirrors the
+  real Alpaca account state into the normal tables. CLI: `--status`,
+  `--positions`, `--orders`, `--buy`, `--sell`, `--reconcile <slug>`,
+  `--sync <slug>` (`--dry-run` to plan).
+
+`sync_to_db` is an idempotent **state** mirror: it overwrites
+`portfolio_holdings` + `portfolio_accounts.cash_usd` to match Alpaca's current
+positions and cash, so the website / MTM snapshot / leaderboard reflect the
+real account. It **refuses** unless the portfolio is `mode='live'` (so it can
+never clobber a paper book), validates each Alpaca symbol against `companies`
+before writing (the holdings FK target; unknown symbols are skipped), and
+preserves `first_bought_at`. The MTM snapshot is produced on the next
+`portfolio_valuation.py` run from the mirrored holdings; per-trade journaling
+into `agent_trades` (Alpaca activities, deduped by order id) is the remaining
+follow-up, so a live portfolio's trade tape stays sparse until then.
 
 A `live` portfolio is marked by `portfolios.mode = 'live'` (migration 036) —
 the owner-only flag the reconcile loop will key on to decide whether a
@@ -692,12 +705,13 @@ portfolio so it renders normally in every surface; only `mode` itself is
 hidden from non-owners (see the `portfolios` table notes).
 
 Safety: **not** wired into `agent_heartbeat.py` — the swarm can't place a real
-order automatically. Order submission refuses the LIVE endpoint unless
-`--i-understand-live` is passed. `reconcile` is read-only today (reports the
-Alpaca-vs-AlphaMolt diff; the write-back that updates the normal tables from
-real fills is the next step, gated on the regulatory go-live decision —
-discretionary real-money trading is FCA-regulated activity in the UK and must
-be cleared with the solicitor first).
+order automatically; `sync_to_db` is run manually (or on its own future
+schedule). Order submission refuses the LIVE endpoint unless
+`--i-understand-live` is passed, and `sync_to_db` refuses any portfolio that
+isn't `mode='live'`. Flipping a portfolio to `mode='live'` against the real
+Alpaca endpoint (rather than the paper sandbox) is gated on the regulatory
+go-live decision — discretionary real-money trading is FCA-regulated activity
+in the UK and must be cleared with the solicitor first.
 
 ## Development Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -647,7 +647,36 @@ GITHUB_DISPATCH_REPO        Optional. Repo for workflow_dispatch (defaults
                             to "update_ai_analysis").
 GITHUB_DISPATCH_REF         Optional. Git ref to dispatch against (defaults
                             to "main").
+ALPACA_API_KEY_ID           Alpaca Trading API key id (real-money spike —
+                            alpaca_client.py / alpaca_execution.py).
+ALPACA_API_SECRET_KEY       Alpaca Trading API secret.
+ALPACA_BASE_URL             Optional. Alpaca endpoint. Defaults to the PAPER
+                            sandbox (https://paper-api.alpaca.markets). Set to
+                            https://api.alpaca.markets ONLY to go live.
 ```
+
+## Real-money execution (Alpaca — spike)
+
+`alpaca_client.py` + `alpaca_execution.py` are a contained spike for routing a
+**single** portfolio's trade decisions to a real broker. Scope is one account
+(the owner's) via Alpaca's **Trading API** against the **paper** sandbox — not
+the Broker API (which is for operating a brokerage for many users, with KYC /
+custody / licensing). The paper and live endpoints are identical in shape, so
+going live is an `ALPACA_BASE_URL` + key swap.
+
+- `alpaca_client.py` — thin REST wrapper (account, clock, positions, orders).
+- `alpaca_execution.py` — `AlpacaExecutionBackend` mirrors `PortfolioManager`'s
+  buy/sell shape (the seam for a future `live`-flagged portfolio) plus a manual
+  CLI (`--status`, `--positions`, `--orders`, `--buy`, `--sell`, `--reconcile
+  <slug>`).
+
+Safety: **not** wired into `agent_heartbeat.py` — the swarm can't place a real
+order automatically. Order submission refuses the LIVE endpoint unless
+`--i-understand-live` is passed. `reconcile` is read-only (reports the
+Alpaca-vs-AlphaMolt diff; writing real fills back into
+`portfolio_holdings`/`portfolio_accounts` is a TODO gated on the regulatory
+go-live decision — discretionary real-money trading is FCA-regulated activity
+in the UK and must be cleared with the solicitor first).
 
 ## Development Notes
 

--- a/alpaca_client.py
+++ b/alpaca_client.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Alpaca Trading API client — thin REST wrapper.
+
+Scope (spike): a single Alpaca account traded with its own API keys. This is
+the *Trading API*, not the Broker API — we are an API client of one account,
+not a brokerage onboarding many users. The paper endpoint
+(``paper-api.alpaca.markets``) is Alpaca's sandbox and is byte-for-byte
+identical in shape to live; going live later is an endpoint + key swap, no
+code change.
+
+Auth is two headers (key id + secret). Reads:
+
+    ALPACA_API_KEY_ID         Alpaca API key id
+    ALPACA_API_SECRET_KEY     Alpaca API secret
+    ALPACA_BASE_URL           Optional. Defaults to the paper endpoint
+                              (https://paper-api.alpaca.markets). Set to
+                              https://api.alpaca.markets ONLY when going live.
+
+Nothing here touches real money while ALPACA_BASE_URL points at paper.
+
+Docs: https://docs.alpaca.markets/reference/
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+PAPER_BASE_URL = "https://paper-api.alpaca.markets"
+LIVE_BASE_URL = "https://api.alpaca.markets"
+
+DEFAULT_TIMEOUT = 15  # seconds
+
+
+class AlpacaError(Exception):
+    """Raised when an Alpaca API call fails."""
+
+
+class AlpacaClient:
+    """Minimal REST client over the Alpaca Trading API (v2)."""
+
+    def __init__(
+        self,
+        key_id: str | None = None,
+        secret_key: str | None = None,
+        base_url: str | None = None,
+    ):
+        self.key_id = key_id or os.environ.get("ALPACA_API_KEY_ID", "")
+        self.secret_key = secret_key or os.environ.get("ALPACA_API_SECRET_KEY", "")
+        self.base_url = (
+            base_url
+            or os.environ.get("ALPACA_BASE_URL")
+            or PAPER_BASE_URL
+        ).rstrip("/")
+
+        if not self.key_id or not self.secret_key:
+            raise AlpacaError(
+                "Missing ALPACA_API_KEY_ID / ALPACA_API_SECRET_KEY env vars"
+            )
+
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "APCA-API-KEY-ID": self.key_id,
+                "APCA-API-SECRET-KEY": self.secret_key,
+                "Accept": "application/json",
+            }
+        )
+
+    @property
+    def is_paper(self) -> bool:
+        """True when pointed at the sandbox (no real money can move)."""
+        return self.base_url == PAPER_BASE_URL or "paper-api" in self.base_url
+
+    # ------------------------------------------------------------------
+    # Low-level request helper
+    # ------------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict | None = None,
+        json_body: dict | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+    ) -> Any:
+        url = f"{self.base_url}{path}"
+        try:
+            resp = self._session.request(
+                method,
+                url,
+                params=params,
+                json=json_body,
+                timeout=timeout,
+            )
+        except requests.exceptions.RequestException as exc:
+            raise AlpacaError(f"{method} {path} failed: {exc}") from exc
+
+        if resp.status_code >= 400:
+            # Alpaca returns {"code": ..., "message": ...} on errors.
+            detail = resp.text
+            try:
+                detail = resp.json().get("message", detail)
+            except ValueError:
+                pass
+            raise AlpacaError(
+                f"{method} {path} -> {resp.status_code}: {detail}"
+            )
+
+        if resp.status_code == 204 or not resp.content:
+            return None
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Account / market
+    # ------------------------------------------------------------------
+
+    def get_account(self) -> dict:
+        """Account snapshot — cash, equity, buying power, status."""
+        return self._request("GET", "/v2/account")
+
+    def get_clock(self) -> dict:
+        """Market clock — is_open, next_open, next_close."""
+        return self._request("GET", "/v2/clock")
+
+    def get_asset(self, symbol: str) -> dict:
+        """Asset metadata — tradable, fractionable, exchange, status."""
+        return self._request("GET", f"/v2/assets/{symbol}")
+
+    # ------------------------------------------------------------------
+    # Positions
+    # ------------------------------------------------------------------
+
+    def list_positions(self) -> list[dict]:
+        return self._request("GET", "/v2/positions") or []
+
+    def get_position(self, symbol: str) -> dict | None:
+        try:
+            return self._request("GET", f"/v2/positions/{symbol}")
+        except AlpacaError as exc:
+            # 404 = no open position for that symbol.
+            if "404" in str(exc):
+                return None
+            raise
+
+    # ------------------------------------------------------------------
+    # Orders
+    # ------------------------------------------------------------------
+
+    def submit_order(
+        self,
+        symbol: str,
+        side: str,
+        *,
+        qty: float | None = None,
+        notional: float | None = None,
+        order_type: str = "market",
+        time_in_force: str = "day",
+        limit_price: float | None = None,
+        client_order_id: str | None = None,
+    ) -> dict:
+        """Submit an order. Pass exactly one of ``qty`` or ``notional``.
+
+        ``client_order_id`` is an idempotency handle — Alpaca rejects a
+        duplicate id, which lets a caller safely retry without
+        double-submitting.
+        """
+        if (qty is None) == (notional is None):
+            raise AlpacaError("submit_order needs exactly one of qty / notional")
+        if side not in ("buy", "sell"):
+            raise AlpacaError(f"invalid side: {side!r}")
+
+        body: dict[str, Any] = {
+            "symbol": symbol,
+            "side": side,
+            "type": order_type,
+            "time_in_force": time_in_force,
+        }
+        if qty is not None:
+            body["qty"] = str(qty)
+        if notional is not None:
+            body["notional"] = str(notional)
+        if limit_price is not None:
+            body["limit_price"] = str(limit_price)
+        if client_order_id is not None:
+            body["client_order_id"] = client_order_id
+
+        return self._request("POST", "/v2/orders", json_body=body)
+
+    def get_order(self, order_id: str) -> dict:
+        return self._request("GET", f"/v2/orders/{order_id}")
+
+    def list_orders(
+        self,
+        status: str = "all",
+        limit: int = 100,
+    ) -> list[dict]:
+        return (
+            self._request(
+                "GET",
+                "/v2/orders",
+                params={"status": status, "limit": limit},
+            )
+            or []
+        )
+
+    def cancel_order(self, order_id: str) -> None:
+        self._request("DELETE", f"/v2/orders/{order_id}")

--- a/alpaca_execution.py
+++ b/alpaca_execution.py
@@ -38,6 +38,7 @@ import argparse
 import logging
 import sys
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from alpaca_client import AlpacaClient, AlpacaError
 from db import SupabaseDB
@@ -143,11 +144,111 @@ class AlpacaExecutionBackend:
                 a = alpaca_pos.get(s, 0.0)
                 d = db_pos.get(s, 0.0)
                 print(f"  {s:<10}{d:>12.2f}{a:>12.2f}{a - d:>12.2f}")
-        # TODO(go-live): write actual Alpaca fills/positions/cash back into
-        # portfolio_holdings + portfolio_accounts so the public leaderboard
-        # reflects the real account instead of the paper estimate. Gated on
-        # the regulatory go-live decision.
         print()
+
+    # ------------------------------------------------------------------
+    # Write-back: mirror real Alpaca state into the normal portfolio tables
+    # ------------------------------------------------------------------
+
+    def sync_to_db(
+        self,
+        db: SupabaseDB,
+        portfolio_slug: str,
+        *,
+        dry_run: bool = False,
+    ) -> None:
+        """Mirror the live Alpaca account into the normal portfolio tables.
+
+        Idempotent *state* mirror: it overwrites ``portfolio_holdings`` +
+        ``portfolio_accounts.cash_usd`` to match Alpaca's current positions and
+        cash, so the website, MTM snapshot and leaderboard reflect the real
+        account. Safe to rerun — it converges, it doesn't accumulate.
+
+        Refuses unless the portfolio is ``mode='live'`` (migration 036): this
+        is destructive to the DB book (Alpaca is the source of truth for a live
+        portfolio), and must never clobber a paper portfolio's simulated book.
+
+        The Alpaca endpoint is independent of this flag — for the spike you run
+        ``mode='live'`` against the Alpaca *paper* sandbox, which mirrors a real
+        broker account shape with zero real money.
+
+        Not handled here (state-only mirror): the per-trade journal
+        (``agent_trades``) and MTM snapshot (``agent_portfolio_history``). The
+        snapshot is produced on the next ``portfolio_valuation.py`` run from the
+        mirrored holdings; journaling individual fills (Alpaca activities, deduped
+        by order id) is a follow-up — see TODO below.
+        """
+        portfolio = db.get_portfolio_by_slug(portfolio_slug)
+        if not portfolio:
+            raise AlpacaError(f"portfolio not found: {portfolio_slug!r}")
+        mode = portfolio.get("mode")
+        if mode != "live":
+            raise AlpacaError(
+                f"refusing to sync: portfolio {portfolio_slug!r} is "
+                f"mode={mode!r}, not 'live'. Set portfolios.mode='live' first "
+                "— sync mirrors real Alpaca state into the normal tables and "
+                "must never overwrite a paper book."
+            )
+        pid = portfolio["id"]
+
+        account = self.client.get_account()
+        alpaca_cash = float(account.get("cash") or 0)
+        alpaca_pos = {
+            p["symbol"]: (float(p["qty"]), float(p["avg_entry_price"]))
+            for p in self.client.list_positions()
+        }
+
+        db_holdings = {h["ticker"]: h for h in db.get_portfolio_holdings(pid)}
+        now = datetime.now(timezone.utc).isoformat()
+
+        tag = "DRY-RUN " if dry_run else ""
+        print(f"\n{tag}sync  portfolio={portfolio_slug}  mode=live  "
+              f"alpaca={'PAPER' if self.client.is_paper else 'LIVE'}\n")
+
+        # Upsert every Alpaca position. Validate the symbol against `companies`
+        # first — portfolio_holdings.ticker FKs to companies, and the website
+        # joins through it for price/name, so an unknown symbol must be skipped
+        # rather than written. (US symbols map 1:1; exchange-suffix / FX mapping
+        # for non-US listings is a follow-up.)
+        for symbol, (qty, avg) in sorted(alpaca_pos.items()):
+            if not db.get_company(symbol):
+                logger.warning(
+                    "skip %s: not in companies universe (FK target missing)",
+                    symbol,
+                )
+                continue
+            existing = db_holdings.get(symbol)
+            first_bought = (
+                existing.get("first_bought_at") if existing else now
+            ) or now
+            row = {
+                "portfolio_id": pid,
+                "ticker": symbol,
+                "quantity": qty,
+                "avg_cost_usd": avg,
+                "first_bought_at": first_bought,
+                "updated_at": now,
+            }
+            print(f"  upsert  {symbol:<8} qty={qty:<10.4f} avg=${avg:,.2f}")
+            if not dry_run:
+                db.upsert_portfolio_holding(row)
+
+        # Delete DB holdings Alpaca no longer reports (fully exited positions).
+        for ticker in sorted(db_holdings):
+            if ticker not in alpaca_pos:
+                print(f"  delete  {ticker:<8} (no longer held on Alpaca)")
+                if not dry_run:
+                    db.delete_portfolio_holding(pid, ticker)
+
+        print(f"  cash    ${alpaca_cash:,.2f}")
+        if not dry_run:
+            db.upsert_portfolio_account(pid, {"cash_usd": alpaca_cash})
+
+        # TODO(trade journal): mirror individual fills into agent_trades by
+        # reading Alpaca activities (FILL events) and deduping on order id, so
+        # the public trade tape reflects real trades. State mirror above is
+        # enough for holdings / MTM / leaderboard.
+        print(f"\n{tag}done.\n")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -157,7 +258,17 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--orders", action="store_true", help="list recent orders")
     ap.add_argument("--buy", nargs=2, metavar=("SYMBOL", "QTY"))
     ap.add_argument("--sell", nargs=2, metavar=("SYMBOL", "QTY"))
-    ap.add_argument("--reconcile", metavar="SLUG", help="diff Alpaca vs portfolio")
+    ap.add_argument("--reconcile", metavar="SLUG", help="diff Alpaca vs portfolio (read-only)")
+    ap.add_argument(
+        "--sync",
+        metavar="SLUG",
+        help="mirror Alpaca state into a mode='live' portfolio's normal tables",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="with --sync: plan the writes without executing them",
+    )
     ap.add_argument(
         "--i-understand-live",
         action="store_true",
@@ -221,6 +332,9 @@ def main(argv: list[str] | None = None) -> int:
 
         if args.reconcile:
             backend.reconcile(SupabaseDB(), args.reconcile)
+
+        if args.sync:
+            backend.sync_to_db(SupabaseDB(), args.sync, dry_run=args.dry_run)
 
     except AlpacaError as exc:
         logger.error("%s", exc)

--- a/alpaca_execution.py
+++ b/alpaca_execution.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Alpaca execution backend — the seam between AlphaMolt's trade *decisions*
+and a real broker.
+
+Today every strategy funnels its decisions through
+``PortfolioManager.buy/sell`` -> the ``execute_portfolio_buy/_sell`` Supabase
+RPCs, which move *paper* cash and holdings. This module adds a parallel
+execution target: an Alpaca account. The intent is that a single portfolio
+flagged ``live`` mirrors the same buy/sell decisions into Alpaca orders, then
+reconciles real fills/positions/cash back.
+
+SPIKE STATUS (read me):
+    - Scope is ONE account (yours), via the Alpaca *Trading API*, against the
+      *paper* sandbox. Nothing here is wired into agent_heartbeat.py yet, so
+      the swarm cannot place a real order by accident — execution is manual
+      via this CLI until the loop is proven and the go-live decision is made.
+    - ``reconcile`` is READ-ONLY: it reports the diff between Alpaca and the
+      AlphaMolt portfolio; it does not write the DB. Writing real fills back
+      into portfolio_holdings/accounts (replacing the v1 "all USD, no
+      fees/slippage" estimates with actual fills) is the next step and is
+      marked TODO below.
+    - Order submission refuses to run against the LIVE endpoint unless the
+      caller passes an explicit confirmation flag.
+
+CLI:
+    python alpaca_execution.py --status
+    python alpaca_execution.py --positions
+    python alpaca_execution.py --orders
+    python alpaca_execution.py --buy AAPL 1
+    python alpaca_execution.py --sell AAPL 1
+    python alpaca_execution.py --reconcile <portfolio-slug>
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+
+from alpaca_client import AlpacaClient, AlpacaError
+from db import SupabaseDB
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Fill:
+    """Normalised result of submitting an order."""
+
+    order_id: str
+    symbol: str
+    side: str
+    qty: float
+    status: str
+
+
+class AlpacaExecutionBackend:
+    """Routes buy/sell decisions to an Alpaca account.
+
+    Mirrors ``PortfolioManager``'s buy/sell shape so it can later be dropped
+    in behind the same interface for a ``live``-flagged portfolio.
+    """
+
+    def __init__(self, client: AlpacaClient | None = None):
+        self.client = client or AlpacaClient()
+
+    def _guard_live(self, allow_live: bool) -> None:
+        if not self.client.is_paper and not allow_live:
+            raise AlpacaError(
+                "Refusing to trade against the LIVE endpoint. Re-run with "
+                "--i-understand-live to place a real-money order."
+            )
+
+    def buy(self, symbol: str, qty: float, *, allow_live: bool = False) -> Fill:
+        self._guard_live(allow_live)
+        order = self.client.submit_order(symbol, "buy", qty=qty)
+        logger.info("BUY %s x%s -> order %s (%s)",
+                    symbol, qty, order["id"], order["status"])
+        return self._to_fill(order)
+
+    def sell(self, symbol: str, qty: float, *, allow_live: bool = False) -> Fill:
+        self._guard_live(allow_live)
+        order = self.client.submit_order(symbol, "sell", qty=qty)
+        logger.info("SELL %s x%s -> order %s (%s)",
+                    symbol, qty, order["id"], order["status"])
+        return self._to_fill(order)
+
+    @staticmethod
+    def _to_fill(order: dict) -> Fill:
+        return Fill(
+            order_id=order["id"],
+            symbol=order["symbol"],
+            side=order["side"],
+            qty=float(order.get("qty") or 0),
+            status=order["status"],
+        )
+
+    # ------------------------------------------------------------------
+    # Reconciliation (read-only in the spike)
+    # ------------------------------------------------------------------
+
+    def reconcile(self, db: SupabaseDB, portfolio_slug: str) -> None:
+        """Report the diff between the Alpaca account and an AlphaMolt portfolio.
+
+        Read-only. Compares per-symbol quantity and the cash balance so we can
+        see exactly what a sync would have to do, without touching the DB.
+        """
+        portfolio = db.get_portfolio_by_slug(portfolio_slug)
+        if not portfolio:
+            raise AlpacaError(f"portfolio not found: {portfolio_slug!r}")
+        pid = portfolio["id"]
+
+        account = self.client.get_account()
+        alpaca_cash = float(account.get("cash") or 0)
+        alpaca_pos = {
+            p["symbol"]: float(p["qty"]) for p in self.client.list_positions()
+        }
+
+        db_account = db.get_portfolio_account(pid) or {}
+        db_cash = float(db_account.get("cash_usd") or 0)
+        db_pos = {
+            h["ticker"]: float(h["quantity"])
+            for h in db.get_portfolio_holdings(pid)
+        }
+
+        print(f"\nReconcile  portfolio={portfolio_slug}  "
+              f"alpaca={'PAPER' if self.client.is_paper else 'LIVE'}\n")
+        print(f"  cash   alphamolt=${db_cash:,.2f}   alpaca=${alpaca_cash:,.2f}   "
+              f"delta=${alpaca_cash - db_cash:,.2f}")
+
+        symbols = sorted(set(alpaca_pos) | set(db_pos))
+        if not symbols:
+            print("  positions: none on either side")
+        else:
+            print(f"\n  {'symbol':<10}{'alphamolt':>12}{'alpaca':>12}{'delta':>12}")
+            for s in symbols:
+                a = alpaca_pos.get(s, 0.0)
+                d = db_pos.get(s, 0.0)
+                print(f"  {s:<10}{d:>12.2f}{a:>12.2f}{a - d:>12.2f}")
+        # TODO(go-live): write actual Alpaca fills/positions/cash back into
+        # portfolio_holdings + portfolio_accounts so the public leaderboard
+        # reflects the real account instead of the paper estimate. Gated on
+        # the regulatory go-live decision.
+        print()
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Alpaca execution spike")
+    ap.add_argument("--status", action="store_true", help="account + clock")
+    ap.add_argument("--positions", action="store_true", help="list Alpaca positions")
+    ap.add_argument("--orders", action="store_true", help="list recent orders")
+    ap.add_argument("--buy", nargs=2, metavar=("SYMBOL", "QTY"))
+    ap.add_argument("--sell", nargs=2, metavar=("SYMBOL", "QTY"))
+    ap.add_argument("--reconcile", metavar="SLUG", help="diff Alpaca vs portfolio")
+    ap.add_argument(
+        "--i-understand-live",
+        action="store_true",
+        help="required to place an order against the LIVE endpoint",
+    )
+    args = ap.parse_args(argv)
+
+    try:
+        backend = AlpacaExecutionBackend()
+    except AlpacaError as exc:
+        logger.error("%s", exc)
+        return 1
+
+    client = backend.client
+    logger.info(
+        "Alpaca endpoint: %s (%s)",
+        client.base_url,
+        "PAPER / sandbox" if client.is_paper else "LIVE — real money",
+    )
+
+    try:
+        if args.status:
+            acct = client.get_account()
+            clock = client.get_clock()
+            print(f"\n  account_number  {acct.get('account_number')}")
+            print(f"  status          {acct.get('status')}")
+            print(f"  cash            ${float(acct.get('cash') or 0):,.2f}")
+            print(f"  equity          ${float(acct.get('equity') or 0):,.2f}")
+            print(f"  buying_power    ${float(acct.get('buying_power') or 0):,.2f}")
+            print(f"  market_open     {clock.get('is_open')}")
+            print()
+
+        if args.positions:
+            positions = client.list_positions()
+            if not positions:
+                print("\n  no open positions\n")
+            else:
+                print(f"\n  {'symbol':<10}{'qty':>10}{'avg_entry':>12}"
+                      f"{'mkt_value':>14}{'unrl_pl':>12}")
+                for p in positions:
+                    print(f"  {p['symbol']:<10}{float(p['qty']):>10.2f}"
+                          f"{float(p['avg_entry_price']):>12.2f}"
+                          f"{float(p['market_value']):>14.2f}"
+                          f"{float(p['unrealized_pl']):>12.2f}")
+                print()
+
+        if args.orders:
+            for o in client.list_orders(limit=20):
+                print(f"  {o['submitted_at']}  {o['side']:<4} "
+                      f"{o['symbol']:<8} qty={o.get('qty')}  {o['status']}")
+
+        if args.buy:
+            symbol, qty = args.buy
+            backend.buy(symbol.upper(), float(qty),
+                        allow_live=args.i_understand_live)
+
+        if args.sell:
+            symbol, qty = args.sell
+            backend.sell(symbol.upper(), float(qty),
+                         allow_live=args.i_understand_live)
+
+        if args.reconcile:
+            backend.reconcile(SupabaseDB(), args.reconcile)
+
+    except AlpacaError as exc:
+        logger.error("%s", exc)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/migrations/036_portfolio_mode.sql
+++ b/migrations/036_portfolio_mode.sql
@@ -1,0 +1,34 @@
+-- Migration 036: per-portfolio paper/live mode (owner-only secret)
+--
+-- Adds `portfolios.mode` so a single portfolio can be backed by a real
+-- broker account (Alpaca — see alpaca_client.py / alpaca_execution.py)
+-- while everything else about it behaves like a normal paper portfolio.
+--
+-- VISIBILITY CONTRACT — read before touching any portfolio read path:
+--   `mode` is OWNER-ONLY. The portfolio itself stays fully visible under
+--   the existing rules (is_public + the 15/10-equity hysteresis); only the
+--   *fact that it is real money* is hidden. To everyone but the owner the
+--   portfolio must be indistinguishable from a paper one.
+--
+--   This is enforced at the QUERY LAYER, not by RLS: public portfolio rows
+--   are world-readable (anon key) and the website reads with the
+--   service-role key, so column-level hiding can't come from RLS. The rule
+--   is therefore: NEVER select `mode` on a code path whose result can reach
+--   a non-owner. Public reads (web/lib/portfolios-query.ts) use an explicit
+--   column list that excludes `mode`; the owner-only marker reads it via the
+--   dedicated `getPortfolioMode(portfolioId, ownerUserId)` accessor.
+--
+--   'live' is what the Alpaca reconcile loop keys on to decide a portfolio's
+--   normal-table writes are mirrored from real fills rather than paper.
+
+ALTER TABLE portfolios
+    ADD COLUMN IF NOT EXISTS mode TEXT NOT NULL DEFAULT 'paper';
+
+ALTER TABLE portfolios
+    DROP CONSTRAINT IF EXISTS chk_portfolios_mode;
+ALTER TABLE portfolios
+    ADD CONSTRAINT chk_portfolios_mode CHECK (mode IN ('paper', 'live'));
+
+COMMENT ON COLUMN portfolios.mode IS
+    'paper | live. OWNER-ONLY — never expose to non-owners (query-layer '
+    'enforced; see migration 036). live = backed by a real Alpaca account.';

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -15,6 +15,7 @@ import {
   getHoldingsCountForPortfolio,
   getMembersForPortfolio,
   getPortfolioBySlug,
+  getPortfolioMode,
   getRecentTradesForPortfolio,
   type Portfolio,
   type PortfolioMember,
@@ -106,6 +107,8 @@ export async function generateMetadata({
 async function getPortfolioPageData(slug: string): Promise<{
   portfolio: Portfolio | null;
   isOwner: boolean;
+  /** Owner-only (migration 036). Always "paper" for non-owners — never leaked. */
+  mode: "paper" | "live";
   snapshot: PortfolioSnapshot | null;
   members: PortfolioMember[];
   thesesByTicker: Record<string, InvestmentThesis>;
@@ -118,6 +121,7 @@ async function getPortfolioPageData(slug: string): Promise<{
     return {
       portfolio: null,
       isOwner: false,
+      mode: "paper",
       snapshot: null,
       members: [],
       thesesByTicker: {},
@@ -127,6 +131,12 @@ async function getPortfolioPageData(slug: string): Promise<{
     };
   }
   const isOwner = await isViewerOwner(portfolio);
+  // `mode` is owner-only: only read (and only ever render) it for the owner,
+  // so the real-money flag never reaches another viewer's browser.
+  const mode =
+    isOwner && portfolio.owner_user_id
+      ? await getPortfolioMode(portfolio.id, portfolio.owner_user_id)
+      : "paper";
 
   // Two snapshot paths: legacy 1:1 agent portfolios are keyed on agent_id
   // (the agent_accounts / agent_holdings tables); human-owned portfolios
@@ -182,6 +192,7 @@ async function getPortfolioPageData(slug: string): Promise<{
   return {
     portfolio,
     isOwner,
+    mode,
     snapshot,
     members,
     thesesByTicker,
@@ -200,6 +211,7 @@ export default async function PortfolioPage({ params }: PageParams) {
   const {
     portfolio,
     isOwner,
+    mode,
     snapshot,
     members,
     thesesByTicker,
@@ -242,6 +254,23 @@ export default async function PortfolioPage({ params }: PageParams) {
                   isPublic={portfolio.is_public}
                   holdingsCount={holdingsCount}
                 />
+              )}
+              {/* Owner-only real-money marker (migration 036). Rendered only
+                  when the viewer is the owner AND mode is live, so the flag
+                  never reaches another viewer. To everyone else this
+                  portfolio is indistinguishable from a paper one. */}
+              {isOwner && mode === "live" && (
+                <span
+                  className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-green)]/40 bg-[var(--color-green)]/[0.08] px-2.5 py-1 text-[11px] font-mono font-bold uppercase tracking-[0.12em] text-[var(--color-green)]"
+                  title="This portfolio is backed by a real Alpaca account. Only you can see this."
+                >
+                  <span
+                    aria-hidden
+                    className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
+                    style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+                  />
+                  Live · real money
+                </span>
               )}
             </div>
           </header>

--- a/web/lib/portfolios-query.ts
+++ b/web/lib/portfolios-query.ts
@@ -27,6 +27,42 @@ export interface Portfolio {
   updated_at: string;
 }
 
+/**
+ * Explicit, non-secret portfolio columns for any read that can reach a
+ * non-owner. Deliberately excludes `mode` (migration 036) — `mode` is
+ * owner-only and would otherwise leak through `select("*")` into props the
+ * server serializes to the browser. Read `mode` only via `getPortfolioMode`.
+ */
+const PORTFOLIO_COLUMNS =
+  "id, slug, display_name, description, owner_agent_id, owner_user_id, is_public, created_at, updated_at";
+
+/**
+ * The owner-only paper/live mode of a portfolio (migration 036). Gated on a
+ * matching `owner_user_id` so it returns null unless the caller passes the
+ * portfolio's actual owner — defense-in-depth on top of the caller's own
+ * ownership check. NEVER call this on a path whose result reaches a
+ * non-owner.
+ */
+export async function getPortfolioMode(
+  portfolioId: string,
+  ownerUserId: string,
+): Promise<"paper" | "live"> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("portfolios")
+    .select("mode")
+    .eq("id", portfolioId)
+    .eq("owner_user_id", ownerUserId)
+    .maybeSingle();
+  if (error) {
+    console.error("getPortfolioMode failed:", error);
+    return "paper";
+  }
+  return (data as { mode?: string } | null)?.mode === "live"
+    ? "live"
+    : "paper";
+}
+
 /** Count of distinct equities a portfolio currently holds. Drives the
  *  Public/Private hysteresis gate (migration 031): a portfolio needs ≥ 15
  *  to flip public and auto-reverts to private below 10. */
@@ -70,7 +106,7 @@ export async function getPortfolioBySlug(slug: string): Promise<Portfolio | null
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from("portfolios")
-    .select("*")
+    .select(PORTFOLIO_COLUMNS)
     .eq("slug", slug)
     .maybeSingle();
   if (error) {
@@ -87,7 +123,7 @@ export async function getPortfolioForUser(
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from("portfolios")
-    .select("*")
+    .select(PORTFOLIO_COLUMNS)
     .eq("owner_user_id", userId)
     .maybeSingle();
   if (error) {
@@ -101,7 +137,7 @@ export async function getPortfolioById(id: string): Promise<Portfolio | null> {
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from("portfolios")
-    .select("*")
+    .select(PORTFOLIO_COLUMNS)
     .eq("id", id)
     .maybeSingle();
   if (error) {
@@ -137,7 +173,7 @@ export async function getPortfoliosForAgent(
   const ids = rows.map((r) => (r as { portfolio_id: string }).portfolio_id);
   const { data: portfolios } = await supabase
     .from("portfolios")
-    .select("*")
+    .select(PORTFOLIO_COLUMNS)
     .in("id", ids)
     .eq("is_public", true);
   const byId = new Map<string, Portfolio>(


### PR DESCRIPTION
## Summary

Lets a **single** portfolio (the owner's) trade real money via Alpaca, while staying fully visible under the normal rules — the only thing hidden from other users is the *fact that it's real money*.

Scope is one account via Alpaca's **Trading API** against the **paper sandbox** (not the Broker API, which is for operating a brokerage for many users). The paper and live endpoints are identical in shape, so going live later is an endpoint + key swap.

> Picks up where merged PR #1274 (homepage hero) left off — same branch, three new commits.

## What's in here

**1. Alpaca client + execution backend** (`alpaca_client.py`, `alpaca_execution.py`)
- Thin REST wrapper over the Trading API v2 (account, clock, positions, orders), two-header auth, paper-vs-live detection.
- `AlpacaExecutionBackend` mirrors `PortfolioManager`'s buy/sell shape (the seam for a live-flagged portfolio), plus a manual CLI.

**2. Owner-only `paper`/`live` mode** (migration `036`, `web/lib/portfolios-query.ts`, portfolio detail page)
- New `portfolios.mode` (`paper` | `live`, default `paper`, CHECK-constrained).
- The portfolio behaves like any other (visible per `is_public` + the 15/10-equity hysteresis); only `mode` is secret.
- **Query-layer enforced** (not RLS — public rows are world-readable and the site reads service-role): public reads now use an explicit `PORTFOLIO_COLUMNS` list that excludes `mode`, so it can't leak via `select("*")` into serialized props. `mode` is read only through the owner-gated `getPortfolioMode(portfolioId, ownerUserId)`.
- Owner sees a private "● Live · real money" marker; to everyone else a live portfolio is indistinguishable from a paper one.

**3. Reconcile write-back** (`alpaca_execution.py` `sync_to_db`)
- Idempotent **state mirror**: overwrites `portfolio_holdings` + `portfolio_accounts.cash_usd` to match Alpaca's real positions and cash, so the website / MTM snapshot / leaderboard reflect the real account.
- Refuses any portfolio that isn't `mode='live'` (never clobbers a paper book); validates each symbol against `companies` (FK target) and skips unknowns; preserves `first_bought_at`; `--dry-run` plans without writing.

## Safety

- **Not wired into `agent_heartbeat.py`** — the swarm can't place a real order automatically; `--sync` is run manually.
- Order submission **refuses the LIVE endpoint** unless `--i-understand-live` is passed; `sync_to_db` refuses non-`live` portfolios.
- Defaults to the **paper sandbox**. Test loop: set the portfolio `mode='live'` but keep `ALPACA_BASE_URL` on paper → proves the full loop with zero real money.
- Flipping to the real Alpaca endpoint is gated on the regulatory go-live decision (discretionary real-money trading is FCA-regulated in the UK) and Alpaca UK live-account eligibility.

## Follow-ups (not in this PR)

- Trade-journal mirror (Alpaca activities → `agent_trades`, deduped by order id) so a live portfolio's trade tape is real too — state mirror covers holdings/MTM/leaderboard.
- Guarded owner-only `paper`→`live` UI toggle (currently a manual DB flip, on purpose).

## Verification

- Web `tsc --noEmit` clean; `next build` compiled + TypeScript passed (export-time failures are the pre-existing missing-Supabase-env on unrelated pages).
- `alpaca_execution.py` smoke-tested: graceful no-cred error, real `401` against paper with throwaway keys (auth + routing confirmed), live-trade guard refuses pre-network, and `sync_to_db` verified with fakes (dry-run writes nothing; real run upserts/deletes/cash correctly; FK skip + cost-basis preservation; non-live refused).

https://claude.ai/code/session_01HjprjAoq4PBL8ZWLJAgr9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjprjAoq4PBL8ZWLJAgr9N)_