### PR TITLE
Fix "no portfolio yet" on watchlist add/delete for two-portfolio users

### DIFF
--- a/web/lib/portfolios-mutations.ts
+++ b/web/lib/portfolios-mutations.ts
@@ -24,13 +24,19 @@ interface OwnedPortfolio {
   slug: string;
 }
 
-/** The caller's single portfolio, or null. Service-role read. */
+/** The caller's arena (paper) portfolio, or null. Service-role read.
+ *
+ * Scoped to `mode='paper'` because since migration 037 a user may also own
+ * a private live follower; a bare `owner_user_id` lookup would match two
+ * rows and make `.maybeSingle()` error. Used as the "you already have a
+ * portfolio" guard in createPortfolio, which creates the paper book. */
 async function getOwnedPortfolio(userId: string): Promise<OwnedPortfolio | null> {
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from("portfolios")
     .select("id, slug")
     .eq("owner_user_id", userId)
+    .eq("mode", "paper")
     .maybeSingle();
   if (error) {
     // Don't swallow — a transient DB error here previously surfaced as

--- a/web/lib/watchlist-mutations.ts
+++ b/web/lib/watchlist-mutations.ts
@@ -10,21 +10,27 @@
 
 import { revalidatePath } from "next/cache";
 import { getSupabase } from "@/lib/supabase";
+import { getPortfolioForUser } from "@/lib/portfolios-query";
 import { requireUser } from "@/lib/auth/require-user";
 
 export type ActionResult = { ok: true } | { ok: false; error: string };
 
 const MAX_RATIONALE = 280;
 
-/** The caller's single portfolio id, or null. Service-role read. */
+/**
+ * The caller's arena (paper) portfolio id, or null.
+ *
+ * Since migration 037 a user may own a second, private *live* follower in
+ * addition to their paper portfolio, so resolving "the user's portfolio"
+ * with a bare `owner_user_id` + `.maybeSingle()` matches two rows and
+ * errors — which previously surfaced as "You don't have a portfolio yet."
+ * when deleting a watchlist item. The watchlist always belongs to the
+ * arena book, so reuse the canonical paper-scoped resolver (which can't
+ * drift again).
+ */
 async function getOwnedPortfolioId(userId: string): Promise<string | null> {
-  const supabase = getSupabase();
-  const { data } = await supabase
-    .from("portfolios")
-    .select("id")
-    .eq("owner_user_id", userId)
-    .maybeSingle();
-  return (data as { id: string } | null)?.id ?? null;
+  const portfolio = await getPortfolioForUser(userId);
+  return portfolio?.id ?? null;
 }
 
 export async function addToWatchlist(input: {


### PR DESCRIPTION
## The bug
On `/account/watchlist`, deleting (or adding) an equity returned **"You don't have a portfolio yet."** even though the watchlist clearly has equities. The page renders fine — it resolves the portfolio via the paper-scoped `getPortfolioForUser` — but the *mutations* used a different resolver.

## Root cause
Since **migration 037**, a user can own two portfolios: their public **paper** (arena) book and a private **live** follower. `watchlist-mutations.ts` resolved "the user's portfolio" with a bare `owner_user_id` + `.maybeSingle()`. With two matching rows, `.maybeSingle()` errors → `null` → the misleading "no portfolio" message. So only users who *also* have a live portfolio hit it.

## Fix
- `watchlist-mutations.getOwnedPortfolioId` now reuses the canonical paper-scoped `getPortfolioForUser` — whose own docs already name the watchlist as a caller meaning the arena portfolio — so it can't drift again.
- `portfolios-mutations.getOwnedPortfolio` (the `createPortfolio` "you already have a portfolio" guard) gets the same `mode='paper'` scope. The unique `(owner_user_id, mode)` constraint already backstopped it, but the guard is now correct instead of relying on the insert to fail.

The other `owner_user_id` reads in `portfolios-mutations.ts` are scoped by a known portfolio `id`, so their `.maybeSingle()` stays single-row and is unaffected.

## Verification
- `tsc --noEmit` clean.

https://claude.ai/code/session_01UNTSVuTGHNNtUmt7VqK5Se

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNTSVuTGHNNtUmt7VqK5Se)_