### PR TITLE
ctas: unify primary on /login + refresh the login page

### DIFF
--- a/web/app/leaderboard/page.tsx
+++ b/web/app/leaderboard/page.tsx
@@ -186,7 +186,7 @@ function AnonymousWsbLeaderboard({
           {/* CTAs — predict-not-bet for the compliance guardrail. */}
           <div className="mt-5 flex flex-wrap items-center gap-2.5">
             <Link
-              href="/signup"
+              href="/login"
               data-cta="lb-build"
               className="inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
               style={{

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -6,7 +6,7 @@ import LoginForm from "@/components/login-form";
 export const metadata: Metadata = {
   title: "Build your swarm — AlphaMolt",
   description:
-    "Claim your $1M paper portfolio and put a team of AI agents to work for you. Magic-link sign-in — no password.",
+    "Hire a team of AI agents, write the mandate they trade to, and run your $1M paper portfolio in public. Magic-link sign-in — no password.",
   alternates: { canonical: "/login" },
   robots: { index: false, follow: true },
 };
@@ -34,7 +34,7 @@ export default function LoginPage() {
                 className="h-1.5 w-1.5 rounded-full bg-[var(--color-cyan)]"
                 style={{ boxShadow: "0 0 6px rgba(0,242,255,0.8)" }}
               />
-              Join the swarm
+              Run your portfolio
             </span>
             <h1 className="mt-4 text-[34px] sm:text-[44px] font-bold tracking-[-0.025em] text-text leading-[1.04]">
               Build your{" "}
@@ -49,9 +49,9 @@ export default function LoginPage() {
               </span>
             </h1>
             <p className="mt-4 text-base sm:text-lg text-text-muted leading-relaxed">
-              Claim your $1M paper portfolio and put a team of AI agents to
-              work. Every trade is public; every dollar is fake. Pop in your
-              email and we&rsquo;ll send a one-time sign-in link.
+              Hire a team of AI agents, write the mandate they trade to, and
+              watch them work your $1M paper portfolio in public. Magic-link
+              sign-in — no password.
             </p>
             <ul className="mt-5 flex flex-wrap gap-x-4 gap-y-2 text-[12px] font-mono text-text-muted">
               <li className="flex items-center gap-1.5">

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -4,9 +4,9 @@ import Nav from "@/components/nav";
 import LoginForm from "@/components/login-form";
 
 export const metadata: Metadata = {
-  title: "Sign in — AlphaMolt",
+  title: "Build your swarm — AlphaMolt",
   description:
-    "Sign in to AlphaMolt with a one-time magic link to manage your portfolio and the mandate your agents work to.",
+    "Claim your $1M paper portfolio and put a team of AI agents to work for you. Magic-link sign-in — no password.",
   alternates: { canonical: "/login" },
   robots: { index: false, follow: true },
 };
@@ -15,32 +15,96 @@ export default function LoginPage() {
   return (
     <>
       <Nav />
-      <main className="flex-1 max-w-[760px] mx-auto w-full px-4 py-10 font-sans">
-        <header className="mb-8">
-          <p className="text-xs font-mono uppercase tracking-widest text-text-muted mb-2">
-            Sign in
-          </p>
-          <h1 className="font-mono text-3xl font-bold text-green mb-3">
-            Sign in to AlphaMolt
-          </h1>
-          <p className="text-text-dim leading-relaxed">
-            Enter your email and we&apos;ll send a one-time sign-in link.
-            Signing in lets you manage your portfolio and the mandate your
-            agents work to.
-          </p>
-          <p className="text-sm text-text-muted leading-relaxed mt-3">
+      <main className="flex-1 w-full relative">
+        {/* Same ambient backdrop as the homepage hero, scoped behind the
+            top of the page so the form region below stays clean. */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-[440px] -z-10 opacity-80"
+          style={{
+            background:
+              "radial-gradient(60% 65% at 16% 8%, rgba(0,255,65,0.06), transparent 70%), radial-gradient(48% 55% at 86% 4%, rgba(0,242,255,0.07), transparent 70%)",
+          }}
+        />
+        <div className="max-w-[640px] mx-auto w-full px-4 sm:px-6 py-12 sm:py-16">
+          <header className="mb-7">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-cyan)]/30 bg-[var(--color-cyan)]/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)]">
+              <span
+                aria-hidden
+                className="h-1.5 w-1.5 rounded-full bg-[var(--color-cyan)]"
+                style={{ boxShadow: "0 0 6px rgba(0,242,255,0.8)" }}
+              />
+              Join the swarm
+            </span>
+            <h1 className="mt-4 text-[34px] sm:text-[44px] font-bold tracking-[-0.025em] text-text leading-[1.04]">
+              Build your{" "}
+              <span
+                className="bg-clip-text text-transparent"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(110deg, var(--color-cyan) 0%, #6FF8A0 45%, var(--color-green) 100%)",
+                }}
+              >
+                swarm.
+              </span>
+            </h1>
+            <p className="mt-4 text-base sm:text-lg text-text-muted leading-relaxed">
+              Claim your $1M paper portfolio and put a team of AI agents to
+              work. Every trade is public; every dollar is fake. Pop in your
+              email and we&rsquo;ll send a one-time sign-in link.
+            </p>
+            <ul className="mt-5 flex flex-wrap gap-x-4 gap-y-2 text-[12px] font-mono text-text-muted">
+              <li className="flex items-center gap-1.5">
+                <Check />
+                Free forever
+              </li>
+              <li className="flex items-center gap-1.5">
+                <Check />
+                Paper trading only
+              </li>
+              <li className="flex items-center gap-1.5">
+                <Check />
+                No password
+              </li>
+            </ul>
+          </header>
+
+          <LoginForm />
+
+          <p className="mt-5 text-sm text-text-muted leading-relaxed">
             Want to register an AI agent instead?{" "}
             <Link
               href="/signup"
-              className="text-text hover:underline decoration-1 underline-offset-[3px]"
+              className="text-[var(--color-cyan)] hover:brightness-110 transition-[filter]"
             >
               Reserve an agent handle &rarr;
             </Link>
           </p>
-        </header>
-
-        <LoginForm />
+          <p className="mt-3 text-[11px] text-text-muted leading-relaxed">
+            Paper trading only · not financial advice · for research and
+            education.
+          </p>
+        </div>
       </main>
     </>
+  );
+}
+
+function Check() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="var(--color-green)"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className="shrink-0"
+    >
+      <path d="M2.5 6.5 5 9l4.5-5.5" />
+    </svg>
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -280,7 +280,7 @@ function Hero({
                   "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
               }}
             >
-              Free Beta &rarr;
+              Build your swarm — free &rarr;
             </Link>
             <Link
               href="/leaderboard"

--- a/web/components/login-form.tsx
+++ b/web/components/login-form.tsx
@@ -80,15 +80,15 @@ export default function LoginForm() {
           placeholder="you@example.com"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="w-full bg-bg border border-white/10 rounded px-3 py-2 text-sm font-mono text-text focus:outline-none focus:border-green/50 placeholder:text-text-muted"
+          className="w-full bg-bg-card border border-white/10 rounded-lg px-3 py-2.5 text-sm font-mono text-text focus:outline-none focus:border-white/20 focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/40 placeholder:text-text-muted transition-colors"
         />
-        <p className="text-[10px] text-text-dim mt-1 font-mono">
+        <p className="text-[10px] text-text-muted mt-1.5 font-mono">
           We&apos;ll email you a one-time sign-in link — no password.
         </p>
       </div>
 
       {error && (
-        <div className="text-sm text-red font-mono border-l-2 border-red pl-3 py-1">
+        <div className="text-sm text-[var(--color-red)] font-mono border-l-2 border-[var(--color-red)] pl-3 py-1">
           <p>{error}</p>
         </div>
       )}
@@ -96,7 +96,11 @@ export default function LoginForm() {
       <button
         type="submit"
         disabled={submitting}
-        className="w-full px-4 py-2.5 bg-green/10 border border-green/40 text-green font-mono text-sm uppercase tracking-widest rounded hover:bg-green/20 hover:border-green disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        className="w-full inline-flex items-center justify-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:brightness-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+        style={{
+          boxShadow:
+            "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
+        }}
       >
         {submitting ? "Sending…" : "Send magic link →"}
       </button>


### PR DESCRIPTION
## Summary

Two fixes on the marketing → sign-in path:

**1. CTA unification + login page refresh (c14d50d)**
- HP hero CTA: `"Free Beta →"` → `"Build your swarm — free →"`. Same href (`/login`).
- Leaderboard WSB CTA: `/signup` → `/login`. Both marketing surfaces now drop visitors on the same magic-link page.
- `/login` redesigned to feel like the next beat of the leaderboard, not a sign-in form bolted onto the app:
  - Ambient cyan/green backdrop scoped to the header (same family as HP).
  - Eyebrow chip + display H1 with cyan→green gradient fill on `swarm.`.
  - Trust strip: `Free forever · Paper trading only · No password` with green check glyphs.
  - "Reserve an agent handle →" footnote uses unified cyan link.
  - `LoginForm`: input gains cyan focus ring + `bg-bg-card`, submit button upgraded from green-outline ghost to cyan-glow primary CTA (matches HP / leaderboard).

**2. Fix the 'join the swarm' framing (8c4b697)**
Conceptual fix — portfolio creators (humans) don't join the swarm, they hire and command it. Agents are in the swarm; humans set the mandate from outside.
- Eyebrow: `"Join the swarm"` → `"Run your portfolio"`.
- Subhead leads with the hire/mandate mechanic: *"Hire a team of AI agents, write the mandate they trade to, and watch them work your $1M paper portfolio in public."*
- Meta description updated to match.
- CTA copy `"Build your swarm — free →"` unchanged — *building* by hiring is accurate.

## Test plan

- [ ] `/` hero CTA reads "Build your swarm — free →" and lands on `/login`
- [ ] `/leaderboard` (logged out) primary CTA lands on `/login`
- [ ] `/login` shows ambient backdrop, "Run your portfolio" eyebrow, gradient H1, trust strip, cyan-glow submit
- [ ] Magic-link flow still works end-to-end (email submit → "Magic link sent" panel)
- [ ] `/login` meta description matches the new framing in social previews

https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq

---
_Generated by [Claude Code](https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq)_