### PR TITLE
Automatic market-hours live mirror (keep the live account tracking paper)

### DIFF
--- a/.github/workflows/live-mirror.yml
+++ b/.github/workflows/live-mirror.yml
@@ -36,6 +36,10 @@ on:
         type: boolean
         default: true
   schedule:
+    # Market-hours auto-mirror: ~30 min after the US open (13:30 UTC), pick up
+    # whatever the swarm changed at the 07:00 heartbeat and trade it while the
+    # market is open. Honors ALPACA_LIVE_EXECUTION_ENABLED (no-op if unset).
+    - cron: "0 14 * * 1-5"
     # Daily drift reconcile (sync) after the close-of-business valuation.
     - cron: "0 23 * * 1-5"
 
@@ -69,14 +73,20 @@ jobs:
           LIVE_ACTION: ${{ inputs.action }}
           LIVE_SLUG: ${{ inputs.slug }}
           LIVE_DRY_RUN: ${{ inputs.dry_run }}
+          SCHEDULE: ${{ github.event.schedule }}
         run: |
           set -u
           ACTION="$(printf '%s' "${LIVE_ACTION}" | tr -d '[:space:]')"
           SLUG="$(printf '%s' "${LIVE_SLUG}" | tr -d '[:space:]')"
-          # Scheduled run (no inputs): reconcile every live portfolio via sync.
+          # Scheduled run (no inputs): branch on which cron fired.
           if [ -z "${ACTION}" ]; then
-            echo "Scheduled drift reconcile across live portfolios"
-            python alpaca_execution.py --sync-all-live
+            if [ "${SCHEDULE}" = "0 14 * * 1-5" ]; then
+              echo "Market-hours auto-mirror across live portfolios"
+              python alpaca_mirror.py --mirror-all-live
+            else
+              echo "Scheduled drift reconcile across live portfolios"
+              python alpaca_execution.py --sync-all-live
+            fi
             exit 0
           fi
           if [ -z "${SLUG}" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -759,13 +759,21 @@ at-the-open / illiquid risk) the order doesn't fill, and the next mirror run
 re-converges. `execute_and_wait(..., ref_price=)` computes the limit; the
 mirror passes the sizing price, the forward path passes `companies.price`.
 
-**Scheduling.** The routine "mirror after rebalance" runs inside
-`agent-heartbeat` (which now carries the `ALPACA_*` secrets). The
-`live-mirror.yml` workflow drives the full lifecycle from the Actions UI
-(`workflow_dispatch`, `dry_run` default on): `create` (bootstrap the follower
-row — slug = the PAPER slug), `go-live`, `mirror` (drifted names only),
-`replicate` (full match — `--threshold 0`, buys the entire current paper book,
-not just changes), `sync`; plus a daily `--sync-all-live` drift reconcile.
+**Scheduling.** The swarm rebalances the paper book at the 07:00 UTC heartbeat,
+which is *before* the US open (13:30 UTC) — so the heartbeat's inline
+`_mirror_live_sibling` can't fill then (the mirror skips when the market is
+closed). The automatic live path is therefore a **market-hours cron** in
+`live-mirror.yml`: `--mirror-all-live` at **14:00 UTC** (≈30 min after the
+open) trades whatever the swarm changed overnight, then `--sync-all-live` at
+23:00 UTC reconciles drift after the close. Both honor the
+`ALPACA_LIVE_EXECUTION_ENABLED` master kill-switch — unset it to halt all
+*automatic* real-money trading (manual `workflow_dispatch` runs still execute,
+gated only by `dry_run`). The `live-mirror.yml` workflow also drives the full
+lifecycle from the Actions UI (`dry_run` default on): `create` (bootstrap the
+follower row — slug = the PAPER slug), `go-live`, `mirror` (drifted names
+only), `replicate` (full match — `--threshold 0`, buys the entire current
+paper book, not just changes), `sync`. The inline heartbeat mirror stays as a
+best-effort top-up for any rebalance that happens to land during market hours.
 
 The per-decision routing below (`ctx.buy/sell` → Alpaca) is the alternative
 mechanism for a live portfolio that runs *its own* agents; a follower has none,

--- a/alpaca_mirror.py
+++ b/alpaca_mirror.py
@@ -203,15 +203,95 @@ def _sibling_paper_portfolio(db: SupabaseDB, live_pf: dict) -> dict | None:
     return None
 
 
+_LIVE_EXEC_ENV = "ALPACA_LIVE_EXECUTION_ENABLED"
+
+
+def _live_exec_enabled() -> bool:
+    return os.environ.get(_LIVE_EXEC_ENV, "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _mirror_all_live(
+    db: SupabaseDB,
+    pm: PortfolioManager,
+    *,
+    threshold: float,
+    dry_run: bool,
+) -> int:
+    """Mirror every mode='live' portfolio to its paper sibling.
+
+    The scheduled / automatic path (market-hours cron). Honors the
+    ALPACA_LIVE_EXECUTION_ENABLED master kill-switch: with it unset, a real run
+    is a no-op (unset the secret to halt all automatic live trading). A
+    --dry-run always previews regardless. Per-portfolio errors are logged and
+    skipped so one bad book can't abort the rest.
+    """
+    if not dry_run and not _live_exec_enabled():
+        logger.warning(
+            "%s not set — automatic live mirror is a no-op. "
+            "Set it to enable scheduled real-money mirroring.", _LIVE_EXEC_ENV,
+        )
+        return 0
+
+    live = [
+        p for p in db.get_human_portfolios()
+        if (p.get("mode") or "paper") == "live"
+    ]
+    if not live:
+        logger.info("no live portfolios to mirror")
+        return 0
+
+    try:
+        from alpaca_execution import AlpacaExecutionBackend
+        executor = AlpacaExecutionBackend()
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Alpaca init failed: %s", exc)
+        return 1
+
+    rc = 0
+    for live_pf in live:
+        slug = live_pf.get("slug") or live_pf["id"][:8]
+        paper_pf = _sibling_paper_portfolio(db, live_pf)
+        if not paper_pf:
+            logger.warning("no paper sibling for %s — skipping", slug)
+            continue
+        try:
+            summary = mirror_paper_to_alpaca(
+                db, pm, executor, live_pf, paper_pf,
+                threshold=threshold, dry_run=dry_run,
+            )
+            logger.info("mirror %s: %s", slug, summary)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("mirror %s failed: %s", slug, exc)
+            rc = 1
+    return rc
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Mirror a paper portfolio to Alpaca")
-    ap.add_argument("--slug", required=True, help="the LIVE portfolio slug")
+    ap.add_argument("--slug", help="the LIVE portfolio slug")
+    ap.add_argument(
+        "--mirror-all-live",
+        action="store_true",
+        help="mirror every mode='live' portfolio to its paper sibling "
+             "(scheduled automatic path; honors ALPACA_LIVE_EXECUTION_ENABLED)",
+    )
     ap.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args(argv)
 
     db = SupabaseDB()
     pm = PortfolioManager(db)
+
+    if args.mirror_all_live:
+        return _mirror_all_live(
+            db, pm, threshold=args.threshold, dry_run=args.dry_run,
+        )
+
+    if not args.slug:
+        logger.error("--slug is required (or use --mirror-all-live)")
+        return 1
     live_pf = db.get_portfolio_by_slug(args.slug)
     if not live_pf:
         logger.error("no portfolio with slug %r", args.slug)


### PR DESCRIPTION
## Summary

Closes a timing gap that stopped the live (Alpaca) follower from auto-tracking the paper book.

The swarm rebalances the paper portfolio at the **07:00 UTC** heartbeat — *before* the US open (13:30 UTC). The heartbeat's inline `_mirror_live_sibling` runs right after, but the mirror **skips when the market is closed**, so it never filled. Net effect: the live account only moved on manual `replicate`/`mirror` clicks, not automatically.

## Fix: a market-hours auto-mirror cron

- **`alpaca_mirror.py --mirror-all-live`** — loops every `mode='live'` portfolio and mirrors each to its paper sibling. Honors the **`ALPACA_LIVE_EXECUTION_ENABLED` master kill-switch**: a real run is a no-op when the switch is unset, so unsetting one secret halts all *automatic* real-money trading; `--dry-run` always previews. Per-portfolio errors are isolated. `--slug` is no longer required when `--mirror-all-live` is passed.
- **`live-mirror.yml`** — new `0 14 * * 1-5` cron (~30 min after the open) runs `--mirror-all-live`; the existing `0 23 * * 1-5` cron stays as the post-close `--sync-all-live` reconcile. Scheduled runs branch on `github.event.schedule`.

The inline heartbeat mirror remains a best-effort top-up for any rebalance that happens to land during market hours.

## After merge — to actually auto-trade
1. Set repo secret **`ALPACA_LIVE_EXECUTION_ENABLED=true`** (the automatic path is a deliberate no-op without it).
2. Scheduled workflows only run from `main`, so the 14:00 UTC mirror starts after this merges.

Manual `workflow_dispatch` runs are unaffected — they still execute gated only by `dry_run`.

## Verification
- Switch-off real run is a no-op without touching Alpaca; switch-on + no live portfolios returns 0; `--dry-run` previews regardless of the switch.
- CLI accepts `--mirror-all-live` without `--slug`; `alpaca_mirror.py` compiles.
- `live-mirror.yml` parses as valid YAML.

https://claude.ai/code/session_01HjprjAoq4PBL8ZWLJAgr9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjprjAoq4PBL8ZWLJAgr9N)_