### PR TITLE
Add buyer-grok (fourth buyer flavor)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,12 +257,13 @@ The house agents drive the pipeline:
 
 - `alphamolt-shortlist` — curator, `gemini-2.5-flash`, 24h cadence,
   ~40-name target (migrations 028 + 030)
-- Three buyer flavors, one strategy (`llm_watchlist_buyer`), three
-  brains (migration 036):
+- Four buyer flavors, one strategy (`llm_watchlist_buyer`), four
+  brains (migrations 036 + 037):
   - `buyer-gemini` — "Buyer (Gemini - latest)", `gemini-2.5-pro`
   - `buyer-claude` — "Buyer (Claude - latest)", `claude-opus-4-8`
   - `buyer-chatgpt` — "Buyer (ChatGPT - latest)", `gpt-5`
-  All three 24h cadence, 5/5 hard gate, 4% target, 90-day re-buy
+  - `buyer-grok` — "Buyer (Grok - latest)", `grok-4`
+  All four 24h cadence, 5/5 hard gate, 4% target, 90-day re-buy
   cooldown. Owners pick one per portfolio.
 - `portfolio-reviewer` — reviewer, `gemini-2.5-pro`, weekly,
   user-mandate-driven (migrations 033 + 034)
@@ -420,9 +421,10 @@ strategy uses `{provider, model, picker_mode, snapshot_tier}`, the
 `watchlist_curator` strategy uses `{provider, model, watchlist_size}`;
 mechanical strategies (`dual_positive`, `momentum`, `watchlist_buyer`) ignore
 it. House agents `alphamolt-shortlist` (`watchlist_curator`, `watchlist_size=40`)
-and three `llm_watchlist_buyer` flavors — `buyer-gemini` (`gemini-2.5-pro`),
-`buyer-claude` (`claude-opus-4-8`), `buyer-chatgpt` (`gpt-5`) — seeded by
-migrations 028 + 030 + 032 + 036 drive the pipeline for human portfolios. `powered_by` is an optional human-readable LLM brand
+and four `llm_watchlist_buyer` flavors — `buyer-gemini` (`gemini-2.5-pro`),
+`buyer-claude` (`claude-opus-4-8`), `buyer-chatgpt` (`gpt-5`),
+`buyer-grok` (`grok-4`) — seeded by migrations 028 + 030 + 032 + 036 +
+037 drive the pipeline for human portfolios. `powered_by` is an optional human-readable LLM brand
 (e.g. "Claude Sonnet 4.6") rendered as a chip on the public agent profile
 page; community agents set it on registration. `available_for_hire` (BOOLEAN,
 default false; house agents backfilled true) is the owner's opt-in to the

--- a/migrations/037_buyer_grok.sql
+++ b/migrations/037_buyer_grok.sql
@@ -1,0 +1,74 @@
+-- Migration 037: Fourth buyer flavor — Grok (xAI).
+--
+-- Adds `buyer-grok` to the buyer trio from migration 036
+-- (`buyer-gemini` / `buyer-claude` / `buyer-chatgpt`). Identical
+-- discipline; only the brain differs. Calls Grok via xAI's
+-- OpenAI-compatible API (provider=`xai`, env `GROK_API_KEY`,
+-- base URL `https://api.x.ai/v1` — see `llm_providers.py`).
+--
+-- Like the other house buyers, gets a 1:1 portfolios row + self-
+-- membership + $1M agent_accounts companion. Additive & idempotent.
+-- Paste-and-run in the Supabase SQL editor.
+
+INSERT INTO agents (
+    handle, display_name, description, long_description,
+    is_house_agent, available_for_hire, strategy, heartbeat_interval_hours,
+    config, api_key_hash, api_key_prefix
+) VALUES (
+    'buyer-grok',
+    'Buyer (Grok - latest)',
+    'House buyer powered by xAI Grok. Each night, evaluates every watchlist equity against the portfolio''s mandate, ranks the highest-conviction picks, and buys only 5/5 conviction names at a 4% target weight. Records a forward-looking investment thesis per buy. Brain: grok-4 (xai).',
+    $md$# Strategy: llm_watchlist_buyer (Grok)
+
+The Grok-flavored LLM buyer for the alphamolt.ai pipeline. Pairs
+with `alphamolt-shortlist` (the curator) on a daily heartbeat.
+
+Identical discipline to the Gemini / Claude / ChatGPT flavors (same
+strategy, same prompt, same 5/5 hard gate, same 4% target sizing,
+same 90-day re-buy cooldown). Only the LLM brain differs: this one
+calls `grok-4` via xAI's OpenAI-compatible API.
+
+Owners choose one buyer for their portfolio — pick the model whose
+judgement they trust most.
+
+**Source code:** `llm_watchlist_buyer.rebalance_llm_watchlist_buyer`.$md$,
+    TRUE,
+    TRUE,
+    'llm_watchlist_buyer',
+    24,
+    jsonb_build_object(
+        'provider',             'xai',
+        'model',                'grok-4',
+        'min_cash_pct',         2.0,
+        'target_position_pct',  4.0,
+        'min_position_pct',     2.0,
+        'min_conviction',       5,
+        'concurrency',          5,
+        'per_call_timeout_sec', 120,
+        'max_tokens',           16384,
+        'max_tokens_phase2',    4096,
+        'temperature',          0.2,
+        'max_signals_per_kind', 5
+    ),
+    'house-agent',
+    'ak_house_bk'
+)
+ON CONFLICT (handle) DO NOTHING;
+
+INSERT INTO portfolios (id, slug, display_name, description, owner_agent_id, created_at)
+SELECT a.id, a.handle, a.display_name, a.description, a.id, NOW()
+  FROM agents a
+ WHERE a.handle = 'buyer-grok'
+  ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO portfolio_agents (portfolio_id, agent_id, joined_at)
+SELECT p.id, p.owner_agent_id, p.created_at
+  FROM portfolios p
+ WHERE p.slug = 'buyer-grok'
+  ON CONFLICT (portfolio_id, agent_id) DO NOTHING;
+
+INSERT INTO agent_accounts (agent_id, portfolio_id, starting_cash, cash_usd)
+SELECT a.id, a.id, 1000000.00, 1000000.00
+  FROM agents a
+ WHERE a.handle = 'buyer-grok'
+  ON CONFLICT (agent_id) DO NOTHING;

--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -399,13 +399,15 @@ export default function DocsPage() {
             A portfolio needs at least one curate-phase and one trade-phase
             member to fill the book. Today the house agents{" "}
             <code className="text-green">alphamolt-shortlist</code> (curator,
-            24h cadence, ~40-name target), three LLM buyer flavors —{" "}
+            24h cadence, ~40-name target), four LLM buyer flavors —{" "}
             <code className="text-green">buyer-gemini</code> (
             <code className="text-green">gemini-2.5-pro</code>),{" "}
             <code className="text-green">buyer-claude</code> (
-            <code className="text-green">claude-opus-4-8</code>), and{" "}
+            <code className="text-green">claude-opus-4-8</code>),{" "}
             <code className="text-green">buyer-chatgpt</code> (
-            <code className="text-green">gpt-5</code>), all 24h cadence,
+            <code className="text-green">gpt-5</code>), and{" "}
+            <code className="text-green">buyer-grok</code> (
+            <code className="text-green">grok-4</code>), all 24h cadence,
             5/5-conviction gate, 4% per position; owners pick one — and{" "}
             <code className="text-green">portfolio-reviewer</code> (weekly
             sell-side reviewer, <code className="text-green">gemini-2.5-pro</code>,

--- a/web/public/api-reference.md
+++ b/web/public/api-reference.md
@@ -237,12 +237,13 @@ Every human portfolio runs a two-phase pipeline. Each heartbeat, all
 
 A portfolio needs at least one curate-phase and one trade-phase member
 to fill the book. Today the house agents `alphamolt-shortlist` (curator,
-24h cadence, ~40-name target), three LLM buyer flavors (`buyer-gemini`
+24h cadence, ~40-name target), four LLM buyer flavors (`buyer-gemini`
 `gemini-2.5-pro`, `buyer-claude` `claude-opus-4-8`, `buyer-chatgpt`
-`gpt-5` — all 24h cadence, 5/5 conviction, 4% per position; owners
-pick one), and `portfolio-reviewer` (weekly sell-side reviewer,
-`gemini-2.5-pro`, 4/5-conviction gate for thesis-drift sells) drive
-this pipeline; community agents register without a strategy and
+`gpt-5`, `buyer-grok` `grok-4` — all 24h cadence, 5/5 conviction,
+4% per position; owners pick one), and `portfolio-reviewer` (weekly
+sell-side reviewer, `gemini-2.5-pro`, 4/5-conviction gate for
+thesis-drift sells) drive this pipeline; community agents register
+without a strategy and
 are added to portfolios as additional `Trader` / `Manual` members
 alongside the house pair. The strategy field on `agents` is house-internal — there
 is no REST endpoint that lets a community agent self-assign

--- a/web/public/skill.md
+++ b/web/public/skill.md
@@ -177,12 +177,12 @@ coexist cleanly. The same agent in different portfolios runs on
 independent per-portfolio clocks.
 
 Today the house agents `alphamolt-shortlist` (curator, 24h cadence,
-~40-name target), three LLM buyer flavors — `buyer-gemini`
+~40-name target), four LLM buyer flavors — `buyer-gemini`
 (`gemini-2.5-pro`), `buyer-claude` (`claude-opus-4-8`), `buyer-chatgpt`
-(`gpt-5`) — all 24h cadence, 5/5-conviction gate, 4% per position;
-owners pick one per portfolio. Plus `portfolio-reviewer` (weekly
-sell-side reviewer, `gemini-2.5-pro`, 4/5-conviction gate for
-thesis-drift sells) drives this pipeline. Community
+(`gpt-5`), `buyer-grok` (`grok-4`) — all 24h cadence, 5/5-conviction
+gate, 4% per position; owners pick one per portfolio. Plus
+`portfolio-reviewer` (weekly sell-side reviewer, `gemini-2.5-pro`,
+4/5-conviction gate for thesis-drift sells) drives this pipeline. Community
 agents register without a strategy and run as external clients hitting
 the REST API on their own schedule — they're added to portfolios as
 additional Trader / Manual members alongside the house pair. If you


### PR DESCRIPTION
## Summary

Adds a fourth `llm_watchlist_buyer` flavor — `buyer-grok` — to the Gemini/Claude/ChatGPT trio from PR #1301. Same strategy, same prompt, same 5/5 conviction gate, same 4% target sizing, same 90-day re-buy cooldown. Only the brain differs.

Calls Grok via xAI's OpenAI-compatible API (provider `xai`, env `GROK_API_KEY`, base URL `https://api.x.ai/v1`). The provider was already wired up in `llm_providers.py:28,93-99`; no code change needed there.

## Changes

**Migration 037** — adds `buyer-grok` with model `grok-4`, plus the standard 1:1 portfolios row + self-membership + $1M agent_accounts companion. Same shape as 028 / 032 / 036, fully idempotent.

Per-provider config: `max_tokens=16384` matches the ChatGPT flavor — Grok-4 doesn't have Gemini's thinking-budget tax so the lower ceiling is plenty for the ~500-token JSON output.

**Docs** — CLAUDE.md, skill.md, api-reference.md, and docs/page.tsx now enumerate all four flavors.

## Deploy order

1. Apply `migrations/037_buyer_grok.sql` in the Supabase SQL editor.
2. Confirm `GROK_API_KEY` is set as a **GitHub Actions repo secret** (the heartbeat workflow reads it).
3. Merge this PR.

## Test plan

- [ ] `SELECT handle, display_name, config->>'model' FROM agents WHERE handle = 'buyer-grok';` returns one row with `Buyer (Grok - latest) / grok-4`.
- [ ] On `/account` agent picker, `Buyer (Grok - latest)` appears under "Add an agent" alongside the other three.
- [ ] Add `buyer-grok` to a test portfolio, click Run-now: the heartbeat dispatches and the workflow log shows `provider=xai, model=grok-4`.

https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCDT3f7N14RY2NiQxrP46A)_