### PR TITLE
leaderboard: WSB scoreboard variant for anonymous visitors

### DIFF
--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -2,14 +2,26 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import Nav from "@/components/nav";
 import LeaderboardTable from "@/components/leaderboard-table";
+import LeaderboardWsbBoard from "@/components/leaderboard-wsb-board";
 import ShareRow from "@/components/share-row";
 import {
   getLeaderboard,
   parseInitialPeriod,
 } from "@/lib/leaderboard-query";
+import {
+  getLeaderboardWsb,
+  type WsbAgentExtras,
+  type WsbRecentTrade,
+} from "@/lib/leaderboard-wsb-query";
+import type { LeaderboardRow } from "@/components/leaderboard-table";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { absoluteUrl } from "@/lib/site";
 
-export const revalidate = 300;
+// Auth-branched render — anonymous visitors get the WSB scoreboard,
+// signed-in users keep the data-dense table. Reading the session opts
+// the route into dynamic rendering; data is still cached at the query
+// layer (unstable_cache, 300s).
+export const dynamic = "force-dynamic";
 
 const META_TITLE = "Leaderboard — agent-powered portfolio rankings";
 const META_DESCRIPTION =
@@ -23,9 +35,6 @@ export const metadata: Metadata = {
     title: "AlphaMolt Leaderboard — agent-powered portfolio rankings",
     description:
       "Live leaderboard of AI agent-powered portfolios competing on rolling 30-day return, ranked alongside S&P 500 and MSCI World benchmarks.",
-    // Deliberately no `url` — X uses og:url as a cache key, and pinning
-    // it to the bare path makes ?v=N cache-busts a no-op (mirrors the
-    // /consensus fix in 90cdc5b).
     type: "website",
   },
   twitter: {
@@ -41,12 +50,294 @@ export default async function LeaderboardPage({
 }: {
   searchParams: Promise<{ period?: string | string[] }>;
 }) {
-  const { rows, latestDate } = await getLeaderboard();
   const initialPeriod = parseInitialPeriod((await searchParams).period);
 
-  // Bump ?v=N when the OG card design changes — X.com caches og:image
-  // per fetched URL, and the only reliable way to dislodge a stale image
-  // is a fresh query string.
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    // Signed-in users keep the existing data-dense view.
+    const { rows, latestDate } = await getLeaderboard();
+    return (
+      <SignedInLeaderboard
+        rows={rows}
+        latestDate={latestDate}
+        initialPeriod={initialPeriod}
+      />
+    );
+  }
+
+  // Anonymous visitor — WSB scoreboard.
+  const { rows, extrasByHandle, recentTrades, latestDate } =
+    await getLeaderboardWsb();
+  return (
+    <AnonymousWsbLeaderboard
+      rows={rows}
+      extrasByHandle={extrasByHandle}
+      recentTrades={recentTrades}
+      latestDate={latestDate}
+      initialPeriod={initialPeriod}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Anonymous / WSB variant
+// ---------------------------------------------------------------------------
+
+function AnonymousWsbLeaderboard({
+  rows,
+  extrasByHandle,
+  recentTrades,
+  latestDate,
+  initialPeriod,
+}: {
+  rows: LeaderboardRow[];
+  extrasByHandle: Record<string, WsbAgentExtras>;
+  recentTrades: WsbRecentTrade[];
+  latestDate: string | null;
+  initialPeriod: ReturnType<typeof parseInitialPeriod>;
+}) {
+  const hasData = rows.length > 0 && latestDate;
+  const biggestMover = pickBiggestMover(rows);
+  const downBad = pickDownBad(rows);
+  const tickerLine = formatTickerLine(recentTrades);
+
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 w-full">
+        <div className="max-w-[1100px] mx-auto w-full px-4 sm:px-6 py-8 sm:py-12">
+          {/* Eyebrow — LIVE with pulsing red dot. No "season" concept yet. */}
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-[11px] font-mono uppercase tracking-[0.06em] text-text-muted">
+            <span
+              aria-hidden
+              className="h-1.5 w-1.5 rounded-full bg-[var(--color-red)] motion-safe:animate-pulse"
+              style={{ boxShadow: "0 0 6px rgba(255,51,51,0.6)" }}
+            />
+            Live · marked to market daily
+          </span>
+
+          <h1 className="mt-4 text-[28px] sm:text-[40px] lg:text-[44px] font-black leading-[1.04] tracking-[-0.02em] text-text max-w-[22ch]">
+            Watch AI swarms{" "}
+            <span className="text-[var(--color-green)]">moon</span> &amp;{" "}
+            <span className="text-[var(--color-red)]">get liquidated</span>{" "}
+            with $1M of fake money.
+          </h1>
+          <p className="mt-3 text-base sm:text-[17px] text-text-muted leading-relaxed max-w-[48em]">
+            Every trade is public — real bags, real receipts, no
+            screenshots. Tap any swarm to see exactly what it&rsquo;s
+            holding right now.
+          </p>
+
+          {/* Callouts — biggest mover + down bad, today. */}
+          {(biggestMover || downBad) && (
+            <div className="mt-4 flex flex-wrap gap-2.5">
+              {biggestMover && (
+                <Callout
+                  label="Biggest mover today"
+                  name={biggestMover.display_name}
+                  pct={biggestMover.today_pct}
+                />
+              )}
+              {downBad && (
+                <Callout
+                  label="Down bad"
+                  name={downBad.display_name}
+                  pct={downBad.today_pct}
+                />
+              )}
+            </div>
+          )}
+
+          {/* Live recent-trades ticker. */}
+          {tickerLine && (
+            <div className="mt-4 flex items-center gap-2.5 rounded-lg border border-white/10 px-3 py-2 text-[12px] font-mono text-text-muted overflow-hidden whitespace-nowrap">
+              <span
+                aria-hidden
+                className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] motion-safe:animate-pulse shrink-0"
+                style={{ boxShadow: "0 0 6px rgba(0,255,65,0.6)" }}
+              />
+              <span className="overflow-hidden text-ellipsis">
+                {tickerLine}
+              </span>
+            </div>
+          )}
+
+          <div className="mt-6">
+            {!hasData ? (
+              <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-8 text-center">
+                <p className="font-mono text-sm text-text-muted">
+                  Snapshots warming up. Check back after the first daily
+                  mark-to-market.
+                </p>
+              </div>
+            ) : (
+              <LeaderboardWsbBoard
+                rows={rows}
+                extrasByHandle={extrasByHandle}
+                initialPeriod={initialPeriod}
+              />
+            )}
+          </div>
+
+          {/* CTAs — predict-not-bet for the compliance guardrail. */}
+          <div className="mt-5 flex flex-wrap items-center gap-2.5">
+            <Link
+              href="/signup"
+              data-cta="lb-build"
+              className="inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+              style={{
+                boxShadow:
+                  "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
+              }}
+            >
+              Build your swarm — free &rarr;
+            </Link>
+            <Link
+              href="/predict"
+              data-cta="lb-predict"
+              className="inline-flex items-center px-5 py-2.5 rounded-lg text-text text-sm font-medium transition-colors hover:bg-white/[0.06] focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40"
+              style={{
+                background:
+                  "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))",
+                border: "1px solid rgba(255,255,255,0.16)",
+                boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+              }}
+            >
+              Call this month&rsquo;s winner
+            </Link>
+            <ShareRow
+              url={`${absoluteUrl("/leaderboard")}?v=2`}
+              text={buildWsbShareText(rows, extrasByHandle)}
+            />
+          </div>
+
+          <p className="mt-4 text-[11px] text-text-muted leading-relaxed">
+            Paper trading only · not financial advice · for research and
+            education.
+          </p>
+        </div>
+      </main>
+    </>
+  );
+}
+
+function Callout({
+  label,
+  name,
+  pct,
+}: {
+  label: string;
+  name: string;
+  pct: number;
+}) {
+  const pos = pct >= 0;
+  return (
+    <div className="rounded-lg border border-white/10 px-3 py-2 bg-white/[0.02]">
+      <div className="text-[10px] font-mono uppercase tracking-[0.06em] text-text-muted">
+        {label}
+      </div>
+      <div className="mt-0.5 text-sm font-mono text-text">
+        {name}{" "}
+        <span
+          className={pos ? "text-[var(--color-green)]" : "text-[var(--color-red)]"}
+        >
+          {pos ? "▲ +" : "▼ "}
+          {pct.toFixed(1)}%
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Anonymous-variant helpers
+// ---------------------------------------------------------------------------
+
+function pickBiggestMover(
+  rows: LeaderboardRow[],
+): { display_name: string; today_pct: number } | null {
+  let best: { display_name: string; today_pct: number } | null = null;
+  for (const r of rows) {
+    if (r.kind !== "agent") continue;
+    const t = r.returns["1d"];
+    if (t == null) continue;
+    if (best == null || t > best.today_pct) {
+      best = { display_name: r.display_name, today_pct: t };
+    }
+  }
+  return best && best.today_pct > 0 ? best : null;
+}
+
+function pickDownBad(
+  rows: LeaderboardRow[],
+): { display_name: string; today_pct: number } | null {
+  let worst: { display_name: string; today_pct: number } | null = null;
+  for (const r of rows) {
+    if (r.kind !== "agent") continue;
+    const t = r.returns["1d"];
+    if (t == null) continue;
+    if (worst == null || t < worst.today_pct) {
+      worst = { display_name: r.display_name, today_pct: t };
+    }
+  }
+  return worst && worst.today_pct < 0 ? worst : null;
+}
+
+function formatTickerLine(trades: WsbRecentTrade[]): string | null {
+  if (trades.length === 0) return null;
+  const parts = trades.slice(0, 4).map((t) => {
+    const verb = t.side === "buy" ? "bought" : "sold";
+    return `${t.display_name} ${verb} ${t.ticker}`;
+  });
+  return parts.join(" · ");
+}
+
+function buildWsbShareText(
+  rows: LeaderboardRow[],
+  extrasByHandle: Record<string, WsbAgentExtras>,
+): string {
+  const top = [...rows]
+    .filter((r) => r.kind === "agent")
+    .sort((a, b) => {
+      const ar = a.returns["30d"] ?? extrasByHandle[a.handle as string]?.inception_pnl_pct ?? -Infinity;
+      const br = b.returns["30d"] ?? extrasByHandle[b.handle as string]?.inception_pnl_pct ?? -Infinity;
+      return (br as number) - (ar as number);
+    })
+    .slice(0, 3);
+  if (top.length === 0) {
+    return "Watch AI swarms moon or get liquidated with $1M of fake money. Real trades, real receipts, no screenshots @alphamolt";
+  }
+  const blurbs = top.map((r) => {
+    const name = r.kind === "agent" ? r.display_name : "—";
+    const ret =
+      r.returns["30d"] ??
+      (r.kind === "agent"
+        ? extrasByHandle[r.handle]?.inception_pnl_pct ?? null
+        : null);
+    const sign = ret != null && ret >= 0 ? "+" : "−";
+    const val = ret != null ? `${sign}${Math.abs(ret).toFixed(1)}%` : "—";
+    return `${name} (${val})`;
+  });
+  return `AI swarms running $1M paper portfolios head-to-head on @alphamolt. This month's top 3 returns: ${blurbs.join(", ")}. Real bags, real receipts:`;
+}
+
+// ---------------------------------------------------------------------------
+// Signed-in variant — the existing data-dense view, kept as-is.
+// ---------------------------------------------------------------------------
+
+function SignedInLeaderboard({
+  rows,
+  latestDate,
+  initialPeriod,
+}: {
+  rows: LeaderboardRow[];
+  latestDate: string | null;
+  initialPeriod: ReturnType<typeof parseInitialPeriod>;
+}) {
   const shareUrl = `${absoluteUrl("/leaderboard")}?v=1`;
   const top3 = topByPeriod(rows, "30d", 3);
   const shareText = buildShareText(top3);
@@ -125,9 +416,6 @@ export default async function LeaderboardPage({
   );
 }
 
-// Cyan-accented "compete" card — mirrors the homepage's gradient-card
-// treatment (BuildYourAgent / StrategyCard) so the two pages read as one
-// product.
 function CompeteCard({
   shareUrl,
   shareText,
@@ -157,14 +445,14 @@ function CompeteCard({
       <div className="flex flex-wrap items-center gap-2.5">
         <ShareRow url={shareUrl} text={shareText} />
         <Link
-          href="/login"
+          href="/account"
           className="inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight whitespace-nowrap transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
           style={{
             boxShadow:
               "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
           }}
         >
-          Set Up Your Portfolio &rarr;
+          Manage your portfolio &rarr;
         </Link>
       </div>
     </div>
@@ -172,7 +460,7 @@ function CompeteCard({
 }
 
 function topByPeriod(
-  rows: Awaited<ReturnType<typeof getLeaderboard>>["rows"],
+  rows: LeaderboardRow[],
   period: "1d" | "1w" | "30d" | "ytd" | "1yr",
   n: number,
 ) {
@@ -182,9 +470,7 @@ function topByPeriod(
     .slice(0, n);
 }
 
-function buildShareText(
-  top: Awaited<ReturnType<typeof getLeaderboard>>["rows"],
-): string {
+function buildShareText(top: LeaderboardRow[]): string {
   if (top.length === 0) {
     return "AI agent-powered portfolios trading head-to-head against SPY & MSCI World on @alphamolt — see who's compounding capital and who's blowing up. Live leaderboard:";
   }

--- a/web/components/leaderboard-wsb-board.tsx
+++ b/web/components/leaderboard-wsb-board.tsx
@@ -1,0 +1,501 @@
+"use client";
+
+/**
+ * WSB-variant leaderboard table for anonymous visitors.
+ *
+ * Six columns (rank, swarm, sparkline, return, today, max pain). Period
+ * toggle re-sorts client-side from the pre-computed per-period payload.
+ * Whole-row click navigates to /portfolios/<handle> (existing route);
+ * the swarm name is a real anchor for progressive enhancement.
+ *
+ * Visual spec lives in /root/.claude/uploads/.../alphamolt-leaderboard-wsb-reference.html
+ * — token mapping: --cyan/--green/--red/--amber → CSS vars defined in
+ * globals.css.
+ */
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMemo, useTransition } from "react";
+import type {
+  LeaderboardRow,
+  LeaderboardAgentRow,
+  Period,
+} from "@/components/leaderboard-table";
+import type { WsbAgentExtras } from "@/lib/leaderboard-wsb-query";
+
+const PERIODS = ["1d", "1w", "30d", "ytd", "1yr"] as const;
+const PERIOD_LABELS: Record<Period, string> = {
+  "1d": "1D",
+  "1w": "1W",
+  "30d": "30D",
+  ytd: "YTD",
+  "1yr": "1YR",
+};
+
+const REKT_THRESHOLD_PCT = -15;
+
+interface Props {
+  rows: LeaderboardRow[];
+  extrasByHandle: Record<string, WsbAgentExtras>;
+  initialPeriod: Period;
+}
+
+export default function LeaderboardWsbBoard({
+  rows,
+  extrasByHandle,
+  initialPeriod,
+}: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
+  // URL is source of truth for the period — deep-links + back-nav restore.
+  const urlPeriod = parsePeriod(searchParams.get("period")) ?? initialPeriod;
+  const period = urlPeriod;
+
+  const sortedRows = useMemo(() => {
+    return [...rows].sort((a, b) => {
+      // Benchmarks always sit just below the agent block, ranked by return.
+      const ar = returnForRow(a, period, extrasByHandle);
+      const br = returnForRow(b, period, extrasByHandle);
+      return (br ?? -Infinity) - (ar ?? -Infinity);
+    });
+  }, [rows, period, extrasByHandle]);
+
+  function onSelect(p: Period) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (p === "30d") params.delete("period");
+    else params.set("period", p);
+    const qs = params.toString();
+    startTransition(() => {
+      router.replace(qs ? `/leaderboard?${qs}` : "/leaderboard", {
+        scroll: false,
+      });
+    });
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-1.5 mb-3">
+        <span className="font-mono text-[11px] uppercase tracking-[0.06em] text-text-muted mr-1.5">
+          Period
+        </span>
+        {PERIODS.map((p) => {
+          const active = p === period;
+          return (
+            <button
+              key={p}
+              type="button"
+              onClick={() => onSelect(p)}
+              aria-pressed={active}
+              className={`font-mono text-xs px-2.5 py-1 rounded-md transition-colors ${
+                active
+                  ? "bg-[var(--color-cyan)]/15 text-[var(--color-cyan)]"
+                  : "text-text-muted hover:text-text"
+              }`}
+            >
+              {PERIOD_LABELS[p]}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="overflow-x-auto rounded-2xl border border-white/10 bg-white/[0.02]">
+        <table
+          aria-label="AI swarm leaderboard"
+          className="w-full min-w-[640px]"
+        >
+          <thead>
+            <tr className="text-left">
+              <Th>#</Th>
+              <Th>Swarm</Th>
+              <Th align="center">{PERIOD_LABELS[period]}</Th>
+              <Th align="right">Return</Th>
+              <Th align="right">Today</Th>
+              <Th align="right">Max pain</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedRows.map((row, i) => {
+              if (row.kind === "benchmark") {
+                return (
+                  <BenchmarkRowView key={`b-${row.ticker}`} row={row} period={period} />
+                );
+              }
+              const extras = extrasByHandle[row.handle];
+              return (
+                <AgentRowView
+                  key={`a-${row.handle}`}
+                  rank={visualRank(sortedRows, i)}
+                  row={row}
+                  extras={extras}
+                  period={period}
+                />
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Row components
+// ---------------------------------------------------------------------------
+
+function AgentRowView({
+  rank,
+  row,
+  extras,
+  period,
+}: {
+  rank: number;
+  row: LeaderboardAgentRow;
+  extras: WsbAgentExtras | undefined;
+  period: Period;
+}) {
+  const { displayReturn, ageBadge } = pickReturn(row, extras, period);
+  const today = row.returns["1d"];
+  const drawdown = extras?.drawdownByPeriod[period] ?? null;
+  const spark = extras?.sparklineByPeriod[period] ?? null;
+  const trend = extras?.trendByPeriod[period] ?? "flat";
+  const isRekt =
+    displayReturn != null && displayReturn <= REKT_THRESHOLD_PCT;
+
+  return (
+    <tr className="border-t border-white/[0.06] hover:bg-white/[0.025] transition-colors group">
+      <td className="px-4 py-2.5 font-mono text-[13px] text-text whitespace-nowrap">
+        {rank}
+      </td>
+      <td className="px-4 py-2.5">
+        <Link
+          href={`/portfolios/${encodeURIComponent(row.handle)}`}
+          className="flex items-center gap-2.5 min-w-0"
+        >
+          <Avatar handle={row.handle} display_name={row.display_name} />
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-baseline gap-1.5">
+              <span className="text-[13px] font-medium text-text group-hover:text-[var(--color-cyan)] transition-colors truncate">
+                {row.display_name}
+              </span>
+              {row.is_house_agent && <Tag tone="house">HOUSE</Tag>}
+              {isRekt && <Tag tone="rekt">REKT</Tag>}
+            </div>
+            <span className="font-mono text-[11px] text-text-muted">
+              @{row.handle}
+            </span>
+          </div>
+        </Link>
+      </td>
+      <td className="px-4 py-2.5 text-center">
+        <Sparkline points={spark} trend={trend} />
+      </td>
+      <td className="px-4 py-2.5 text-right">
+        <ReturnCell value={displayReturn} ageBadge={ageBadge} />
+      </td>
+      <td
+        className={`px-4 py-2.5 text-right font-mono ${chgColor(today)}`}
+      >
+        {fmtPct(today, { signed: true })}
+      </td>
+      <td className="px-4 py-2.5 text-right font-mono text-text-muted">
+        {drawdown != null && drawdown < 0
+          ? `${drawdown.toFixed(0)}%`
+          : "—"}
+      </td>
+    </tr>
+  );
+}
+
+function BenchmarkRowView({
+  row,
+  period,
+}: {
+  row: Extract<LeaderboardRow, { kind: "benchmark" }>;
+  period: Period;
+}) {
+  const r = row.returns[period];
+  const today = row.returns["1d"];
+  return (
+    <tr className="border-t border-white/[0.06] bg-[var(--color-orange)]/[0.04]">
+      <td className="px-4 py-2.5 font-mono text-[var(--color-orange)] text-center">
+        ·
+      </td>
+      <td className="px-4 py-2.5">
+        <div className="flex items-center gap-2.5 min-w-0">
+          <Avatar
+            handle={row.ticker}
+            display_name={row.display_name}
+            tone="amber"
+          />
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-baseline gap-1.5">
+              <span className="text-[13px] font-medium text-text-muted">
+                {row.display_name}
+              </span>
+              <Tag tone="index">INDEX</Tag>
+            </div>
+            <span className="font-mono text-[11px] text-text-muted">
+              the thing to beat
+            </span>
+          </div>
+        </div>
+      </td>
+      <td className="px-4 py-2.5 text-center">
+        <Sparkline points={null} trend="flat" />
+      </td>
+      <td className="px-4 py-2.5 text-right">
+        <span className="font-mono text-[15px] text-text-muted">
+          {fmtPct(r, { signed: true }) ?? "—"}
+        </span>
+      </td>
+      <td className="px-4 py-2.5 text-right font-mono text-text-muted">
+        {fmtPct(today, { signed: true }) ?? "—"}
+      </td>
+      <td className="px-4 py-2.5 text-right font-mono text-text-muted">—</td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pieces
+// ---------------------------------------------------------------------------
+
+function Th({
+  children,
+  align = "left",
+}: {
+  children: React.ReactNode;
+  align?: "left" | "right" | "center";
+}) {
+  const cls =
+    align === "right"
+      ? "text-right"
+      : align === "center"
+        ? "text-center"
+        : "text-left";
+  return (
+    <th
+      className={`px-4 py-2.5 font-mono text-[11px] uppercase tracking-[0.06em] text-text-muted font-normal ${cls}`}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Avatar({
+  handle,
+  display_name,
+  tone = "auto",
+}: {
+  handle: string;
+  display_name: string;
+  tone?: "auto" | "amber";
+}) {
+  const initials = monogramInitials(display_name || handle);
+  const color = tone === "amber" ? "rgba(240,181,74,0.18)" : colorForHandle(handle);
+  const fg = tone === "amber" ? "var(--color-orange)" : "#06141a";
+  return (
+    <span
+      aria-hidden
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[11px] font-bold"
+      style={{ background: color, color: fg }}
+    >
+      {initials}
+    </span>
+  );
+}
+
+function Tag({
+  tone,
+  children,
+}: {
+  tone: "house" | "index" | "rekt";
+  children: React.ReactNode;
+}) {
+  const styles: Record<typeof tone, string> = {
+    house: "bg-white/[0.06] text-text-muted",
+    index: "bg-[var(--color-orange)]/[0.14] text-[var(--color-orange)]",
+    rekt: "bg-[var(--color-red)]/[0.16] text-[var(--color-red)]",
+  };
+  return (
+    <span
+      className={`font-mono text-[10px] tracking-[0.03em] px-1.5 py-px rounded ${styles[tone]}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Sparkline({
+  points,
+  trend,
+}: {
+  points: number[] | null;
+  trend: "up" | "down" | "flat";
+}) {
+  if (!points || points.length < 2) {
+    return (
+      <svg
+        viewBox="0 0 54 18"
+        width={54}
+        height={18}
+        aria-hidden
+        className="inline-block"
+      >
+        <line x1="0" y1="9" x2="54" y2="9" stroke="#5e696f" strokeWidth="1.2" />
+      </svg>
+    );
+  }
+  const stroke =
+    trend === "down"
+      ? "var(--color-red)"
+      : trend === "up"
+        ? "var(--color-green)"
+        : "#5e696f";
+  const w = 54;
+  const h = 18;
+  const stepX = w / (points.length - 1);
+  const pts = points
+    .map((y, i) => `${(i * stepX).toFixed(2)},${(h - 2 - y * (h - 4)).toFixed(2)}`)
+    .join(" ");
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      width={w}
+      height={h}
+      aria-hidden
+      className="inline-block"
+    >
+      <polyline fill="none" stroke={stroke} strokeWidth="1.5" points={pts} />
+    </svg>
+  );
+}
+
+function ReturnCell({
+  value,
+  ageBadge,
+}: {
+  value: number | null;
+  ageBadge: string | null;
+}) {
+  if (value == null) return <span className="text-text-muted">—</span>;
+  const pos = value >= 0;
+  return (
+    <span
+      className={`font-mono text-[15px] font-semibold ${
+        pos ? "text-[var(--color-green)]" : "text-[var(--color-red)]"
+      }`}
+    >
+      {pos ? "+" : ""}
+      {value.toFixed(1)}%
+      {ageBadge && (
+        <span className="ml-1 text-[10px] font-normal text-text-muted">
+          {ageBadge}
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick the return value to render for an agent row at the chosen period.
+ * Per the brief: never show "calculating" — when the portfolio is younger
+ * than the window, fall back to the since-inception return and surface
+ * the age as an inline badge ("+12.2% 18d").
+ */
+function pickReturn(
+  row: LeaderboardAgentRow,
+  extras: WsbAgentExtras | undefined,
+  period: Period,
+): { displayReturn: number | null; ageBadge: string | null } {
+  const periodReturn = row.returns[period];
+  if (periodReturn != null) {
+    return { displayReturn: periodReturn, ageBadge: null };
+  }
+  // Fallback: since-inception + age tag.
+  if (extras?.inception_pnl_pct != null && extras.age_days > 0) {
+    return {
+      displayReturn: extras.inception_pnl_pct,
+      ageBadge: `${extras.age_days}d`,
+    };
+  }
+  return { displayReturn: null, ageBadge: null };
+}
+
+function returnForRow(
+  row: LeaderboardRow,
+  period: Period,
+  extrasByHandle: Record<string, WsbAgentExtras>,
+): number | null {
+  if (row.kind === "benchmark") return row.returns[period];
+  const periodReturn = row.returns[period];
+  if (periodReturn != null) return periodReturn;
+  return extrasByHandle[row.handle]?.inception_pnl_pct ?? null;
+}
+
+function visualRank(rows: LeaderboardRow[], indexInList: number): number {
+  // Benchmark rows do not consume a rank slot — their "·" indicator is
+  // shown by the row itself. Recompute the visible rank by counting how
+  // many agent rows precede this index.
+  let n = 0;
+  for (let i = 0; i <= indexInList; i++) {
+    if (rows[i].kind === "agent") n++;
+  }
+  return n;
+}
+
+function chgColor(v: number | null): string {
+  if (v == null) return "text-text-muted";
+  if (v > 0) return "text-[var(--color-green)]";
+  if (v < 0) return "text-[var(--color-red)]";
+  return "text-text-muted";
+}
+
+function fmtPct(
+  v: number | null,
+  opts: { signed?: boolean } = {},
+): string | null {
+  if (v == null) return null;
+  const sign = opts.signed && v >= 0 ? "+" : "";
+  return `${sign}${v.toFixed(1)}%`;
+}
+
+function monogramInitials(name: string): string {
+  const parts = name.trim().split(/[\s\-_]+/).filter(Boolean);
+  if (parts.length === 0) return "??";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
+}
+
+function colorForHandle(handle: string): string {
+  // Deterministic palette pick per handle — matches the reference's
+  // per-swarm colour idea without hardcoding any one swarm's hue.
+  const palette = [
+    "#26e0f0",
+    "#37db80",
+    "#f0584a",
+    "#f0b54a",
+    "#a78bfa",
+    "#f471b5",
+    "#60a5fa",
+    "#34d399",
+  ];
+  let hash = 0;
+  for (let i = 0; i < handle.length; i++) {
+    hash = (hash * 31 + handle.charCodeAt(i)) >>> 0;
+  }
+  return palette[hash % palette.length];
+}
+
+function parsePeriod(raw: string | null): Period | null {
+  if (raw === "1d" || raw === "1w" || raw === "30d" || raw === "ytd" || raw === "1yr") {
+    return raw;
+  }
+  return null;
+}

--- a/web/lib/leaderboard-wsb-query.ts
+++ b/web/lib/leaderboard-wsb-query.ts
@@ -1,0 +1,332 @@
+/**
+ * Server-side query for the WSB-variant /leaderboard (anonymous visitors).
+ *
+ * Builds on the existing getLeaderboard() — same agent/benchmark rows — and
+ * enriches each agent with the extras the WSB design needs: max drawdown
+ * per period, a tiny normalised sparkline per period, since-inception
+ * return + age (so young portfolios show "+12.2% · 18d" instead of
+ * "calculating"), and a few page-level extras (biggest mover / down bad
+ * callout picks, the recent-trades ticker).
+ *
+ * Period sorting + drawdown comparison happens client-side from the
+ * payload below.
+ */
+
+import { unstable_cache } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+import { getLeaderboard } from "@/lib/leaderboard-query";
+import type {
+  LeaderboardRow,
+  Period,
+} from "@/components/leaderboard-table";
+
+const PERIODS: readonly Period[] = ["1d", "1w", "30d", "ytd", "1yr"];
+
+const PERIOD_DAYS: Record<Period, number> = {
+  "1d": 1,
+  "1w": 7,
+  "30d": 30,
+  ytd: 0, // special-cased
+  "1yr": 365,
+};
+
+// Sparkline target length. Small enough to render as a tight inline SVG;
+// the source series gets resampled to this count via even-stride pick.
+const SPARK_POINTS = 8;
+
+// REKT threshold per the brief — any portfolio whose 30d (or selected
+// period) return is below this gets the REKT tag. The threshold itself
+// lives on the client; the query just emits the raw returns.
+export const REKT_THRESHOLD_PCT = -15;
+
+export interface WsbAgentExtras {
+  handle: string;
+  /** Max drawdown over the period (negative %). null if window too young. */
+  drawdownByPeriod: Record<Period, number | null>;
+  /** Normalised 0-1 sparkline per period (SPARK_POINTS entries). */
+  sparklineByPeriod: Record<Period, number[] | null>;
+  /** Whole-life trend direction for the sparkline colour cue. */
+  trendByPeriod: Record<Period, "up" | "down" | "flat">;
+  /** Days since the portfolio's inception. */
+  age_days: number;
+  /** Since-inception pnl% — fallback for periods younger than the window. */
+  inception_pnl_pct: number | null;
+}
+
+export interface WsbRecentTrade {
+  handle: string;
+  display_name: string;
+  side: "buy" | "sell";
+  ticker: string;
+  quantity: number;
+  executed_at: string;
+}
+
+export interface LeaderboardWsbData {
+  rows: LeaderboardRow[];
+  extrasByHandle: Record<string, WsbAgentExtras>;
+  recentTrades: WsbRecentTrade[];
+  latestDate: string | null;
+}
+
+async function fetchLeaderboardWsb(): Promise<LeaderboardWsbData> {
+  const { rows, latestDate } = await getLeaderboard();
+
+  const agentHandles = rows
+    .filter((r): r is Extract<LeaderboardRow, { kind: "agent" }> => r.kind === "agent")
+    .map((r) => r.handle);
+
+  if (agentHandles.length === 0) {
+    return { rows, extrasByHandle: {}, recentTrades: [], latestDate };
+  }
+
+  const [snapshotsByHandle, recentTrades] = await Promise.all([
+    fetchAgentSnapshots(agentHandles),
+    fetchRecentTrades(),
+  ]);
+
+  const today = new Date();
+  const extrasByHandle: Record<string, WsbAgentExtras> = {};
+
+  for (const handle of agentHandles) {
+    const snapshots = snapshotsByHandle.get(handle) ?? [];
+    extrasByHandle[handle] = buildExtras(handle, snapshots, today);
+  }
+
+  return { rows, extrasByHandle, recentTrades, latestDate };
+}
+
+interface Snapshot {
+  date: string;
+  total_value_usd: number;
+}
+
+/**
+ * Pull the last 365 days of mark-to-market snapshots for every agent on
+ * the leaderboard in one bulk query, grouped by handle. The view only
+ * exposes the latest row per agent, but the underlying history table is
+ * cheap to slice on.
+ */
+async function fetchAgentSnapshots(
+  handles: string[],
+): Promise<Map<string, Snapshot[]>> {
+  const out = new Map<string, Snapshot[]>();
+  if (handles.length === 0) return out;
+
+  const supabase = getSupabase();
+  const { data: idRows, error: idErr } = await supabase
+    .from("agents")
+    .select("id, handle")
+    .in("handle", handles);
+  if (idErr || !idRows) {
+    if (idErr) console.error("WSB leaderboard: agents id lookup failed:", idErr);
+    return out;
+  }
+  const handleById = new Map<string, string>();
+  const agentIds: string[] = [];
+  for (const r of idRows as { id: string; handle: string }[]) {
+    handleById.set(r.id, r.handle);
+    agentIds.push(r.id);
+  }
+  if (agentIds.length === 0) return out;
+
+  const since = new Date();
+  since.setUTCDate(since.getUTCDate() - 365);
+  const sinceIso = since.toISOString().slice(0, 10);
+
+  const { data: histRows, error: histErr } = await supabase
+    .from("agent_portfolio_history")
+    .select("agent_id, snapshot_date, total_value_usd")
+    .in("agent_id", agentIds)
+    .gte("snapshot_date", sinceIso)
+    .order("snapshot_date", { ascending: true });
+  if (histErr || !histRows) {
+    if (histErr) console.error("WSB leaderboard: history fetch failed:", histErr);
+    return out;
+  }
+
+  for (const r of histRows as {
+    agent_id: string;
+    snapshot_date: string;
+    total_value_usd: number | string;
+  }[]) {
+    const handle = handleById.get(r.agent_id);
+    if (!handle) continue;
+    let bucket = out.get(handle);
+    if (!bucket) {
+      bucket = [];
+      out.set(handle, bucket);
+    }
+    bucket.push({
+      date: r.snapshot_date,
+      total_value_usd: Number(r.total_value_usd),
+    });
+  }
+  return out;
+}
+
+function buildExtras(
+  handle: string,
+  snapshots: Snapshot[],
+  today: Date,
+): WsbAgentExtras {
+  const inception_pnl_pct = computeInceptionPnlPct(snapshots);
+  const age_days =
+    snapshots.length > 0
+      ? Math.max(
+          0,
+          Math.floor(
+            (today.getTime() -
+              new Date(`${snapshots[0].date}T00:00:00Z`).getTime()) /
+              86_400_000,
+          ),
+        )
+      : 0;
+
+  const drawdownByPeriod: Record<Period, number | null> = {
+    "1d": null,
+    "1w": null,
+    "30d": null,
+    ytd: null,
+    "1yr": null,
+  };
+  const sparklineByPeriod: Record<Period, number[] | null> = {
+    "1d": null,
+    "1w": null,
+    "30d": null,
+    ytd: null,
+    "1yr": null,
+  };
+  const trendByPeriod: Record<Period, "up" | "down" | "flat"> = {
+    "1d": "flat",
+    "1w": "flat",
+    "30d": "flat",
+    ytd: "flat",
+    "1yr": "flat",
+  };
+
+  for (const p of PERIODS) {
+    const slice = sliceForPeriod(snapshots, p, today);
+    if (slice.length === 0) continue;
+    drawdownByPeriod[p] = maxDrawdownPct(slice);
+    sparklineByPeriod[p] = resample(slice.map((s) => s.total_value_usd));
+    const first = slice[0].total_value_usd;
+    const last = slice[slice.length - 1].total_value_usd;
+    trendByPeriod[p] = last > first ? "up" : last < first ? "down" : "flat";
+  }
+
+  return {
+    handle,
+    drawdownByPeriod,
+    sparklineByPeriod,
+    trendByPeriod,
+    age_days,
+    inception_pnl_pct,
+  };
+}
+
+function sliceForPeriod(
+  snapshots: Snapshot[],
+  period: Period,
+  today: Date,
+): Snapshot[] {
+  if (snapshots.length === 0) return [];
+  if (period === "ytd") {
+    const yearStart = `${today.getUTCFullYear()}-01-01`;
+    return snapshots.filter((s) => s.date >= yearStart);
+  }
+  const days = PERIOD_DAYS[period];
+  const cutoff = new Date(today);
+  cutoff.setUTCDate(cutoff.getUTCDate() - days);
+  const cutoffIso = cutoff.toISOString().slice(0, 10);
+  return snapshots.filter((s) => s.date >= cutoffIso);
+}
+
+/** Max peak-to-trough drawdown over the slice as a negative percent. */
+function maxDrawdownPct(slice: Snapshot[]): number {
+  if (slice.length < 2) return 0;
+  let peak = slice[0].total_value_usd;
+  let worst = 0;
+  for (const s of slice) {
+    if (s.total_value_usd > peak) peak = s.total_value_usd;
+    if (peak > 0) {
+      const dd = ((s.total_value_usd - peak) / peak) * 100;
+      if (dd < worst) worst = dd;
+    }
+  }
+  return Number(worst.toFixed(2));
+}
+
+/** Resample to SPARK_POINTS via even-stride sampling, then normalise 0-1. */
+function resample(values: number[]): number[] | null {
+  if (values.length === 0) return null;
+  if (values.length === 1) return Array(SPARK_POINTS).fill(0.5);
+
+  const picked: number[] = [];
+  for (let i = 0; i < SPARK_POINTS; i++) {
+    const t = i / (SPARK_POINTS - 1);
+    const idx = Math.min(values.length - 1, Math.round(t * (values.length - 1)));
+    picked.push(values[idx]);
+  }
+  const min = Math.min(...picked);
+  const max = Math.max(...picked);
+  const span = max - min;
+  if (span <= 0) return picked.map(() => 0.5);
+  return picked.map((v) => (v - min) / span);
+}
+
+function computeInceptionPnlPct(snapshots: Snapshot[]): number | null {
+  if (snapshots.length < 2) return null;
+  const first = snapshots[0].total_value_usd;
+  const last = snapshots[snapshots.length - 1].total_value_usd;
+  if (first <= 0) return null;
+  return Number((((last - first) / first) * 100).toFixed(2));
+}
+
+/**
+ * Pull the N most recent trades across every public portfolio for the
+ * live ticker. Joined to agents for the display name. Bounded query —
+ * we sort desc and take the top slice in memory after a single LIMIT.
+ */
+async function fetchRecentTrades(limit = 6): Promise<WsbRecentTrade[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("agent_trades")
+    .select(
+      "side, ticker, quantity, executed_at, agents:agent_id(handle, display_name)",
+    )
+    .order("executed_at", { ascending: false })
+    .limit(limit);
+  if (error || !data) {
+    if (error) console.error("WSB leaderboard: recent trades fetch failed:", error);
+    return [];
+  }
+
+  return (data as unknown as RawTradeRow[])
+    .filter((t) => t.agents)
+    .map((t) => ({
+      handle: t.agents!.handle,
+      display_name: t.agents!.display_name,
+      side: t.side,
+      ticker: t.ticker,
+      quantity: Number(t.quantity),
+      executed_at: t.executed_at,
+    }));
+}
+
+interface RawTradeRow {
+  side: "buy" | "sell";
+  ticker: string;
+  quantity: number | string;
+  executed_at: string;
+  agents: { handle: string; display_name: string } | null;
+}
+
+export const getLeaderboardWsb = unstable_cache(
+  fetchLeaderboardWsb,
+  ["leaderboard-wsb-v1"],
+  {
+    revalidate: 300,
+    tags: ["leaderboard"],
+  },
+);


### PR DESCRIPTION
## Summary

Implements the WSB-facing leaderboard brief. Auth-branched at the route — signed-in users keep the existing data-dense table; anonymous visitors land on the new scoreboard.

**New WSB layout (anonymous only):**
- Eyebrow "Live · marked to market daily" with pulsing red dot (season counter deferred — open question in the brief, no schema concept yet)
- H1 "Watch AI swarms **moon** & **get liquidated** with $1M of fake money." (green/red accents)
- Biggest mover / Down bad callouts (today's best+worst)
- Live trade ticker — 4 most recent `agent_trades` joined to agents
- 6-column scoreboard: # · Swarm · Sparkline · Return · Today · Max pain
- REKT tag at return ≤ -15% on the selected period
- Young portfolios show since-inception % + age tag (`+12.2% 18d`) — never "calculating" per brief
- Row click → `/portfolios/<handle>` (existing route — brief's `/swarm/<handle>` is just WSB-voice rebrand)
- CTAs: cyan-glow "Build your swarm — free →" / ghost "Call this month's winner" (predict-not-bet per compliance guardrail) / ShareRow

**Data layer (`lib/leaderboard-wsb-query.ts`):**
Wraps `getLeaderboard()` and adds per-agent extras computed from `agent_portfolio_history` over 365d: max drawdown per period (peak-to-trough), 8-point normalised sparkline per period, `age_days`, `inception_pnl_pct`. Plus the recent-trades query for the ticker. `unstable_cache` 300s, `leaderboard` tag.

**Compliance guardrails honoured:** no return/risk promises, predict-not-bet CTA, paper-only disclaimer visible, losers intentionally surfaced (red rows + REKT tag + DOWN BAD callout).

**A11y:** real `<table>`/`<thead>`/`<th>`, single h1, motion gated by `prefers-reduced-motion`, ▲/▼ arrows back colour for colour-blind viewers, sparklines `aria-hidden`.

**Deferred to follow-up** (called out in the brief's open questions):
- `rank_delta` vs yesterday — requires fetching prior-day per-period rankings; v1 ships without ▲n/▼n indicator
- Season concept — eyebrow drops "SEASON ENDS IN Nd" until there's a seasons schema

## Test plan

- [ ] Hit `/leaderboard` logged out — see the WSB scoreboard with new copy, six columns, callouts, ticker
- [ ] Hit `/leaderboard` logged in — see the existing data-dense table (unchanged)
- [ ] Period toggle (1D / 1W / 30D / YTD / 1YR) — re-sorts client-side, sparkline + max pain + return all update
- [ ] Click a row — lands on `/portfolios/<handle>`
- [ ] Click "Build your swarm" → `/signup` ; "Call this month's winner" → `/predict`
- [ ] Verify a portfolio whose 30d return is null (young portfolio) shows since-inception % + age tag, not "calculating"
- [ ] Verify any portfolio at ≤ -15% return shows REKT tag
- [ ] `prefers-reduced-motion: reduce` — pulse dots stop animating

https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq

---
_Generated by [Claude Code](https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq)_