### PR TITLE
Configurable screener as the funnel's selection stage (screener brief v2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,8 +106,47 @@ valuation/sector views — those are lenses downstream.
 **Three clocks** (per data type): membership/identity weekly
 (`universe_sync.py`), prices daily (`prices_daily_updater.py`), fundamentals on
 new filing, distribution stats nightly (`metric_stats`, reused from migration
-038). See migration 039. Backend foundation only — the configurable screener
-over the wider universe (the spec's step-6 "visible win") is a follow-up.
+038). See migration 039. The configurable screener over this universe (the
+spec's step-6 "visible win") is built on top — see below.
+
+## Configurable Screener — the funnel's selection stage
+
+The public `/screener` page (top-nav, viewable logged-out) is both the
+configurable research tool **and** the selection stage of the funnel: the
+ranked **top N** of a portfolio's screen feed the buyer directly. The separate
+`watchlist_curator` agent + watchlist page are **removed** — the "watchlist" is
+just the top N of the screen. Net pipeline: **Screener (deterministic rank) →
+Buyer (per-name LLM judgment + sizing) → Reviewer (sell).** See migration 040
+and the screener brief v2.
+
+**Two config layers.** A plain-English **brief** (human layer) compiles —
+design-time only, via `POST /api/compile-brief` (Gemini 2.5 Flash) — into an
+editable **compiled screen**: `filters` (a non-destructive query) + `weights`
+(Quality / Value / Momentum) + an `aiMultiplier` toggle + `topN`. Agents read
+the compiled config, **never** the prose. The daily re-rank is pure
+deterministic computation — **no LLM in the ranking loop**.
+
+**Scoring is a parameterised read, not a pipeline.** `GET /api/screen?config=`
+ranks the whole Tier 1 universe for a given config. The score is
+**lens-relative**: each component is an *empirical percentile within the
+filtered candidate set* (so outliers pin to p100 instead of blowing up the
+scale). Composite = weighted blend of Quality (0.60·R40 + 0.25·FCF + 0.15·GM),
+Value (inverse P/S ÷ 12-mo median) and Momentum (collared 52-week return),
+×optional AI bull/bear multiplier. Implemented once in TS
+(`web/lib/screen/score.ts`) and mirrored in Python (`screen.py`) so the buyer's
+top N is identical to the page's.
+
+Config lives in the **URL** (shareable/indexable); house presets + sector
+screens are indexed, arbitrary custom permutations `noindex`. **Save** persists
+a shareable recipe (`saved_screens`, owner-gated; viewing/sharing is not gated).
+A portfolio's selection recipe lives in `portfolios.screen_config`.
+
+### screen.py
+Deterministic scoring-as-a-function (Python mirror of
+`web/lib/screen/score.ts`). Reads Level 0 via the `screen_facts()` RPC +
+`screen_ai_overlay()`; `run_screen(db, config)` ranks, `portfolio_screen_
+candidates(db, portfolio_id)` returns the top N `{ticker: rationale}` that both
+buyers (`watchlist_buyer`, `llm_watchlist_buyer`) now trade from. Pure, no LLM.
 
 ## Scripts
 

--- a/agent_strategies.py
+++ b/agent_strategies.py
@@ -1129,8 +1129,21 @@ WATCHLIST_BUYER_DEFAULTS = {
 }
 
 
+def _portfolio_screen_candidates(ctx: RebalanceContext) -> dict[str, str | None]:
+    """The buyer's candidate set: the top N of the portfolio's screen.
+
+    The configurable screener is the funnel's selection stage (screener brief
+    v2 §3) — the curator/watchlist is removed. Delegates to
+    ``screen.portfolio_screen_candidates`` so the mechanical and LLM buyers
+    share one selection path.
+    """
+    import screen as _screen
+
+    return _screen.portfolio_screen_candidates(ctx.db, ctx.portfolio_id)
+
+
 def _format_watchlist_sell_note(ticker: str) -> str:
-    return f"Sold {ticker} — no longer on the portfolio watchlist."
+    return f"Sold {ticker} — no longer in the portfolio's screen top N."
 
 
 def _format_watchlist_buy_note(ticker: str, rationale: str | None) -> str:
@@ -1165,24 +1178,13 @@ def rebalance_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
         result.notes["reason"] = "watchlist_buyer only runs on a human portfolio"
         return result
 
-    watchlist = ctx.db.get_portfolio_watchlist(ctx.portfolio_id)
-    # Dedupe by ticker (a ticker could in principle appear once per source);
-    # the (portfolio_id, ticker) PK makes that impossible today, but keep the
-    # buyer robust. Prefer a row that carries a rationale.
-    rationale_for: dict[str, str | None] = {}
-    for row in watchlist:
-        ticker = str(row.get("ticker") or "").strip().upper()
-        if not ticker:
-            continue
-        rationale = (row.get("rationale") or "").strip() or None
-        if ticker not in rationale_for or (
-            rationale and not rationale_for.get(ticker)
-        ):
-            rationale_for[ticker] = rationale
+    # Candidate set is the top N of the portfolio's screen (the screener IS
+    # the selection now — curator/watchlist removed, brief v2 §3).
+    rationale_for = _portfolio_screen_candidates(ctx)
     watchlist_tickers = list(rationale_for.keys())
 
     if not watchlist_tickers:
-        result.notes["reason"] = "portfolio watchlist is empty"
+        result.notes["reason"] = "portfolio has no screen configured or screen is empty"
         return result
 
     # 90-day re-buy cooldown — drop tickers the portfolio sold recently.
@@ -1355,12 +1357,17 @@ def _trading_agents_lazy(ctx: RebalanceContext) -> RebalanceResult:
     return rebalance_trading_agents(ctx)
 
 
+# NOTE: `watchlist_curator` is intentionally NOT registered. The configurable
+# screener is the funnel's selection stage now (screener brief v2 §3) — a
+# portfolio's candidate set is the top N of its `screen_config`, read directly
+# by the buyers via `screen.run_screen`. The curator no longer runs; its
+# function body is retained below only as a reference until the watchlist UI is
+# fully removed in a follow-up cleanup.
 STRATEGIES: dict[str, Strategy] = {
     "dual_positive": rebalance_dual_positive,
     "momentum": rebalance_momentum,
     "llm_pick": _llm_pick_lazy,
     "trading_agents": _trading_agents_lazy,
-    "watchlist_curator": rebalance_watchlist_curator,
     "watchlist_buyer": rebalance_watchlist_buyer,
     "llm_watchlist_buyer": _llm_watchlist_buyer_lazy,
     "portfolio_reviewer": _portfolio_reviewer_lazy,
@@ -1380,8 +1387,9 @@ STRATEGIES: dict[str, Strategy] = {
 
 DEFAULT_STRATEGY_PHASE = "trade"
 
+# With the curator removed, no strategy is currently 'curate' phase. The
+# phase machinery stays (cheap, and a future curate-phase strategy may return).
 STRATEGY_PHASES: dict[str, str] = {
-    "watchlist_curator": "curate",
     "llm_watchlist_buyer": "trade",
     "portfolio_reviewer": "trade",
 }

--- a/llm_watchlist_buyer.py
+++ b/llm_watchlist_buyer.py
@@ -486,45 +486,20 @@ def rebalance_llm_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
     # evaluate any add.
     portfolio_mandate = ctx.mandate
 
-    watchlist = ctx.db.get_portfolio_watchlist(ctx.portfolio_id)
-    # Dedupe by ticker; combine rationales when both source='user' and
-    # source='agent' rows exist (PK is (portfolio_id, ticker, source)? No —
-    # see migration 027: PK is (portfolio_id, ticker); only one source per
-    # row possible. But we tolerate either schema defensively.)
-    rationales: dict[str, list[tuple[str, str]]] = {}
-    for row in watchlist:
-        ticker = str(row.get("ticker") or "").strip().upper()
-        if not ticker:
-            continue
-        source = str(row.get("source") or "").lower()
-        rationale = (row.get("rationale") or "").strip()
-        if not rationale:
-            continue
-        rationales.setdefault(ticker, []).append((source, rationale))
+    # Candidate set is the top N of the portfolio's screen — the screener IS
+    # the selection now (curator/watchlist removed, brief v2 §3). The screen
+    # rank + score is the per-ticker rationale handed to the LLM evaluator.
+    import screen as _screen
 
-    watchlist_tickers = sorted({
-        str(row.get("ticker") or "").strip().upper()
-        for row in watchlist
-        if row.get("ticker")
-    })
+    screen_candidates = _screen.portfolio_screen_candidates(ctx.db, ctx.portfolio_id)
+    watchlist_tickers = sorted(screen_candidates.keys())
     if not watchlist_tickers:
-        result.notes["reason"] = "portfolio watchlist is empty"
+        result.notes["reason"] = "portfolio has no screen configured or screen is empty"
         return result
 
-    # Combine rationales into a single string per ticker for the prompt.
-    combined_rationale: dict[str, str] = {}
-    for ticker in watchlist_tickers:
-        pairs = rationales.get(ticker) or []
-        if not pairs:
-            combined_rationale[ticker] = ""
-            continue
-        # Prefer USER first, then AGENT/CURATOR; label both when present.
-        user_text = next((r for s, r in pairs if s == "user"), None)
-        agent_text = next((r for s, r in pairs if s != "user"), None)
-        if user_text and agent_text:
-            combined_rationale[ticker] = f"USER: {user_text} | CURATOR: {agent_text}"
-        else:
-            combined_rationale[ticker] = user_text or agent_text or ""
+    combined_rationale: dict[str, str] = {
+        t: (screen_candidates[t] or "") for t in watchlist_tickers
+    }
 
     # Filter: already-held at >= target weight (concentration cap).
     target_pct = float(params["target_position_pct"])

--- a/migrations/040_screener_selection.sql
+++ b/migrations/040_screener_selection.sql
@@ -1,0 +1,134 @@
+-- Migration 040: Configurable screener as the funnel's selection stage.
+--
+-- The /screener page becomes both the configurable research tool AND the
+-- selection stage of the funnel (screener brief v2): the ranked top N of the
+-- screen feed the buyer directly. The separate watchlist_curator agent +
+-- watchlist page are removed; a portfolio's "watchlist" is now just the top N
+-- of its screen.
+--
+-- 1. screen_facts() — a STABLE function returning one row of Level 0 facts per
+--    Tier 1 ticker (identity + latest fundamentals + latest valuation + last
+--    price + trailing 52w return). The deterministic scoring-as-a-function
+--    (web /screen + the Python buyer) ranks over this. Holds NO strategy —
+--    the lens (filters + weights) lives in the caller's config.
+-- 2. saved_screens — persisted, shareable screen recipes (the "Save" feature).
+--    Public-read so a shared /screener?screen=<slug> link resolves logged-out;
+--    owner-only writes.
+-- 3. portfolios.screen_config — a portfolio's selection recipe (filters +
+--    weights + topN). Replaces the removed watchlist: the buyer ranks Level 0
+--    via screen_facts() against this and buys the top N.
+--
+-- Depends on migration 039 (Level 0 fact store). Idempotent.
+
+-- ---- screen_facts() -------------------------------------------------------
+CREATE OR REPLACE FUNCTION screen_facts()
+RETURNS TABLE (
+    ticker            TEXT,
+    name              TEXT,
+    sector            TEXT,
+    industry          TEXT,
+    country           TEXT,
+    price             NUMERIC,
+    price_asof        DATE,
+    rev_growth_ttm    NUMERIC,
+    gross_margin      NUMERIC,
+    fcf_margin        NUMERIC,
+    net_margin        NUMERIC,
+    operating_margin  NUMERIC,
+    rule_of_40        NUMERIC,
+    ps                NUMERIC,
+    ps_median_12m     NUMERIC,
+    ret_52w           NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public, pg_temp
+AS $$
+    SELECT
+        s.ticker,
+        s.name,
+        s.gics_sector,
+        s.gics_industry,
+        s.country,
+        lp.close,
+        lp.date,
+        f.rev_growth_ttm,
+        f.gross_margin,
+        f.fcf_margin,
+        f.net_margin,
+        f.operating_margin,
+        f.rule_of_40,
+        v.ps,
+        v.ps_median_12m,
+        CASE WHEN p52.close IS NOT NULL AND p52.close > 0
+             THEN (lp.close / p52.close - 1) * 100 END AS ret_52w
+    FROM securities s
+    LEFT JOIN LATERAL (
+        SELECT close, date FROM prices_daily pd
+        WHERE pd.ticker = s.ticker ORDER BY pd.date DESC LIMIT 1
+    ) lp ON true
+    LEFT JOIN LATERAL (
+        SELECT close FROM prices_daily pd
+        WHERE pd.ticker = s.ticker AND pd.date <= (CURRENT_DATE - INTERVAL '52 weeks')
+        ORDER BY pd.date DESC LIMIT 1
+    ) p52 ON true
+    LEFT JOIN LATERAL (
+        SELECT * FROM fundamentals fd
+        WHERE fd.ticker = s.ticker ORDER BY fd.period_end DESC LIMIT 1
+    ) f ON true
+    LEFT JOIN LATERAL (
+        SELECT * FROM valuation vl
+        WHERE vl.ticker = s.ticker ORDER BY vl.date DESC LIMIT 1
+    ) v ON true
+    WHERE s.is_tier1 AND s.status = 'active';
+$$;
+
+-- ---- saved_screens --------------------------------------------------------
+CREATE TABLE IF NOT EXISTS saved_screens (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    slug          TEXT UNIQUE NOT NULL,
+    name          TEXT NOT NULL,
+    config        JSONB NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_saved_screens_owner ON saved_screens (owner_user_id);
+
+DROP TRIGGER IF EXISTS saved_screens_updated_at ON saved_screens;
+CREATE TRIGGER saved_screens_updated_at
+    BEFORE UPDATE ON saved_screens
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE saved_screens ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "public read" ON saved_screens;
+CREATE POLICY "public read" ON saved_screens FOR SELECT USING (true);
+DROP POLICY IF EXISTS "owner insert" ON saved_screens;
+CREATE POLICY "owner insert" ON saved_screens
+    FOR INSERT WITH CHECK (auth.uid() = owner_user_id);
+DROP POLICY IF EXISTS "owner update" ON saved_screens;
+CREATE POLICY "owner update" ON saved_screens
+    FOR UPDATE USING (auth.uid() = owner_user_id) WITH CHECK (auth.uid() = owner_user_id);
+DROP POLICY IF EXISTS "owner delete" ON saved_screens;
+CREATE POLICY "owner delete" ON saved_screens
+    FOR DELETE USING (auth.uid() = owner_user_id);
+
+-- ---- screen_ai_overlay() --------------------------------------------------
+-- The optional AI bull/bear verdict overlay (a lens, NOT a Level 0 fact —
+-- kept out of screen_facts() so that function stays strategy-neutral). The
+-- verdict is the leading ✅/❌ of the narrative eval text in `companies`;
+-- exposing it as a 1-char-derived boolean means the screener never fetches
+-- the full narratives. NULL = no eval (the multiplier is then 1.0).
+CREATE OR REPLACE FUNCTION screen_ai_overlay()
+RETURNS TABLE (ticker TEXT, bull BOOLEAN, bear BOOLEAN)
+LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public, pg_temp AS $$
+  SELECT ticker,
+    CASE WHEN left(bull_eval,1)='✅' THEN true WHEN left(bull_eval,1)='❌' THEN false END,
+    CASE WHEN left(bear_eval,1)='✅' THEN true WHEN left(bear_eval,1)='❌' THEN false END
+  FROM companies
+  WHERE bull_eval IS NOT NULL OR bear_eval IS NOT NULL;
+$$;
+
+-- ---- portfolios.screen_config --------------------------------------------
+ALTER TABLE portfolios ADD COLUMN IF NOT EXISTS screen_config JSONB;

--- a/screen.py
+++ b/screen.py
@@ -1,0 +1,248 @@
+"""
+screen.py — deterministic scoring-as-a-function (Python mirror of
+web/lib/screen/score.ts).
+
+The configurable screener is the funnel's selection stage (screener brief v2):
+the ranked top N of a portfolio's screen feed the buyer directly — there is no
+separate curator/watchlist anymore. This module is what the buyer ranks
+through, so the top N it computes is identical to what the website shows.
+
+Reads Level 0 facts via the `screen_facts()` RPC (one row per Tier 1 ticker:
+identity + latest fundamentals + latest valuation + last price + 52w return)
+and the optional `screen_ai_overlay()` (bull/bear verdict, a lens). Scoring is
+pure, deterministic, lens-relative (empirical percentiles within the filtered
+candidate set) — NO LLM in the ranking loop. See migration 040.
+
+The config is a plain dict (a portfolio's `screen_config`):
+    {
+      "filters": [{"field": "ps", "op": "<=", "value": 15}, ...],
+      "weights": {"quality": 60, "value": 25, "momentum": 15},
+      "aiMultiplier": true,
+      "topN": 40,
+      "sort": {"column": "score", "dir": "desc"},
+    }
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("screen")
+
+FILTER_FIELDS = {
+    "sector", "country", "ps", "rev_growth_ttm", "gross_margin", "fcf_margin",
+    "net_margin", "operating_margin", "rule_of_40", "ret_52w", "price",
+}
+TEXT_FIELDS = {"sector", "country"}
+
+MOM_FLOOR = -50.0  # falling-knife collar
+MOM_CAP = 40.0     # blow-off-top collar
+
+
+# ---- pure scoring ---------------------------------------------------------
+
+def _percentiles(values: list[float | None]) -> list[float | None]:
+    """value -> 0..1 empirical percentile over a column (nulls stay None)."""
+    present = sorted(v for v in values if v is not None)
+    n = len(present)
+    if n == 0:
+        return [None] * len(values)
+    out: list[float | None] = []
+    import bisect
+    for v in values:
+        if v is None:
+            out.append(None)
+        else:
+            out.append(bisect.bisect_right(present, v) / n)
+    return out
+
+
+def _matches(row: dict, f: dict) -> bool:
+    field = f.get("field")
+    op = f.get("op")
+    if field not in FILTER_FIELDS:
+        return True
+    raw = row.get(field)
+    if field in TEXT_FIELDS:
+        a = ("" if raw is None else str(raw)).lower()
+        b = str(f.get("value", "")).lower()
+        return {
+            "==": a == b, "!=": a != b, "<=": a <= b,
+            ">=": a >= b, "<": a < b, ">": a > b,
+        }.get(op, True)
+    if raw is None:
+        return False  # a numeric filter excludes names missing that datum
+    try:
+        v = float(raw)
+        t = float(f.get("value"))
+    except (TypeError, ValueError):
+        return True
+    return {
+        "<=": v <= t, ">=": v >= t, "<": v < t,
+        ">": v > t, "==": v == t, "!=": v != t,
+    }.get(op, True)
+
+
+def apply_filters(facts: list[dict], filters: list[dict]) -> list[dict]:
+    if not filters:
+        return list(facts)
+    return [r for r in facts if all(_matches(r, f) for f in filters)]
+
+
+def _ai_multiplier(bull: bool | None, bear: bool | None) -> float:
+    if bull is None or bear is None:
+        return 1.0
+    if bull and bear:
+        return 1.3
+    if (not bull) and bear:
+        return 1.0
+    if bull and (not bear):
+        return 0.7
+    return 0.4
+
+
+def _f(v: Any) -> float | None:
+    if v is None:
+        return None
+    try:
+        x = float(v)
+    except (TypeError, ValueError):
+        return None
+    return x if x == x else None  # drop NaN
+
+
+def score_screen(facts: list[dict], config: dict) -> list[dict]:
+    """Return the ranked rows (each a copy of the fact dict + score/rank)."""
+    filters = config.get("filters") or []
+    weights = config.get("weights") or {"quality": 45, "value": 25, "momentum": 20}
+    subset = apply_filters(facts, filters)
+
+    ps_ratio = []
+    mom = []
+    for r in subset:
+        ps = _f(r.get("ps"))
+        med = _f(r.get("ps_median_12m"))
+        ps_ratio.append(None if ps is None else ps / (med if med and med > 0 else ps))
+        ret = _f(r.get("ret_52w"))
+        mom.append(None if ret is None else max(MOM_FLOOR, min(MOM_CAP, ret)))
+
+    p_r40 = _percentiles([_f(r.get("rule_of_40")) for r in subset])
+    p_fcf = _percentiles([_f(r.get("fcf_margin")) for r in subset])
+    p_gm = _percentiles([_f(r.get("gross_margin")) for r in subset])
+    p_val = _percentiles(ps_ratio)
+    p_mom = _percentiles(mom)
+
+    wq = float(weights.get("quality", 0))
+    wv = float(weights.get("value", 0))
+    wm = float(weights.get("momentum", 0))
+    wsum = wq + wv + wm or 1.0
+    ai_on = bool(config.get("aiMultiplier", True))
+
+    scored: list[dict] = []
+    for i, r in enumerate(subset):
+        quality = 0.6 * (p_r40[i] or 0) + 0.25 * (p_fcf[i] or 0) + 0.15 * (p_gm[i] or 0)
+        value = 0.0 if p_val[i] is None else 1 - p_val[i]
+        momentum = p_mom[i] or 0
+        score = ((wq * quality + wv * value + wm * momentum) / wsum) * 100
+        if ai_on:
+            score *= _ai_multiplier(r.get("bull"), r.get("bear"))
+        row = dict(r)
+        row["score"] = score
+        row["quality_pct"] = round(quality * 100)
+        row["value_pct"] = round(value * 100)
+        row["momentum_pct"] = round(momentum * 100)
+        scored.append(row)
+
+    sort = config.get("sort") or {}
+    col = sort.get("column", "score")
+    sign = -1.0 if sort.get("dir", "desc") != "asc" else 1.0
+
+    def _key(r: dict):
+        v = r.get(col)
+        nv = v if isinstance(v, (int, float)) else float("-inf")
+        # Ascending sort on (sign*value, ticker): for desc this yields value
+        # descending with ticker as an ascending tie-break — matching score.ts.
+        return (sign * nv, r["ticker"])
+
+    scored.sort(key=_key)
+    for idx, r in enumerate(scored, 1):
+        r["rank"] = idx
+    return scored
+
+
+# ---- data load + buyer entrypoint ----------------------------------------
+
+def _rpc_all(db, fn: str) -> list[dict]:
+    rows: list[dict] = []
+    page = 0
+    while True:
+        resp = db.client.rpc(fn).range(page * 1000, (page + 1) * 1000 - 1).execute()
+        batch = resp.data or []
+        rows.extend(batch)
+        if len(batch) < 1000:
+            break
+        page += 1
+    return rows
+
+
+def load_facts(db) -> list[dict]:
+    """Load Level 0 facts for the whole Tier 1 universe + the AI overlay."""
+    facts = _rpc_all(db, "screen_facts")
+    overlay = {r["ticker"]: r for r in _rpc_all(db, "screen_ai_overlay")}
+    for r in facts:
+        v = overlay.get(r["ticker"])
+        r["bull"] = (v or {}).get("bull")
+        r["bear"] = (v or {}).get("bear")
+    return facts
+
+
+def run_screen(db, config: dict) -> list[dict]:
+    """Ranked rows for a config (the full matched subset)."""
+    return score_screen(load_facts(db), config)
+
+
+def top_n_tickers(db, config: dict, n: int | None = None) -> list[str]:
+    """The buyer's candidate list — the top N tickers of the portfolio's
+    screen. `n` defaults to config['topN'] (default 40)."""
+    limit = n if n is not None else int(config.get("topN", 40))
+    return [r["ticker"] for r in run_screen(db, config)[:limit]]
+
+
+def portfolio_screen_config(db, portfolio_id: str | None) -> dict | None:
+    """Load a portfolio's stored selection recipe (portfolios.screen_config)."""
+    if not portfolio_id:
+        return None
+    try:
+        resp = (
+            db.client.table("portfolios")
+            .select("screen_config")
+            .eq("id", portfolio_id)
+            .maybe_single()
+            .execute()
+        )
+    except Exception:
+        return None
+    if not resp or not resp.data:
+        return None
+    return resp.data.get("screen_config")
+
+
+def portfolio_screen_candidates(db, portfolio_id: str | None) -> dict[str, str | None]:
+    """The buyer's candidate set: the top N of a portfolio's screen.
+
+    The screener is the funnel's selection stage (screener brief v2 §3) — a
+    portfolio's candidate names are the top N of its `screen_config`, ranked
+    deterministically here. Returns ``{ticker: rationale}`` where the rationale
+    records the screen rank + score (so a recorded thesis carries the "why").
+    Empty when the portfolio has no screen configured.
+    """
+    cfg = portfolio_screen_config(db, portfolio_id)
+    if not cfg:
+        return {}
+    ranked = run_screen(db, cfg)
+    top_n = int(cfg.get("topN", 40))
+    return {
+        r["ticker"]: f"screen rank #{r['rank']} · score {r['score']:.1f}"
+        for r in ranked[:top_n]
+    }

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -810,3 +810,42 @@ DROP POLICY IF EXISTS "public read" ON estimates;
 CREATE POLICY "public read" ON estimates    FOR SELECT USING (true);
 DROP POLICY IF EXISTS "public read" ON events;
 CREATE POLICY "public read" ON events       FOR SELECT USING (true);
+
+
+-- ============================================================
+-- Configurable screener / selection stage (migration 040)
+--
+-- The /screener page is the configurable research tool AND the funnel's
+-- selection stage: the ranked top N of a portfolio's screen feed the buyer
+-- directly (the watchlist_curator agent + watchlist page are removed). See
+-- migrations/040_screener_selection.sql for the screen_facts() /
+-- screen_ai_overlay() functions (the deterministic scoring-as-a-function
+-- reads them). saved_screens persists shareable screen recipes.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS saved_screens (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    slug          TEXT UNIQUE NOT NULL,
+    name          TEXT NOT NULL,
+    config        JSONB NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_saved_screens_owner ON saved_screens (owner_user_id);
+DROP TRIGGER IF EXISTS saved_screens_updated_at ON saved_screens;
+CREATE TRIGGER saved_screens_updated_at BEFORE UPDATE ON saved_screens
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+ALTER TABLE saved_screens ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "public read" ON saved_screens;
+CREATE POLICY "public read" ON saved_screens FOR SELECT USING (true);
+DROP POLICY IF EXISTS "owner insert" ON saved_screens;
+CREATE POLICY "owner insert" ON saved_screens FOR INSERT WITH CHECK (auth.uid() = owner_user_id);
+DROP POLICY IF EXISTS "owner update" ON saved_screens;
+CREATE POLICY "owner update" ON saved_screens FOR UPDATE USING (auth.uid() = owner_user_id) WITH CHECK (auth.uid() = owner_user_id);
+DROP POLICY IF EXISTS "owner delete" ON saved_screens;
+CREATE POLICY "owner delete" ON saved_screens FOR DELETE USING (auth.uid() = owner_user_id);
+
+-- A portfolio's selection recipe (filters + weights + topN). Replaces the
+-- removed watchlist: the buyer ranks Level 0 via screen_facts() against this
+-- and buys the top N.
+ALTER TABLE portfolios ADD COLUMN IF NOT EXISTS screen_config JSONB;

--- a/test_screen.py
+++ b/test_screen.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Unit tests for the deterministic screener scoring (screen.py).
+
+Pure-logic tests (no DB): filters, empirical-percentile components, the
+value inversion, the momentum collar, the AI multiplier, weighting and
+ranking. Mirrors the cases in web/lib/screen/score.ts so the Python buyer
+and the website agree. Run: python test_screen.py
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import screen
+
+
+def facts(*rows: dict) -> list[dict]:
+    base = {
+        "ticker": "", "name": None, "sector": None, "country": "USA",
+        "price": 10, "price_asof": "2026-06-03", "rev_growth_ttm": None,
+        "gross_margin": None, "fcf_margin": None, "net_margin": None,
+        "operating_margin": None, "rule_of_40": None, "ps": None,
+        "ps_median_12m": None, "ret_52w": None, "bull": None, "bear": None,
+    }
+    return [{**base, **r} for r in rows]
+
+
+class TestFilters(unittest.TestCase):
+    def test_numeric_lte(self):
+        rows = facts({"ticker": "A", "ps": 10}, {"ticker": "B", "ps": 20})
+        out = screen.apply_filters(rows, [{"field": "ps", "op": "<=", "value": 15}])
+        self.assertEqual([r["ticker"] for r in out], ["A"])
+
+    def test_numeric_filter_excludes_missing(self):
+        rows = facts({"ticker": "A", "ps": None})
+        out = screen.apply_filters(rows, [{"field": "ps", "op": "<=", "value": 15}])
+        self.assertEqual(out, [])
+
+    def test_sector_not_equal_case_insensitive(self):
+        rows = facts(
+            {"ticker": "A", "sector": "Health Technology"},
+            {"ticker": "B", "sector": "Technology Services"},
+        )
+        out = screen.apply_filters(
+            rows, [{"field": "sector", "op": "!=", "value": "health technology"}]
+        )
+        self.assertEqual([r["ticker"] for r in out], ["B"])
+
+
+class TestPercentiles(unittest.TestCase):
+    def test_basic(self):
+        self.assertEqual(screen._percentiles([1, 2, 3, 4]), [0.25, 0.5, 0.75, 1.0])
+
+    def test_nulls_preserved(self):
+        self.assertEqual(screen._percentiles([None, 5]), [None, 1.0])
+
+    def test_all_null(self):
+        self.assertEqual(screen._percentiles([None, None]), [None, None])
+
+
+class TestScoring(unittest.TestCase):
+    def test_quality_winner_ranks_first(self):
+        rows = facts(
+            {"ticker": "HI", "rule_of_40": 80, "fcf_margin": 40, "gross_margin": 90, "ps": 5, "ps_median_12m": 5, "ret_52w": 10},
+            {"ticker": "LO", "rule_of_40": 5, "fcf_margin": -10, "gross_margin": 20, "ps": 5, "ps_median_12m": 5, "ret_52w": 10},
+        )
+        cfg = {"weights": {"quality": 100, "value": 0, "momentum": 0}, "aiMultiplier": False}
+        out = screen.score_screen(rows, cfg)
+        self.assertEqual(out[0]["ticker"], "HI")
+        self.assertEqual(out[0]["rank"], 1)
+        self.assertGreater(out[0]["score"], out[1]["score"])
+
+    def test_value_inversion_cheaper_wins(self):
+        # Lower P/S vs its median = cheaper = higher value score.
+        rows = facts(
+            {"ticker": "CHEAP", "ps": 4, "ps_median_12m": 8, "rule_of_40": 10, "fcf_margin": 1, "gross_margin": 1},
+            {"ticker": "RICH", "ps": 12, "ps_median_12m": 8, "rule_of_40": 10, "fcf_margin": 1, "gross_margin": 1},
+        )
+        cfg = {"weights": {"quality": 0, "value": 100, "momentum": 0}, "aiMultiplier": False}
+        out = screen.score_screen(rows, cfg)
+        self.assertEqual(out[0]["ticker"], "CHEAP")
+
+    def test_momentum_collar(self):
+        # A huge winner is capped, a crash floored — both still rank by collar.
+        rows = facts(
+            {"ticker": "MOON", "ret_52w": 500, "rule_of_40": 1, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+            {"ticker": "KNIFE", "ret_52w": -90, "rule_of_40": 1, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+        )
+        cfg = {"weights": {"quality": 0, "value": 0, "momentum": 100}, "aiMultiplier": False}
+        out = screen.score_screen(rows, cfg)
+        self.assertEqual(out[0]["ticker"], "MOON")
+        self.assertEqual(out[1]["ticker"], "KNIFE")
+
+    def test_ai_multiplier_dual_positive_boost(self):
+        rows = facts(
+            {"ticker": "DP", "rule_of_40": 50, "fcf_margin": 20, "gross_margin": 60, "ps": 5, "ps_median_12m": 5, "bull": True, "bear": True},
+            {"ticker": "AV", "rule_of_40": 50, "fcf_margin": 20, "gross_margin": 60, "ps": 5, "ps_median_12m": 5, "bull": False, "bear": False},
+        )
+        on = {"weights": {"quality": 100, "value": 0, "momentum": 0}, "aiMultiplier": True}
+        out = screen.score_screen(rows, on)
+        dp = next(r for r in out if r["ticker"] == "DP")
+        av = next(r for r in out if r["ticker"] == "AV")
+        # identical quality percentiles (both p100), so the multiplier decides
+        self.assertAlmostEqual(dp["score"] / av["score"], 1.3 / 0.4, places=5)
+
+    def test_outlier_r40_does_not_blow_up_scale(self):
+        # Empirical-percentile scoring: a 26000 R40 just pins to p100.
+        rows = facts(
+            {"ticker": "OUT", "rule_of_40": 26000, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+            {"ticker": "NORM", "rule_of_40": 40, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+        )
+        cfg = {"weights": {"quality": 100, "value": 0, "momentum": 0}, "aiMultiplier": False}
+        out = screen.score_screen(rows, cfg)
+        self.assertLessEqual(out[0]["score"], 100.0001)
+        self.assertEqual(out[0]["ticker"], "OUT")
+
+    def test_ticker_tiebreak_ascending_on_score_desc(self):
+        rows = facts(
+            {"ticker": "ZZZ", "rule_of_40": 10, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+            {"ticker": "AAA", "rule_of_40": 10, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+        )
+        cfg = {"weights": {"quality": 100, "value": 0, "momentum": 0}, "aiMultiplier": False}
+        out = screen.score_screen(rows, cfg)
+        # equal scores → AAA before ZZZ
+        self.assertEqual([r["ticker"] for r in out], ["AAA", "ZZZ"])
+
+    def test_topn_helper_via_run(self):
+        rows = facts(
+            {"ticker": "A", "rule_of_40": 90, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+            {"ticker": "B", "rule_of_40": 50, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+            {"ticker": "C", "rule_of_40": 10, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+        )
+        cfg = {"weights": {"quality": 100, "value": 0, "momentum": 0}, "aiMultiplier": False, "topN": 2}
+        ranked = screen.score_screen(rows, cfg)
+        top2 = [r["ticker"] for r in ranked[: cfg["topN"]]]
+        self.assertEqual(top2, ["A", "B"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/web/app/api/compile-brief/route.ts
+++ b/web/app/api/compile-brief/route.ts
@@ -1,0 +1,120 @@
+/**
+ * POST /api/compile-brief  (brief v2 §2/§6)
+ *
+ * The DESIGN-TIME LLM translation: a plain-English brief → a proposed
+ * `{filters, weights, aiMultiplier}` screen config. Called only when the user
+ * hits "Compile to screen" — NEVER per render and NEVER in the daily ranking
+ * loop (that stays pure deterministic computation). The user sees and edits
+ * the result; the compiled config is the source of truth.
+ *
+ * Powered by Gemini 2.5 Flash (cheap/fast, design-time only). Output is
+ * validated + clamped against the same zod schema the deterministic scorer
+ * uses, so a hallucinated field/op can never reach the ranking.
+ */
+
+import { errorResponse, jsonResponse } from "@/lib/api-utils";
+import {
+  FILTER_FIELDS,
+  FILTER_OPS,
+  filterSchema,
+  weightsSchema,
+  type Filter,
+} from "@/lib/screen/config";
+import { z } from "zod";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const MODEL = "gemini-2.5-flash";
+const ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent`;
+
+const compiledSchema = z.object({
+  filters: z.array(filterSchema).max(20).default([]),
+  weights: weightsSchema,
+  aiMultiplier: z.boolean().default(true),
+});
+
+const SYSTEM = `You translate a plain-English stock-screen brief into a strict JSON screen config. You are a DESIGN-TIME translator only — never a stock picker.
+
+Allowed filter fields (numbers are percentages or multiples as noted):
+- sector, country        (text; use op "==" or "!=")
+- ps                     (price/sales multiple)
+- rev_growth_ttm         (revenue growth %, TTM)
+- gross_margin, fcf_margin, net_margin, operating_margin   (%)
+- rule_of_40             (number)
+- ret_52w                (trailing 52-week price return %)
+- price                  ($)
+Allowed ops: ${FILTER_OPS.join(", ")}.
+
+Common US GICS-ish sectors you may reference for sector filters: "Health Technology", "Technology Services", "Electronic Technology", "Finance", "Retail Trade", "Consumer Services", "Producer Manufacturing", "Energy Minerals", "Commercial Services".
+
+weights: integers for "quality", "value", "momentum" that sum to ~100. Quality = margins/Rule-of-40 strength; value = cheapness on P/S; momentum = 52-week price strength. Tilt them to match the brief's emphasis.
+
+aiMultiplier: true unless the brief says to ignore AI bull/bear signals.
+
+Return ONLY strict JSON of shape {"filters":[{"field","op","value"}],"weights":{"quality","value","momentum"},"aiMultiplier"}. No prose, no markdown.`;
+
+const bodySchema = z.object({ brief: z.string().min(1).max(2000) });
+
+export async function POST(req: Request) {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) return errorResponse("GEMINI_API_KEY not configured", 503);
+
+  let brief: string;
+  try {
+    brief = bodySchema.parse(await req.json()).brief;
+  } catch {
+    return errorResponse("Body must be { brief: string }", 400);
+  }
+
+  try {
+    const resp = await fetch(`${ENDPOINT}?key=${apiKey}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        systemInstruction: { parts: [{ text: SYSTEM }] },
+        contents: [{ role: "user", parts: [{ text: `BRIEF:\n${brief}` }] }],
+        generationConfig: { responseMimeType: "application/json", temperature: 0.2 },
+      }),
+    });
+    if (!resp.ok) {
+      return errorResponse(`Gemini error ${resp.status}`, 502);
+    }
+    const data = await resp.json();
+    const text: string =
+      data?.candidates?.[0]?.content?.parts?.map((p: { text?: string }) => p.text ?? "").join("") ?? "";
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stripFences(text));
+    } catch {
+      return errorResponse("LLM returned non-JSON", 502);
+    }
+
+    // Validate + clamp. Drop any filter that doesn't pass the schema rather
+    // than failing the whole compile.
+    const raw = parsed as { filters?: unknown[]; weights?: unknown; aiMultiplier?: unknown };
+    const filters: Filter[] = [];
+    for (const f of raw.filters ?? []) {
+      const r = filterSchema.safeParse(f);
+      if (r.success && FILTER_FIELDS.includes(r.data.field)) filters.push(r.data);
+    }
+    const compiled = compiledSchema.parse({
+      filters,
+      weights: raw.weights,
+      aiMultiplier: raw.aiMultiplier ?? true,
+    });
+
+    return jsonResponse({ compiled, brief });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Compile failed";
+    return errorResponse(message, 500);
+  }
+}
+
+function stripFences(s: string): string {
+  return s
+    .replace(/^\s*```(?:json)?\s*/i, "")
+    .replace(/\s*```\s*$/i, "")
+    .trim();
+}

--- a/web/app/api/screen/route.ts
+++ b/web/app/api/screen/route.ts
@@ -1,0 +1,77 @@
+/**
+ * GET /api/screen?config={base64url}  (brief v2 §6)
+ *
+ * The deterministic scoring-as-a-function contract. Decodes a screen config
+ * from the URL, ranks the full Tier 1 universe for THAT config (lens-relative
+ * score), and returns the ranked rows + counts + as-of. No LLM, no per-user
+ * pipeline — a parameterised read. Also accepts ?preset= / ?sector= shortcuts.
+ *
+ * The client calls this on every filter/weight change to re-rank; SSR uses the
+ * same `runScreen()` directly for the initial paint.
+ */
+
+import { errorResponse, jsonResponse } from "@/lib/api-utils";
+import { configFromParams, screenConfigSchema } from "@/lib/screen/config";
+import { runScreen } from "@/lib/screen/query";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+// Display projection — the client never needs the full fact row.
+const DISPLAY = [
+  "rank",
+  "ticker",
+  "name",
+  "sector",
+  "country",
+  "price",
+  "price_asof",
+  "score",
+  "ps",
+  "rev_growth_ttm",
+  "gross_margin",
+  "fcf_margin",
+  "rule_of_40",
+  "ret_52w",
+  "bull",
+  "bear",
+] as const;
+
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const config = configFromParams({
+      config: url.searchParams.get("config") ?? undefined,
+      preset: url.searchParams.get("preset") ?? undefined,
+      sector: url.searchParams.get("sector") ?? undefined,
+    });
+    // Validate (defends against a hand-edited config param).
+    screenConfigSchema.parse(config);
+
+    const result = await runScreen(config);
+    const rows = result.rows.map((r) =>
+      Object.fromEntries(DISPLAY.map((k) => [k, (r as unknown as Record<string, unknown>)[k]])),
+    );
+
+    return jsonResponse(
+      {
+        rows,
+        match_count: result.match_count,
+        total_universe: result.total_universe,
+        cut_index: result.cut_index,
+        data_asof: result.data_asof,
+        config,
+      },
+      {
+        headers: {
+          // Re-rank feels live but still gets CDN relief; invalidated by the
+          // daily data refresh well inside this window.
+          "Cache-Control": "public, max-age=60, stale-while-revalidate=300",
+        },
+      },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 400);
+  }
+}

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -1,104 +1,148 @@
 import type { Metadata } from "next";
-import { getSupabase } from "@/lib/supabase";
-import { Company, SCREENER_COLUMNS } from "@/lib/types";
 import Nav from "@/components/nav";
-import DataTable from "@/components/data-table";
+import {
+  DEFAULT_PRESET,
+  PRESETS,
+  configFromParams,
+  encodeConfig,
+  isHousePreset,
+} from "@/lib/screen/config";
+import { runScreen } from "@/lib/screen/query";
+import { getSupabase } from "@/lib/supabase";
+import { screenConfigSchema, type ScreenConfig } from "@/lib/screen/config";
+import ScreenerClient from "@/app/screener/screener-client";
 
-// 300s matches the 15-min intraday price cadence so visitors see the
-// refreshed prices roughly within ¼ of a refresh window.
+// Re-rank is live client-side; the SSR paint is cached for crawlers + first
+// load. 300s matches the intraday price cadence.
 export const revalidate = 300;
 
-export const metadata: Metadata = {
-  title: "Stock Screener — US growth stocks ranked by AI agent score",
-  description:
-    "Hundreds of US-listed growth stocks (incl. ADRs) ranked by AlphaMolt's AI agent composite score. Filter by sector, sort by R40, P/S, gross margin, FCF margin.",
-  alternates: { canonical: "/screener" },
-  openGraph: {
-    title: "AlphaMolt Stock Screener — US growth stocks",
-    description:
-      "Browse hundreds of US-listed growth stocks ranked by composite score from AlphaMolt's AI agents. Fundamentals and AI narratives refreshed daily.",
-    url: "/screener",
-    type: "website",
-  },
-};
+type SP = { config?: string; preset?: string; sector?: string; screen?: string };
 
-async function getCompanies(sector: string | null): Promise<Company[]> {
-  const supabase = getSupabase();
-  // Sector filter is server-side so /screener?sector=Health+Technology
-  // is a real URL — same hit as if it were a static page. Makes the
-  // breadcrumb link from /company/[ticker] actually work, and gives
-  // crawlers per-sector pages without us needing to mint slug routes.
-  let query = supabase
-    .from("companies")
-    .select(SCREENER_COLUMNS)
-    .order("sort_order", { ascending: true, nullsFirst: false });
-  if (sector) query = query.eq("sector", sector);
-
-  const [companiesRes, psRes] = await Promise.all([
-    query,
-    supabase.from("price_sales").select("ticker, median_12m"),
-  ]);
-
-  if (companiesRes.error) {
-    console.error("Failed to fetch companies:", companiesRes.error);
-    return [];
-  }
-  if (psRes.error) {
-    console.error("Failed to fetch price_sales:", psRes.error);
-  }
-
-  const psMap = new Map<string, number | null>(
-    ((psRes.data ?? []) as Array<{ ticker: string; median_12m: number | null }>)
-      .map((r) => [r.ticker, r.median_12m]),
-  );
-
-  const rows = (companiesRes.data ?? []) as unknown as Company[];
-  return rows.map((c) => ({ ...c, ps_median_12m: psMap.get(c.ticker) ?? null }));
+async function resolveParams(searchParams: Promise<SP>): Promise<SP> {
+  const sp = await searchParams;
+  return {
+    config: typeof sp.config === "string" ? sp.config : undefined,
+    preset: typeof sp.preset === "string" ? sp.preset : undefined,
+    sector: typeof sp.sector === "string" ? sp.sector : undefined,
+    screen: typeof sp.screen === "string" ? sp.screen : undefined,
+  };
 }
 
-function parseSector(raw: string | string[] | undefined): string | null {
-  if (Array.isArray(raw)) return raw[0] ?? null;
-  return raw ?? null;
+/** A saved screen (?screen=<slug>) resolves to its stored config. Public-read
+ *  so a shared saved link works logged-out. */
+async function savedConfig(slug: string): Promise<ScreenConfig | null> {
+  const { data } = await getSupabase()
+    .from("saved_screens")
+    .select("config")
+    .eq("slug", slug)
+    .maybeSingle();
+  if (!data?.config) return null;
+  const parsed = screenConfigSchema.safeParse(data.config);
+  return parsed.success ? parsed.data : null;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<SP>;
+}): Promise<Metadata> {
+  const sp = await resolveParams(searchParams);
+  const config = configFromParams(sp);
+
+  // Index curated house presets + sector screens; noindex arbitrary custom
+  // permutations (brief §7) so we don't mint near-infinite low-value URLs.
+  const house = isHousePreset(config) && !config.filters.some((f) => f.field === "sector");
+  const sector = sp.sector;
+  const presetMeta = config.preset ? PRESETS[config.preset] : undefined;
+
+  let title: string;
+  let description: string;
+  let canonical: string;
+  if (sector) {
+    title = `${sector} Stock Screener — AI-ranked US equities | alphamolt`;
+    description = `All US-listed ${sector} equities ranked by a composite score you control: growth, margins, FCF and Rule of 40, weighted to taste. Research only.`;
+    canonical = `/screener?sector=${encodeURIComponent(sector)}`;
+  } else if (house && presetMeta) {
+    title = `${presetMeta.label} Stock Screener — AI-Ranked US Equities | alphamolt`;
+    description = `${presetMeta.description} Configure filters and score weighting; share the exact screen via its URL. Research only — not financial advice.`;
+    canonical = `/screener?preset=${presetMeta.id}`;
+  } else {
+    title = "Stock Screener — All US Equities, Ranked by a Score You Control | alphamolt";
+    description =
+      "All US-listed equities (incl. ADRs) ranked by a quality-growth composite you control: revenue growth, margins, FCF and Rule of 40, weighted to taste.";
+    canonical = "/screener";
+  }
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    robots: house || sector ? { index: true, follow: true } : { index: false, follow: true },
+    openGraph: { title, description, url: canonical, type: "website" },
+    twitter: { card: "summary_large_image" },
+  };
 }
 
 export default async function ScreenerPage({
   searchParams,
 }: {
-  searchParams: Promise<{ sector?: string | string[] }>;
+  searchParams: Promise<SP>;
 }) {
-  const sector = parseSector((await searchParams).sector);
-  const companies = await getCompanies(sector);
-
-  const heading = sector
-    ? `${sector} Stock Screener`
-    : "Stock Screener";
-  const sub = sector
-    ? `${companies.length} ${sector} ${
-        companies.length === 1 ? "equity" : "equities"
-      } ranked by AI agent composite score`
-    : `${companies.length} US-listed equities (incl. ADRs) ranked by AI agent composite score`;
+  const sp = await resolveParams(searchParams);
+  const config = (sp.screen ? await savedConfig(sp.screen) : null) ?? configFromParams(sp);
+  const initial = await runScreen(config);
 
   return (
     <>
       <Nav />
       <main className="flex-1 w-full">
-        <div className="max-w-[1280px] mx-auto w-full px-4 sm:px-6 py-10 sm:py-14">
-          <header className="mb-8 sm:mb-10 max-w-[760px]">
+        <div className="max-w-[1280px] mx-auto w-full px-4 sm:px-6 py-8 sm:py-12">
+          <header className="mb-6 max-w-[760px]">
             <p className="text-[11px] font-mono uppercase tracking-[0.14em] text-text-muted">
               Stock screener
             </p>
             <h1 className="mt-2 text-[30px] sm:text-[36px] font-bold tracking-[-0.02em] leading-[1.08] text-text">
-              {heading}
+              Stock Screener
             </h1>
             <p className="mt-3 text-base text-text-muted leading-relaxed">
-              {sub}
+              All US-listed equities (incl. ADRs), ranked by a composite score
+              you control. Write a brief or tune the knobs — the table re-ranks
+              live and the config lives in the URL.
             </p>
             <p className="mt-2 text-xs text-text-muted">
-              Prices 15-minute delayed (EODHD) · refreshed every 15 min during
-              US market hours
+              Prices 15-minute delayed (EODHD) · ranked by your configured
+              composite · a research tool, not a recommendation.
             </p>
           </header>
-          <DataTable companies={companies} />
+
+          <ScreenerClient
+            initialConfig={config}
+            initialData={{
+              rows: initial.rows.map((r) => ({
+                rank: r.rank,
+                ticker: r.ticker,
+                name: r.name,
+                sector: r.sector,
+                country: r.country,
+                price: r.price,
+                price_asof: r.price_asof,
+                score: r.score,
+                ps: r.ps,
+                rev_growth_ttm: r.rev_growth_ttm,
+                gross_margin: r.gross_margin,
+                fcf_margin: r.fcf_margin,
+                rule_of_40: r.rule_of_40,
+                ret_52w: r.ret_52w,
+                bull: r.bull,
+                bear: r.bear,
+              })),
+              match_count: initial.match_count,
+              total_universe: initial.total_universe,
+              cut_index: initial.cut_index,
+              data_asof: initial.data_asof,
+            }}
+            defaultEncoded={encodeConfig(configFromParams({ preset: DEFAULT_PRESET }))}
+          />
         </div>
       </main>
     </>

--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -1,0 +1,547 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+import { saveScreen } from "@/lib/screen/saved-mutations";
+import {
+  FILTER_FIELDS,
+  FILTER_OPS,
+  PRESETS,
+  TEXT_FIELDS,
+  encodeConfig,
+  presetConfig,
+  type Filter,
+  type FilterField,
+  type FilterOp,
+  type ScreenConfig,
+} from "@/lib/screen/config";
+
+interface Row {
+  rank: number;
+  ticker: string;
+  name: string | null;
+  sector: string | null;
+  country: string | null;
+  price: number | null;
+  price_asof: string | null;
+  score: number;
+  ps: number | null;
+  rev_growth_ttm: number | null;
+  gross_margin: number | null;
+  fcf_margin: number | null;
+  rule_of_40: number | null;
+  ret_52w: number | null;
+  bull: boolean | null;
+  bear: boolean | null;
+}
+interface ScreenData {
+  rows: Row[];
+  match_count: number;
+  total_universe: number;
+  cut_index: number;
+  data_asof: string | null;
+}
+
+const FIELD_LABEL: Record<FilterField, string> = {
+  sector: "Sector",
+  country: "Country",
+  ps: "P/S",
+  rev_growth_ttm: "Rev growth %",
+  gross_margin: "Gross margin %",
+  fcf_margin: "FCF margin %",
+  net_margin: "Net margin %",
+  operating_margin: "Op margin %",
+  rule_of_40: "Rule of 40",
+  ret_52w: "52w return %",
+  price: "Price $",
+};
+
+function fmt(v: number | null, opts?: { pct?: boolean; mult?: boolean; dp?: number }): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  const dp = opts?.dp ?? (opts?.pct ? 1 : opts?.mult ? 1 : 2);
+  const s = v.toFixed(dp);
+  if (opts?.pct) return `${s}%`;
+  if (opts?.mult) return `${s}×`;
+  return s;
+}
+
+export default function ScreenerClient({
+  initialConfig,
+  initialData,
+  defaultEncoded,
+}: {
+  initialConfig: ScreenConfig;
+  initialData: ScreenData;
+  defaultEncoded: string;
+}) {
+  const [config, setConfig] = useState<ScreenConfig>(initialConfig);
+  const [data, setData] = useState<ScreenData>(initialData);
+  const [loading, setLoading] = useState(false);
+  const [brief, setBrief] = useState(initialConfig.brief ?? "");
+  const [compileStatus, setCompileStatus] = useState<string | null>(null);
+  const [compiling, setCompiling] = useState(false);
+  const [signedIn, setSignedIn] = useState(false);
+  const [saveLink, setSaveLink] = useState<string | null>(null);
+  const [shareMsg, setShareMsg] = useState<string | null>(null);
+  const firstRender = useRef(true);
+
+  useEffect(() => {
+    const supabase = createSupabaseBrowserClient();
+    supabase.auth.getSession().then(({ data }) => setSignedIn(!!data.session));
+  }, []);
+
+  // Live re-rank: whenever the compiled config changes, re-fetch /api/screen
+  // (debounced) and sync the URL. Skips the initial mount (SSR already paid).
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
+    const handle = setTimeout(async () => {
+      setLoading(true);
+      const encoded = encodeConfig(config);
+      try {
+        const res = await fetch(`/api/screen?config=${encoded}`, { cache: "no-store" });
+        if (res.ok) {
+          const json = await res.json();
+          setData(json as ScreenData);
+        }
+      } finally {
+        setLoading(false);
+      }
+      // Clean URL for an unmodified preset, else the encoded config.
+      const isClean = encoded === encodeConfig(presetConfig(config.preset ?? ""));
+      const url =
+        isClean && config.preset && config.preset !== "custom"
+          ? `/screener?preset=${config.preset}`
+          : `/screener?config=${encoded}`;
+      window.history.replaceState(null, "", url);
+    }, 350);
+    return () => clearTimeout(handle);
+  }, [config]);
+
+  const patch = useCallback((p: Partial<ScreenConfig>) => {
+    setConfig((c) => ({ ...c, preset: "custom", ...p }));
+    setSaveLink(null);
+  }, []);
+
+  function selectPreset(id: string) {
+    const c = presetConfig(id);
+    setConfig(c);
+    setBrief("");
+    setCompileStatus(null);
+    setSaveLink(null);
+  }
+
+  async function compile() {
+    if (!brief.trim()) return;
+    setCompiling(true);
+    setCompileStatus("Compiling…");
+    try {
+      const res = await fetch("/api/compile-brief", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ brief }),
+      });
+      if (!res.ok) {
+        setCompileStatus("Compile failed — edit the knobs directly.");
+        return;
+      }
+      const { compiled } = await res.json();
+      setConfig((c) => ({
+        ...c,
+        preset: "custom",
+        brief,
+        filters: compiled.filters,
+        weights: compiled.weights,
+        aiMultiplier: compiled.aiMultiplier,
+      }));
+      const fc = compiled.filters.length;
+      const tilt = topWeight(compiled.weights);
+      setCompileStatus(`compiled — ${fc} filter${fc === 1 ? "" : "s"} + a ${tilt}-tilted weighting`);
+    } finally {
+      setCompiling(false);
+    }
+  }
+
+  async function onSave() {
+    if (!signedIn) {
+      setSaveLink(null);
+      setShareMsg("Sign in to save — viewing & sharing stay open.");
+      return;
+    }
+    const name = config.preset && config.preset !== "custom"
+      ? PRESETS[config.preset]?.label ?? "My screen"
+      : "Custom screen";
+    const res = await saveScreen({ name, config });
+    if (res.ok) setSaveLink(`/screener?screen=${res.slug}`);
+    else setShareMsg(res.error);
+  }
+
+  async function onShare() {
+    const encoded = encodeConfig(config);
+    const url = `${window.location.origin}/screener?config=${encoded}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setShareMsg("Link copied to clipboard");
+    } catch {
+      setShareMsg(url);
+    }
+  }
+
+  function addFilter() {
+    const used = new Set(config.filters.map((f) => f.field));
+    const field = FILTER_FIELDS.find((f) => !used.has(f)) ?? "ps";
+    const isText = TEXT_FIELDS.has(field);
+    patch({
+      filters: [
+        ...config.filters,
+        { field, op: isText ? "==" : "<=", value: isText ? "" : 0 } as Filter,
+      ],
+    });
+  }
+  function updateFilter(i: number, p: Partial<Filter>) {
+    const next = config.filters.map((f, idx) => (idx === i ? { ...f, ...p } : f));
+    patch({ filters: next as Filter[] });
+  }
+  function removeFilter(i: number) {
+    patch({ filters: config.filters.filter((_, idx) => idx !== i) });
+  }
+
+  const rows = data.rows;
+
+  return (
+    <div>
+      {/* ---- Brief panel ---- */}
+      <section
+        className="rounded-xl border border-white/10 bg-white/[0.02] p-4 mb-3"
+        aria-label="Screen brief"
+      >
+        <div className="flex items-center gap-2 flex-wrap mb-2">
+          <span className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted mr-1">
+            Preset
+          </span>
+          {Object.values(PRESETS).map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => selectPreset(p.id)}
+              aria-pressed={config.preset === p.id}
+              className={`font-mono text-[11px] rounded-md px-2.5 py-1.5 border transition-colors ${
+                config.preset === p.id
+                  ? "text-green border-green/50 bg-green/10"
+                  : "text-text-muted border-white/10 hover:text-text"
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+          <span
+            className={`font-mono text-[11px] rounded-md px-2.5 py-1.5 border ${
+              config.preset === "custom"
+                ? "text-green border-green/50 bg-green/10"
+                : "text-text-muted/60 border-white/10"
+            }`}
+          >
+            Custom
+          </span>
+        </div>
+
+        <label htmlFor="brief" className="sr-only">
+          Plain-English screen brief
+        </label>
+        <textarea
+          id="brief"
+          value={brief}
+          onChange={(e) => setBrief(e.target.value)}
+          rows={2}
+          placeholder="e.g. Rule of 40 winners, no biotech, P/S under 15, lean quality-tilted…"
+          className="w-full resize-y rounded-md bg-black/30 border border-white/10 px-3 py-2 text-sm text-text placeholder:text-text-muted/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40"
+        />
+        <div className="flex items-center gap-3 mt-2 flex-wrap">
+          <button
+            type="button"
+            onClick={compile}
+            disabled={compiling || !brief.trim()}
+            className="font-mono text-[11px] rounded-md px-3 py-1.5 bg-green text-black disabled:opacity-40"
+          >
+            {compiling ? "Compiling…" : "Compile to screen"}
+          </button>
+          {compileStatus && (
+            <span className="font-mono text-[11px] text-text-muted" aria-live="polite">
+              {compileStatus}
+            </span>
+          )}
+          <span className="font-mono text-[10px] text-text-muted/70">
+            the brief is for humans; the compiled knobs below are what the buyer
+            reads
+          </span>
+        </div>
+      </section>
+
+      {/* ---- Compiled screen panel ---- */}
+      <details className="rounded-xl border border-white/10 bg-white/[0.02] p-4 mb-3" open>
+        <summary className="cursor-pointer text-green font-mono text-[11px] select-none">
+          Compiled screen — filters &amp; score weighting
+        </summary>
+
+        <div className="flex items-center gap-2 flex-wrap mt-3 pb-3 border-b border-white/10">
+          <span className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted mr-1">
+            Filters
+          </span>
+          {config.filters.map((f, i) => (
+            <span
+              key={i}
+              className="inline-flex items-center gap-1 font-mono text-[11px] rounded-md border border-green/30 bg-black/30 px-2 py-1"
+            >
+              <select
+                aria-label="Filter field"
+                value={f.field}
+                onChange={(e) => {
+                  const field = e.target.value as FilterField;
+                  const isText = TEXT_FIELDS.has(field);
+                  updateFilter(i, {
+                    field,
+                    op: isText ? "==" : f.op,
+                    value: isText ? String(f.value ?? "") : Number(f.value) || 0,
+                  });
+                }}
+                className="bg-transparent text-text focus:outline-none"
+              >
+                {FILTER_FIELDS.map((ff) => (
+                  <option key={ff} value={ff} className="bg-black">
+                    {FIELD_LABEL[ff]}
+                  </option>
+                ))}
+              </select>
+              <select
+                aria-label="Filter operator"
+                value={f.op}
+                onChange={(e) => updateFilter(i, { op: e.target.value as FilterOp })}
+                className="bg-transparent text-text focus:outline-none"
+              >
+                {FILTER_OPS.map((op) => (
+                  <option key={op} value={op} className="bg-black">
+                    {op}
+                  </option>
+                ))}
+              </select>
+              {TEXT_FIELDS.has(f.field) ? (
+                <input
+                  aria-label="Filter value"
+                  value={String(f.value ?? "")}
+                  onChange={(e) => updateFilter(i, { value: e.target.value })}
+                  className="w-28 bg-transparent text-text focus:outline-none border-b border-white/10"
+                />
+              ) : (
+                <input
+                  aria-label="Filter value"
+                  type="number"
+                  value={Number(f.value)}
+                  onChange={(e) => updateFilter(i, { value: Number(e.target.value) })}
+                  className="w-16 bg-transparent text-text focus:outline-none border-b border-white/10"
+                />
+              )}
+              <button
+                type="button"
+                aria-label="Remove filter"
+                onClick={() => removeFilter(i)}
+                className="text-text-muted hover:text-text"
+              >
+                ✕
+              </button>
+            </span>
+          ))}
+          <button
+            type="button"
+            onClick={addFilter}
+            className="font-mono text-[11px] rounded-md border border-dashed border-white/20 text-text-muted px-2 py-1 hover:text-text"
+          >
+            + add filter
+          </button>
+          <span className="font-mono text-[11px] text-text-muted ml-auto" aria-live="polite">
+            {data.match_count} match{data.match_count === 1 ? "" : "es"}
+            {loading ? " · …" : ""}
+          </span>
+        </div>
+
+        <div className="flex items-center justify-between mt-3 mb-2">
+          <span className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted">
+            Score weighting — this screen&apos;s own ranking
+          </span>
+          <label className="font-mono text-[11px] text-green inline-flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={config.aiMultiplier}
+              onChange={(e) => patch({ aiMultiplier: e.target.checked })}
+            />
+            AI bull/bear ×
+          </label>
+        </div>
+        <div className="flex gap-5 flex-wrap">
+          {(["quality", "value", "momentum"] as const).map((k) => (
+            <label key={k} className="flex-1 min-w-[150px]">
+              <span className="font-mono text-[11px] text-text-muted flex justify-between capitalize">
+                <span>{k}</span>
+                <span className="text-text">{config.weights[k]}</span>
+              </span>
+              <input
+                type="range"
+                min={0}
+                max={100}
+                value={config.weights[k]}
+                onChange={(e) =>
+                  patch({ weights: { ...config.weights, [k]: Number(e.target.value) } })
+                }
+                className="w-full accent-green"
+                aria-label={`${k} weight`}
+              />
+            </label>
+          ))}
+          <label className="min-w-[110px]">
+            <span className="font-mono text-[11px] text-text-muted flex justify-between">
+              <span>Top N → buyer</span>
+              <span className="text-text">{config.topN}</span>
+            </span>
+            <input
+              type="number"
+              min={1}
+              max={200}
+              value={config.topN}
+              onChange={(e) => patch({ topN: Math.max(1, Math.min(200, Number(e.target.value))) })}
+              className="w-full bg-black/30 border border-white/10 rounded-md px-2 py-1 text-sm text-text mt-1"
+            />
+          </label>
+        </div>
+
+        <div className="flex gap-2 mt-3">
+          <button
+            type="button"
+            onClick={onShare}
+            className="font-mono text-[11px] rounded-md border border-white/10 text-text-muted px-3 py-1.5 hover:text-text"
+          >
+            Share ↗
+          </button>
+          <button
+            type="button"
+            onClick={onSave}
+            className="font-mono text-[11px] rounded-md border border-white/10 text-text-muted px-3 py-1.5 hover:text-text"
+          >
+            Save
+          </button>
+          {saveLink && (
+            <Link href={saveLink} className="font-mono text-[11px] text-green px-2 py-1.5 underline">
+              saved → {saveLink}
+            </Link>
+          )}
+          {shareMsg && (
+            <span className="font-mono text-[11px] text-text-muted px-2 py-1.5" aria-live="polite">
+              {shareMsg}
+            </span>
+          )}
+        </div>
+      </details>
+
+      <div className="font-mono text-[10.5px] text-text-muted mb-2 flex justify-between flex-wrap gap-1.5">
+        <span>
+          {data.match_count} companies · top {Math.min(config.topN, data.match_count)} feed your
+          buyer · re-ranks live · {data.total_universe} in universe
+        </span>
+        <span className="text-green">filters &amp; weights live in this URL</span>
+      </div>
+
+      {/* ---- Results ---- */}
+      <div className="rounded-xl border border-white/10 overflow-hidden">
+        <table className="w-full border-collapse" aria-label="Screened equities, ranked by your composite score">
+          <thead>
+            <tr className="bg-white/[0.02]">
+              <Th className="text-left w-8">#</Th>
+              <Th className="text-left">Ticker</Th>
+              <Th>Score</Th>
+              <Th>P/S</Th>
+              <Th>Rev gr%</Th>
+              <Th>GM%</Th>
+              <Th>FCF M%</Th>
+              <Th>R40</Th>
+              <Th>52w%</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <RowView key={r.ticker} r={r} cut={i === data.cut_index && data.cut_index < rows.length} dim={i >= data.cut_index} />
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={9} className="p-6 text-center text-sm text-text-muted">
+                  No matches — loosen your filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <footer className="border-t border-white/10 mt-5 pt-4">
+        <p className="font-mono text-[10.5px] text-text-muted">
+          Ranked by your configured composite · a research tool, not a
+          recommendation · paper-trading only, not financial advice.
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+function Th({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  return (
+    <th
+      className={`font-mono text-[10px] tracking-[0.04em] text-text-muted font-normal px-2.5 py-2 text-right ${className}`}
+    >
+      {children}
+    </th>
+  );
+}
+
+function RowView({ r, cut, dim }: { r: Row; cut: boolean; dim: boolean }) {
+  return (
+    <>
+      {cut && (
+        <tr aria-hidden>
+          <td colSpan={9} className="px-2.5 py-1 bg-green/[0.06] border-t border-green/30">
+            <span className="font-mono text-[10px] text-green">
+              ── cut line: above feeds your buyer · below is ranked, not bought ──
+            </span>
+          </td>
+        </tr>
+      )}
+      <tr className={dim ? "opacity-45" : ""}>
+        <td className="px-2.5 py-2 text-left font-mono text-text-muted text-xs border-t border-white/10">
+          {r.rank}
+        </td>
+        <td className="px-2.5 py-2 text-left border-t border-white/10">
+          <Link href={`/company/${r.ticker}`} className="hover:text-green">
+            <span className="font-mono text-text text-[12.5px]">{r.ticker}</span>{" "}
+            <span className="text-[11px] text-text-muted">{r.name}</span>
+          </Link>
+        </td>
+        <Td className="text-green font-mono">{fmt(r.score, { dp: 1 })}</Td>
+        <Td className="font-mono">{fmt(r.ps, { mult: true })}</Td>
+        <Td className="font-mono text-green">{fmt(r.rev_growth_ttm, { pct: true })}</Td>
+        <Td className="font-mono text-green">{fmt(r.gross_margin, { pct: true })}</Td>
+        <Td className="font-mono text-green">{fmt(r.fcf_margin, { pct: true })}</Td>
+        <Td className="font-mono text-green">{fmt(r.rule_of_40, { dp: 0 })}</Td>
+        <Td className="font-mono">{fmt(r.ret_52w, { pct: true, dp: 0 })}</Td>
+      </tr>
+    </>
+  );
+}
+
+function Td({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  return <td className={`px-2.5 py-2 text-right text-[12.5px] border-t border-white/10 ${className}`}>{children}</td>;
+}
+
+function topWeight(w: { quality: number; value: number; momentum: number }): string {
+  const entries = Object.entries(w) as [string, number][];
+  entries.sort((a, b) => b[1] - a[1]);
+  return entries[0][0];
+}

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -6,8 +6,11 @@ import Logo from "@/components/logo";
 import NavAuth from "@/components/nav-auth";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 
-// Links available to every visitor.
+// Links available to every visitor. The screener is now a public, top-nav
+// product surface (screener brief v2 §7) — viewable logged-out, and the
+// funnel's selection stage.
 const PUBLIC_LINKS: { href: string; label: string }[] = [
+  { href: "/screener", label: "Screener" },
   { href: "/leaderboard", label: "Leaderboard" },
   { href: "/docs", label: "Docs" },
 ];
@@ -18,9 +21,11 @@ const PUBLIC_LINKS: { href: string; label: string }[] = [
 // user's portfolio detail), via /account → /portfolios/<slug> and
 // /account/portfolio → /portfolios/<slug> respectively. Settings is
 // reachable from the chip on the portfolio header.
+//
+// The standalone Watchlist link is gone: the screener's top N IS the
+// selection now (curator/watchlist removed, brief v2 §3).
 const AUTHED_LINKS: { href: string; label: string }[] = [
   { href: "/account", label: "Dashboard" },
-  { href: "/account/watchlist", label: "Watchlist" },
   { href: "/account/portfolio", label: "Portfolio" },
 ];
 

--- a/web/lib/screen/config.ts
+++ b/web/lib/screen/config.ts
@@ -1,0 +1,186 @@
+/**
+ * Screener config model (brief v2 §4) — the small, shareable recipe that
+ * defines a screen. Encoded in the URL so any screen is bookmarkable /
+ * indexable, and stored verbatim on a portfolio (`portfolios.screen_config`)
+ * as that portfolio's selection recipe.
+ *
+ * Two config layers (brief §2): a plain-English `brief` (human layer) that the
+ * design-time `/compile-brief` LLM translates into the deterministic
+ * `filters` + `weights` (machine layer). Agents read the compiled config,
+ * never the prose. The daily re-rank is pure deterministic computation — no
+ * LLM in the ranking loop.
+ */
+
+import { z } from "zod";
+
+// Fields a filter can target — these map 1:1 onto screen_facts() columns
+// (migration 040). Numeric unless noted.
+export const FILTER_FIELDS = [
+  "sector", // text
+  "country", // text
+  "ps", // P/S
+  "rev_growth_ttm",
+  "gross_margin",
+  "fcf_margin",
+  "net_margin",
+  "operating_margin",
+  "rule_of_40",
+  "ret_52w",
+  "price",
+] as const;
+export type FilterField = (typeof FILTER_FIELDS)[number];
+
+export const TEXT_FIELDS = new Set<FilterField>(["sector", "country"]);
+
+export const FILTER_OPS = ["<=", ">=", "<", ">", "==", "!="] as const;
+export type FilterOp = (typeof FILTER_OPS)[number];
+
+export const filterSchema = z.object({
+  field: z.enum(FILTER_FIELDS),
+  op: z.enum(FILTER_OPS),
+  value: z.union([z.number(), z.string()]),
+});
+export type Filter = z.infer<typeof filterSchema>;
+
+export const weightsSchema = z.object({
+  quality: z.number().min(0).max(100),
+  value: z.number().min(0).max(100),
+  momentum: z.number().min(0).max(100),
+});
+export type Weights = z.infer<typeof weightsSchema>;
+
+export const screenConfigSchema = z.object({
+  brief: z.string().max(2000).optional(),
+  preset: z.string().optional(),
+  filters: z.array(filterSchema).max(20).default([]),
+  weights: weightsSchema.default({ quality: 45, value: 25, momentum: 20 }),
+  aiMultiplier: z.boolean().default(true),
+  topN: z.number().int().min(1).max(200).default(40),
+  sort: z
+    .object({
+      column: z.string().default("score"),
+      dir: z.enum(["asc", "desc"]).default("desc"),
+    })
+    .default({ column: "score", dir: "desc" }),
+});
+export type ScreenConfig = z.infer<typeof screenConfigSchema>;
+
+// ---- House presets (indexable; brief §7) ---------------------------------
+
+export interface Preset {
+  id: string;
+  label: string;
+  description: string;
+  config: Omit<ScreenConfig, "preset">;
+}
+
+const base = {
+  brief: undefined,
+  sort: { column: "score", dir: "desc" as const },
+  topN: 40,
+  aiMultiplier: true,
+};
+
+export const PRESETS: Record<string, Preset> = {
+  "quality-growth": {
+    id: "quality-growth",
+    label: "Quality Growth",
+    description:
+      "Durable compounders — Rule of 40, fat FCF and gross margins, valuation kept sane.",
+    config: {
+      ...base,
+      filters: [{ field: "ps", op: "<=", value: 15 }],
+      weights: { quality: 60, value: 25, momentum: 15 },
+    },
+  },
+  "deep-value": {
+    id: "deep-value",
+    label: "Deep Value",
+    description: "Cheap on sales relative to their own history; quality is secondary.",
+    config: {
+      ...base,
+      filters: [{ field: "ps", op: "<=", value: 8 }],
+      weights: { quality: 20, value: 60, momentum: 20 },
+    },
+  },
+  momentum: {
+    id: "momentum",
+    label: "Momentum",
+    description: "Leaders by trailing 52-week price strength, quality as a sanity check.",
+    config: {
+      ...base,
+      filters: [],
+      weights: { quality: 25, value: 15, momentum: 60 },
+    },
+  },
+  "high-fcf": {
+    id: "high-fcf",
+    label: "High FCF",
+    description: "Cash machines — free-cash-flow margin and Rule of 40 lead the score.",
+    config: {
+      ...base,
+      filters: [{ field: "fcf_margin", op: ">=", value: 10 }],
+      weights: { quality: 65, value: 20, momentum: 15 },
+    },
+  },
+};
+
+export const DEFAULT_PRESET = "quality-growth";
+
+export function presetConfig(id: string): ScreenConfig {
+  const p = PRESETS[id] ?? PRESETS[DEFAULT_PRESET];
+  return screenConfigSchema.parse({ ...p.config, preset: p.id });
+}
+
+// ---- URL <-> config (brief §4: config lives in the URL) -------------------
+//
+// Canonical form is a single compact `config` param (base64url JSON) so an
+// arbitrary custom screen round-trips losslessly and shareably. A bare
+// `?preset=` or `?sector=` shortcut yields the clean, indexable URLs.
+
+function b64urlEncode(s: string): string {
+  const b = typeof btoa === "function" ? btoa(s) : Buffer.from(s, "utf8").toString("base64");
+  return b.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function b64urlDecode(s: string): string {
+  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
+  const b = s.replace(/-/g, "+").replace(/_/g, "/") + pad;
+  return typeof atob === "function" ? atob(b) : Buffer.from(b, "base64").toString("utf8");
+}
+
+export function encodeConfig(config: ScreenConfig): string {
+  return b64urlEncode(JSON.stringify(config));
+}
+
+/** Resolve a config from URL search params (config param > preset > sector). */
+export function configFromParams(params: {
+  config?: string;
+  preset?: string;
+  sector?: string;
+}): ScreenConfig {
+  if (params.config) {
+    try {
+      return screenConfigSchema.parse(JSON.parse(b64urlDecode(params.config)));
+    } catch {
+      // fall through to preset/default on a malformed param
+    }
+  }
+  const cfg = presetConfig(params.preset ?? DEFAULT_PRESET);
+  if (params.sector) {
+    cfg.filters = [
+      ...cfg.filters.filter((f) => f.field !== "sector"),
+      { field: "sector", op: "==", value: params.sector },
+    ];
+    cfg.preset = "custom";
+  }
+  return cfg;
+}
+
+/** True when the config is an unmodified house preset (drives index policy). */
+export function isHousePreset(config: ScreenConfig): boolean {
+  if (!config.preset || config.preset === "custom") return false;
+  const p = PRESETS[config.preset];
+  if (!p) return false;
+  const a = screenConfigSchema.parse({ ...p.config, preset: p.id });
+  return JSON.stringify({ ...a, brief: undefined }) === JSON.stringify({ ...config, brief: undefined });
+}

--- a/web/lib/screen/query.ts
+++ b/web/lib/screen/query.ts
@@ -1,0 +1,97 @@
+/**
+ * Server-side data load for the screener (brief v2 §6 contract).
+ *
+ * Pulls the Level 0 facts (screen_facts()) for the whole Tier 1 universe,
+ * merges the optional AI bull/bear overlay (screen_ai_overlay()), then hands
+ * the rows to the pure scoring function. No scoring lives here — this module
+ * only fetches; scoreScreen() ranks.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+import { scoreScreen, type ScreenFacts, type ScreenResult } from "@/lib/screen/score";
+import type { ScreenConfig } from "@/lib/screen/config";
+
+const PAGE = 1000;
+
+/** Fetch every Tier 1 fact row (paginated past PostgREST's 1000-row cap). */
+export async function loadFacts(): Promise<ScreenFacts[]> {
+  const supabase = getSupabase();
+
+  const [factsRaw, overlay] = await Promise.all([
+    fetchAll(supabase, "screen_facts"),
+    fetchAll(supabase, "screen_ai_overlay"),
+  ]);
+
+  const ai = new Map<string, { bull: boolean | null; bear: boolean | null }>();
+  for (const r of overlay) {
+    ai.set(r.ticker as string, {
+      bull: (r.bull as boolean | null) ?? null,
+      bear: (r.bear as boolean | null) ?? null,
+    });
+  }
+
+  return factsRaw.map((r) => {
+    const verdict = ai.get(r.ticker as string);
+    return {
+      ticker: r.ticker as string,
+      name: (r.name as string) ?? null,
+      sector: (r.sector as string) ?? null,
+      industry: (r.industry as string) ?? null,
+      country: (r.country as string) ?? null,
+      price: num(r.price),
+      price_asof: (r.price_asof as string) ?? null,
+      rev_growth_ttm: num(r.rev_growth_ttm),
+      gross_margin: num(r.gross_margin),
+      fcf_margin: num(r.fcf_margin),
+      net_margin: num(r.net_margin),
+      operating_margin: num(r.operating_margin),
+      rule_of_40: num(r.rule_of_40),
+      ps: num(r.ps),
+      ps_median_12m: num(r.ps_median_12m),
+      ret_52w: num(r.ret_52w),
+      bull: verdict?.bull ?? null,
+      bear: verdict?.bear ?? null,
+    } satisfies ScreenFacts;
+  });
+}
+
+async function fetchAll(
+  supabase: ReturnType<typeof getSupabase>,
+  fn: string,
+): Promise<Record<string, unknown>[]> {
+  const out: Record<string, unknown>[] = [];
+  for (let page = 0; ; page++) {
+    const { data, error } = await supabase
+      .rpc(fn)
+      .range(page * PAGE, (page + 1) * PAGE - 1);
+    if (error) {
+      console.error(`${fn} failed:`, error.message);
+      break;
+    }
+    const batch = (data ?? []) as Record<string, unknown>[];
+    out.push(...batch);
+    if (batch.length < PAGE) break;
+  }
+  return out;
+}
+
+export interface ScreenResponse extends ScreenResult {
+  data_asof: string | null;
+}
+
+/** Full contract response for a config: scored rows + counts + as-of. */
+export async function runScreen(config: ScreenConfig): Promise<ScreenResponse> {
+  const facts = await loadFacts();
+  const result = scoreScreen(facts, config, facts.length);
+  const data_asof = facts.reduce<string | null>((acc, f) => {
+    if (f.price_asof && (!acc || f.price_asof > acc)) return f.price_asof;
+    return acc;
+  }, null);
+  return { ...result, data_asof };
+}
+
+function num(v: unknown): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}

--- a/web/lib/screen/saved-mutations.ts
+++ b/web/lib/screen/saved-mutations.ts
@@ -1,0 +1,61 @@
+"use server";
+
+/**
+ * Server Action for saving a screen (brief v2 §10 — "Save produces a working
+ * link"). Saving is gated behind login; viewing/sharing is not. Same auth
+ * model as the other mutations: verify the SSR cookie session, then write with
+ * the service-role client (owner_user_id stamped explicitly).
+ */
+
+import { getSupabase } from "@/lib/supabase";
+import { requireUser } from "@/lib/auth/require-user";
+import { slugify } from "@/lib/slug";
+import { screenConfigSchema, type ScreenConfig } from "@/lib/screen/config";
+
+export type SaveResult =
+  | { ok: true; slug: string }
+  | { ok: false; error: string };
+
+async function uniqueScreenSlug(name: string): Promise<string> {
+  const supabase = getSupabase();
+  const root = slugify(name);
+  let candidate = root;
+  for (let n = 2; n < 1000; n++) {
+    const { data } = await supabase
+      .from("saved_screens")
+      .select("slug")
+      .eq("slug", candidate)
+      .maybeSingle();
+    if (!data) return candidate;
+    candidate = `${root.slice(0, 34)}-${n}`;
+  }
+  return `${root.slice(0, 28)}-${Date.now().toString(36)}`;
+}
+
+export async function saveScreen(input: {
+  name: string;
+  config: ScreenConfig;
+}): Promise<SaveResult> {
+  let user;
+  try {
+    ({ user } = await requireUser());
+  } catch {
+    return { ok: false, error: "Sign in to save a screen." };
+  }
+
+  const name = (input.name || "").trim().slice(0, 80) || "My screen";
+  let config: ScreenConfig;
+  try {
+    config = screenConfigSchema.parse(input.config);
+  } catch {
+    return { ok: false, error: "Invalid screen config." };
+  }
+
+  const slug = await uniqueScreenSlug(name);
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from("saved_screens")
+    .insert({ owner_user_id: user.id, slug, name, config });
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, slug };
+}

--- a/web/lib/screen/score.ts
+++ b/web/lib/screen/score.ts
@@ -1,0 +1,191 @@
+/**
+ * Deterministic scoring-as-a-function (brief v2 §2/§6).
+ *
+ * Given the shared Level 0 facts (one row per Tier 1 ticker from
+ * screen_facts()) and a screen config, produce the ranked rows for THAT
+ * config. Pure computation — no LLM, no per-user precomputed pipeline, no DB
+ * access. The same formula is mirrored in screen.py so the Python buyer ranks
+ * the identical top N.
+ *
+ * Lens-relative by construction: each component is an EMPIRICAL percentile
+ * within the filtered candidate set, so outliers (e.g. a Rule-of-40 of 26,000
+ * from a tiny-revenue base) pin to the top percentile instead of blowing up
+ * the scale. Composite = weighted blend of the three component percentiles,
+ * scaled 0–100, then an optional AI bull/bear multiplier.
+ */
+
+import type { Filter, ScreenConfig } from "@/lib/screen/config";
+import { TEXT_FIELDS } from "@/lib/screen/config";
+
+export interface ScreenFacts {
+  ticker: string;
+  name: string | null;
+  sector: string | null;
+  industry: string | null;
+  country: string | null;
+  price: number | null;
+  price_asof: string | null;
+  rev_growth_ttm: number | null;
+  gross_margin: number | null;
+  fcf_margin: number | null;
+  net_margin: number | null;
+  operating_margin: number | null;
+  rule_of_40: number | null;
+  ps: number | null;
+  ps_median_12m: number | null;
+  ret_52w: number | null;
+  // AI verdict overlay (from companies; Level 0 itself is strategy-neutral)
+  bull: boolean | null;
+  bear: boolean | null;
+}
+
+export interface ScoredRow extends ScreenFacts {
+  rank: number;
+  score: number;
+  quality_pct: number; // 0–100, for transparency / debugging
+  value_pct: number;
+  momentum_pct: number;
+}
+
+// Momentum collar (brief / CLAUDE.md): a falling knife scores 0, a blow-off
+// top is capped — applied before percentile-ranking the 52w return.
+const MOM_FLOOR = -50;
+const MOM_CAP = 40;
+
+/** A value→0..1 empirical percentile map over a column (nulls stay null). */
+function percentiles(values: (number | null)[]): (number | null)[] {
+  const present = values.filter((v): v is number => v != null && Number.isFinite(v));
+  if (present.length === 0) return values.map(() => null);
+  const sorted = [...present].sort((a, b) => a - b);
+  const n = sorted.length;
+  return values.map((v) => {
+    if (v == null || !Number.isFinite(v)) return null;
+    // fraction of values <= v (upper bound), in [1/n, 1]
+    let lo = 0;
+    let hi = n;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (sorted[mid] <= v) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo / n;
+  });
+}
+
+function matchesFilter(row: ScreenFacts, f: Filter): boolean {
+  const raw = (row as unknown as Record<string, unknown>)[f.field === "ps" ? "ps" : f.field];
+  if (TEXT_FIELDS.has(f.field)) {
+    const a = (raw == null ? "" : String(raw)).toLowerCase();
+    const b = String(f.value).toLowerCase();
+    if (f.op === "==") return a === b;
+    if (f.op === "!=") return a !== b;
+    // ordering ops on text fall back to string compare
+    if (f.op === "<=") return a <= b;
+    if (f.op === ">=") return a >= b;
+    if (f.op === "<") return a < b;
+    return a > b;
+  }
+  const v = typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+  if (v == null) return false; // a numeric filter excludes names missing that datum
+  const t = Number(f.value);
+  switch (f.op) {
+    case "<=":
+      return v <= t;
+    case ">=":
+      return v >= t;
+    case "<":
+      return v < t;
+    case ">":
+      return v > t;
+    case "==":
+      return v === t;
+    case "!=":
+      return v !== t;
+  }
+}
+
+export function applyFilters(facts: ScreenFacts[], filters: Filter[]): ScreenFacts[] {
+  if (!filters.length) return facts;
+  return facts.filter((row) => filters.every((f) => matchesFilter(row, f)));
+}
+
+function aiMultiplier(bull: boolean | null, bear: boolean | null): number {
+  if (bull == null || bear == null) return 1.0; // no penalty for missing eval
+  if (bull && bear) return 1.3; // dual-positive
+  if (!bull && bear) return 1.0; // sound, no edge
+  if (bull && !bear) return 0.7; // story but red flags
+  return 0.4; // avoid
+}
+
+export interface ScreenResult {
+  rows: ScoredRow[];
+  match_count: number;
+  total_universe: number;
+  cut_index: number; // rows[0..cut_index) are the buyer's candidates (top N)
+}
+
+/**
+ * Rank the universe for a config. `total` is the full Tier 1 count (pre-filter)
+ * for the `total_universe` field; defaults to facts.length.
+ */
+export function scoreScreen(
+  facts: ScreenFacts[],
+  config: ScreenConfig,
+  total?: number,
+): ScreenResult {
+  const subset = applyFilters(facts, config.filters);
+
+  // Value driver: P/S relative to the stock's own 12-month median (cheaper =
+  // better). Falls back to raw P/S when no median is recorded.
+  const psRatio = subset.map((r) =>
+    r.ps == null ? null : r.ps / (r.ps_median_12m && r.ps_median_12m > 0 ? r.ps_median_12m : r.ps),
+  );
+  const mom = subset.map((r) =>
+    r.ret_52w == null ? null : Math.max(MOM_FLOOR, Math.min(MOM_CAP, r.ret_52w)),
+  );
+
+  const pR40 = percentiles(subset.map((r) => r.rule_of_40));
+  const pFcf = percentiles(subset.map((r) => r.fcf_margin));
+  const pGm = percentiles(subset.map((r) => r.gross_margin));
+  const pVal = percentiles(psRatio); // lower ratio → lower pct → inverted below
+  const pMom = percentiles(mom);
+
+  const { quality: wq, value: wv, momentum: wm } = config.weights;
+  const wsum = wq + wv + wm || 1;
+
+  const scored: ScoredRow[] = subset.map((r, i) => {
+    const quality = 0.6 * (pR40[i] ?? 0) + 0.25 * (pFcf[i] ?? 0) + 0.15 * (pGm[i] ?? 0);
+    const value = pVal[i] == null ? 0 : 1 - (pVal[i] as number); // invert: cheap = high
+    const momentum = pMom[i] ?? 0;
+    let score = ((wq * quality + wv * value + wm * momentum) / wsum) * 100;
+    if (config.aiMultiplier) score *= aiMultiplier(r.bull, r.bear);
+    return {
+      ...r,
+      rank: 0,
+      score,
+      quality_pct: Math.round(quality * 100),
+      value_pct: Math.round(value * 100),
+      momentum_pct: Math.round(momentum * 100),
+    };
+  });
+
+  // Sort: by the configured column (default score), then ticker for stability.
+  const col = config.sort.column;
+  const dir = config.sort.dir === "asc" ? 1 : -1;
+  scored.sort((a, b) => {
+    const av = (a as unknown as Record<string, unknown>)[col];
+    const bv = (b as unknown as Record<string, unknown>)[col];
+    const an = typeof av === "number" ? av : Number.NEGATIVE_INFINITY;
+    const bn = typeof bv === "number" ? bv : Number.NEGATIVE_INFINITY;
+    if (an !== bn) return (an - bn) * dir;
+    return a.ticker.localeCompare(b.ticker);
+  });
+  scored.forEach((r, i) => (r.rank = i + 1));
+
+  return {
+    rows: scored,
+    match_count: scored.length,
+    total_universe: total ?? facts.length,
+    cut_index: Math.min(config.topN, scored.length),
+  };
+}


### PR DESCRIPTION
## Configurable screener → the funnel's selection stage

Turns `/screener` from a hidden read-only table into a **public, configurable, shareable** research tool that doubles as the **selection stage**: the ranked **top N** of a portfolio's screen feed the buyer directly. Implements screener brief v2 (single PR; curator removed now; compile via Gemini 2.5 Flash; query-param URLs).

### Architecture
- **Two config layers** — a plain-English **brief** compiles (design-time only, `POST /api/compile-brief`, Gemini 2.5 Flash) into an editable **compiled screen** (filters + Quality/Value/Momentum weights + AI toggle + `topN`). Agents read the compiled config, **never the prose**. **No LLM in the daily ranking loop.**
- **Scoring-as-a-function** — `GET /api/screen?config=` ranks the whole Tier 1 universe for a config. Lens-relative: each component is an **empirical percentile within the filtered set** (outliers pin to p100 instead of distorting the scale). Composite = Quality (0.60·R40 + 0.25·FCF + 0.15·GM) + Value (inverse P/S÷median) + Momentum (collared 52w return), × optional AI bull/bear. Implemented in TS (`web/lib/screen/score.ts`) **and mirrored in Python (`screen.py`)** so the buyer's top N == the page's.

### Backend / DB (migration 040 — applied to live DB ✅)
- `screen_facts()` RPC (Level 0 facts per Tier 1 ticker), `screen_ai_overlay()` (bull/bear verdict, kept out of the strategy-neutral facts), `saved_screens` (Save; public-read, owner-write), `portfolios.screen_config` (a portfolio's selection recipe).
- `securities.gics_sector` backfilled from `companies`; 4 human portfolios seeded with a default quality-growth screen.
- `screen.py` + `test_screen.py` (13 tests, all passing).

### Funnel teardown (curator removed)
- `watchlist_curator` **unregistered** (`STRATEGIES`/`STRATEGY_PHASES`); curator agents' `strategy` cleared in DB.
- **Both buyers repointed**: `watchlist_buyer` + `llm_watchlist_buyer` now trade the top N of `portfolios.screen_config` via `screen.portfolio_screen_candidates`, not `portfolio_watchlist`.

### Web
- `lib/screen/{config,score,query,saved-mutations}.ts` — zod config model, URL-encoded, 4 house presets (Quality Growth / Deep Value / Momentum / High FCF).
- `GET /api/screen`, `POST /api/compile-brief`.
- SSR `/screener`: brief → compile → editable filters/weights/AI toggle, **live re-rank**, **cut line at `topN`** (below dimmed, "ranked, not bought"), Share/Save, per-preset/sector `<title>`/canonical (presets+sectors indexable, custom `noindex`), semantic table / single h1 / range sliders / live region. **Public + added to top nav; Watchlist nav link removed.**
- `web/lib/screen` typechecks clean (`tsc --noEmit` ✅).

### Deliberately deferred (flagged for a focused follow-up)
The **watchlist UI files** (`app/account/watchlist`, `lib/watchlist-*.ts`, `components/portfolio/watchlist-manager.tsx`) are now **orphaned** — the nav link is gone and no strategy reads them — but I did **not** delete them in this PR: ~12 web files reference the watchlist (company page, account, reports), so a wholesale delete needs build-time validation against secrets I don't have here. They're inert; a focused cleanup PR can remove them safely. The curator's `rebalance_watchlist_curator` function body is likewise retained (unregistered) until that cleanup.

### Notes for review
- Data source is **Level 0** (per your call): the screener scores the ~937 Tier 1 names that currently have seeded fundamentals/valuation; it grows as real Level 0 fundamentals ingestion lands.
- `metric_stats` percentiles still reflect the `companies` universe — but scoring here uses **empirical percentiles over the live candidate set**, so it doesn't depend on that.

https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN)_