### PR TITLE
company page: fix 4 bugs from the SEZL report

### DIFF
--- a/eodhd_updater.py
+++ b/eodhd_updater.py
@@ -520,6 +520,20 @@ def fetch_eodhd_data(ticker: str, api_key: str, logger: logging.Logger,
                 gp = rev - cor
         if gp is not None and rev and rev > 0:
             gross_margin_val = (gp / rev) * 100
+    # Reject impossible values (>100%, <-100%). EODHD occasionally
+    # publishes a restated quarter where grossProfit briefly exceeds
+    # revenue (one-time GAAP adjustments, currency translation, etc.).
+    # Better to surface no value than a 106% GM that the UI would
+    # render literally.
+    if gross_margin_val is not None and (
+        gross_margin_val > 100 or gross_margin_val < -100
+    ):
+        logging.getLogger().warning(
+            "%s: discarding implausible gross_margin %.1f%% — "
+            "likely a restated quarter where grossProfit > revenue.",
+            ticker, gross_margin_val,
+        )
+        gross_margin_val = None
     result["gross_margin"] = round(gross_margin_val, 1) if gross_margin_val is not None else None
 
     # ── GM Trend (Qtly) ──────────────────────────────────────────────
@@ -537,7 +551,19 @@ def fetch_eodhd_data(ticker: str, api_key: str, logger: logging.Logger,
                 if cor is not None:
                     gp = rev - cor
             if gp is not None and rev and rev > 0:
-                margins.append((gp / rev) * 100)
+                m = (gp / rev) * 100
+                # Skip impossible quarters (>100% / <-100%) — usually
+                # a one-time restatement where grossProfit briefly
+                # exceeds revenue. Rendering "106%" in the trend
+                # string is misleading.
+                if -100 <= m <= 100:
+                    margins.append(m)
+                else:
+                    logging.getLogger().warning(
+                        "%s: skipping implausible quarterly GM %.1f%% "
+                        "in gm_trend (entry: %s).",
+                        ticker, m, entry[0],
+                    )
         if len(margins) >= 2:
             gm_trend_val = margins[0] - margins[-1]  # pp change newest vs oldest
             arrow = "↑" if gm_trend_val > 1 else ("↓" if gm_trend_val < -1 else "→")

--- a/update_ai_narratives.py
+++ b/update_ai_narratives.py
@@ -262,6 +262,13 @@ FULL OUTLOOK RULES:
 - Explain the fundamental earnings quality story
 - Mention path to profitability if not yet profitable, or sustainability of profits if already profitable
 - Do NOT use bullet points
+- Do NOT quote specific percentages, dollar figures, or growth rates in the
+  prose. The page already shows these in live structured fields next to the
+  narrative; the narrative is regenerated only every \u224890 days while those
+  fields refresh weekly, so any hard number you put in the prose will drift
+  out of sync within a quarter. Use qualitative language instead: "strong
+  revenue growth", "expanding margins", "approaching breakeven" \u2014 not "30%
+  YoY revenue growth" or "91% gross margins".
 
 KEY RISKS RULES:
 - One sentence, max 15 words

--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -406,9 +406,11 @@ export default async function CompanyPage({
           ticker={company.ticker}
           bullColor={bull.color}
           bullLabel={bull.label}
+          bullPassed={bull.passed}
           bullText={company.full_outlook || bullRationale}
           bearColor={bear.color}
           bearLabel={bear.label}
+          bearPassed={bear.passed}
           bearText={company.key_risks || bearRationale}
           buysSinceEval={buysSinceEval}
           totalAgents={swarm.total_agents}
@@ -624,12 +626,16 @@ function HeroSection({
         />
         <HeroStat
           label="Rank"
-          value={company.sort_order != null ? `#${company.sort_order}` : "—"}
+          value={company.sort_order != null ? `#${company.sort_order}` : "Pending"}
           accent="text"
         />
         <HeroStat
           label="Score"
-          value={formatNumber(company.composite_score, { decimals: 0 })}
+          value={
+            company.composite_score != null
+              ? formatNumber(company.composite_score, { decimals: 0 })
+              : "Pending"
+          }
           accent="text"
         />
       </div>
@@ -1821,9 +1827,11 @@ function HouseBullBear({
   ticker,
   bullColor,
   bullLabel,
+  bullPassed,
   bullText,
   bearColor,
   bearLabel,
+  bearPassed,
   bearText,
   buysSinceEval,
   totalAgents,
@@ -1831,13 +1839,45 @@ function HouseBullBear({
   ticker: string;
   bullColor: string;
   bullLabel: string;
+  bullPassed: boolean | null;
   bullText: string | null;
   bearColor: string;
   bearLabel: string;
+  bearPassed: boolean | null;
   bearText: string | null;
   buysSinceEval: number;
   totalAgents: number;
 }) {
+  // Bull side: ✅ → the case content, ❌ → the rejection rationale.
+  // Bear side: ❌ → the concerns (bears flagged something), ✅ →
+  // bears couldn't find concerns ("sound" — usually no rationale).
+  // Don't render FAIL text as if it's the case for — that's the
+  // SEZL bug.
+  const bullCaption =
+    bullPassed === true
+      ? "Why bulls are right"
+      : bullPassed === false
+        ? "Why bulls couldn't make a case"
+        : "House bull case";
+  const bearCaption =
+    bearPassed === false
+      ? "What bears are flagging"
+      : bearPassed === true
+        ? "Why bears couldn't find concerns"
+        : "House bear case";
+  const bullFallback =
+    bullPassed === true
+      ? "No rationale recorded."
+      : bullPassed === false
+        ? "Bulls walked away without a thesis."
+        : "Not yet evaluated";
+  const bearFallback =
+    bearPassed === false
+      ? "No specific concerns recorded."
+      : bearPassed === true
+        ? "Bears couldn't find material concerns."
+        : "Not yet evaluated";
+
   return (
     <section className="mb-6">
       <h2 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-2">
@@ -1853,7 +1893,7 @@ function HouseBullBear({
         >
           <div className="flex items-baseline gap-2 mb-2">
             <span className="font-mono text-xs uppercase tracking-wider text-text-muted">
-              House bull case
+              {bullCaption}
             </span>
             <span
               className="font-mono text-sm font-bold"
@@ -1865,7 +1905,7 @@ function HouseBullBear({
           {bullText ? (
             <p className="text-sm text-text-dim leading-relaxed">{bullText}</p>
           ) : (
-            <p className="text-xs text-text-muted italic">Not yet evaluated</p>
+            <p className="text-xs text-text-muted italic">{bullFallback}</p>
           )}
         </div>
         <div
@@ -1877,7 +1917,7 @@ function HouseBullBear({
         >
           <div className="flex items-baseline gap-2 mb-2">
             <span className="font-mono text-xs uppercase tracking-wider text-text-muted">
-              House bear case
+              {bearCaption}
             </span>
             <span
               className="font-mono text-sm font-bold"
@@ -1889,7 +1929,7 @@ function HouseBullBear({
           {bearText ? (
             <p className="text-sm text-text-dim leading-relaxed">{bearText}</p>
           ) : (
-            <p className="text-xs text-text-muted italic">Not yet evaluated</p>
+            <p className="text-xs text-text-muted italic">{bearFallback}</p>
           )}
         </div>
       </div>
@@ -1960,6 +2000,25 @@ function AiOutlook({ company }: { company: Company }) {
       company.event_impact
     );
 
+  // Surface narrative staleness vs the structured fundamentals. The
+  // narrative is regenerated only every ~90 days; fundamentals refresh
+  // weekly. When the gap is wide, any hard numbers the prose quotes are
+  // probably out of sync with the rest of the page.
+  const narrativeDate = company.ai_analyzed_at;
+  const dataDate = company.data_updated_at;
+  const staleDays =
+    narrativeDate && dataDate
+      ? Math.max(
+          0,
+          Math.floor(
+            (new Date(dataDate).getTime() -
+              new Date(narrativeDate).getTime()) /
+              86_400_000,
+          ),
+        )
+      : null;
+  const isStale = staleDays != null && staleDays > 30;
+
   return (
     <section className="mb-6">
       <h2 className="text-xs font-mono uppercase tracking-wider text-text-muted mb-2">
@@ -1973,6 +2032,17 @@ function AiOutlook({ company }: { company: Company }) {
         ) : (
           <p className="text-sm text-text-muted italic">
             No outlook recorded yet.
+          </p>
+        )}
+        {(narrativeDate || dataDate) && (
+          <p
+            className={`text-[11px] font-mono mt-3 ${
+              isStale ? "text-[var(--color-orange)]" : "text-text-muted"
+            }`}
+          >
+            {isStale && "⚠ "}
+            Narrative {narrativeDate ?? "—"} · fundamentals {dataDate ?? "—"}
+            {isStale && ` (${staleDays}d gap — figures in the prose may lag)`}
           </p>
         )}
         {hasMore && (

--- a/web/components/ps-chart.tsx
+++ b/web/components/ps-chart.tsx
@@ -9,14 +9,37 @@ import {
   Tooltip,
 } from "recharts";
 
+// History rows on `price_sales.history_json` are stored as
+// `[date, ps_value]` tuples by price_sales_updater.py (see
+// price_sales_updater.py:364). The TS type `Array<{date, ps}>` on
+// lib/types.ts was aspirational — Recharts couldn't find the keys on
+// the tuples, so the chart rendered axis labels only with no plotted
+// series. Accept both shapes here and normalise.
+type PsHistoryRow =
+  | { date: string; ps: number }
+  | [string, number];
+
 interface PsDataPoint {
   date: string;
   ps: number;
 }
 
-export default function PsChart({ data }: { data: PsDataPoint[] }) {
-  const sorted = [...data].sort(
-    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+function normalise(row: PsHistoryRow): PsDataPoint | null {
+  if (Array.isArray(row)) {
+    const [date, ps] = row;
+    if (typeof date !== "string" || typeof ps !== "number") return null;
+    return { date, ps };
+  }
+  if (typeof row?.date !== "string" || typeof row?.ps !== "number") return null;
+  return { date: row.date, ps: row.ps };
+}
+
+export default function PsChart({ data }: { data: PsHistoryRow[] }) {
+  const points = data
+    .map(normalise)
+    .filter((p): p is PsDataPoint => p !== null);
+  const sorted = [...points].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
   );
 
   return (

--- a/web/lib/company-agents-query.ts
+++ b/web/lib/company-agents-query.ts
@@ -690,10 +690,34 @@ export function buildSwarmViewLine({
   const valuationStretched =
     psNow != null && psMedian != null && psMedian > 0 && psNow / psMedian > 1.2;
 
-  if (verdict === "bullish") {
+  // Rationales must be gated on pass/fail. A bull_eval `❌ (X)` row
+  // means "the bull case fails *because* X" — quoting X as if bulls
+  // cite it is the SEZL bug. Only treat rationale as a "case for"
+  // when the eval passed (bulls ✅) or the bear concern was raised
+  // (bears ❌, i.e. they DID flag something).
+  const bullCaseRationale = bullPass === true ? bullRationale : null;
+  const bullRejectionRationale = bullPass === false ? bullRationale : null;
+  const bearFlagRationale = bearPass === false ? bearRationale : null;
+
+  // Override the holdings-based verdict with the eval pair when BOTH
+  // evals are present — they're a stronger signal than current
+  // holdings alone (which can lag a reversal). Mapping matches the
+  // AI multiplier in score_ai_analysis.py:
+  //   bull ✅ + bear ✅ (sound + story)   → Bullish
+  //   bull ❌ + bear ❌ (no case)         → Bearish
+  //   bull ✅ + bear ❌ (story w/ flags)  → Mixed
+  //   bull ❌ + bear ✅ (sound, no edge)  → Mixed
+  let effectiveVerdict: CompanyConsensus["verdict"] = verdict;
+  if (bullPass != null && bearPass != null) {
+    if (bullPass && bearPass) effectiveVerdict = "bullish";
+    else if (!bullPass && !bearPass) effectiveVerdict = "bearish";
+    else effectiveVerdict = "mixed";
+  }
+
+  if (effectiveVerdict === "bullish") {
     let headline: string;
-    if (bearPass === false && bearRationale) {
-      headline = `Bullish, but bears flag ${lowerFirstClause(bearRationale)}.`;
+    if (bearFlagRationale) {
+      headline = `Bullish, but bears flag ${lowerFirstClause(bearFlagRationale)}.`;
     } else if (valuationStretched) {
       headline = "Bullish, but valuation is stretched vs its 12-month median.";
     } else if (recentExitName) {
@@ -704,24 +728,33 @@ export function buildSwarmViewLine({
     return { headline, verdict_word: "Bullish" };
   }
 
-  if (verdict === "bearish") {
+  if (effectiveVerdict === "bearish") {
     let headline: string;
-    if (bullPass === true && bullRationale) {
-      headline = `Bearish, though the bull case still cites ${lowerFirstClause(bullRationale)}.`;
+    if (bullCaseRationale) {
+      headline = `Bearish, though the bull case still cites ${lowerFirstClause(bullCaseRationale)}.`;
+    } else if (bullRejectionRationale) {
+      // bull ❌: rationale explains why bulls couldn't make a case.
+      headline = `Bearish — bulls couldn't make a case (${lowerFirstClause(bullRejectionRationale)}).`;
     } else {
       headline = "Bearish — agents have walked away.";
     }
     return { headline, verdict_word: "Bearish" };
   }
 
-  // mixed
+  // mixed — present only the verified signal on each side. Never
+  // quote a FAIL rationale as if it's the "case for".
   let headline: string;
-  if (bullRationale && bearRationale) {
-    headline = `Split: bulls cite ${lowerFirstClause(bullRationale)}, bears cite ${lowerFirstClause(bearRationale)}.`;
-  } else if (bullRationale) {
-    headline = `Split — bulls still see ${lowerFirstClause(bullRationale)}.`;
-  } else if (bearRationale) {
-    headline = `Split — bears flag ${lowerFirstClause(bearRationale)}.`;
+  if (bullCaseRationale && bearFlagRationale) {
+    headline = `Split: bulls cite ${lowerFirstClause(bullCaseRationale)}, bears flag ${lowerFirstClause(bearFlagRationale)}.`;
+  } else if (bullCaseRationale) {
+    headline = `Split — bulls still see ${lowerFirstClause(bullCaseRationale)}.`;
+  } else if (bearFlagRationale) {
+    headline = `Split — bears flag ${lowerFirstClause(bearFlagRationale)}.`;
+  } else if (bullPass === false && bearPass === true) {
+    // The SEZL shape: sound but no edge. Surface the lack of a thesis
+    // explicitly rather than fishing for content the evals didn't
+    // produce.
+    headline = "Split — sound fundamentals, but no clear bull thesis.";
   } else {
     headline = "Split — no clear thesis yet.";
   }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -93,7 +93,10 @@ export interface PriceSales {
   median_12m: number | null;
   ath: number | null;
   pct_of_ath: number | null;
-  history_json: Array<{ date: string; ps: number }>;
+  // Stored as `[date, ps]` tuples by price_sales_updater.py — the chart
+  // accepts both shapes via its own normaliser, but this type matches
+  // what actually lands in JSONB.
+  history_json: Array<[string, number] | { date: string; ps: number }>;
   last_updated: string | null;
   first_recorded: string | null;
 }


### PR DESCRIPTION
## Summary

Fixes 4 of the 5 bugs from the SEZL bug report, plus a staleness indicator for the 5th. Two items deferred (notes at the bottom).

| # | Bug | Fix |
|---|---|---|
| **5** | P/S history chart empty despite data | `price_sales.history_json` is stored as `[date, ps]` tuples (`price_sales_updater.py:364`) but `PsChart` expected `{date, ps}` objects — Recharts drew the axes and nothing else. Chart now normalises both shapes; lying TS type in `lib/types.ts` updated to match the actual JSONB shape. |
| **4** | bull/bear eval rendered with the rejection rationale framed as the bull case | `buildSwarmViewLine` was treating `bullRationale` / `bearRationale` as a "case for" regardless of pass/fail — so for SEZL (bull ❌, bear ✅) the headline read "Split — bulls still see {rejection rationale}". Now: rationales are gated on pass/fail (only bull ✅ → "case for", only bear ❌ → "bears flag"). When both evals are present the headline verdict derives from the eval pair (matches the AI multiplier in `score_ai_analysis.py`). `HouseBullBear` panel header swaps to "Why bulls couldn't make a case" on ❌, so the prose under a FAIL badge can't masquerade as the case for. |
| **3** | gm_trend contains `106%` | `eodhd_updater` drops per-quarter GMs outside `[-100, 100]%` from `gm_trend` and discards the TTM `gross_margin` when out of range (logs a warning). Source is usually a one-time restatement where reported `grossProfit` briefly exceeds revenue. |
| **1 (UI)** | `composite_score` / `sort_order` null → bare `—` on hero tiles | Score + Rank now render `Pending` when null instead of an ambiguous dash. |
| **2 (mitigated)** | Narrative quotes hard numbers that drift from structured fields | (a) `update_ai_narratives` prompt now forbids specific percentages, dollar figures, and growth rates in the FULL OUTLOOK prose — qualitative language only ("strong margins" not "91% gross margins"). (b) Company-page AI Outlook block surfaces `ai_analyzed_at` vs `data_updated_at` with an orange ⚠ when the gap > 30d, so staleness is visible at a glance. Existing rows refresh on their next 90-day cycle; `python update_ai_narratives.py --force` flushes them sooner. |

## Deferred (not fixed in this PR)

- **Bug 1, data side** — why `score_ai_analysis.py` skipped SEZL needs DB/run-log inspection (`scored_at` field, recent run logs).
- **Low-priority** — `@smoke-test-claude` handle cleanup is a DB action.

## Test plan

- [ ] Visit `/company/SEZL` → P/S History chart actually plots a series (not just axes)
- [ ] Bull/Bear panel for SEZL header reads "Why bulls couldn't make a case" + FAIL badge, body text is the rejection rationale — never framed as bullish content
- [ ] Hero shows `Pending` for Score / Rank (until next `score_ai_analysis.py` run picks SEZL up)
- [ ] AI Outlook block shows orange ⚠ when narrative date is > 30d older than data date
- [ ] Run `eodhd_updater.py` against a ticker with a known bad restatement quarter → log warning, no `106%` in gm_trend
- [ ] After next `update_ai_narratives.py --force`, full_outlook prose contains no `X%` / `$X` / growth rate quotes

https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq

---
_Generated by [Claude Code](https://claude.ai/code/session_017pnJcYgJZJddWSs2PGFeSq)_