### PR TITLE
fix: mandate save no longer false-negatives 'no portfolio'

### DIFF
--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -238,6 +238,7 @@ function PortfolioView({
         intro="Your investment brief — the agents trade to it. Pick an example to start, then edit and save."
       >
         <PortfolioDetailsEditor
+          portfolioId={portfolio.id}
           initialName={portfolio.display_name}
           initialMandate={portfolio.description ?? ""}
         />

--- a/web/components/portfolio/portfolio-details-editor.tsx
+++ b/web/components/portfolio/portfolio-details-editor.tsx
@@ -55,9 +55,11 @@ export const MANDATE_EXAMPLES: MandateExample[] = [
 ];
 
 export default function PortfolioDetailsEditor({
+  portfolioId,
   initialName,
   initialMandate,
 }: {
+  portfolioId: string;
   initialName: string;
   initialMandate: string;
 }) {
@@ -75,7 +77,11 @@ export default function PortfolioDetailsEditor({
     setError(null);
     setSaved(false);
     startTransition(async () => {
-      const result = await updatePortfolioDetails({ name, mandate });
+      const result = await updatePortfolioDetails({
+        portfolioId,
+        name,
+        mandate,
+      });
       if (!result.ok) {
         setError(result.error);
         return;

--- a/web/lib/portfolios-mutations.ts
+++ b/web/lib/portfolios-mutations.ts
@@ -28,11 +28,18 @@ interface OwnedPortfolio {
 /** The caller's single portfolio, or null. Service-role read. */
 async function getOwnedPortfolio(userId: string): Promise<OwnedPortfolio | null> {
   const supabase = getSupabase();
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("portfolios")
     .select("id, slug")
     .eq("owner_user_id", userId)
     .maybeSingle();
+  if (error) {
+    // Don't swallow — a transient DB error here previously surfaced as
+    // "You don't have a portfolio yet" in the UI, which is wrong and
+    // confusing. Bubble it up via logs so we can tell the two apart.
+    console.error("getOwnedPortfolio lookup failed:", error);
+    return null;
+  }
   return (data as OwnedPortfolio | null) ?? null;
 }
 
@@ -87,6 +94,7 @@ export async function createPortfolio(input: {
 }
 
 export async function updatePortfolioDetails(input: {
+  portfolioId: string;
   name: string;
   mandate: string;
 }): Promise<ActionResult> {
@@ -103,22 +111,31 @@ export async function updatePortfolioDetails(input: {
       error: `Mandate must be ${MAX_MANDATE} characters or fewer.`,
     };
 
-  const portfolio = await getOwnedPortfolio(user.id);
-  if (!portfolio) return { ok: false, error: "You don't have a portfolio yet." };
-
+  // Single update with the ownership check in the WHERE clause — no
+  // separate lookup, no race window. If the row doesn't exist or this
+  // user doesn't own it, `data` comes back null.
   const supabase = getSupabase();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("portfolios")
     .update({ display_name: name, description: mandate || null })
-    .eq("id", portfolio.id)
-    .eq("owner_user_id", user.id);
+    .eq("id", input.portfolioId)
+    .eq("owner_user_id", user.id)
+    .select("slug")
+    .maybeSingle();
 
   if (error) {
     console.error("updatePortfolioDetails failed:", error);
     return { ok: false, error: "Could not save changes. Try again." };
   }
+  if (!data) {
+    return {
+      ok: false,
+      error:
+        "Couldn't find your portfolio. Refresh the page and try again.",
+    };
+  }
 
-  revalidate(portfolio.slug);
+  revalidate(data.slug);
   return { ok: true };
 }
 


### PR DESCRIPTION
## Summary

Bug fix — the mandate save action was returning `"You don't have a portfolio yet"` for users who clearly did. Reproduced from a screenshot where the editor was visibly populated with the user's portfolio name + mandate text, but `Save changes →` failed with the no-portfolio error.

**Root cause:** the save path did two independent portfolio lookups — once in the page (rendered the editor) and again inside `updatePortfolioDetails` via `getOwnedPortfolio(user.id)`. The helper was silently swallowing Supabase error responses, so if the second lookup transiently failed it returned `null` and the action surfaced the wrong error.

**Fix:**

1. **Single query in the mutation.** `updatePortfolioDetails` now takes `portfolioId` from the page and writes with `.eq("id", portfolioId).eq("owner_user_id", user.id)` — the ownership check is the WHERE clause, one query, no race window. If 0 rows match, the error is *"Couldn't find your portfolio. Refresh the page and try again"* — explicit about the recovery step rather than implying you never had a portfolio.
2. **No more silent error-swallowing.** `getOwnedPortfolio` (still used by visibility toggle, launch, agent membership) now captures Supabase's error response and `console.error`s it. Next time anything hits the same class of failure, the server log tells us why instead of us guessing.

Editor + page updated to thread `portfolioId` through.

## Test plan

- [ ] `/account` with a portfolio — Save changes still works on happy path (mandate / name update persists, page refreshes)
- [ ] Watch server logs while testing: no `getOwnedPortfolio lookup failed:` lines on healthy runs
- [ ] Try saving while signed out / with a tampered request — gets the "Couldn't find your portfolio" message rather than a generic 500
- [ ] Visibility toggle, launch flow, agent picker — still work (they share `getOwnedPortfolio`; behaviour is unchanged on happy path, just better logged)

https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq

---
_Generated by [Claude Code](https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq)_