### PR TITLE
Per-portfolio Alpaca accounts (multi-owner live) + live-feature risk gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -693,6 +693,17 @@ ALPACA_PRICE_BAND_PCT       Optional. Slippage cap for live orders (default
                             than band% below); a gap past the band simply
                             doesn't fill and the next mirror re-converges. 0
                             disables (raw market orders).
+ALPACA_ACCOUNTS             Optional. JSON object keyed by LIVE portfolio slug
+                            mapping each to its OWN Alpaca account:
+                            {"toby-live": {"key_id": "...", "secret_key": "...",
+                            "base_url": "https://api.alpaca.markets"}, ...}.
+                            Lets several owners each run a live follower against
+                            their own account. When set it is AUTHORITATIVE — a
+                            live portfolio trades only if it has an entry
+                            (unmapped → refused, never the shared account). When
+                            unset, the bare ALPACA_* vars are the single shared
+                            account, but the mirror REFUSES to use them once
+                            more than one live portfolio exists (anti-commingle).
 ```
 
 ## Real-money execution (Alpaca — spike)
@@ -778,6 +789,17 @@ best-effort top-up for any rebalance that happens to land during market hours.
 The per-decision routing below (`ctx.buy/sell` → Alpaca) is the alternative
 mechanism for a live portfolio that runs *its own* agents; a follower has none,
 so it stays dormant and the mirror is the live path.
+
+**Multiple owners, separate accounts.** Each live portfolio trades its **own**
+Alpaca account, resolved by `AlpacaExecutionBackend.for_slug(slug)` from the
+`ALPACA_ACCOUNTS` JSON map (keyed by live slug). The map is authoritative when
+set; unmapped live portfolios are refused rather than routed to anyone else's
+account. The loops (`--mirror-all-live`, `--sync-all-live`) pass
+`allow_shared_fallback` only when exactly one live portfolio exists, so a
+second live portfolio (e.g. a collaborator's) can never land in the shared
+bare-env account by accident — it must be explicitly mapped. NOTE: running real
+trades for *another person* is the "operating for others" activity gated on the
+FCA / solicitor go-live decision; the plumbing existing does not lift that gate.
 
 ### Forward execution — swarm decisions → real Alpaca orders
 

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -77,7 +77,7 @@ def _mirror_live_sibling(db, pm, *, paper: dict, live: dict, dry_run: bool) -> N
         from alpaca_execution import AlpacaExecutionBackend
         from alpaca_mirror import mirror_paper_to_alpaca
 
-        executor = AlpacaExecutionBackend()
+        executor = AlpacaExecutionBackend.for_slug(slug, allow_shared_fallback=True)
         summary = mirror_paper_to_alpaca(
             db, pm, executor, live, paper, dry_run=False,
         )

--- a/alpaca_execution.py
+++ b/alpaca_execution.py
@@ -35,6 +35,7 @@ CLI:
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -50,6 +51,33 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+
+def _alpaca_accounts_map() -> dict[str, dict]:
+    """Per-portfolio Alpaca credentials from the ``ALPACA_ACCOUNTS`` secret.
+
+    A JSON object keyed by **live portfolio slug**::
+
+        {"toby-live":     {"key_id": "...", "secret_key": "...",
+                           "base_url": "https://api.alpaca.markets"},
+         "chuckyegg-live": {"key_id": "...", "secret_key": "...",
+                           "base_url": "https://api.alpaca.markets"}}
+
+    Lets several owners each run a live follower against their **own** Alpaca
+    account. Unset/empty -> ``{}`` (single-account mode via the bare
+    ``ALPACA_*`` env vars). Raises ``AlpacaError`` on malformed JSON rather than
+    silently degrading to the shared account.
+    """
+    raw = os.environ.get("ALPACA_ACCOUNTS", "").strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AlpacaError(f"ALPACA_ACCOUNTS is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise AlpacaError("ALPACA_ACCOUNTS must be a JSON object keyed by slug")
+    return data
 
 
 @dataclass
@@ -102,6 +130,47 @@ class AlpacaExecutionBackend:
             self.price_band = float(os.environ.get("ALPACA_PRICE_BAND_PCT", "0.03"))
         except ValueError:
             self.price_band = 0.03
+
+    @classmethod
+    def for_slug(
+        cls,
+        slug: str,
+        *,
+        allow_shared_fallback: bool = False,
+    ) -> "AlpacaExecutionBackend":
+        """Build a backend bound to a live portfolio's OWN Alpaca account.
+
+        Resolution + anti-commingle rule:
+
+        - ``ALPACA_ACCOUNTS`` set -> **authoritative**. ``slug`` present uses its
+          credentials; ``slug`` absent raises ``AlpacaError`` (never silently
+          trade one owner's targets through another's account).
+        - ``ALPACA_ACCOUNTS`` unset -> legacy single-account mode (bare
+          ``ALPACA_*`` env), but only when ``allow_shared_fallback`` is True.
+          Callers iterating more than one live portfolio pass False, so a second
+          live portfolio can never land in the shared account by accident.
+        """
+        accounts = _alpaca_accounts_map()
+        if accounts:
+            entry = accounts.get(slug)
+            if not entry:
+                raise AlpacaError(
+                    f"no ALPACA_ACCOUNTS entry for live portfolio {slug!r} — "
+                    f"refusing to trade it against another account"
+                )
+            client = AlpacaClient(
+                key_id=entry.get("key_id"),
+                secret_key=entry.get("secret_key"),
+                base_url=entry.get("base_url"),
+            )
+            return cls(client)
+        if not allow_shared_fallback:
+            raise AlpacaError(
+                f"ALPACA_ACCOUNTS not set and {slug!r} can't use the shared "
+                f"account here (multiple live portfolios) — configure "
+                f"ALPACA_ACCOUNTS with a per-portfolio entry"
+            )
+        return cls()  # single-account legacy mode (bare ALPACA_* env)
 
     def _guard_live(self, allow_live: bool) -> None:
         if not self.client.is_paper and not allow_live:
@@ -409,18 +478,28 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = ap.parse_args(argv)
 
-    try:
-        backend = AlpacaExecutionBackend()
-    except AlpacaError as exc:
-        logger.error("%s", exc)
-        return 1
-
-    client = backend.client
-    logger.info(
-        "Alpaca endpoint: %s (%s)",
-        client.base_url,
-        "PAPER / sandbox" if client.is_paper else "LIVE — real money",
-    )
+    # Account-level commands operate the single account from the bare ALPACA_*
+    # env. Portfolio commands (sync / go-live / sync-all-live) resolve each live
+    # portfolio's OWN account via for_slug, so the shared backend is only built
+    # when actually needed (and won't fail a multi-account-only setup).
+    needs_shared = any([
+        args.status, args.positions, args.orders, args.buy, args.sell,
+        args.reconcile,
+    ])
+    backend = None
+    client = None
+    if needs_shared:
+        try:
+            backend = AlpacaExecutionBackend()
+        except AlpacaError as exc:
+            logger.error("%s", exc)
+            return 1
+        client = backend.client
+        logger.info(
+            "Alpaca endpoint: %s (%s)",
+            client.base_url,
+            "PAPER / sandbox" if client.is_paper else "LIVE — real money",
+        )
 
     try:
         if args.status:
@@ -467,10 +546,12 @@ def main(argv: list[str] | None = None) -> int:
             backend.reconcile(SupabaseDB(), args.reconcile)
 
         if args.sync:
-            backend.sync_to_db(SupabaseDB(), args.sync, dry_run=args.dry_run)
+            be = AlpacaExecutionBackend.for_slug(args.sync, allow_shared_fallback=True)
+            be.sync_to_db(SupabaseDB(), args.sync, dry_run=args.dry_run)
 
         if args.go_live:
-            backend.sync_to_db(
+            be = AlpacaExecutionBackend.for_slug(args.go_live, allow_shared_fallback=True)
+            be.sync_to_db(
                 SupabaseDB(), args.go_live,
                 dry_run=args.dry_run, reset_baseline=True,
             )
@@ -483,9 +564,13 @@ def main(argv: list[str] | None = None) -> int:
             ]
             if not live:
                 logger.info("no live portfolios to reconcile")
+            single = len(live) == 1
             for p in live:
                 try:
-                    backend.sync_to_db(db, p["slug"], dry_run=args.dry_run)
+                    be = AlpacaExecutionBackend.for_slug(
+                        p["slug"], allow_shared_fallback=single,
+                    )
+                    be.sync_to_db(db, p["slug"], dry_run=args.dry_run)
                 except AlpacaError as exc:
                     logger.error("sync %s failed: %s", p["slug"], exc)
 

--- a/alpaca_mirror.py
+++ b/alpaca_mirror.py
@@ -242,19 +242,26 @@ def _mirror_all_live(
         logger.info("no live portfolios to mirror")
         return 0
 
-    try:
-        from alpaca_execution import AlpacaExecutionBackend
-        executor = AlpacaExecutionBackend()
-    except Exception as exc:  # noqa: BLE001
-        logger.error("Alpaca init failed: %s", exc)
-        return 1
+    from alpaca_execution import AlpacaError, AlpacaExecutionBackend
 
+    # Each live portfolio trades its OWN Alpaca account (for_slug). With more
+    # than one live portfolio, shared-account fallback is refused so one owner's
+    # targets can never land in another's account.
+    single = len(live) == 1
     rc = 0
     for live_pf in live:
         slug = live_pf.get("slug") or live_pf["id"][:8]
         paper_pf = _sibling_paper_portfolio(db, live_pf)
         if not paper_pf:
             logger.warning("no paper sibling for %s — skipping", slug)
+            continue
+        try:
+            executor = AlpacaExecutionBackend.for_slug(
+                slug, allow_shared_fallback=single,
+            )
+        except AlpacaError as exc:
+            logger.warning("skipping %s: %s", slug, exc)
+            rc = 1
             continue
         try:
             summary = mirror_paper_to_alpaca(
@@ -307,7 +314,9 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         from alpaca_execution import AlpacaExecutionBackend
-        executor = AlpacaExecutionBackend()
+        executor = AlpacaExecutionBackend.for_slug(
+            args.slug, allow_shared_fallback=True,
+        )
     except Exception as exc:  # noqa: BLE001
         logger.error("Alpaca init failed: %s", exc)
         return 1

--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -16,6 +16,7 @@ import {
   getPortfolioByPortfolioId,
   type PortfolioSnapshot,
 } from "@/lib/portfolio";
+import BetaDisclaimer from "@/components/beta-disclaimer";
 import { listPublicAgents, getAgentReturns30d } from "@/lib/agents-query";
 import { roleFor } from "@/lib/agent-roles";
 import CreatePortfolioForm from "@/components/portfolio/create-portfolio-form";
@@ -169,6 +170,8 @@ function LivePortfolioPanel({
 
   return (
     <section className="mt-12">
+      {/* Risk acknowledgement — gated to this secret live (real-money) surface. */}
+      <BetaDisclaimer />
       <div
         className="rounded-2xl border p-6 sm:p-7"
         style={{

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,7 +3,6 @@ import { Inter, JetBrains_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import Footer from "@/components/footer";
-import BetaDisclaimer from "@/components/beta-disclaimer";
 import { SITE, absoluteUrl } from "@/lib/site";
 import "./globals.css";
 
@@ -163,7 +162,6 @@ export default function RootLayout({
         />
         {children}
         <Footer />
-        <BetaDisclaimer />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, JetBrains_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import Footer from "@/components/footer";
+import BetaDisclaimer from "@/components/beta-disclaimer";
 import { SITE, absoluteUrl } from "@/lib/site";
 import "./globals.css";
 
@@ -162,6 +163,7 @@ export default function RootLayout({
         />
         {children}
         <Footer />
+        <BetaDisclaimer />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -6,6 +6,7 @@ import HoldingsList from "@/components/holdings-list";
 import { AgentMonogram } from "@/components/agent-monogram";
 import { TradeTape, type Trade } from "@/components/trade-tape";
 import VisibilityToggle from "@/components/portfolio/visibility-toggle";
+import BetaDisclaimer from "@/components/beta-disclaimer";
 import {
   getPortfolio,
   getPortfolioByPortfolioId,
@@ -260,17 +261,21 @@ export default async function PortfolioPage({ params }: PageParams) {
                   never reaches another viewer. To everyone else this
                   portfolio is indistinguishable from a paper one. */}
               {isOwner && mode === "live" && (
-                <span
-                  className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-green)]/40 bg-[var(--color-green)]/[0.08] px-2.5 py-1 text-[11px] font-mono font-bold uppercase tracking-[0.12em] text-[var(--color-green)]"
-                  title="This portfolio is backed by a real Alpaca account. Only you can see this."
-                >
+                <>
                   <span
-                    aria-hidden
-                    className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
-                    style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
-                  />
-                  Live · real money
-                </span>
+                    className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-green)]/40 bg-[var(--color-green)]/[0.08] px-2.5 py-1 text-[11px] font-mono font-bold uppercase tracking-[0.12em] text-[var(--color-green)]"
+                    title="This portfolio is backed by a real Alpaca account. Only you can see this."
+                  >
+                    <span
+                      aria-hidden
+                      className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
+                      style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+                    />
+                    Live · real money
+                  </span>
+                  {/* Risk acknowledgement — only on this owner-only live surface. */}
+                  <BetaDisclaimer />
+                </>
               )}
             </div>
           </header>

--- a/web/components/beta-disclaimer.tsx
+++ b/web/components/beta-disclaimer.tsx
@@ -3,10 +3,12 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 
-// Bump the version suffix to re-prompt everyone (e.g. after a material change
-// to the terms). Acknowledgement is per-browser via localStorage — deliberately
-// lightweight; it's a beta notice, not a signed agreement.
-const ACK_KEY = "alphamolt_beta_ack_v1";
+// Risk acknowledgement for the SECRET live (real-money / Alpaca) portfolio
+// feature — rendered only on the surfaces that expose it, not site-wide.
+// Bump the version suffix to re-prompt everyone after a material wording
+// change. Per-browser via localStorage — deliberately lightweight; it's an
+// in-group beta notice, not a signed agreement.
+const ACK_KEY = "alphamolt_live_risk_ack_v1";
 
 export default function BetaDisclaimer() {
   // Start "acknowledged" so the server render and first client render both emit
@@ -52,24 +54,25 @@ export default function BetaDisclaimer() {
         }}
       >
         <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-orange)]/40 bg-[var(--color-orange)]/[0.08] px-2.5 py-1 text-[11px] font-mono font-bold uppercase tracking-[0.14em] text-[var(--color-orange)]">
-          Beta
+          Real money · private beta
         </span>
 
         <h2
           id="beta-disclaimer-title"
           className="mt-4 text-[20px] sm:text-[22px] font-bold tracking-[-0.02em] text-text leading-snug"
         >
-          Use entirely at your own risk
+          Live trading — entirely at your own risk
         </h2>
 
         <p className="mt-3 text-sm text-text-muted leading-relaxed">
-          AlphaMolt is a <strong className="text-text-dim">beta product</strong>.
-          Everything here — data, analysis, AI narratives, portfolios and any
-          live trading — is provided <em>as-is</em>, with no guarantee of
-          accuracy or availability. We bear{" "}
-          <strong className="text-text-dim">no responsibility</strong> for data
-          errors, losses, or any decisions made using it. Nothing here is
-          financial advice.
+          This is an <strong className="text-text-dim">experimental, private
+          beta</strong> feature that mirrors your portfolio to a{" "}
+          <strong className="text-text-dim">real brokerage account and places
+          real-money orders</strong>. It&rsquo;s provided <em>as-is</em>, with
+          no guarantee of data accuracy, execution, or availability. You use it{" "}
+          <strong className="text-text-dim">entirely at your own risk</strong>{" "}
+          — we bear no responsibility for any losses. Nothing here is financial
+          advice.
         </p>
 
         <p className="mt-3 text-xs text-text-muted leading-relaxed">

--- a/web/components/beta-disclaimer.tsx
+++ b/web/components/beta-disclaimer.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+// Bump the version suffix to re-prompt everyone (e.g. after a material change
+// to the terms). Acknowledgement is per-browser via localStorage — deliberately
+// lightweight; it's a beta notice, not a signed agreement.
+const ACK_KEY = "alphamolt_beta_ack_v1";
+
+export default function BetaDisclaimer() {
+  // Start "acknowledged" so the server render and first client render both emit
+  // nothing (no hydration mismatch, no flash for returning visitors). The
+  // effect then reveals the modal only for users who haven't accepted.
+  const [acknowledged, setAcknowledged] = useState(true);
+
+  useEffect(() => {
+    try {
+      setAcknowledged(window.localStorage.getItem(ACK_KEY) === "1");
+    } catch {
+      // localStorage blocked (private mode / disabled) — show it each visit
+      // rather than suppress it.
+      setAcknowledged(false);
+    }
+  }, []);
+
+  function accept() {
+    try {
+      window.localStorage.setItem(ACK_KEY, "1");
+    } catch {
+      /* non-fatal — dismiss for this session regardless */
+    }
+    setAcknowledged(true);
+  }
+
+  if (acknowledged) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="beta-disclaimer-title"
+      className="fixed inset-0 z-[100] flex items-end sm:items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+    >
+      <div
+        className="w-full max-w-[480px] rounded-2xl border p-6 sm:p-7"
+        style={{
+          background: "var(--color-bg-card)",
+          borderColor: "rgba(255,255,255,0.12)",
+          boxShadow:
+            "0 20px 60px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,255,255,0.05)",
+        }}
+      >
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--color-orange)]/40 bg-[var(--color-orange)]/[0.08] px-2.5 py-1 text-[11px] font-mono font-bold uppercase tracking-[0.14em] text-[var(--color-orange)]">
+          Beta
+        </span>
+
+        <h2
+          id="beta-disclaimer-title"
+          className="mt-4 text-[20px] sm:text-[22px] font-bold tracking-[-0.02em] text-text leading-snug"
+        >
+          Use entirely at your own risk
+        </h2>
+
+        <p className="mt-3 text-sm text-text-muted leading-relaxed">
+          AlphaMolt is a <strong className="text-text-dim">beta product</strong>.
+          Everything here — data, analysis, AI narratives, portfolios and any
+          live trading — is provided <em>as-is</em>, with no guarantee of
+          accuracy or availability. We bear{" "}
+          <strong className="text-text-dim">no responsibility</strong> for data
+          errors, losses, or any decisions made using it. Nothing here is
+          financial advice.
+        </p>
+
+        <p className="mt-3 text-xs text-text-muted leading-relaxed">
+          By continuing you accept this and our{" "}
+          <Link
+            href="/terms"
+            className="text-text-dim underline decoration-1 underline-offset-2 hover:text-text"
+          >
+            Terms
+          </Link>{" "}
+          and{" "}
+          <Link
+            href="/privacy"
+            className="text-text-dim underline decoration-1 underline-offset-2 hover:text-text"
+          >
+            Privacy
+          </Link>{" "}
+          policy.
+        </p>
+
+        <button
+          type="button"
+          onClick={accept}
+          autoFocus
+          className="mt-6 w-full rounded-lg border border-[var(--color-green)]/40 bg-[var(--color-green)]/[0.10] px-4 py-2.5 text-sm font-bold text-[var(--color-green)] hover:bg-[var(--color-green)]/[0.18] transition-colors"
+        >
+          I understand — continue
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Two things on top of the merged live-follower work: let a **second owner** (a trusted collaborator) run a live follower against their **own** Alpaca account, and gate the secret real-money feature behind a one-time risk acknowledgement.

## 1. Per-portfolio Alpaca accounts (multi-owner)

The spike resolved one shared Alpaca account from the bare `ALPACA_*` env, so `--mirror-all-live` would have pushed *every* live portfolio's targets into that single account. This adds per-portfolio credential routing with a hard anti-commingle rule.

- **`ALPACA_ACCOUNTS`** — a JSON map keyed by live slug → `{key_id, secret_key, base_url}`, resolved via `AlpacaExecutionBackend.for_slug(slug)`.
- **Authoritative when set:** a live portfolio trades only if it has an entry; unmapped → `AlpacaError` (never another owner's account). Malformed JSON raises rather than degrading to the shared account.
- **Anti-commingle when unset:** the loops (`--mirror-all-live`, `--sync-all-live`) only allow the bare-env shared account when exactly **one** live portfolio exists. The moment a second live portfolio appears, both are refused until explicitly mapped — so a collaborator's targets can never land in your account by accident.
- CLI shared backend is built lazily (account-level commands only); `sync` / `go-live` / `sync-all-live` and the heartbeat mirror all resolve per-slug.

> ⚠️ **Plumbing only — it moves no money.** Running real trades for *another person* remains gated on the FCA / solicitor go-live decision; this code doesn't lift that. It also means a collaborator's Alpaca secret lives in this repo's secrets.

## 2. Risk click-through for the secret live feature

A one-time "Real money · private beta — entirely at your own risk" modal (no guarantee of accuracy/execution, no responsibility for losses, not financial advice; links Terms + Privacy). Acknowledged per browser (`alphamolt_live_risk_ack_v1`).

- Scoped to the **owner-only live surfaces** — `LivePortfolioPanel` on `/account` and the `isOwner && mode === "live"` block on the portfolio detail page. The public site is untouched; the modal (and the feature's existence) never reaches a non-owner.
- Renders nothing on the server / first client render, so no hydration flash for returning visitors.

## Verification
- Credential resolution unit-tested: bare-env fallback only when single + no map; refusal when no map + multiple; map authoritative per-slug; unmapped slug refused even with fallback; malformed JSON raises; full `--mirror-all-live` loop refuses both live portfolios when two exist with no map (Alpaca never touched). All Python compiles.
- Web `tsc --noEmit` clean; `next build` compiled + TypeScript passed.

https://claude.ai/code/session_01HjprjAoq4PBL8ZWLJAgr9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjprjAoq4PBL8ZWLJAgr9N)_