### PR TITLE
Level 0: strategy-neutral universe &amp; fact store (backend foundation)

### DIFF
--- a/.github/workflows/prices-daily.yml
+++ b/.github/workflows/prices-daily.yml
@@ -1,0 +1,62 @@
+name: Level 0 Prices Daily
+
+# Daily EOD price layer for the Tier 1 set (spec §3 — the "prices" clock).
+# Writes the latest trading day for every Tier 1 ticker and backfills 2y of
+# history for any newly-promoted name. Runs 04:15 UTC, after the weekly gate
+# has settled and alongside the other daily fundamentals jobs.
+
+on:
+  schedule:
+    - cron: "15 4 * * *"
+  workflow_dispatch:
+    inputs:
+      backfill:
+        description: "Force full 2y backfill for ALL Tier 1 (not just new names)"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Compute but write nothing"
+        type: boolean
+        default: false
+
+jobs:
+  prices:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run Prices Daily Updater
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          EODHD_API_KEY: ${{ secrets.EODHD_API_KEY }}
+        run: |
+          ARGS=""
+          if [ "${{ github.event.inputs.backfill }}" = "true" ]; then
+            ARGS="$ARGS --backfill"
+          fi
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          python prices_daily_updater.py $ARGS
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: prices-daily-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 30

--- a/.github/workflows/universe-sync.yml
+++ b/.github/workflows/universe-sync.yml
@@ -1,0 +1,61 @@
+name: Level 0 Universe Sync
+
+# Weekly membership / identity refresh + affordability gate (spec §3 — the
+# "membership" clock). Listings change slowly, so this runs weekly. Sundays
+# 02:00 UTC, ahead of the daily price/fundamental jobs.
+
+on:
+  schedule:
+    - cron: "0 2 * * 0"
+  workflow_dispatch:
+    inputs:
+      skip_gate:
+        description: "Identity refresh only (skip the affordability gate)"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Compute but write nothing"
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run Universe Sync
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          EODHD_API_KEY: ${{ secrets.EODHD_API_KEY }}
+        run: |
+          ARGS=""
+          if [ "${{ github.event.inputs.skip_gate }}" = "true" ]; then
+            ARGS="$ARGS --skip-gate"
+          fi
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          python universe_sync.py $ARGS
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: universe-sync-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,73 @@ extend/break signals. Exposes `build_snapshot`, `record_thesis`,
 `mark_thesis_status`. Signal operators: `>`, `>=`, `<`, `<=`, `==`, `!=`,
 `change_pct_lt`, `change_pct_gt`. See migration 020.
 
+### eodhd.py
+Thin, reusable EODHD REST client for the Level 0 fact store. Wraps the three
+universe endpoints the legacy scripts don't use — `exchange-symbol-list/{EX}`
+(full ticker list + security type), `eod/{SYMBOL}` (daily OHLCV history) and
+`eod-bulk-last-day/{EX}` (all tickers for one trading day) — plus a
+`fundamentals` passthrough, behind one rate-limited, retrying `get()`
+(`EODHDClient`). `EODHD_API_KEY` env var.
+
+### level0.py
+The **§9 contract** Level 0 exposes upward — a read-only `FactStore` facade
+over the fact tables, the single seam every visible surface reads through.
+`get_tier1_universe()` (candidate scan), `get_facts(ticker)` /
+`get_facts_bulk()` (identity + latest fundamentals/valuation/price + events +
+estimates, each stamped with its as-of date), `get_distribution(metric,
+sector)` / `get_all_distributions()` (percentile strips off `metric_stats`).
+Holds NO strategy — returns facts + distributions, callers decide.
+
+## Level 0 — strategy-neutral universe & fact store
+
+A single store of **facts, never strategy**, about all liquid US equities
+(spec: alphamolt Level 0). It sits *underneath* the existing pipeline: the old
+opinionated TradingView screen becomes one *lens* applied on top of Tier 1,
+downstream — it no longer *defines* the universe. The legacy
+`companies` / `price_sales` pipeline is untouched and runs alongside.
+
+**Two tiers.** *Tier 0* (`securities`) is identity-level reference data for
+every US-listed common stock + ADR + REIT (units/warrants/preferreds/SPACs
+excluded), status-tracked, soft-deleted on delisting. *Tier 1* is the subset
+passing the **affordability gate** (`securities.is_tier1`) that receives full
+enrichment (prices, fundamentals, valuation).
+
+**The affordability gate is the only gate** (`universe_sync.passes_gate`) and
+carries no strategy: trailing-30d ADDV ≥ $5M, last close ≥ $1, enough price
+history, active US listing of an included security type. No margin/growth/
+valuation/sector views — those are lenses downstream.
+
+**Three clocks** (per data type): membership/identity weekly
+(`universe_sync.py`), prices daily (`prices_daily_updater.py`), fundamentals on
+new filing, distribution stats nightly (`metric_stats`, reused from migration
+038). See migration 039. Backend foundation only — the configurable screener
+over the wider universe (the spec's step-6 "visible win") is a follow-up.
+
 ## Scripts
+
+### universe_sync.py (02:00 UTC Sundays — weekly)
+Level 0 membership/identity + affordability gate. Ingests the full EODHD US
+`exchange-symbol-list` into `securities` (Tier 0): keeps common stock / ADR /
+REIT, drops funds / preferreds / warrants / units / SPACs (`classify_security`),
+adds new listings, soft-deletes names that fell off the list (`status=
+'delisted'`). Then computes the trailing-30d ADDV for the whole universe from
+~30 `eod-bulk-last-day` calls and sets `is_tier1` via `passes_gate`. Flags:
+`--dry-run`, `--skip-gate`, `--limit N`.
+
+### prices_daily_updater.py (04:15 UTC daily)
+Level 0 price layer. One `eod-bulk-last-day` call writes the latest trading
+day's OHLCV for every Tier 1 ticker (idempotent on `(ticker, date)`); any Tier 1
+name with no recent row (a fresh gate promotion) gets a full 2y per-ticker
+backfill. Stores `dollar_volume` + `adj_close`. Flags: `--backfill` (force 2y
+for all Tier 1), `--tickers`, `--years`, `--dry-run`.
+
+### migrate_companies_to_level0.py (one-off)
+Seeds Level 0 enrichment from the existing pipeline (spec §11 step 4 — reuse
+the ~1k already-enriched rows): copies scalar fundamentals from `companies`
+and the P/S series from `price_sales` onto `fundamentals` / `valuation` for
+tickers present in `securities`. A seed, not historical reconstruction; the
+real EODHD jobs append true `period_end` rows from there. Flags: `--dry-run`,
+`--tier1-only`.
 
 ### nightly_screen.py (03:00 UTC daily)
 TradingView screener over the US-listed universe (NYSE/NASDAQ/AMEX/NYSEARCA/
@@ -381,6 +447,43 @@ the schema for backward compat but are no longer read anywhere; a later
 cleanup migration will drop them.
 
 ## Database Tables
+
+### Level 0 fact store (migration 039 — facts, never strategy)
+
+**`securities`** (Tier 0 identity — every liquid US equity)
+```
+ticker (PK), name, exchange, cik, figi, isin, security_type (Common Stock|ADR|REIT),
+gics_sector, gics_industry, country, share_class, status (active|delisted),
+ipo_date, first_seen, last_seen, is_tier1, addv_30d, last_close,
+tier1_evaluated_at, created_at, updated_at
+```
+`is_tier1` is set by the affordability gate; `addv_30d` / `last_close` are the
+gate inputs, stamped for transparency. Soft-delete only (`status='delisted'`).
+
+**`prices_daily`** (2y daily OHLCV per Tier 1 ticker)
+```
+ticker (FK), date, open, high, low, close, adj_close, volume, dollar_volume — PK (ticker, date)
+```
+
+**`fundamentals`** (append-only history)
+```
+ticker (FK), period_end, fetched_at, source, revenue, rev_growth_ttm, rev_growth_qoq,
+rev_cagr, gross_margin, operating_margin, net_margin, fcf_margin, rule_of_40,
+cash, debt, shares_out, eps, opex_pct_rev — PK (ticker, period_end)
+```
+
+**`valuation`** (multiples + P/S series)
+```
+ticker (FK), date, ps, pe, ev_sales, p_fcf, ps_high_52w, ps_low_52w, ps_median_12m,
+ps_ath, ps_pct_of_ath, history_json, source, fetched_at — PK (ticker, date)
+```
+
+**`estimates`** (optional, latest per ticker) `ticker (PK), consensus_rating, price_target, eps_revisions_4w, source, fetched_at`
+
+**`events`** `ticker (FK), type (earnings|split|dividend), date, value, source, fetched_at — PK (ticker, type, date)`
+
+All Level 0 tables: public-read RLS, service-role writes. `metric_stats`
+(distribution percentiles) is reused from migration 038.
 
 ### companies (primary — replaces AI Analysis sheet)
 ```
@@ -873,6 +976,16 @@ python intraday_prices.py --dry-run
 python intraday_prices.py --tickers NVDA AAPL META
 python build_universe_snapshot.py           # daily 3-tier JSON snapshot
 python build_universe_snapshot.py --tier compact --dry-run
+
+# Level 0 universe & fact store
+python universe_sync.py                      # weekly: Tier 0 ingest + affordability gate
+python universe_sync.py --dry-run
+python universe_sync.py --skip-gate          # identity refresh only
+python prices_daily_updater.py               # daily: Tier 1 EOD prices + 2y backfill for new names
+python prices_daily_updater.py --backfill    # force full 2y for all Tier 1
+python prices_daily_updater.py --tickers NVDA AAPL
+python migrate_companies_to_level0.py        # one-off: seed Level 0 from companies/price_sales
+python test_level0.py                        # Level 0 unit tests
 
 # Portfolio manager
 python bootstrap_portfolios.py              # open $1M accounts for all agents

--- a/db.py
+++ b/db.py
@@ -166,6 +166,232 @@ class SupabaseDB:
                 .execute()
             )
 
+    def get_metric_stats(self, metric: str | None = None,
+                         sector: str | None = None) -> list[dict]:
+        """Read precomputed metric_stats rows (migration 038).
+
+        Powers the §9 query contract's distribution stats (percentile strips
+        on the company page, lens-relative percentiles). `sector=''` is the
+        universe-wide row; a named sector is that sector's distribution.
+        """
+        q = self.client.table("metric_stats").select("*")
+        if metric is not None:
+            q = q.eq("metric", metric)
+        if sector is not None:
+            q = q.eq("sector", sector)
+        return q.execute().data or []
+
+    # ------------------------------------------------------------------
+    # Level 0 — strategy-neutral universe & fact store (migration 039)
+    #
+    # securities (Tier 0 identity) + prices_daily / fundamentals / valuation /
+    # estimates / events (Tier 1 enrichment). These are FACTS only — no
+    # strategy lives here. See the alphamolt Level 0 spec.
+    # ------------------------------------------------------------------
+
+    # --- securities (Tier 0) ---
+
+    def get_security(self, ticker: str) -> dict | None:
+        """Return a single securities row, or None."""
+        resp = (
+            self.client.table("securities")
+            .select("*")
+            .eq("ticker", ticker)
+            .execute()
+        )
+        return resp.data[0] if resp.data else None
+
+    def get_all_securities(self, columns: str = "*",
+                           status: str | None = None) -> list[dict]:
+        """Return securities rows, optionally filtered by status.
+
+        Paginates so the full ~5-7k-row Tier 0 universe comes back (Supabase
+        caps a single select at 1000 rows).
+        """
+        rows: list[dict] = []
+        page = 0
+        page_size = 1000
+        while True:
+            q = self.client.table("securities").select(columns)
+            if status is not None:
+                q = q.eq("status", status)
+            resp = q.range(page * page_size, (page + 1) * page_size - 1).execute()
+            batch = resp.data or []
+            rows.extend(batch)
+            if len(batch) < page_size:
+                break
+            page += 1
+        return rows
+
+    def get_tier1_tickers(self) -> set[str]:
+        """Return the set of tickers currently flagged is_tier1."""
+        tickers: set[str] = set()
+        page = 0
+        page_size = 1000
+        while True:
+            resp = (
+                self.client.table("securities")
+                .select("ticker")
+                .eq("is_tier1", True)
+                .range(page * page_size, (page + 1) * page_size - 1)
+                .execute()
+            )
+            batch = resp.data or []
+            tickers.update(r["ticker"] for r in batch)
+            if len(batch) < page_size:
+                break
+            page += 1
+        return tickers
+
+    def upsert_securities_batch(self, rows: list[dict]) -> None:
+        """Insert or update many securities rows (conflict on ticker PK)."""
+        for row in rows:
+            self._sanitize(row)
+        if rows:
+            self.client.table("securities").upsert(rows).execute()
+
+    # --- prices_daily ---
+
+    def upsert_prices_daily_batch(self, rows: list[dict]) -> None:
+        """Insert or update many prices_daily rows (conflict on ticker,date).
+
+        Chunks large batches (a 2y backfill is ~500 rows/ticker) so a single
+        request stays a sane size.
+        """
+        cleaned = [r for r in rows if r.get("ticker") and r.get("date")]
+        for row in cleaned:
+            self._sanitize(row)
+        for i in range(0, len(cleaned), 1000):
+            chunk = cleaned[i:i + 1000]
+            (
+                self.client.table("prices_daily")
+                .upsert(chunk, on_conflict="ticker,date")
+                .execute()
+            )
+
+    def get_prices_daily(self, ticker: str, since: str | None = None) -> list[dict]:
+        """Return a ticker's daily prices ascending by date (optional since)."""
+        q = self.client.table("prices_daily").select("*").eq("ticker", ticker)
+        if since:
+            q = q.gte("date", since)
+        resp = q.order("date").execute()
+        return resp.data or []
+
+    def get_tickers_with_recent_prices(self, since: str) -> set[str]:
+        """Return tickers that have a prices_daily row on/after `since`.
+
+        Used to tell which Tier 1 names still need a 2y backfill (absent here)
+        vs. just a daily increment (present here)."""
+        tickers: set[str] = set()
+        page = 0
+        page_size = 1000
+        while True:
+            resp = (
+                self.client.table("prices_daily")
+                .select("ticker")
+                .gte("date", since)
+                .range(page * page_size, (page + 1) * page_size - 1)
+                .execute()
+            )
+            batch = resp.data or []
+            tickers.update(r["ticker"] for r in batch)
+            if len(batch) < page_size:
+                break
+            page += 1
+        return tickers
+
+    def get_latest_price_date(self, ticker: str) -> str | None:
+        """Return the most-recent prices_daily date for a ticker, or None."""
+        resp = (
+            self.client.table("prices_daily")
+            .select("date")
+            .eq("ticker", ticker)
+            .order("date", desc=True)
+            .limit(1)
+            .execute()
+        )
+        return resp.data[0]["date"] if resp.data else None
+
+    # --- fundamentals (history) ---
+
+    def upsert_fundamentals_batch(self, rows: list[dict]) -> None:
+        """Insert or update fundamentals rows (conflict on ticker,period_end).
+
+        Append-only by design — each new filing is a fresh period_end row;
+        existing periods are corrected in place but never collapsed.
+        """
+        for row in rows:
+            self._sanitize(row)
+        if rows:
+            (
+                self.client.table("fundamentals")
+                .upsert(rows, on_conflict="ticker,period_end")
+                .execute()
+            )
+
+    def get_fundamentals(self, ticker: str, latest_only: bool = False) -> list[dict]:
+        """Return a ticker's fundamentals history (newest first).
+
+        latest_only=True returns just the most-recent period as a 1-list.
+        """
+        q = (
+            self.client.table("fundamentals")
+            .select("*")
+            .eq("ticker", ticker)
+            .order("period_end", desc=True)
+        )
+        if latest_only:
+            q = q.limit(1)
+        resp = q.execute()
+        return resp.data or []
+
+    # --- valuation ---
+
+    def upsert_valuation_batch(self, rows: list[dict]) -> None:
+        """Insert or update valuation rows (conflict on ticker,date)."""
+        for row in rows:
+            self._sanitize(row)
+        if rows:
+            (
+                self.client.table("valuation")
+                .upsert(rows, on_conflict="ticker,date")
+                .execute()
+            )
+
+    def get_valuation(self, ticker: str, latest_only: bool = True) -> list[dict]:
+        """Return a ticker's valuation rows (newest first)."""
+        q = (
+            self.client.table("valuation")
+            .select("*")
+            .eq("ticker", ticker)
+            .order("date", desc=True)
+        )
+        if latest_only:
+            q = q.limit(1)
+        resp = q.execute()
+        return resp.data or []
+
+    # --- estimates / events ---
+
+    def upsert_estimates_batch(self, rows: list[dict]) -> None:
+        """Insert or update estimates rows (conflict on ticker PK)."""
+        for row in rows:
+            self._sanitize(row)
+        if rows:
+            self.client.table("estimates").upsert(rows).execute()
+
+    def upsert_events_batch(self, rows: list[dict]) -> None:
+        """Insert or update events rows (conflict on ticker,type,date)."""
+        cleaned = [r for r in rows if r.get("ticker") and r.get("type") and r.get("date")]
+        for row in cleaned:
+            self._sanitize(row)
+        if cleaned:
+            (
+                self.client.table("events")
+                .upsert(cleaned, on_conflict="ticker,type,date")
+                .execute()
+            )
+
     # ------------------------------------------------------------------
     # Agents / Portfolio Manager
     # ------------------------------------------------------------------

--- a/eodhd.py
+++ b/eodhd.py
@@ -1,0 +1,133 @@
+"""
+Thin, reusable EODHD REST client for the Level 0 fact store.
+
+The existing pipeline (eodhd_updater.py / price_sales_updater.py) embeds its
+own EODHD calls for the /fundamentals and /real-time endpoints. Level 0 needs
+three further endpoints — the full exchange symbol list, end-of-day history,
+and the bulk end-of-day snapshot — so they live here as one small wrapper
+rather than being scattered. All calls share one rate-limited, retrying
+`get()` so a fresh universe build doesn't hammer the API.
+
+Endpoints used:
+    GET /exchange-symbol-list/{EXCHANGE}   full ticker list + security type
+    GET /eod/{SYMBOL}                       daily OHLCV history (per ticker)
+    GET /eod-bulk-last-day/{EXCHANGE}       all tickers for one trading day
+    GET /fundamentals/{SYMBOL}              full fundamentals blob
+
+Environment:
+    EODHD_API_KEY — required.
+"""
+
+import logging
+import os
+import time
+
+import requests
+
+logger = logging.getLogger("eodhd")
+
+BASE_URL = "https://eodhd.com/api"
+DEFAULT_TIMEOUT = 60          # bulk endpoints return large payloads
+DELAY_BETWEEN_CALLS = 1.0     # seconds — matches eodhd_updater convention
+MAX_RETRIES = 4
+RETRY_BACKOFF = 2.0           # 2s, 4s, 8s, 16s
+
+
+class EODHDError(RuntimeError):
+    """Raised when EODHD returns an unrecoverable error."""
+
+
+class EODHDClient:
+    """Rate-limited, retrying wrapper over the EODHD REST API."""
+
+    def __init__(self, api_key: str | None = None, delay: float = DELAY_BETWEEN_CALLS):
+        self.api_key = api_key or os.environ.get("EODHD_API_KEY", "")
+        if not self.api_key:
+            raise RuntimeError("EODHD_API_KEY env var must be set")
+        self.delay = delay
+        self._session = requests.Session()
+
+    # ------------------------------------------------------------------
+    # Low-level
+    # ------------------------------------------------------------------
+
+    def get(self, path: str, params: dict | None = None) -> object:
+        """GET {BASE_URL}/{path} as JSON, with rate-limit + retry/backoff.
+
+        Retries on network errors and 5xx; raises EODHDError on 4xx (other
+        than 404, which returns None so callers can treat "not found" as a
+        soft miss).
+        """
+        params = dict(params or {})
+        params.setdefault("api_token", self.api_key)
+        params.setdefault("fmt", "json")
+        url = f"{BASE_URL}/{path.lstrip('/')}"
+
+        last_err: Exception | None = None
+        for attempt in range(MAX_RETRIES):
+            try:
+                resp = self._session.get(url, params=params, timeout=DEFAULT_TIMEOUT)
+                if resp.status_code == 404:
+                    return None
+                if resp.status_code == 429 or resp.status_code >= 500:
+                    raise EODHDError(f"{resp.status_code} from {path}")
+                if resp.status_code >= 400:
+                    raise EODHDError(f"{resp.status_code} from {path}: {resp.text[:200]}")
+                time.sleep(self.delay)
+                return resp.json()
+            except (requests.RequestException, EODHDError, ValueError) as e:
+                last_err = e
+                if attempt < MAX_RETRIES - 1:
+                    wait = RETRY_BACKOFF ** (attempt + 1)
+                    logger.warning("EODHD %s failed (%s); retry in %.0fs", path, e, wait)
+                    time.sleep(wait)
+        raise EODHDError(f"EODHD {path} failed after {MAX_RETRIES} attempts: {last_err}")
+
+    # ------------------------------------------------------------------
+    # Level 0 endpoints
+    # ------------------------------------------------------------------
+
+    def exchange_symbol_list(self, exchange: str = "US") -> list[dict]:
+        """Full ticker list for an exchange.
+
+        Each row: {Code, Name, Country, Exchange, Currency, Type, Isin}.
+        `Type` distinguishes Common Stock / Preferred Stock / ETF / FUND /
+        Unit / Note / etc. — the raw material for the Tier 0 security-type
+        filter.
+        """
+        data = self.get(f"exchange-symbol-list/{exchange}")
+        return data if isinstance(data, list) else []
+
+    def eod(self, symbol: str, from_date: str | None = None,
+            to_date: str | None = None, period: str = "d") -> list[dict]:
+        """Daily OHLCV history for one symbol (e.g. 'AAPL.US').
+
+        Each row: {date, open, high, low, close, adjusted_close, volume}.
+        """
+        params: dict = {"period": period}
+        if from_date:
+            params["from"] = from_date
+        if to_date:
+            params["to"] = to_date
+        data = self.get(f"eod/{symbol}", params)
+        return data if isinstance(data, list) else []
+
+    def bulk_last_day(self, exchange: str = "US", date: str | None = None) -> list[dict]:
+        """All tickers' OHLCV for a single trading day (one cheap call).
+
+        With `date=YYYY-MM-DD` returns that day; without it returns the last
+        completed trading day. Each row:
+        {code, exchange_short_name, date, open, high, low, close,
+         adjusted_close, volume}. Used to compute the trailing-30d ADDV for
+        the whole universe in ~30 calls instead of thousands.
+        """
+        params = {}
+        if date:
+            params["date"] = date
+        data = self.get(f"eod-bulk-last-day/{exchange}", params)
+        return data if isinstance(data, list) else []
+
+    def fundamentals(self, symbol: str) -> dict | None:
+        """Full fundamentals blob for one symbol (e.g. 'AAPL.US')."""
+        data = self.get(f"fundamentals/{symbol}")
+        return data if isinstance(data, dict) else None

--- a/level0.py
+++ b/level0.py
@@ -1,0 +1,177 @@
+"""
+level0.py — the contract Level 0 exposes upward (spec §9).
+
+A thin, read-only query interface over the strategy-neutral fact store. It is
+the single seam every visible surface reads through, so none of them touch the
+raw tables directly:
+
+  * the SCREENER sources candidates from the Tier 1 universe and runs its own
+    `filters + weights` against the assembled facts,
+  * the COMPANY PAGE reads one ticker's facts + the distribution stats for its
+    percentile strips,
+  * AGENTS / LENSES source candidates and compute their own signals.
+
+Everything returned is timestamped (price as-of, data as-of) for
+zero-hallucination — see the `as_of` block on each payload. This layer holds
+NO strategy: it returns facts and distributions; callers decide what to do
+with them.
+"""
+
+import logging
+from datetime import datetime
+
+from db import SupabaseDB
+
+logger = logging.getLogger("level0")
+
+# Identity columns returned for a Tier 1 universe listing (cheap candidate scan).
+UNIVERSE_COLUMNS = (
+    "ticker,name,exchange,security_type,gics_sector,gics_industry,country,"
+    "share_class,status,is_tier1,addv_30d,last_close,tier1_evaluated_at"
+)
+
+
+class FactStore:
+    """Read-only facade over the Level 0 tables (the §9 contract)."""
+
+    def __init__(self, db: SupabaseDB | None = None):
+        self.db = db or SupabaseDB()
+
+    # ------------------------------------------------------------------
+    # Universe (candidate sourcing)
+    # ------------------------------------------------------------------
+
+    def get_tier1_universe(self) -> dict:
+        """The enriched/active set — identity + affordability-gate stamps.
+
+        The screener's first pass picks candidates from here, then calls
+        `get_facts` / `get_facts_bulk` for the columns it filters/weights on.
+        """
+        rows = [s for s in self.db.get_all_securities(columns=UNIVERSE_COLUMNS,
+                                                       status="active")
+                if s.get("is_tier1")]
+        return {
+            "as_of": datetime.utcnow().isoformat(),
+            "tier": 1,
+            "count": len(rows),
+            "securities": rows,
+        }
+
+    # ------------------------------------------------------------------
+    # Per-ticker facts (company page / agent signals)
+    # ------------------------------------------------------------------
+
+    def get_facts(self, ticker: str, price_history: bool = False,
+                  fundamentals_history: bool = False) -> dict | None:
+        """Assemble one ticker's facts across the Level 0 tables.
+
+        Returns identity + latest fundamentals + latest valuation + last price
+        + upcoming/recent events + estimates, each stamped with its as-of date.
+        Set `price_history` / `fundamentals_history` to include the full series
+        rather than just the latest point.
+        """
+        ticker = ticker.upper()
+        security = self.db.get_security(ticker)
+        if security is None:
+            return None
+
+        fundamentals = self.db.get_fundamentals(ticker, latest_only=not fundamentals_history)
+        valuation = self.db.get_valuation(ticker, latest_only=True)
+        prices = self.db.get_prices_daily(ticker) if price_history else []
+        if prices:
+            latest_price = prices[-1]
+        else:
+            # Cheap path — pull just the most-recent row, not the whole series.
+            latest_rows = (
+                self.db.client.table("prices_daily")
+                .select("*")
+                .eq("ticker", ticker)
+                .order("date", desc=True)
+                .limit(1)
+                .execute()
+            ).data or []
+            latest_price = latest_rows[0] if latest_rows else None
+
+        events = (
+            self.db.client.table("events")
+            .select("*")
+            .eq("ticker", ticker)
+            .order("date", desc=True)
+            .limit(20)
+            .execute()
+        ).data or []
+        estimates_rows = (
+            self.db.client.table("estimates")
+            .select("*")
+            .eq("ticker", ticker)
+            .execute()
+        ).data or []
+
+        return {
+            "ticker": ticker,
+            "as_of": {
+                "queried_at": datetime.utcnow().isoformat(),
+                "price_date": (latest_price or {}).get("date"),
+                "fundamentals_period_end": fundamentals[0]["period_end"] if fundamentals else None,
+                "valuation_date": valuation[0]["date"] if valuation else None,
+            },
+            "identity": security,
+            "latest_price": latest_price,
+            "fundamentals": fundamentals if fundamentals_history else (fundamentals[0] if fundamentals else None),
+            "valuation": valuation[0] if valuation else None,
+            "estimates": estimates_rows[0] if estimates_rows else None,
+            "events": events,
+            "price_history": prices if price_history else None,
+        }
+
+    def get_facts_bulk(self, tickers: list[str]) -> list[dict]:
+        """Assemble facts for several tickers (screener weighting pass)."""
+        out = []
+        for t in tickers:
+            facts = self.get_facts(t)
+            if facts is not None:
+                out.append(facts)
+        return out
+
+    # ------------------------------------------------------------------
+    # Distribution stats (percentile strips / lens-relative percentiles)
+    # ------------------------------------------------------------------
+
+    def get_distribution(self, metric: str, sector: str = "") -> dict | None:
+        """Return the precomputed distribution for one metric + scope.
+
+        `sector=''` (default) is the universe-wide distribution; a named
+        sector is that sector's distribution. Carries min/p25/p50/p75/max and
+        the sample count for rendering a percentile ruler.
+        """
+        rows = self.db.get_metric_stats(metric=metric, sector=sector)
+        if not rows:
+            return None
+        r = rows[0]
+        return {
+            "metric": metric,
+            "scope": "universe" if sector == "" else f"sector:{sector}",
+            "as_of": r.get("computed_on"),
+            "min": r.get("min_val"),
+            "p25": r.get("p25"),
+            "p50": r.get("p50"),
+            "p75": r.get("p75"),
+            "max": r.get("max_val"),
+            "n": r.get("sample_count"),
+        }
+
+    def get_all_distributions(self, sector: str = "") -> dict:
+        """All metric distributions for a scope, keyed by metric."""
+        rows = self.db.get_metric_stats(sector=sector)
+        return {
+            "as_of": datetime.utcnow().isoformat(),
+            "scope": "universe" if sector == "" else f"sector:{sector}",
+            "metrics": {
+                r["metric"]: {
+                    "min": r.get("min_val"), "p25": r.get("p25"),
+                    "p50": r.get("p50"), "p75": r.get("p75"),
+                    "max": r.get("max_val"), "n": r.get("sample_count"),
+                }
+                for r in rows
+            },
+        }

--- a/migrate_companies_to_level0.py
+++ b/migrate_companies_to_level0.py
@@ -1,0 +1,139 @@
+"""
+migrate_companies_to_level0.py — one-off seed of Level 0 enrichment from the
+existing pipeline (spec §11 step 4: "you already have ~1k enriched — reuse it").
+
+Copies the scalar fundamentals already in `companies` and the P/S series in
+`price_sales` onto the Level 0 `fundamentals` / `valuation` tables, for the
+tickers that exist in `securities` (the FK target). This is a SEED, not a
+historical reconstruction: each ticker gets one latest fundamentals row (keyed
+by the company's `data_updated_at` as a synthetic period_end) and one latest
+valuation row. The Level 0 fundamentals/valuation jobs take over from here on
+their own cadence, appending real period_end rows as filings land.
+
+Only scalar metrics that map cleanly are copied; revenue/cash/debt/shares_out
+(stored as JSON snapshots in `companies`, not scalars) are left for the real
+EODHD fundamentals pull to populate.
+
+Usage:
+    python migrate_companies_to_level0.py            # seed all overlapping tickers
+    python migrate_companies_to_level0.py --dry-run
+    python migrate_companies_to_level0.py --tier1-only
+"""
+
+import argparse
+import logging
+import time
+from datetime import date
+
+from db import SupabaseDB
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("migrate_level0")
+
+# companies column -> fundamentals column (scalar metrics only)
+FUND_MAP = {
+    "rev_growth_ttm_pct": "rev_growth_ttm",
+    "rev_growth_qoq_pct": "rev_growth_qoq",
+    "rev_cagr_pct": "rev_cagr",
+    "gross_margin_pct": "gross_margin",
+    "operating_margin_pct": "operating_margin",
+    "net_margin_pct": "net_margin",
+    "fcf_margin_pct": "fcf_margin",
+    "rule_of_40": "rule_of_40",
+    "eps_only": "eps",
+    "opex_pct_revenue": "opex_pct_rev",
+}
+
+
+def _as_date(val) -> str:
+    """Coerce a timestamp/date string to YYYY-MM-DD, defaulting to today."""
+    if not val:
+        return date.today().isoformat()
+    return str(val)[:10]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Seed Level 0 from companies/price_sales")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--tier1-only", action="store_true",
+                    help="only seed tickers already flagged is_tier1")
+    args = ap.parse_args()
+
+    started = time.time()
+    db = SupabaseDB()
+
+    securities = db.get_all_securities(columns="ticker,is_tier1")
+    sec_set = {s["ticker"] for s in securities}
+    tier1_set = {s["ticker"] for s in securities if s.get("is_tier1")}
+    target = tier1_set if args.tier1_only else sec_set
+    logger.info("Level 0 has %d securities (%d Tier 1); seeding into %d",
+                len(sec_set), len(tier1_set), len(target))
+
+    companies = db.get_all_companies()
+    price_sales = db.get_all_price_sales()
+
+    fund_rows: list[dict] = []
+    val_rows: list[dict] = []
+    skipped = 0
+    for c in companies:
+        ticker = c.get("ticker")
+        if ticker not in target:
+            skipped += 1
+            continue
+
+        period_end = _as_date(c.get("data_updated_at"))
+        fund = {"ticker": ticker, "period_end": period_end, "source": "migrated:companies"}
+        has_fund = False
+        for src, dst in FUND_MAP.items():
+            v = db.safe_float(c.get(src))
+            if v is not None:
+                fund[dst] = v
+                has_fund = True
+        if has_fund:
+            fund_rows.append(fund)
+
+        ps = price_sales.get(ticker)
+        ps_now = db.safe_float((ps or {}).get("ps_now") if ps else c.get("ps_now"))
+        if ps_now is not None or ps:
+            val = {
+                "ticker": ticker,
+                "date": _as_date((ps or {}).get("last_updated")),
+                "ps": ps_now,
+                "source": "migrated:price_sales",
+            }
+            if ps:
+                val.update({
+                    "ps_high_52w": db.safe_float(ps.get("high_52w")),
+                    "ps_low_52w": db.safe_float(ps.get("low_52w")),
+                    "ps_median_12m": db.safe_float(ps.get("median_12m")),
+                    "ps_ath": db.safe_float(ps.get("ath")),
+                    "ps_pct_of_ath": db.safe_float(ps.get("pct_of_ath")),
+                    "history_json": ps.get("history_json"),
+                })
+            val_rows.append(val)
+
+    logger.info("Prepared %d fundamentals + %d valuation rows (%d companies skipped)",
+                len(fund_rows), len(val_rows), skipped)
+
+    if not args.dry_run:
+        for i in range(0, len(fund_rows), 500):
+            db.upsert_fundamentals_batch(fund_rows[i:i + 500])
+        for i in range(0, len(val_rows), 500):
+            db.upsert_valuation_batch(val_rows[i:i + 500])
+
+    stats = {
+        "updated": len(fund_rows) + len(val_rows),
+        "skipped": skipped,
+        "errors": 0,
+        "duration_secs": round(time.time() - started, 1),
+        "details": {"fundamentals": len(fund_rows), "valuation": len(val_rows),
+                    "dry_run": args.dry_run},
+    }
+    logger.info("Done: %s", stats["details"])
+    if not args.dry_run:
+        db.log_run("migrate_companies_to_level0", stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/migrations/039_level0_universe.sql
+++ b/migrations/039_level0_universe.sql
@@ -1,0 +1,203 @@
+-- Migration 039: Level 0 — strategy-neutral universe & fact store.
+--
+-- A single, strategy-neutral store of facts about all liquid US equities.
+-- It is invisible to users; every visible surface (screener, company pages,
+-- lens scoring, agents) reads from it. See the alphamolt Level 0 spec.
+--
+-- THE LINE THAT MUST HOLD: Level 0 contains FACTS, never STRATEGY. No
+-- margin/growth/valuation/sector OPINIONS live here — those are lenses applied
+-- downstream. The only gate Level 0 applies is strategy-neutral AFFORDABILITY
+-- (liquidity + has-data + valid listing — see securities.is_tier1 / spec §6).
+--
+-- Two-tier model:
+--   * Tier 0 — reference universe: every US-listed common stock + ADRs + REITs
+--     (units, warrants, preferreds, SPACs excluded). Identity-level only, cheap,
+--     slow-changing, status-tracked. Soft-delete on delisting — never hard-delete;
+--     delisted names keep their history (status='delisted').
+--   * Tier 1 — enriched/active set: the subset passing the affordability gate
+--     that receives full enrichment (prices, fundamentals, valuation). This is
+--     where compute is spent. Flagged by securities.is_tier1.
+--
+-- Every fact-bearing row carries `source` and an as-of date (`fetched_at` and/or
+-- `period_end`/`date`) for zero-hallucination. Latest values stamped with their
+-- as-of date — NOT full historical point-in-time reconstruction (spec §12).
+--
+-- These tables are ADDITIVE: the existing companies / price_sales pipeline is
+-- untouched. The old opinionated TradingView screen becomes one lens applied on
+-- top of Tier 1, downstream.
+--
+-- Idempotent: re-runnable (CREATE TABLE IF NOT EXISTS, upserts on the PKs).
+
+-- ============================================================
+-- securities — Tier 0 identity (the reference universe)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS securities (
+    ticker              TEXT PRIMARY KEY,
+    name                TEXT,
+    exchange            TEXT,
+    cik                 TEXT,          -- SEC Central Index Key (ticker↔CIK↔name)
+    figi                TEXT,
+    isin                TEXT,
+    security_type       TEXT,          -- 'Common Stock' | 'ADR' | 'REIT'
+    gics_sector         TEXT,
+    gics_industry       TEXT,
+    country             TEXT,
+    share_class         TEXT,          -- dual-class marker, e.g. GOOG vs GOOGL
+
+    status              TEXT NOT NULL DEFAULT 'active',  -- 'active' | 'delisted'
+
+    ipo_date            DATE,
+    first_seen          DATE NOT NULL DEFAULT CURRENT_DATE,
+    last_seen           DATE NOT NULL DEFAULT CURRENT_DATE,
+
+    -- Tier 1 membership + the strategy-neutral affordability gate inputs that
+    -- decided it (stamped for transparency; recomputed weekly).
+    is_tier1            BOOLEAN NOT NULL DEFAULT FALSE,
+    addv_30d            NUMERIC,       -- avg daily dollar volume, trailing 30d
+    last_close          NUMERIC,       -- last close used by the gate
+    tier1_evaluated_at  TIMESTAMPTZ,
+
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_securities_status   ON securities (status);
+CREATE INDEX IF NOT EXISTS idx_securities_tier1    ON securities (is_tier1) WHERE is_tier1;
+CREATE INDEX IF NOT EXISTS idx_securities_sector   ON securities (gics_sector);
+CREATE INDEX IF NOT EXISTS idx_securities_type     ON securities (security_type);
+
+DROP TRIGGER IF EXISTS securities_updated_at ON securities;
+CREATE TRIGGER securities_updated_at
+    BEFORE UPDATE ON securities
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ============================================================
+-- prices_daily — the Pareto king (technicals, valuation-over-time, liquidity)
+-- 2y of history per Tier 1 ticker.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS prices_daily (
+    ticker          TEXT NOT NULL REFERENCES securities(ticker) ON DELETE CASCADE,
+    date            DATE NOT NULL,
+    open            NUMERIC,
+    high            NUMERIC,
+    low             NUMERIC,
+    close           NUMERIC,
+    adj_close       NUMERIC,           -- split/dividend-adjusted
+    volume          BIGINT,
+    dollar_volume   NUMERIC,           -- close * volume (powers the liquidity gate)
+    PRIMARY KEY (ticker, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_prices_daily_date ON prices_daily (date);
+
+-- ============================================================
+-- fundamentals — keep HISTORY, not just the current snapshot.
+-- One row per (ticker, period_end); never overwrite history — append a new
+-- period_end on each new filing.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS fundamentals (
+    ticker              TEXT NOT NULL REFERENCES securities(ticker) ON DELETE CASCADE,
+    period_end          DATE NOT NULL,
+    fetched_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    source              TEXT,
+
+    revenue             NUMERIC,
+    rev_growth_ttm      NUMERIC,
+    rev_growth_qoq      NUMERIC,
+    rev_cagr            NUMERIC,
+    gross_margin        NUMERIC,
+    operating_margin    NUMERIC,
+    net_margin          NUMERIC,
+    fcf_margin          NUMERIC,
+    rule_of_40          NUMERIC,
+    cash                NUMERIC,
+    debt                NUMERIC,
+    shares_out          NUMERIC,
+    eps                 NUMERIC,
+    opex_pct_rev        NUMERIC,
+
+    PRIMARY KEY (ticker, period_end)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fundamentals_period ON fundamentals (period_end);
+
+-- ============================================================
+-- valuation — multiples + series. One row per (ticker, date). The P/S summary
+-- columns (52w hi/lo, 12m median, ATH) + history_json mirror the existing
+-- price_sales semantics and are meaningful on the latest dated row.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS valuation (
+    ticker          TEXT NOT NULL REFERENCES securities(ticker) ON DELETE CASCADE,
+    date            DATE NOT NULL,
+    ps              NUMERIC,
+    pe              NUMERIC,
+    ev_sales        NUMERIC,
+    p_fcf           NUMERIC,
+
+    -- P/S distribution context (carried on the latest row; mirrors price_sales)
+    ps_high_52w     NUMERIC,
+    ps_low_52w      NUMERIC,
+    ps_median_12m   NUMERIC,
+    ps_ath          NUMERIC,
+    ps_pct_of_ath   NUMERIC,
+    history_json    JSONB,             -- rolling [[date, ps], ...] series
+
+    source          TEXT,
+    fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (ticker, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_valuation_date ON valuation (date);
+
+-- ============================================================
+-- estimates — optional, high value/cost. Latest snapshot per ticker.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS estimates (
+    ticker              TEXT PRIMARY KEY REFERENCES securities(ticker) ON DELETE CASCADE,
+    consensus_rating    TEXT,
+    price_target        NUMERIC,
+    eps_revisions_4w    NUMERIC,
+    source              TEXT,
+    fetched_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================
+-- events — next + past earnings, splits, ex-div.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS events (
+    ticker          TEXT NOT NULL REFERENCES securities(ticker) ON DELETE CASCADE,
+    type            TEXT NOT NULL,     -- 'earnings' | 'split' | 'dividend'
+    date            DATE NOT NULL,
+    value           NUMERIC,           -- split ratio / dividend amount / eps (type-dependent)
+    source          TEXT,
+    fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (ticker, type, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_ticker_date ON events (ticker, date);
+CREATE INDEX IF NOT EXISTS idx_events_type_date   ON events (type, date);
+
+-- ============================================================
+-- RLS — public read, service-role-only writes (matches migrations 020 / 038).
+-- These are facts; the website reads them with the anon key, the pipeline
+-- writes them with the service-role key (which bypasses RLS).
+-- ============================================================
+ALTER TABLE securities   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE prices_daily ENABLE ROW LEVEL SECURITY;
+ALTER TABLE fundamentals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE valuation    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE estimates    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE events       ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "public read" ON securities;
+CREATE POLICY "public read" ON securities   FOR SELECT USING (true);
+DROP POLICY IF EXISTS "public read" ON prices_daily;
+CREATE POLICY "public read" ON prices_daily FOR SELECT USING (true);
+DROP POLICY IF EXISTS "public read" ON fundamentals;
+CREATE POLICY "public read" ON fundamentals FOR SELECT USING (true);
+DROP POLICY IF EXISTS "public read" ON valuation;
+CREATE POLICY "public read" ON valuation    FOR SELECT USING (true);
+DROP POLICY IF EXISTS "public read" ON estimates;
+CREATE POLICY "public read" ON estimates    FOR SELECT USING (true);
+DROP POLICY IF EXISTS "public read" ON events;
+CREATE POLICY "public read" ON events       FOR SELECT USING (true);

--- a/prices_daily_updater.py
+++ b/prices_daily_updater.py
@@ -1,0 +1,159 @@
+"""
+prices_daily_updater.py — Level 0 daily price layer (the Pareto king).
+
+Daily clock (spec §3). Maintains `prices_daily` for the Tier 1 set:
+
+  * Daily increment — one `eod-bulk-last-day` call writes the latest trading
+    day's OHLCV for every Tier 1 ticker (idempotent upsert on (ticker, date)).
+  * Backfill — any Tier 1 ticker with no recent prices_daily row (a fresh
+    promotion from the weekly gate) gets a full 2y per-ticker history pull
+    (spec §11 step 3 / §12 — 2 years of daily history).
+
+`dollar_volume` (close * volume) is stored alongside so the affordability gate
+and liquidity lenses don't recompute it. `adj_close` carries EODHD's
+split/dividend-adjusted close so valuation-over-time stays consistent.
+
+Usage:
+    python prices_daily_updater.py                 # increment + backfill new names
+    python prices_daily_updater.py --backfill      # force full 2y for all Tier 1
+    python prices_daily_updater.py --tickers NVDA AAPL
+    python prices_daily_updater.py --dry-run
+"""
+
+import argparse
+import logging
+import time
+from datetime import date, timedelta
+
+from db import SupabaseDB
+from eodhd import EODHDClient
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("prices_daily")
+
+HISTORY_YEARS = 2
+RECENT_WINDOW_DAYS = 7   # a Tier 1 ticker with a row newer than this is "current"
+
+
+def _row(ticker: str, r: dict) -> dict | None:
+    """Map one EODHD eod / bulk row to a prices_daily row."""
+    d = r.get("date")
+    close = r.get("close")
+    vol = r.get("volume")
+    if not d or close is None:
+        return None
+    dollar_volume = None
+    if vol is not None:
+        try:
+            dollar_volume = float(close) * float(vol)
+        except (TypeError, ValueError):
+            dollar_volume = None
+    return {
+        "ticker": ticker,
+        "date": d,
+        "open": r.get("open"),
+        "high": r.get("high"),
+        "low": r.get("low"),
+        "close": close,
+        "adj_close": r.get("adjusted_close"),
+        "volume": vol,
+        "dollar_volume": dollar_volume,
+    }
+
+
+def backfill_ticker(db: SupabaseDB, client: EODHDClient, ticker: str,
+                    years: int, dry_run: bool) -> int:
+    """Pull `years` of daily history for one ticker into prices_daily."""
+    from_date = (date.today() - timedelta(days=365 * years + 5)).isoformat()
+    history = client.eod(f"{ticker}.US", from_date=from_date)
+    rows = [r for r in (_row(ticker, h) for h in history) if r]
+    if rows and not dry_run:
+        db.upsert_prices_daily_batch(rows)
+    return len(rows)
+
+
+def daily_increment(db: SupabaseDB, client: EODHDClient, tier1: set[str],
+                    dry_run: bool) -> int:
+    """Write the latest trading day's OHLCV for every Tier 1 ticker."""
+    bulk = client.bulk_last_day("US")
+    rows = []
+    for r in bulk:
+        code = (r.get("code") or "").strip().upper()
+        if code in tier1:
+            mapped = _row(code, r)
+            if mapped:
+                rows.append(mapped)
+    if rows and not dry_run:
+        db.upsert_prices_daily_batch(rows)
+    logger.info("Daily increment: %d Tier 1 rows for %s",
+                len(rows), bulk[0].get("date") if bulk else "?")
+    return len(rows)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Level 0 prices_daily updater")
+    ap.add_argument("--backfill", action="store_true",
+                    help="force full 2y backfill for all Tier 1 (not just new names)")
+    ap.add_argument("--tickers", nargs="+", help="limit to these tickers")
+    ap.add_argument("--years", type=int, default=HISTORY_YEARS)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    started = time.time()
+    db = SupabaseDB()
+    client = EODHDClient()
+
+    tier1 = db.get_tier1_tickers()
+    if args.tickers:
+        wanted = {t.upper() for t in args.tickers}
+        tier1 = tier1 & wanted if not args.backfill else wanted
+        logger.info("Restricted to %d requested ticker(s)", len(tier1))
+    logger.info("Tier 1 universe: %d tickers", len(tier1))
+
+    # Which names need a full backfill?
+    if args.backfill or args.tickers:
+        to_backfill = set(tier1)
+    else:
+        since = (date.today() - timedelta(days=RECENT_WINDOW_DAYS)).isoformat()
+        current = db.get_tickers_with_recent_prices(since)
+        to_backfill = tier1 - current
+    logger.info("Backfilling %d ticker(s) (2y history)", len(to_backfill))
+
+    backfilled_rows = 0
+    errors = 0
+    for i, t in enumerate(sorted(to_backfill), 1):
+        try:
+            n = backfill_ticker(db, client, t, args.years, args.dry_run)
+            backfilled_rows += n
+            if i % 50 == 0:
+                logger.info("  ... %d/%d backfilled", i, len(to_backfill))
+        except Exception as e:  # one bad ticker must not abort the run
+            errors += 1
+            logger.warning("Backfill failed for %s: %s", t, e)
+
+    inc_rows = 0
+    if not args.tickers or not args.backfill:
+        inc_rows = daily_increment(db, client, tier1, args.dry_run)
+
+    stats = {
+        "backfilled": len(to_backfill),
+        "updated": inc_rows,
+        "errors": errors,
+        "duration_secs": round(time.time() - started, 1),
+        "details": {
+            "tier1": len(tier1),
+            "backfill_rows": backfilled_rows,
+            "increment_rows": inc_rows,
+            "dry_run": args.dry_run,
+        },
+    }
+    logger.info("Done: %s", stats["details"])
+    if not args.dry_run:
+        db.log_run("prices_daily", stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -666,3 +666,147 @@ DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
 CREATE TRIGGER on_auth_user_created
     AFTER INSERT ON auth.users
     FOR EACH ROW EXECUTE FUNCTION handle_new_user();
+
+
+-- ============================================================
+-- Level 0 — strategy-neutral universe & fact store (migration 039)
+--
+-- A single store of FACTS (never strategy) about all liquid US equities. The
+-- old opinionated TradingView screen becomes one lens applied on top of Tier 1,
+-- downstream. The only gate here is strategy-neutral affordability (securities
+-- .is_tier1 — liquidity + has-data + valid listing). See the alphamolt Level 0
+-- spec and migrations/039_level0_universe.sql for full notes.
+-- ============================================================
+
+-- securities — Tier 0 identity (every US common stock + ADR + REIT).
+CREATE TABLE IF NOT EXISTS securities (
+    ticker              TEXT PRIMARY KEY,
+    name                TEXT,
+    exchange            TEXT,
+    cik                 TEXT,
+    figi                TEXT,
+    isin                TEXT,
+    security_type       TEXT,          -- 'Common Stock' | 'ADR' | 'REIT'
+    gics_sector         TEXT,
+    gics_industry       TEXT,
+    country             TEXT,
+    share_class         TEXT,
+    status              TEXT NOT NULL DEFAULT 'active',  -- 'active' | 'delisted'
+    ipo_date            DATE,
+    first_seen          DATE NOT NULL DEFAULT CURRENT_DATE,
+    last_seen           DATE NOT NULL DEFAULT CURRENT_DATE,
+    is_tier1            BOOLEAN NOT NULL DEFAULT FALSE,
+    addv_30d            NUMERIC,
+    last_close          NUMERIC,
+    tier1_evaluated_at  TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_securities_status ON securities (status);
+CREATE INDEX IF NOT EXISTS idx_securities_tier1  ON securities (is_tier1) WHERE is_tier1;
+CREATE INDEX IF NOT EXISTS idx_securities_sector ON securities (gics_sector);
+CREATE INDEX IF NOT EXISTS idx_securities_type   ON securities (security_type);
+DROP TRIGGER IF EXISTS securities_updated_at ON securities;
+CREATE TRIGGER securities_updated_at BEFORE UPDATE ON securities
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- prices_daily — 2y daily OHLCV per Tier 1 ticker (the Pareto king).
+CREATE TABLE IF NOT EXISTS prices_daily (
+    ticker          TEXT NOT NULL REFERENCES securities(ticker) ON DELETE CASCADE,
+    date            DATE NOT NULL,
+    open            NUMERIC,
+    high            NUMERIC,
+    low             NUMERIC,
+    close           NUMERIC,
+    adj_close       NUMERIC,
+    volume          BIGINT,
+    dollar_volume   NUMERIC,
+    PRIMARY KEY (ticker, date)
+);
+CREATE INDEX IF NOT EXISTS idx_prices_daily_date ON prices_daily (date);
+
+-- fundamentals — append-only history, one row per (ticker, period_end).
+CREATE TABLE IF NOT EXISTS fundamentals (
+    ticker              TEXT NOT NULL REFERENCES securities(ticker) ON DELETE CASCADE,
+    period_end          DATE NOT NULL,
+    fetched_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    source              TEXT,
+    revenue             NUMERIC,
+    rev_growth_ttm      NUMERIC,
+    rev_growth_qoq      NUMERIC,
+    rev_cagr            NUMERIC,
+    gross_margin        NUMERIC,
+    operating_margin    NUMERIC,
+    net_margin          NUMERIC,
+    fcf_margin          NUMERIC,
+    rule_of_40          NUMERIC,
+    cash                NUMERIC,
+    debt                NUMERIC,
+    shares_out          NUMERIC,
+    eps                 NUMERIC,
+    opex_pct_rev        NUMERIC,
+    PRIMARY KEY (ticker, period_end)
+);
+CREATE INDEX IF NOT EXISTS idx_fundamentals_period ON fundamentals (period_end);
+
+-- valuation — multiples + P/S series, one row per (ticker, date).
+CREATE TABLE IF NOT EXISTS valuation (
+    ticker          TEXT NOT NULL REFERENCES securities(ticker) ON DELETE CASCADE,
+    date            DATE NOT NULL,
+    ps              NUMERIC,
+    pe              NUMERIC,
+    ev_sales        NUMERIC,
+    p_fcf           NUMERIC,
+    ps_high_52w     NUMERIC,
+    ps_low_52w      NUMERIC,
+    ps_median_12m   NUMERIC,
+    ps_ath          NUMERIC,
+    ps_pct_of_ath   NUMERIC,
+    history_json    JSONB,
+    source          TEXT,
+    fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (ticker, date)
+);
+CREATE INDEX IF NOT EXISTS idx_valuation_date ON valuation (date);
+
+-- estimates — optional latest snapshot per ticker.
+CREATE TABLE IF NOT EXISTS estimates (
+    ticker              TEXT PRIMARY KEY REFERENCES securities(ticker) ON DELETE CASCADE,
+    consensus_rating    TEXT,
+    price_target        NUMERIC,
+    eps_revisions_4w    NUMERIC,
+    source              TEXT,
+    fetched_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- events — earnings / split / dividend.
+CREATE TABLE IF NOT EXISTS events (
+    ticker          TEXT NOT NULL REFERENCES securities(ticker) ON DELETE CASCADE,
+    type            TEXT NOT NULL,
+    date            DATE NOT NULL,
+    value           NUMERIC,
+    source          TEXT,
+    fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (ticker, type, date)
+);
+CREATE INDEX IF NOT EXISTS idx_events_ticker_date ON events (ticker, date);
+CREATE INDEX IF NOT EXISTS idx_events_type_date   ON events (type, date);
+
+ALTER TABLE securities   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE prices_daily ENABLE ROW LEVEL SECURITY;
+ALTER TABLE fundamentals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE valuation    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE estimates    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE events       ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "public read" ON securities;
+CREATE POLICY "public read" ON securities   FOR SELECT USING (true);
+DROP POLICY IF EXISTS "public read" ON prices_daily;
+CREATE POLICY "public read" ON prices_daily FOR SELECT USING (true);
+DROP POLICY IF EXISTS "public read" ON fundamentals;
+CREATE POLICY "public read" ON fundamentals FOR SELECT USING (true);
+DROP POLICY IF EXISTS "public read" ON valuation;
+CREATE POLICY "public read" ON valuation    FOR SELECT USING (true);
+DROP POLICY IF EXISTS "public read" ON estimates;
+CREATE POLICY "public read" ON estimates    FOR SELECT USING (true);
+DROP POLICY IF EXISTS "public read" ON events;
+CREATE POLICY "public read" ON events       FOR SELECT USING (true);

--- a/test_level0.py
+++ b/test_level0.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Unit tests for the Level 0 universe & fact store.
+
+Covers the pure logic that decides the universe — security-type
+classification, the affordability gate, the price-row mapper — and the
+FactStore distribution contract, all with stubbed dependencies (no live DB,
+no EODHD calls). Run directly:
+
+    python test_level0.py
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+import universe_sync as us
+import prices_daily_updater as pdu
+from level0 import FactStore
+
+
+class TestClassifySecurity(unittest.TestCase):
+    def _row(self, **kw):
+        base = {"Code": "AAA", "Name": "Some Co", "Type": "Common Stock"}
+        base.update(kw)
+        return base
+
+    def test_common_stock_kept(self):
+        self.assertEqual(us.classify_security(self._row())[0], "Common Stock")
+
+    def test_etf_dropped(self):
+        self.assertIsNone(us.classify_security(self._row(Type="ETF")))
+
+    def test_preferred_type_dropped(self):
+        self.assertIsNone(us.classify_security(self._row(Type="Preferred Stock")))
+
+    def test_fund_and_note_dropped(self):
+        self.assertIsNone(us.classify_security(self._row(Type="FUND")))
+        self.assertIsNone(us.classify_security(self._row(Type="Note")))
+
+    def test_warrant_by_name_dropped(self):
+        self.assertIsNone(
+            us.classify_security(self._row(Name="Acme Inc Warrant")))
+
+    def test_unit_by_name_dropped(self):
+        self.assertIsNone(
+            us.classify_security(self._row(Name="Acme Acquisition Unit")))
+
+    def test_spac_by_name_dropped(self):
+        self.assertIsNone(
+            us.classify_security(self._row(Name="Pioneer Acquisition Corp")))
+
+    def test_adr_tagged(self):
+        self.assertEqual(
+            us.classify_security(self._row(Name="Taiwan Semi ADR"))[0], "ADR")
+
+    def test_reit_tagged(self):
+        self.assertEqual(
+            us.classify_security(self._row(Name="Prologis REIT Inc"))[0], "REIT")
+
+    def test_dual_class_share_class_parsed(self):
+        kind, share_class = us.classify_security(
+            self._row(Code="BRK-A", Name="Berkshire Hathaway"))
+        self.assertEqual(kind, "Common Stock")
+        self.assertEqual(share_class, "A")
+
+    def test_real_ticker_ending_in_w_not_dropped(self):
+        # SNOW ends in W but is not a warrant — must survive.
+        self.assertEqual(
+            us.classify_security(self._row(Code="SNOW", Name="Snowflake Inc"))[0],
+            "Common Stock")
+
+
+class TestAffordabilityGate(unittest.TestCase):
+    def test_passes_when_liquid_and_priced(self):
+        self.assertTrue(us.passes_gate(addv_30d=10_000_000, last_close=42.0, days=30))
+
+    def test_fails_below_dollar_volume(self):
+        self.assertFalse(us.passes_gate(addv_30d=1_000_000, last_close=42.0, days=30))
+
+    def test_fails_penny_stock(self):
+        self.assertFalse(us.passes_gate(addv_30d=10_000_000, last_close=0.5, days=30))
+
+    def test_fails_insufficient_history(self):
+        self.assertFalse(us.passes_gate(addv_30d=10_000_000, last_close=42.0, days=5))
+
+    def test_fails_on_missing_stats(self):
+        self.assertFalse(us.passes_gate(addv_30d=None, last_close=None, days=0))
+
+    def test_boundary_exactly_at_thresholds(self):
+        self.assertTrue(us.passes_gate(
+            addv_30d=us.GATE_MIN_DOLLAR_VOLUME,
+            last_close=us.GATE_MIN_PRICE,
+            days=us.GATE_MIN_DAYS))
+
+
+class TestPriceRowMapper(unittest.TestCase):
+    def test_maps_and_computes_dollar_volume(self):
+        row = pdu._row("NVDA", {
+            "date": "2026-06-01", "open": 100, "high": 110, "low": 99,
+            "close": 105, "adjusted_close": 105, "volume": 1000,
+        })
+        self.assertEqual(row["ticker"], "NVDA")
+        self.assertEqual(row["dollar_volume"], 105 * 1000)
+        self.assertEqual(row["adj_close"], 105)
+
+    def test_drops_row_without_date_or_close(self):
+        self.assertIsNone(pdu._row("X", {"close": 5}))
+        self.assertIsNone(pdu._row("X", {"date": "2026-06-01"}))
+
+    def test_null_volume_yields_null_dollar_volume(self):
+        row = pdu._row("X", {"date": "2026-06-01", "close": 5, "volume": None})
+        self.assertIsNone(row["dollar_volume"])
+
+
+class _StubDB:
+    """Minimal stub exposing only what FactStore.get_distribution needs."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def get_metric_stats(self, metric=None, sector=None):
+        return [r for r in self._rows
+                if (metric is None or r["metric"] == metric)
+                and (sector is None or r["sector"] == sector)]
+
+
+class TestFactStoreDistribution(unittest.TestCase):
+    def setUp(self):
+        rows = [
+            {"metric": "ps_now", "sector": "", "min_val": 0.5, "p25": 2,
+             "p50": 5, "p75": 9, "max_val": 40, "sample_count": 1200,
+             "computed_on": "2026-06-03"},
+            {"metric": "ps_now", "sector": "Technology", "min_val": 1,
+             "p25": 4, "p50": 8, "p75": 14, "max_val": 50, "sample_count": 300,
+             "computed_on": "2026-06-03"},
+        ]
+        self.fs = FactStore(db=_StubDB(rows))
+
+    def test_universe_scope_default(self):
+        d = self.fs.get_distribution("ps_now")
+        self.assertEqual(d["scope"], "universe")
+        self.assertEqual(d["p50"], 5)
+        self.assertEqual(d["n"], 1200)
+        self.assertEqual(d["as_of"], "2026-06-03")
+
+    def test_sector_scope(self):
+        d = self.fs.get_distribution("ps_now", sector="Technology")
+        self.assertEqual(d["scope"], "sector:Technology")
+        self.assertEqual(d["p50"], 8)
+
+    def test_missing_metric_returns_none(self):
+        self.assertIsNone(self.fs.get_distribution("rule_of_40"))
+
+    def test_all_distributions_keyed_by_metric(self):
+        out = self.fs.get_all_distributions(sector="")
+        self.assertIn("ps_now", out["metrics"])
+        self.assertEqual(out["metrics"]["ps_now"]["p50"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/universe_sync.py
+++ b/universe_sync.py
@@ -1,0 +1,282 @@
+"""
+universe_sync.py — Level 0 membership / identity + affordability gate.
+
+Weekly clock (spec §3). Two jobs, both strategy-neutral:
+
+  1. Tier 0 (identity) — ingest the full US exchange symbol list into
+     `securities`: every US-listed common stock, ADR and REIT (units,
+     warrants, preferreds, SPACs excluded). New listings are added,
+     names no longer in the list are soft-deleted (status='delisted',
+     never hard-deleted — delisted names keep their history).
+
+  2. The affordability gate (spec §6) — the ONLY gate Level 0 applies, and it
+     carries no strategy. A security is promoted to Tier 1 when:
+        * liquidity:  trailing-30d avg daily dollar volume >= $5M AND
+                      last close >= $1   (conservative, tunable)
+        * has data:   enough recent daily prices to evaluate it
+        * listing:    active, US exchange, included security type
+     The trailing-30d ADDV for the WHOLE universe is computed from ~30
+     `eod-bulk-last-day` calls (one per trading day) rather than thousands
+     of per-ticker history pulls.
+
+No margins / growth / valuation / sector views here — those are lenses
+downstream. This script only decides WHO is liquid enough to enrich; the
+enrichment itself (prices_daily backfill, fundamentals, valuation) is owned
+by the daily/per-filing jobs.
+
+Usage:
+    python universe_sync.py                 # full weekly sync
+    python universe_sync.py --dry-run       # compute, write nothing
+    python universe_sync.py --skip-gate     # identity refresh only
+    python universe_sync.py --limit 200     # cap symbols (smoke test)
+"""
+
+import argparse
+import logging
+import time
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+
+from db import SupabaseDB
+from eodhd import EODHDClient
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("universe_sync")
+
+# --- affordability gate constants (conservative starting values, tunable) ---
+GATE_MIN_DOLLAR_VOLUME = 5_000_000   # trailing-30d avg daily $ volume
+GATE_MIN_PRICE = 1.0                 # last close
+GATE_MIN_DAYS = 15                   # min trading days of price data to judge
+ADDV_WINDOW = 30                     # trailing trading days for ADDV
+BULK_LOOKBACK_DAYS = 50              # calendar-day cap when collecting 30 days
+
+# --- security-type classification (spec §4 / §12) ---
+# EODHD's symbol-list `Type` labels ETFs, funds, preferreds, notes, units etc.
+# distinctly; common stock, most ADRs and most REITs all arrive as
+# "Common Stock". We include only "Common Stock" then drop warrants / units /
+# rights / SPACs by name, and tag ADR / REIT for downstream lenses.
+INCLUDE_TYPES = {"common stock"}
+# Name keywords that mark a non-common-equity instrument to exclude even when
+# EODHD typed it "Common Stock".
+EXCLUDE_NAME_KEYWORDS = (
+    "WARRANT", "RIGHTS", " RIGHT ", "UNIT", "DEPOSITARY SHARE",
+    "PREFERRED", "ACQUISITION CORP", "ACQUISITION CO ", "ACQUISITION CO.",
+)
+ADR_KEYWORDS = ("ADR", "ADS", "AMERICAN DEPOSITARY")
+REIT_KEYWORDS = ("REIT",)
+
+
+def classify_security(row: dict) -> tuple[str, str | None] | None:
+    """Map one EODHD symbol-list row to (security_type, share_class), or None
+    to drop it from Tier 0.
+
+    Strategy-neutral: this is a security-*kind* filter (keep equities, drop
+    derivatives/funds), never a quality/strategy filter.
+    """
+    sec_type = (row.get("Type") or "").strip().lower()
+    if sec_type not in INCLUDE_TYPES:
+        return None
+
+    name = (row.get("Name") or "").upper()
+    if any(kw in name for kw in EXCLUDE_NAME_KEYWORDS):
+        return None
+
+    code = (row.get("Code") or "").strip().upper()
+    # Dual-class tickers use a hyphen (BRK-A / BRK-B); the part after the
+    # hyphen is the share class. (Preferreds arrive as Type "Preferred Stock"
+    # and are already excluded above, so a hyphen here means dual-class.)
+    share_class = code.split("-")[-1] if "-" in code else None
+
+    if any(kw in name for kw in ADR_KEYWORDS):
+        kind = "ADR"
+    elif any(kw in name for kw in REIT_KEYWORDS):
+        kind = "REIT"
+    else:
+        kind = "Common Stock"
+    return kind, share_class
+
+
+def passes_gate(addv_30d: float | None, last_close: float | None,
+                days: int) -> bool:
+    """The strategy-neutral affordability gate (spec §6).
+
+    Pure decision over a security's liquidity stats: enough trading days to
+    judge it, price >= $1, and trailing-30d ADDV >= $5M. No margins / growth /
+    valuation / sector views — those are lenses downstream.
+    """
+    return bool(
+        days >= GATE_MIN_DAYS
+        and last_close is not None and last_close >= GATE_MIN_PRICE
+        and addv_30d is not None and addv_30d >= GATE_MIN_DOLLAR_VOLUME
+    )
+
+
+def ingest_tier0(db: SupabaseDB, client: EODHDClient, limit: int | None,
+                 dry_run: bool) -> dict:
+    """Ingest the US symbol list into `securities`; soft-delete delistings."""
+    raw = client.exchange_symbol_list("US")
+    logger.info("EODHD returned %d raw US symbols", len(raw))
+    if limit:
+        raw = raw[:limit]
+
+    today = date.today().isoformat()
+    seen: set[str] = set()
+    rows: list[dict] = []
+    dropped = 0
+    for r in raw:
+        code = (r.get("Code") or "").strip().upper()
+        if not code:
+            continue
+        classified = classify_security(r)
+        if classified is None:
+            dropped += 1
+            continue
+        kind, share_class = classified
+        seen.add(code)
+        rows.append({
+            "ticker": code,
+            "name": r.get("Name"),
+            "exchange": r.get("Exchange"),
+            "isin": r.get("Isin"),
+            "country": r.get("Country") or "USA",
+            "security_type": kind,
+            "share_class": share_class,
+            "status": "active",
+            "last_seen": today,
+        })
+
+    # Soft-delete: anything previously active but absent from the fresh list.
+    existing = db.get_all_securities(columns="ticker,status")
+    existing_active = {s["ticker"] for s in existing if s.get("status") == "active"}
+    delisted = sorted(existing_active - seen)
+    delist_rows = [{"ticker": t, "status": "delisted", "is_tier1": False}
+                   for t in delisted]
+
+    logger.info("Tier 0: %d kept, %d dropped (type/name), %d newly delisted",
+                len(rows), dropped, len(delist_rows))
+
+    if not dry_run:
+        for i in range(0, len(rows), 500):
+            db.upsert_securities_batch(rows[i:i + 500])
+        if delist_rows:
+            db.upsert_securities_batch(delist_rows)
+
+    return {"kept": len(rows), "dropped": dropped, "delisted": len(delist_rows)}
+
+
+def collect_addv(client: EODHDClient) -> dict[str, dict]:
+    """Walk `eod-bulk-last-day` back over trading days, returning per-ticker
+    {addv_30d, last_close, days} from up to ADDV_WINDOW trading days."""
+    per_ticker_dv: dict[str, list[float]] = defaultdict(list)
+    last_close: dict[str, float] = {}
+    last_close_date: dict[str, str] = {}
+    trading_days: set[str] = set()
+
+    cursor = date.today() - timedelta(days=1)
+    checked = 0
+    while len(trading_days) < ADDV_WINDOW and checked < BULK_LOOKBACK_DAYS:
+        checked += 1
+        if cursor.weekday() >= 5:               # skip Sat/Sun
+            cursor -= timedelta(days=1)
+            continue
+        day = cursor.isoformat()
+        cursor -= timedelta(days=1)
+        rows = client.bulk_last_day("US", date=day)
+        if not rows:
+            continue
+        actual = rows[0].get("date", day)        # holiday → EODHD returns prior day
+        if actual in trading_days:
+            continue
+        trading_days.add(actual)
+        for r in rows:
+            code = (r.get("code") or "").strip().upper()
+            close = r.get("close")
+            vol = r.get("volume")
+            if not code or close is None or vol is None:
+                continue
+            try:
+                dv = float(close) * float(vol)
+            except (TypeError, ValueError):
+                continue
+            per_ticker_dv[code].append(dv)
+            if actual >= last_close_date.get(code, ""):
+                last_close_date[code] = actual
+                last_close[code] = float(close)
+
+    logger.info("Collected %d trading days of bulk EOD for ADDV", len(trading_days))
+    out: dict[str, dict] = {}
+    for code, dvs in per_ticker_dv.items():
+        out[code] = {
+            "addv_30d": sum(dvs) / len(dvs),
+            "last_close": last_close.get(code),
+            "days": len(dvs),
+        }
+    return out
+
+
+def apply_gate(db: SupabaseDB, client: EODHDClient, dry_run: bool) -> dict:
+    """Compute the affordability gate over active securities and set is_tier1."""
+    addv = collect_addv(client)
+    active = db.get_all_securities(columns="ticker,security_type,status", status="active")
+    now = datetime.utcnow().isoformat()
+
+    updates: list[dict] = []
+    promoted = 0
+    for s in active:
+        t = s["ticker"]
+        stats = addv.get(t)
+        addv_30d = stats["addv_30d"] if stats else None
+        last_close = stats["last_close"] if stats else None
+        days = stats["days"] if stats else 0
+        is_tier1 = passes_gate(addv_30d, last_close, days)
+        if is_tier1:
+            promoted += 1
+        updates.append({
+            "ticker": t,
+            "addv_30d": addv_30d,
+            "last_close": last_close,
+            "is_tier1": is_tier1,
+            "tier1_evaluated_at": now,
+        })
+
+    logger.info("Affordability gate: %d / %d active securities promoted to Tier 1",
+                promoted, len(active))
+    if not dry_run:
+        for i in range(0, len(updates), 500):
+            db.upsert_securities_batch(updates[i:i + 500])
+    return {"evaluated": len(active), "tier1": promoted}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Level 0 universe sync + affordability gate")
+    ap.add_argument("--dry-run", action="store_true", help="compute but write nothing")
+    ap.add_argument("--skip-gate", action="store_true", help="identity refresh only")
+    ap.add_argument("--limit", type=int, default=None, help="cap symbols (smoke test)")
+    args = ap.parse_args()
+
+    started = time.time()
+    db = SupabaseDB()
+    client = EODHDClient()
+
+    tier0 = ingest_tier0(db, client, args.limit, args.dry_run)
+    gate = {"evaluated": 0, "tier1": 0}
+    if not args.skip_gate:
+        gate = apply_gate(db, client, args.dry_run)
+
+    stats = {
+        "updated": tier0["kept"],
+        "skipped": tier0["dropped"],
+        "errors": 0,
+        "duration_secs": round(time.time() - started, 1),
+        "details": {**tier0, **gate, "dry_run": args.dry_run},
+    }
+    logger.info("Done: %s", stats["details"])
+    if not args.dry_run:
+        db.log_run("universe_sync", stats)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Level 0 — strategy-neutral universe & fact store

Introduces the **Level 0** fact store from the alphamolt spec: a single,
strategy-neutral store of facts about all liquid US equities. It sits
*underneath* the existing pipeline — the old opinionated TradingView screen
becomes one *lens* applied on top of Tier 1, rather than *defining* the
universe. The legacy `companies` / `price_sales` pipeline is untouched and
runs alongside.

**The line that holds:** Level 0 contains facts, never strategy. The only gate
it applies is strategy-neutral *affordability* (liquidity + has-data + valid
listing).

### Two-tier model
- **Tier 0** (`securities`) — identity-level reference data for every US-listed
  common stock + ADR + REIT (units / warrants / preferreds / SPACs excluded),
  status-tracked, soft-deleted on delisting (never hard-deleted).
- **Tier 1** — the subset passing the affordability gate (`is_tier1`) that
  receives full enrichment (prices, fundamentals, valuation).

### What's included (scope: backend foundation)
- **Migration 039** — `securities`, `prices_daily`, `fundamentals`,
  `valuation`, `estimates`, `events` (public-read RLS, service-role writes).
  ✅ **Applied to the live Supabase project** (`nojoooddiadyrduikgsk`); all six
  tables verified present, no new security advisories.
- **`eodhd.py`** — reusable EODHD client (`exchange-symbol-list`, `eod`,
  `eod-bulk-last-day`) with shared rate-limit + retry.
- **`universe_sync.py`** *(weekly)* — Tier 0 ingest + security-type filter +
  soft-delete delistings + the affordability gate (trailing-30d ADDV ≥ $5M,
  close ≥ $1), computed for the whole universe from ~30 bulk-EOD calls.
- **`prices_daily_updater.py`** *(daily)* — Tier 1 EOD increment (one bulk
  call) + 2y backfill for newly-promoted names; stores `dollar_volume` +
  `adj_close`.
- **`migrate_companies_to_level0.py`** *(one-off)* — seeds `fundamentals` /
  `valuation` from the existing ~1k enriched rows (spec §11 step 4).
- **`level0.py`** — the **§9 contract**: a read-only `FactStore` facade
  (`get_tier1_universe`, `get_facts`, `get_distribution`) — the single seam
  every visible surface reads through. Holds no strategy.
- **`db.py`** — Level 0 access methods + `metric_stats` reader (reusing
  migration 038).
- **Workflows** — `universe-sync.yml` (Sun 02:00 UTC), `prices-daily.yml`
  (04:15 UTC daily).
- **`test_level0.py`** — 24 unit tests (security classification, affordability
  gate, price mapper, distribution contract). All passing.
- Docs: `supabase_schema.sql` + `CLAUDE.md` updated.

### Deliberately deferred (follow-ups)
- The step-6 configurable **screener web UI** (the spec's "visible win").
- Live EODHD **fundamentals / events** ingestion (the migrate-then-real-fetch
  handoff; `cik` / `figi` / SEC cross-check columns exist but aren't populated
  yet).
- Pointing `metric_stats`' nightly recompute at Tier 1.

### Note for review
The affordability gate's "has data" currently keys on price-history presence;
fundamentals-availability is treated as a Tier-1 enrichment *outcome* (a name
that later fails fundamentals can be demoted) rather than a pre-gate
requirement — documented in `universe_sync.py`. Happy to tighten if preferred.

https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN)_