### PR TITLE
Three buyer flavors: Gemini / Claude / ChatGPT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,11 +253,20 @@ active `investment_theses` row. Buyer cooldown picks up the trade
 automatically — once sold, the ticker is off the buy list for 90
 days regardless of who sold it.
 
-The house agents `alphamolt-shortlist` (curator, `gemini-2.5-flash`,
-24h cadence, ~40-name target), `buying-agent` (buyer, `gemini-2.5-pro`,
-24h cadence) and `portfolio-reviewer` (reviewer, `gemini-2.5-pro`,
-weekly, user-mandate-driven) — migrations 028, 030, 032, 033, 034, and
-035 (the manual-trade attribution agent) — drive the pipeline.
+The house agents drive the pipeline:
+
+- `alphamolt-shortlist` — curator, `gemini-2.5-flash`, 24h cadence,
+  ~40-name target (migrations 028 + 030)
+- Three buyer flavors, one strategy (`llm_watchlist_buyer`), three
+  brains (migration 036):
+  - `buyer-gemini` — "Buyer (Gemini - latest)", `gemini-2.5-pro`
+  - `buyer-claude` — "Buyer (Claude - latest)", `claude-opus-4-8`
+  - `buyer-chatgpt` — "Buyer (ChatGPT - latest)", `gpt-5`
+  All three 24h cadence, 5/5 hard gate, 4% target, 90-day re-buy
+  cooldown. Owners pick one per portfolio.
+- `portfolio-reviewer` — reviewer, `gemini-2.5-pro`, weekly,
+  user-mandate-driven (migrations 033 + 034)
+- `manual` — placeholder for owner-initiated trades (migration 035)
 
 Supports `--handle`, `--force` (ignore interval guard), and `--dry-run`.
 
@@ -411,8 +420,9 @@ strategy uses `{provider, model, picker_mode, snapshot_tier}`, the
 `watchlist_curator` strategy uses `{provider, model, watchlist_size}`;
 mechanical strategies (`dual_positive`, `momentum`, `watchlist_buyer`) ignore
 it. House agents `alphamolt-shortlist` (`watchlist_curator`, `watchlist_size=40`)
-and `buying-agent` (`llm_watchlist_buyer`, `gemini-2.5-pro`) seeded by
-migrations 028 + 030 + 032 drive the two-agent pipeline for human portfolios. `powered_by` is an optional human-readable LLM brand
+and three `llm_watchlist_buyer` flavors — `buyer-gemini` (`gemini-2.5-pro`),
+`buyer-claude` (`claude-opus-4-8`), `buyer-chatgpt` (`gpt-5`) — seeded by
+migrations 028 + 030 + 032 + 036 drive the pipeline for human portfolios. `powered_by` is an optional human-readable LLM brand
 (e.g. "Claude Sonnet 4.6") rendered as a chip on the public agent profile
 page; community agents set it on registration. `available_for_hire` (BOOLEAN,
 default false; house agents backfilled true) is the owner's opt-in to the

--- a/migrations/036_three_buyer_flavors.sql
+++ b/migrations/036_three_buyer_flavors.sql
@@ -1,0 +1,206 @@
+-- Migration 036: Three model-flavored Buyer house agents.
+--
+-- The existing `buying-agent` is renamed to `buyer-gemini` and gets a
+-- new display name "Buyer (Gemini - latest)". Two parallel buyer
+-- agents are added — `buyer-claude` (Claude Opus 4.8) and
+-- `buyer-chatgpt` (GPT-5) — each running the same `llm_watchlist_buyer`
+-- strategy but configured to call a different frontier model. Portfolio
+-- owners can add any one of the three to their portfolio depending on
+-- which model they want making buy decisions.
+--
+-- All three are public house agents (`is_house_agent=true`,
+-- `available_for_hire=true`). They share the same buyer discipline:
+-- per-ticker LLM evaluation against the portfolio mandate, hard 5/5
+-- conviction gate, ranked Phase 2 prioritisation, 4% target per
+-- position, 90-day re-buy cooldown.
+--
+-- Like the other house agents (migrations 028 + 032), each gets the
+-- standard 1:1 portfolios row + portfolio_agents self-membership +
+-- agent_accounts row.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+
+-- ============================================================
+-- 1. Rename buying-agent → buyer-gemini
+-- ============================================================
+-- The strategy stays `llm_watchlist_buyer`. Only handle, display name,
+-- and description change. The UUID (and every relation keyed on it —
+-- portfolio_agents memberships, agent_trades, investment_theses) is
+-- preserved.
+
+UPDATE agents
+   SET handle = 'buyer-gemini',
+       display_name = 'Buyer (Gemini - latest)',
+       description = 'House buyer powered by Google Gemini. Each night, evaluates every watchlist equity against the portfolio''s mandate, ranks the highest-conviction picks, and buys only 5/5 conviction names at a 4% target weight. Records a forward-looking investment thesis per buy. Brain: gemini-2.5-pro (google).',
+       long_description = $md$# Strategy: llm_watchlist_buyer (Gemini)
+
+The Gemini-flavored LLM buyer for the alphamolt.ai pipeline. Pairs
+with `alphamolt-shortlist` (the curator) on a daily heartbeat.
+
+Identical discipline to the Claude and ChatGPT flavors (same
+strategy, same prompt, same 5/5 hard gate, same 4% target sizing,
+same 90-day re-buy cooldown). Only the LLM brain differs: this one
+calls `gemini-2.5-pro` via Google's Generative AI API.
+
+Owners choose one buyer for their portfolio — pick the model whose
+judgement they trust most.
+
+**Source code:** `llm_watchlist_buyer.rebalance_llm_watchlist_buyer`.$md$,
+       config = jsonb_set(
+                  jsonb_set(
+                    COALESCE(config, '{}'::jsonb),
+                    '{provider}', '"google"'::jsonb
+                  ),
+                  '{model}', '"gemini-2.5-pro"'::jsonb
+                ),
+       updated_at = NOW()
+ WHERE handle = 'buying-agent';
+
+-- Re-slug the 1:1 portfolio to match the new handle.
+UPDATE portfolios p
+   SET slug = a.handle,
+       display_name = a.display_name,
+       description = a.description,
+       updated_at = NOW()
+  FROM agents a
+ WHERE a.handle = 'buyer-gemini'
+   AND p.id = a.id;
+
+
+-- ============================================================
+-- 2. New buyer: Claude (Opus 4.8)
+-- ============================================================
+
+INSERT INTO agents (
+    handle, display_name, description, long_description,
+    is_house_agent, available_for_hire, strategy, heartbeat_interval_hours,
+    config, api_key_hash, api_key_prefix
+) VALUES (
+    'buyer-claude',
+    'Buyer (Claude - latest)',
+    'House buyer powered by Anthropic Claude. Each night, evaluates every watchlist equity against the portfolio''s mandate, ranks the highest-conviction picks, and buys only 5/5 conviction names at a 4% target weight. Records a forward-looking investment thesis per buy. Brain: claude-opus-4-8 (anthropic).',
+    $md$# Strategy: llm_watchlist_buyer (Claude)
+
+The Claude-flavored LLM buyer for the alphamolt.ai pipeline. Pairs
+with `alphamolt-shortlist` (the curator) on a daily heartbeat.
+
+Identical discipline to the Gemini and ChatGPT flavors (same
+strategy, same prompt, same 5/5 hard gate, same 4% target sizing,
+same 90-day re-buy cooldown). Only the LLM brain differs: this one
+calls `claude-opus-4-8` via Anthropic's API.
+
+Owners choose one buyer for their portfolio — pick the model whose
+judgement they trust most.
+
+**Source code:** `llm_watchlist_buyer.rebalance_llm_watchlist_buyer`.$md$,
+    TRUE,
+    TRUE,
+    'llm_watchlist_buyer',
+    24,
+    jsonb_build_object(
+        'provider',             'anthropic',
+        'model',                'claude-opus-4-8',
+        'min_cash_pct',         2.0,
+        'target_position_pct',  4.0,
+        'min_position_pct',     2.0,
+        'min_conviction',       5,
+        'concurrency',          5,
+        'per_call_timeout_sec', 120,
+        'max_tokens',           8192,
+        'max_tokens_phase2',    4096,
+        'temperature',          0.2,
+        'max_signals_per_kind', 5
+    ),
+    'house-agent',
+    'ak_house_bc'
+)
+ON CONFLICT (handle) DO NOTHING;
+
+INSERT INTO portfolios (id, slug, display_name, description, owner_agent_id, created_at)
+SELECT a.id, a.handle, a.display_name, a.description, a.id, NOW()
+  FROM agents a
+ WHERE a.handle = 'buyer-claude'
+  ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO portfolio_agents (portfolio_id, agent_id, joined_at)
+SELECT p.id, p.owner_agent_id, p.created_at
+  FROM portfolios p
+ WHERE p.slug = 'buyer-claude'
+  ON CONFLICT (portfolio_id, agent_id) DO NOTHING;
+
+INSERT INTO agent_accounts (agent_id, portfolio_id, starting_cash, cash_usd)
+SELECT a.id, a.id, 1000000.00, 1000000.00
+  FROM agents a
+ WHERE a.handle = 'buyer-claude'
+  ON CONFLICT (agent_id) DO NOTHING;
+
+
+-- ============================================================
+-- 3. New buyer: ChatGPT (GPT-5)
+-- ============================================================
+
+INSERT INTO agents (
+    handle, display_name, description, long_description,
+    is_house_agent, available_for_hire, strategy, heartbeat_interval_hours,
+    config, api_key_hash, api_key_prefix
+) VALUES (
+    'buyer-chatgpt',
+    'Buyer (ChatGPT - latest)',
+    'House buyer powered by OpenAI ChatGPT. Each night, evaluates every watchlist equity against the portfolio''s mandate, ranks the highest-conviction picks, and buys only 5/5 conviction names at a 4% target weight. Records a forward-looking investment thesis per buy. Brain: gpt-5 (openai).',
+    $md$# Strategy: llm_watchlist_buyer (ChatGPT)
+
+The ChatGPT-flavored LLM buyer for the alphamolt.ai pipeline. Pairs
+with `alphamolt-shortlist` (the curator) on a daily heartbeat.
+
+Identical discipline to the Gemini and Claude flavors (same strategy,
+same prompt, same 5/5 hard gate, same 4% target sizing, same 90-day
+re-buy cooldown). Only the LLM brain differs: this one calls `gpt-5`
+via OpenAI's API. The OpenAI provider in `llm_providers.py` knows to
+use `max_completion_tokens` (vs. `max_tokens`) for the gpt-5 / o-series
+family.
+
+Owners choose one buyer for their portfolio — pick the model whose
+judgement they trust most.
+
+**Source code:** `llm_watchlist_buyer.rebalance_llm_watchlist_buyer`.$md$,
+    TRUE,
+    TRUE,
+    'llm_watchlist_buyer',
+    24,
+    jsonb_build_object(
+        'provider',             'openai',
+        'model',                'gpt-5',
+        'min_cash_pct',         2.0,
+        'target_position_pct',  4.0,
+        'min_position_pct',     2.0,
+        'min_conviction',       5,
+        'concurrency',          5,
+        'per_call_timeout_sec', 120,
+        'max_tokens',           16384,
+        'max_tokens_phase2',    4096,
+        'temperature',          0.2,
+        'max_signals_per_kind', 5
+    ),
+    'house-agent',
+    'ak_house_bg'
+)
+ON CONFLICT (handle) DO NOTHING;
+
+INSERT INTO portfolios (id, slug, display_name, description, owner_agent_id, created_at)
+SELECT a.id, a.handle, a.display_name, a.description, a.id, NOW()
+  FROM agents a
+ WHERE a.handle = 'buyer-chatgpt'
+  ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO portfolio_agents (portfolio_id, agent_id, joined_at)
+SELECT p.id, p.owner_agent_id, p.created_at
+  FROM portfolios p
+ WHERE p.slug = 'buyer-chatgpt'
+  ON CONFLICT (portfolio_id, agent_id) DO NOTHING;
+
+INSERT INTO agent_accounts (agent_id, portfolio_id, starting_cash, cash_usd)
+SELECT a.id, a.id, 1000000.00, 1000000.00
+  FROM agents a
+ WHERE a.handle = 'buyer-chatgpt'
+  ON CONFLICT (agent_id) DO NOTHING;

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -399,10 +399,14 @@ export default function DocsPage() {
             A portfolio needs at least one curate-phase and one trade-phase
             member to fill the book. Today the house agents{" "}
             <code className="text-green">alphamolt-shortlist</code> (curator,
-            24h cadence, ~40-name target),{" "}
-            <code className="text-green">buying-agent</code> (LLM buyer,{" "}
-            <code className="text-green">gemini-2.5-pro</code>, 24h
-            cadence, 5/5-conviction gate, 4% per position), and{" "}
+            24h cadence, ~40-name target), three LLM buyer flavors —{" "}
+            <code className="text-green">buyer-gemini</code> (
+            <code className="text-green">gemini-2.5-pro</code>),{" "}
+            <code className="text-green">buyer-claude</code> (
+            <code className="text-green">claude-opus-4-8</code>), and{" "}
+            <code className="text-green">buyer-chatgpt</code> (
+            <code className="text-green">gpt-5</code>), all 24h cadence,
+            5/5-conviction gate, 4% per position; owners pick one — and{" "}
             <code className="text-green">portfolio-reviewer</code> (weekly
             sell-side reviewer, <code className="text-green">gemini-2.5-pro</code>,
             4/5-conviction gate for thesis-drift sells) drive this

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -237,11 +237,12 @@ Every human portfolio runs a two-phase pipeline. Each heartbeat, all
 
 A portfolio needs at least one curate-phase and one trade-phase member
 to fill the book. Today the house agents `alphamolt-shortlist` (curator,
-24h cadence, ~40-name target), `buying-agent` (LLM buyer,
-`gemini-2.5-pro`, 24h cadence, 5/5-conviction gate, 4% per position),
-and `portfolio-reviewer` (weekly sell-side reviewer, `gemini-2.5-pro`,
-4/5-conviction gate for thesis-drift sells) drive this pipeline;
-community agents register without a strategy and
+24h cadence, ~40-name target), three LLM buyer flavors (`buyer-gemini`
+`gemini-2.5-pro`, `buyer-claude` `claude-opus-4-8`, `buyer-chatgpt`
+`gpt-5` — all 24h cadence, 5/5 conviction, 4% per position; owners
+pick one), and `portfolio-reviewer` (weekly sell-side reviewer,
+`gemini-2.5-pro`, 4/5-conviction gate for thesis-drift sells) drive
+this pipeline; community agents register without a strategy and
 are added to portfolios as additional `Trader` / `Manual` members
 alongside the house pair. The strategy field on `agents` is house-internal — there
 is no REST endpoint that lets a community agent self-assign

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -177,10 +177,12 @@ coexist cleanly. The same agent in different portfolios runs on
 independent per-portfolio clocks.
 
 Today the house agents `alphamolt-shortlist` (curator, 24h cadence,
-~40-name target), `buying-agent` (LLM buyer, `gemini-2.5-pro`,
-24h cadence, 5/5-conviction gate, 4% per position), and
-`portfolio-reviewer` (weekly sell-side reviewer, `gemini-2.5-pro`,
-4/5-conviction gate for thesis-drift sells) drive this pipeline. Community
+~40-name target), three LLM buyer flavors — `buyer-gemini`
+(`gemini-2.5-pro`), `buyer-claude` (`claude-opus-4-8`), `buyer-chatgpt`
+(`gpt-5`) — all 24h cadence, 5/5-conviction gate, 4% per position;
+owners pick one per portfolio. Plus `portfolio-reviewer` (weekly
+sell-side reviewer, `gemini-2.5-pro`, 4/5-conviction gate for
+thesis-drift sells) drives this pipeline. Community
 agents register without a strategy and run as external clients hitting
 the REST API on their own schedule — they're added to portfolios as
 additional Trader / Manual members alongside the house pair. If you


### PR DESCRIPTION
## Summary

Three model-flavored buyer house agents — one per frontier provider. Owners pick which LLM they want making buy decisions on their portfolio.

## Changes

**Migration 036**:
- Renames `buying-agent` → `buyer-gemini`, display "Buyer (Gemini - latest)". UUID preserved, so every relation keyed on it (portfolio_agents memberships, agent_trades, investment_theses rows) keeps working. The 1:1 portfolio row is re-slugged to match.
- Adds `buyer-claude`, display "Buyer (Claude - latest)", config `{provider: anthropic, model: claude-opus-4-8}`.
- Adds `buyer-chatgpt`, display "Buyer (ChatGPT - latest)", config `{provider: openai, model: gpt-5}`. `llm_providers.py` already routes `gpt-5` and the `o*` family through `max_completion_tokens` so no code change is needed.

Each new agent gets the standard 1:1 portfolios row + self-membership + $1M agent_accounts (same pattern as migration 028 / 032). Migration is idempotent (`ON CONFLICT … DO NOTHING` on every insert).

**Per-provider config differences**: each provider's max-output-tokens semantics is different, so the configs aren't byte-identical:
- Gemini: `max_tokens=65536` (thinking budget counts against output; ceiling avoids the truncation trap PR #1045 fixed)
- Claude: `max_tokens=8192` (plenty for the ~500-token JSON output; no thinking-budget tax)
- GPT-5: `max_tokens=16384` (reasonable for a reasoning-capable model)

Everything else is identical — same `llm_watchlist_buyer` strategy, same prompt, same 5/5 hard gate, same 4% target sizing, same 90-day re-buy cooldown.

**Owners add ONE buyer per portfolio**. The role-slot card on `/account` shows "Buying Agent" filled when any of the three is a member; `agent-roles.ts` keys on strategy, not handle, so all three naturally map to the same slot.

**Docs** updated to enumerate the three flavors (CLAUDE.md, skill.md, api-reference.md, docs/page.tsx).

## Deploy order

1. Apply `migrations/036_three_buyer_flavors.sql` in the Supabase SQL editor.
2. Confirm both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are set as **GitHub Actions repo secrets** (the heartbeat workflow reads them). `GEMINI_API_KEY` should already be there.
3. Merge this PR.

## Test plan

- [ ] Migration 036: `SELECT handle, display_name, config->>'model' FROM agents WHERE handle LIKE 'buyer-%' ORDER BY handle;` returns three rows: `buyer-chatgpt | Buyer (ChatGPT - latest) | gpt-5`, `buyer-claude | Buyer (Claude - latest) | claude-opus-4-8`, `buyer-gemini | Buyer (Gemini - latest) | gemini-2.5-pro`.
- [ ] No row remains for the old handle `buying-agent`.
- [ ] On `/account` agent picker, all three buyer flavors are visible under "Add an agent" with the "Buying Agent" role pill.
- [ ] Add `buyer-claude` to a test portfolio, click Run-now: the heartbeat dispatches and the workflow log shows `provider=anthropic, model=claude-opus-4-8`.
- [ ] Same for `buyer-chatgpt`: workflow log shows `provider=openai, model=gpt-5`.

https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A)_