### PR TITLE
Portfolio swarm: snake-draft buying + first-valid-sell + config-in-place page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,35 @@ Deterministic scoring-as-a-function (Python mirror of
 candidates(db, portfolio_id)` returns the top N `{ticker: rationale}` that both
 buyers (`watchlist_buyer`, `llm_watchlist_buyer`) now trade from. Pure, no LLM.
 
+## Portfolio swarm — multi-buyer / multi-reviewer coordination
+
+A portfolio runs a **swarm**: multiple specialist buyers + reviewers over one
+shared cash pool (portfolio page brief). Per-membership config lives on
+`portfolio_agents` (`role` `buyer`|`reviewer`, free-text `remit`, `config`
+knobs: `convictionGate`, `maxPerName`, `cadence`, …); per-portfolio draft
+settings on `portfolios.draft_config`; per-position attribution on
+`portfolio_holdings.opened_by_agent_id`. See migration 041.
+
+**Coordination is opt-in.** `agent_heartbeat._run_portfolio_swarm` runs only
+when a portfolio has a `draft_config` set **and** role-tagged buyers; otherwise
+the legacy independent per-member loop runs unchanged.
+
+- **Buy — snake draft** (`swarm.snake_draft_plan`): buyers draft from the
+  shared top-N screen candidates one name at a time, order rotating/reversing
+  each round; a buyer only drafts a name clearing **its own** conviction gate,
+  sized by its `maxPerName` against shared cash; a drafted name is taken (no
+  double-buying); each opened position is attributed to its buyer. Conviction
+  source is a deterministic screen-rank baseline (`swarm.rank_to_conviction`) —
+  per-brain LLM conviction can replace it by populating the convictions map; the
+  draft mechanics don't change.
+- **Sell — first valid sell** (`swarm.first_valid_sell_plan` semantics):
+  reviewers run their existing sell strategy in order on the shared book, so the
+  first to close a name wins.
+
+### swarm.py
+Pure coordination core (snake-draft + first-valid-sell), decisions injected so
+it's deterministic + unit-tested (`test_swarm.py`). No DB, no LLM.
+
 ## Scripts
 
 ### universe_sync.py (02:00 UTC Sundays — weekly)

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -293,6 +293,177 @@ def _portfolio_is_due(portfolio: dict, now: datetime) -> bool:
     return now >= last + timedelta(hours=PORTFOLIO_HEARTBEAT_INTERVAL_HOURS)
 
 
+def _run_portfolio_swarm(
+    db: SupabaseDB,
+    pm: PortfolioManager,
+    portfolio: dict,
+    member_rows: list[dict],
+    *,
+    dry_run: bool,
+    logger: logging.Logger,
+    triggered_by: str | None = None,
+) -> dict[str, int]:
+    """Coordinate a portfolio's swarm for one cycle (portfolio brief §4).
+
+    BUY — snake draft: the buyers draft from the shared top-N screen
+    candidates one name at a time (rotating/reversing order), each only
+    drafting names that clear its own conviction gate, sized by its
+    max-per-name against the shared cash. A drafted name is taken (no
+    double-buying) and the opened position is attributed to the buyer.
+
+    SELL — first valid sell: each reviewer runs its existing sell strategy
+    sequentially against the shared book, so the first reviewer to close a
+    name removes it before the next sees it (first-valid-sell by construction;
+    each sell is tagged with the acting reviewer via agent_trades.agent_id).
+
+    Conviction source: a deterministic screen-rank baseline (swarm.rank_to_
+    conviction). Per-brain LLM conviction can replace it by populating the
+    convictions map — the draft mechanics are unchanged.
+    """
+    import screen as _screen
+    import swarm as _swarm
+
+    counts = {"ok": 0, "dry-run": 0, "skipped": 0, "error": 0}
+    pid = portfolio["id"]
+    slug = portfolio.get("slug") or pid[:8]
+    mandate = portfolio.get("description")
+    members = [m["agent"] for m in member_rows]
+    agent_by_id = {m["agent"]["id"]: m for m in member_rows}
+    buyers_m = [m for m in member_rows if (m.get("role") == "buyer")]
+    reviewers_m = [m for m in member_rows if (m.get("role") == "reviewer")]
+    mode, executor = _resolve_live_executor(portfolio, dry_run=dry_run)
+
+    # ---- BUY: snake draft over the screen's top-N candidates ----
+    cand_map = _screen.portfolio_screen_candidates(db, pid)  # {ticker: rationale}
+    book = pm.get_portfolio_book(pid)
+    held = {h.get("ticker") for h in (book.get("holdings") or [])}
+    recently_sold = db.get_recently_sold_tickers(pid, days=90)
+    prices: dict[str, float] = {}
+    for t in cand_map:
+        if t in held or t in recently_sold:
+            continue
+        try:
+            prices[t] = pm.get_price(t)
+        except Exception:  # noqa: BLE001 — unpriced names just aren't draftable
+            continue
+    draftable = [t for t in cand_map if t in prices]
+
+    total_value = float(book.get("total_value_usd") or 0)
+    cash = float(book.get("cash_usd") or 0)
+    n = len(draftable)
+    rank_conv = {t: _swarm.rank_to_conviction(i, n) for i, t in enumerate(draftable)}
+
+    sw_buyers: list = []
+    convictions: dict[str, dict[str, int]] = {}
+    for m in buyers_m:
+        aid = m["agent"]["id"]
+        cfg = m.get("config") or {}
+        sw_buyers.append(
+            _swarm.Buyer(
+                aid,
+                gate=int(cfg.get("convictionGate", 1) or 1),
+                max_per_name=float(cfg.get("maxPerName", 0.08) or 0.08),
+            )
+        )
+        convictions[aid] = dict(rank_conv)
+
+    plan = _swarm.snake_draft_plan(
+        sw_buyers, draftable, prices, total_value, cash, convictions=convictions
+    )
+    logger.info(
+        "  portfolio %-22s swarm: %d buyer(s), %d candidate(s), %d draft pick(s)%s",
+        slug, len(sw_buyers), n, len(plan.picks), " [dry-run]" if dry_run else "",
+    )
+
+    buy_counts: dict[str, int] = {}
+    for pick in plan.picks:
+        m = agent_by_id.get(pick.agent_id)
+        if not m:
+            continue
+        buy_counts[pick.agent_id] = buy_counts.get(pick.agent_id, 0)
+        if dry_run:
+            buy_counts[pick.agent_id] += 1
+            continue
+        ctx = RebalanceContext(
+            db=db, pm=pm, agent=m["agent"], dry_run=False,
+            params=dict(m.get("config") or {}), portfolio_id=pid,
+            members=members, mandate=mandate, mode=mode, executor=executor,
+        )
+        rationale = cand_map.get(pick.ticker)
+        note = f"swarm draft (conviction {pick.conviction}/5): {rationale or ''}".strip()
+        thesis = {"thesis_text": rationale} if rationale else None
+        try:
+            ctx.buy(pick.ticker, pick.qty, note=note, thesis=thesis)
+            buy_counts[pick.agent_id] += 1
+            # Attribution — stamp the opener (only if unset, to preserve the
+            # original buyer across later top-ups).
+            try:
+                db.client.table("portfolio_holdings").update(
+                    {"opened_by_agent_id": pick.agent_id}
+                ).eq("portfolio_id", pid).eq("ticker", pick.ticker).is_(
+                    "opened_by_agent_id", "null"
+                ).execute()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("attribution stamp failed for %s: %s", pick.ticker, exc)
+        except Exception as exc:  # noqa: BLE001 — one bad buy must not abort
+            logger.warning("swarm buy %s x%s failed: %s", pick.ticker, pick.qty, exc)
+
+    for m in buyers_m:
+        aid = m["agent"]["id"]
+        res = RebalanceResult()
+        res.buys = buy_counts.get(aid, 0)
+        res.notes["role"] = "buyer"
+        res.notes["remit"] = m.get("remit")
+        status = "dry-run" if dry_run else "ok"
+        _journal(
+            db, agent_id=aid, strategy=m["agent"].get("strategy") or "swarm_buyer",
+            started_at=_now_utc(), status=status, result=res, portfolio_id=pid,
+            advance_agent=False, dry_run=dry_run, triggered_by=triggered_by,
+        )
+        counts[status] = counts.get(status, 0) + 1
+
+    # ---- SELL: each reviewer runs its strategy in order (first-valid-sell) ----
+    for m in reviewers_m:
+        agent = m["agent"]
+        strategy_name = agent.get("strategy")
+        strategy = get_strategy(strategy_name) if strategy_name else None
+        started = _now_utc()
+        if strategy is None:
+            counts["skipped"] += 1
+            continue
+        ctx = RebalanceContext(
+            db=db, pm=pm, agent=agent, dry_run=dry_run,
+            params=dict(m.get("config") or {}), portfolio_id=pid,
+            members=members, mandate=mandate, mode=mode, executor=executor,
+        )
+        try:
+            result = strategy(ctx)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("    reviewer %s crashed", agent.get("handle"))
+            _journal(
+                db, agent_id=agent["id"], strategy=strategy_name or "reviewer",
+                started_at=started, status="error",
+                error_message=f"{exc}\n{traceback.format_exc()}",
+                portfolio_id=pid, advance_agent=False, dry_run=dry_run,
+                triggered_by=triggered_by,
+            )
+            counts["error"] += 1
+            continue
+        status = "dry-run" if dry_run else ("ok" if not result.errors else "error")
+        _journal(
+            db, agent_id=agent["id"], strategy=strategy_name or "reviewer",
+            started_at=started, status=status, result=result,
+            error_message="; ".join(result.errors) if result.errors else None,
+            portfolio_id=pid, advance_agent=False, dry_run=dry_run,
+            triggered_by=triggered_by,
+        )
+        counts[status] = counts.get(status, 0) + 1
+
+    if not dry_run:
+        db.update_portfolio_last_heartbeat(pid, _now_utc().isoformat())
+    return counts
+
+
 def _run_portfolio(
     db: SupabaseDB,
     pm: PortfolioManager,
@@ -322,7 +493,25 @@ def _run_portfolio(
         counts["skipped"] += 1
         return counts
 
-    members = [m["agent"] for m in db.get_portfolio_members(portfolio["id"])]
+    member_rows = db.get_portfolio_members(portfolio["id"])
+
+    # Swarm path (portfolio brief §4): when the owner has configured a draft
+    # (portfolios.draft_config) and there are role-tagged buyers, coordinate
+    # the members as a swarm — snake-draft buys + first-valid-sell — instead of
+    # the legacy independent per-member loop. Opt-in, so portfolios without a
+    # draft_config are completely unaffected. Skipped for a single-member
+    # "Run now" (handle_filter) so targeted runs keep the per-member behaviour.
+    if (
+        portfolio.get("draft_config")
+        and not handle_filter
+        and any(m.get("role") == "buyer" for m in member_rows)
+    ):
+        return _run_portfolio_swarm(
+            db, pm, portfolio, member_rows,
+            dry_run=dry_run, logger=logger, triggered_by=triggered_by,
+        )
+
+    members = [m["agent"] for m in member_rows]
     mandate = portfolio.get("description")
     if handle_filter:
         members = [m for m in members if m.get("handle") == handle_filter]

--- a/db.py
+++ b/db.py
@@ -529,6 +529,11 @@ class SupabaseDB:
                     "agent": agent.data[0],
                     "notes": m.get("notes"),
                     "joined_at": m.get("joined_at"),
+                    # Swarm membership (migration 041): role ('buyer'|'reviewer'),
+                    # free-text remit/focus, and per-member knobs (config).
+                    "role": m.get("role"),
+                    "remit": m.get("remit"),
+                    "config": m.get("config"),
                     # Per-membership heartbeat clock (migration 029) — each
                     # member rebalances on its own cadence in every
                     # portfolio it joins.

--- a/migrations/041_portfolio_swarm.sql
+++ b/migrations/041_portfolio_swarm.sql
@@ -1,0 +1,46 @@
+-- Migration 041: portfolio swarm (portfolio page brief §3/§4).
+--
+-- A portfolio runs a SWARM: multiple specialist buyers + multiple reviewers,
+-- coordinated per cycle (snake-draft buying, first-valid-sell). This adds the
+-- per-membership config the coordination engine (swarm.py + agent_heartbeat.
+-- _run_portfolio_swarm) needs, plus per-position attribution.
+--
+-- Buying — snake draft: each cycle the buyers draft from the shared top-N
+-- screen candidates one name at a time (rotating/reversing order); a buyer only
+-- drafts a name that clears ITS conviction bar; shared cash; a drafted name is
+-- taken (resolves duplicate picks). Each position is attributed to its buyer.
+-- Selling — first valid sell: reviewers run in order on the shared book; the
+-- first to close a name wins.
+--
+-- Backward compatible: the swarm path is opt-in (runs only when
+-- portfolios.draft_config is set AND the portfolio has role='buyer' members).
+-- NULL role = legacy member, runs its agents.strategy as before. Depends on
+-- migration 040 (screen_config / screen_facts). Idempotent.
+
+-- Per-membership role + remit + knobs (conviction gate, max % per name,
+-- cadence, focus, sell rules, brain).
+ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS role  TEXT;   -- 'buyer' | 'reviewer'
+ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS remit TEXT;   -- free-text specialty/focus
+ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS config JSONB; -- {convictionGate,maxPerName,cadence,sellRules,brain}
+
+-- Per-portfolio draft settings, e.g. {"order":"snake","cycle":"daily"}.
+-- Presence of this column value is the opt-in switch for the swarm path.
+ALTER TABLE portfolios ADD COLUMN IF NOT EXISTS draft_config JSONB;
+
+-- Attribution: which buyer drafted (opened) the position. Track records stay
+-- per-buyer even though cash is a shared pool.
+ALTER TABLE portfolio_holdings ADD COLUMN IF NOT EXISTS opened_by_agent_id UUID REFERENCES agents(id);
+
+-- Backfill role from each member's current strategy so existing swarms keep
+-- working once their owner opts into a draft_config.
+UPDATE portfolio_agents pa SET role = 'buyer'
+FROM agents a
+WHERE a.id = pa.agent_id
+  AND a.strategy IN ('llm_watchlist_buyer', 'watchlist_buyer')
+  AND pa.role IS NULL;
+
+UPDATE portfolio_agents pa SET role = 'reviewer'
+FROM agents a
+WHERE a.id = pa.agent_id
+  AND a.strategy = 'portfolio_reviewer'
+  AND pa.role IS NULL;

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -849,3 +849,19 @@ CREATE POLICY "owner delete" ON saved_screens FOR DELETE USING (auth.uid() = own
 -- removed watchlist: the buyer ranks Level 0 via screen_facts() against this
 -- and buys the top N.
 ALTER TABLE portfolios ADD COLUMN IF NOT EXISTS screen_config JSONB;
+
+
+-- ============================================================
+-- Portfolio swarm (migration 041 — portfolio page brief §3/§4)
+--
+-- A portfolio runs a swarm: multiple specialist buyers + reviewers coordinated
+-- per cycle (snake-draft buying, first-valid-sell — see swarm.py +
+-- agent_heartbeat._run_portfolio_swarm). Per-membership role/remit/knobs;
+-- per-portfolio draft settings (opt-in switch for the swarm path); per-position
+-- buyer attribution. Backward compatible (NULL role = legacy member).
+-- ============================================================
+ALTER TABLE portfolio_agents  ADD COLUMN IF NOT EXISTS role   TEXT;   -- 'buyer' | 'reviewer'
+ALTER TABLE portfolio_agents  ADD COLUMN IF NOT EXISTS remit  TEXT;   -- free-text specialty/focus
+ALTER TABLE portfolio_agents  ADD COLUMN IF NOT EXISTS config JSONB;  -- {convictionGate,maxPerName,cadence,sellRules,brain}
+ALTER TABLE portfolios        ADD COLUMN IF NOT EXISTS draft_config JSONB;  -- {order:'snake',cycle:'daily'}
+ALTER TABLE portfolio_holdings ADD COLUMN IF NOT EXISTS opened_by_agent_id UUID REFERENCES agents(id);

--- a/swarm.py
+++ b/swarm.py
@@ -1,0 +1,156 @@
+"""
+swarm.py — portfolio swarm coordination (portfolio page brief §4).
+
+A portfolio runs a swarm of specialist buyers + reviewers over a SHARED cash
+pool. This module is the pure coordination core — the buy/sell *decisions*
+(conviction per name, sell verdicts) are injected, so the algorithm is
+deterministic and unit-testable without LLMs or a DB. agent_heartbeat wires the
+real per-name LLM evaluations into these functions.
+
+Buying — snake draft per cycle:
+  * Candidates = the shared top-N of the portfolio's screen.
+  * Buyers draft ONE name at a time; draft order rotates and reverses each
+    round (A-B-C, then C-B-A, …).
+  * A buyer only drafts a name that clears ITS OWN conviction bar; a turn can
+    be a pass.
+  * Shared cash; a drafted name is taken (no double-buying) — duplicate-pick
+    conflicts resolve inherently.
+  * Each pick is attributed to the buyer that drafted it.
+
+Selling — first valid sell wins:
+  * Any reviewer can trigger a sell on a name it covers; the first reviewer (in
+    order) that says SELL executes it. Not consensus. Each sell is tagged with
+    the reviewer + reason.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Buyer:
+    agent_id: str
+    gate: int = 1                 # minimum conviction (1..5) to draft a name
+    max_per_name: float = 0.08    # target position as a fraction of total value
+
+
+@dataclass
+class DraftPick:
+    agent_id: str
+    ticker: str
+    qty: int
+    price: float
+    conviction: int
+
+
+@dataclass
+class SellTrigger:
+    ticker: str
+    agent_id: str
+    reason: str
+
+
+@dataclass
+class DraftResult:
+    picks: list[DraftPick] = field(default_factory=list)
+    cash_remaining: float = 0.0
+    passes: dict[str, int] = field(default_factory=dict)  # agent_id -> pass count
+
+
+def snake_draft_plan(
+    buyers: list[Buyer],
+    candidates: list[str],
+    prices: dict[str, float],
+    total_value: float,
+    cash: float,
+    *,
+    cash_reserve_pct: float = 0.02,
+    convictions: dict[str, dict[str, int]],
+) -> DraftResult:
+    """Plan a snake-draft buy cycle. Pure — returns the ordered picks.
+
+    `convictions[agent_id][ticker]` is that buyer's conviction (1..5) for a
+    name; a missing entry means "no opinion / won't draft". A buyer drafts the
+    highest-conviction candidate it can both clear (>= its gate) and afford
+    (>= 1 share within its max_per_name and the shared cash, minus reserve).
+    """
+    result = DraftResult(cash_remaining=cash)
+    available = [t for t in candidates if prices.get(t, 0) and prices[t] > 0]
+    taken: set[str] = set()
+    min_cash = total_value * cash_reserve_pct
+
+    round_idx = 0
+    while available:
+        order = buyers if round_idx % 2 == 0 else list(reversed(buyers))
+        drafted = 0
+        for b in order:
+            conv = convictions.get(b.agent_id, {})
+            # Eligible = cleared the gate, still available; best conviction first,
+            # tie-broken by the candidate pool's order (its screen rank).
+            eligible = sorted(
+                (t for t in available if t not in taken and conv.get(t, 0) >= b.gate),
+                key=lambda t: (-conv.get(t, 0), candidates.index(t)),
+            )
+            picked = None
+            for t in eligible:
+                price = prices[t]
+                target = b.max_per_name * total_value
+                spendable = min(target, result.cash_remaining - min_cash)
+                qty = int(math.floor(spendable / price))
+                if qty >= 1:
+                    picked = (t, qty, price)
+                    break
+            if picked is None:
+                result.passes[b.agent_id] = result.passes.get(b.agent_id, 0) + 1
+                continue
+            t, qty, price = picked
+            result.picks.append(
+                DraftPick(b.agent_id, t, qty, price, int(conv.get(t, 0)))
+            )
+            result.cash_remaining -= qty * price
+            taken.add(t)
+            drafted += 1
+        available = [t for t in available if t not in taken]
+        round_idx += 1
+        if drafted == 0:
+            break  # a full round with no picks — nothing left anyone can/will buy
+    return result
+
+
+def rank_to_conviction(index: int, n: int) -> int:
+    """Map a 0-based screen rank (0 = best) to a 1..5 conviction bucket.
+
+    A deterministic conviction baseline derived from the screen rank: the top
+    fifth of the candidate pool is 5, the next fifth 4, … the bottom fifth 1.
+    Used when a buyer has no per-brain LLM conviction wired (the swarp's draft
+    mechanics — order, gates, shared cash, attribution — are unchanged; only
+    the conviction *source* differs; per-brain LLM convictions can replace
+    this by populating the `convictions` map directly.
+    """
+    if n <= 0:
+        return 1
+    bucket = max(1, (n + 4) // 5)  # ceil(n/5)
+    return max(1, 5 - index // bucket)
+
+
+def first_valid_sell_plan(
+    reviewers: list[str],
+    holdings: list[str],
+    verdicts: dict[str, dict[str, dict]],
+) -> list[SellTrigger]:
+    """For each held name, the first reviewer (in order) that returns a SELL
+    triggers the sell. `verdicts[agent_id][ticker] = {"verdict": "SELL"|"HOLD",
+    "reason": str}`. Returns one SellTrigger per name that any reviewer sells.
+    """
+    triggers: list[SellTrigger] = []
+    for ticker in holdings:
+        for agent_id in reviewers:
+            v = verdicts.get(agent_id, {}).get(ticker)
+            if v and str(v.get("verdict", "")).upper() == "SELL":
+                triggers.append(
+                    SellTrigger(ticker, agent_id, str(v.get("reason", "")).strip())
+                )
+                break
+    return triggers

--- a/test_swarm.py
+++ b/test_swarm.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Unit tests for the portfolio swarm coordination (swarm.py).
+
+Pure-logic tests of the snake-draft buy cycle and first-valid-sell — the
+decisions (convictions, verdicts) are injected. Run: python test_swarm.py
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from swarm import Buyer, snake_draft_plan, first_valid_sell_plan
+
+
+PRICES = {"AAA": 10.0, "BBB": 10.0, "CCC": 10.0, "DDD": 10.0}
+
+
+class TestSnakeDraft(unittest.TestCase):
+    def test_rotates_and_reverses_each_round(self):
+        buyers = [Buyer("A", gate=1, max_per_name=0.25), Buyer("B", gate=1, max_per_name=0.25)]
+        # Both love everything equally; pool order decides preference.
+        conv = {"A": {t: 5 for t in PRICES}, "B": {t: 5 for t in PRICES}}
+        res = snake_draft_plan(
+            buyers, ["AAA", "BBB", "CCC", "DDD"], PRICES,
+            total_value=1000, cash=1000, cash_reserve_pct=0.0, convictions=conv,
+        )
+        order = [(p.agent_id, p.ticker) for p in res.picks]
+        # Round 0: A→AAA, B→BBB. Round 1 (reversed): B→CCC, A→DDD.
+        self.assertEqual(order, [("A", "AAA"), ("B", "BBB"), ("B", "CCC"), ("A", "DDD")])
+
+    def test_conviction_gate_can_pass(self):
+        buyers = [Buyer("A", gate=4, max_per_name=0.5), Buyer("B", gate=1, max_per_name=0.5)]
+        conv = {"A": {"AAA": 2, "BBB": 2}, "B": {"AAA": 5, "BBB": 5}}
+        res = snake_draft_plan(
+            buyers, ["AAA", "BBB"], PRICES,
+            total_value=1000, cash=1000, cash_reserve_pct=0.0, convictions=conv,
+        )
+        # A clears nothing (all below its gate of 4) → only B drafts; A passes
+        # every round it gets a turn.
+        self.assertTrue(all(p.agent_id == "B" for p in res.picks))
+        self.assertGreaterEqual(res.passes.get("A", 0), 1)
+
+    def test_drafted_name_is_taken_no_double_buy(self):
+        buyers = [Buyer("A", gate=1, max_per_name=0.25), Buyer("B", gate=1, max_per_name=0.25)]
+        conv = {"A": {"AAA": 5}, "B": {"AAA": 5}}  # both only want AAA
+        res = snake_draft_plan(
+            buyers, ["AAA"], PRICES,
+            total_value=1000, cash=1000, cash_reserve_pct=0.0, convictions=conv,
+        )
+        tickers = [p.ticker for p in res.picks]
+        self.assertEqual(tickers, ["AAA"])  # taken once, by A (drafts first)
+        self.assertEqual(res.picks[0].agent_id, "A")
+
+    def test_shared_cash_exhausts(self):
+        buyers = [Buyer("A", gate=1, max_per_name=1.0)]
+        conv = {"A": {t: 5 for t in PRICES}}
+        # Only $25 cash, $10 price, max_per_name lets it spend all → 2 shares of
+        # the first name, then no cash for a second name.
+        res = snake_draft_plan(
+            buyers, ["AAA", "BBB"], PRICES,
+            total_value=1000, cash=25, cash_reserve_pct=0.0, convictions=conv,
+        )
+        self.assertEqual(len(res.picks), 1)
+        self.assertEqual(res.picks[0].ticker, "AAA")
+        self.assertEqual(res.picks[0].qty, 2)
+        self.assertAlmostEqual(res.cash_remaining, 5.0)
+
+    def test_attribution_recorded(self):
+        buyers = [Buyer("deep-value", gate=1, max_per_name=0.5)]
+        conv = {"deep-value": {"AAA": 3}}
+        res = snake_draft_plan(
+            buyers, ["AAA"], PRICES,
+            total_value=1000, cash=1000, cash_reserve_pct=0.0, convictions=conv,
+        )
+        self.assertEqual(res.picks[0].agent_id, "deep-value")
+        self.assertEqual(res.picks[0].conviction, 3)
+
+    def test_unaffordable_top_pick_falls_through_to_affordable(self):
+        # Buyer wants AAA most but can't afford a full max position of it at the
+        # cash left; it should still draft the next eligible it can afford.
+        prices = {"AAA": 10000.0, "BBB": 10.0}
+        buyers = [Buyer("A", gate=1, max_per_name=0.01)]  # 0.01*1000 = $10 budget/name
+        conv = {"A": {"AAA": 5, "BBB": 4}}
+        res = snake_draft_plan(
+            buyers, ["AAA", "BBB"], prices,
+            total_value=1000, cash=1000, cash_reserve_pct=0.0, convictions=conv,
+        )
+        self.assertEqual([p.ticker for p in res.picks], ["BBB"])
+
+    def test_no_convictions_means_no_picks(self):
+        buyers = [Buyer("A", gate=1, max_per_name=0.5)]
+        res = snake_draft_plan(
+            buyers, ["AAA"], PRICES,
+            total_value=1000, cash=1000, cash_reserve_pct=0.0, convictions={},
+        )
+        self.assertEqual(res.picks, [])
+
+
+class TestFirstValidSell(unittest.TestCase):
+    def test_first_reviewer_in_order_wins(self):
+        verdicts = {
+            "R1": {"AAA": {"verdict": "HOLD"}},
+            "R2": {"AAA": {"verdict": "SELL", "reason": "thesis broken"}},
+            "R3": {"AAA": {"verdict": "SELL", "reason": "drawdown"}},
+        }
+        out = first_valid_sell_plan(["R1", "R2", "R3"], ["AAA"], verdicts)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].agent_id, "R2")
+        self.assertEqual(out[0].reason, "thesis broken")
+
+    def test_no_sell_when_all_hold(self):
+        verdicts = {"R1": {"AAA": {"verdict": "HOLD"}}}
+        self.assertEqual(first_valid_sell_plan(["R1"], ["AAA"], verdicts), [])
+
+    def test_only_covered_names_considered(self):
+        verdicts = {"R1": {"AAA": {"verdict": "SELL", "reason": "x"}}}
+        out = first_valid_sell_plan(["R1"], ["AAA", "BBB"], verdicts)
+        self.assertEqual([t.ticker for t in out], ["AAA"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -6,6 +6,7 @@ import HoldingsList from "@/components/holdings-list";
 import { AgentMonogram } from "@/components/agent-monogram";
 import { TradeTape, type Trade } from "@/components/trade-tape";
 import VisibilityToggle from "@/components/portfolio/visibility-toggle";
+import SwarmConfig from "@/components/portfolio/swarm-config";
 import BetaDisclaimer from "@/components/beta-disclaimer";
 import {
   getPortfolio,
@@ -281,6 +282,31 @@ export default async function PortfolioPage({ params }: PageParams) {
             </div>
           </header>
 
+          {/* Config-in-place for the owner (portfolio brief): mandate +
+              building blocks + the swarm roster + draft toggle. Non-owners see
+              the read-only mandate + agents below. */}
+          {isOwner ? (
+            <section className="mb-12 sm:mb-14">
+              <SwarmConfig
+                portfolioId={portfolio.id}
+                slug={portfolio.slug}
+                name={portfolio.display_name}
+                mandate={portfolio.description ?? ""}
+                members={members.map((m) => ({
+                  agent_id: m.agent_id,
+                  handle: m.handle,
+                  display_name: m.display_name,
+                  powered_by: m.powered_by,
+                  role: m.role,
+                  remit: m.remit,
+                  config: m.config,
+                }))}
+                screenConfig={portfolio.screen_config}
+                draftEnabled={!!portfolio.draft_config}
+              />
+            </section>
+          ) : (
+          <>
           {/* Mandate — the brief agents work to */}
           <section className="mb-12 sm:mb-14">
             <h2 className="text-[11px] font-mono font-bold uppercase tracking-[0.14em] text-text-dim mb-1.5">
@@ -359,6 +385,8 @@ export default async function PortfolioPage({ params }: PageParams) {
               .
             </p>
           </section>
+          </>
+          )}
 
           {/* Portfolio summary */}
           {snapshot ? (

--- a/web/components/portfolio/swarm-config.tsx
+++ b/web/components/portfolio/swarm-config.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+/**
+ * Config-in-place home for a portfolio (portfolio page brief). Owner-only:
+ * the mandate (brief + building blocks), the swarm roster (buyers + reviewers
+ * with per-member remit/knobs), the snake-draft toggle, and a thin link to the
+ * portfolio's screen. Nothing here lives on the Dashboard.
+ */
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import {
+  updatePortfolioDetails,
+  addAgentToPortfolio,
+  removeAgentFromPortfolio,
+  setMemberSwarmConfig,
+  setDraftConfig,
+} from "@/lib/portfolios-mutations";
+
+interface Member {
+  agent_id: string;
+  handle: string;
+  display_name: string;
+  powered_by: string | null;
+  role: "buyer" | "reviewer" | null;
+  remit: string | null;
+  config: Record<string, unknown> | null;
+}
+
+interface Props {
+  portfolioId: string;
+  slug: string;
+  name: string;
+  mandate: string;
+  members: Member[];
+  screenConfig: Record<string, unknown> | null;
+  draftEnabled: boolean;
+}
+
+// Curated building blocks (brief §2). Clicking inserts the phrase into the
+// brief; popular ones marked ★. A data-driven popularity list can come later.
+const BLOCKS: { group: string; items: { label: string; text: string; star?: boolean }[] }[] = [
+  {
+    group: "Quality",
+    items: [
+      { label: "★ Rule of 40 winners", text: "Rule of 40 winners", star: true },
+      { label: "Fat gross margins", text: "gross margin > 60%" },
+      { label: "Strong FCF", text: "FCF margin > 10%" },
+    ],
+  },
+  {
+    group: "Value",
+    items: [
+      { label: "★ Cheap on sales", text: "P/S below its own 12-month median", star: true },
+      { label: "P/S < 15", text: "P/S < 15" },
+    ],
+  },
+  {
+    group: "Exclude",
+    items: [
+      { label: "★ No biotech", text: "exclude Health Technology", star: true },
+      { label: "No finance", text: "exclude Finance" },
+    ],
+  },
+  {
+    group: "Rules",
+    items: [
+      { label: "Momentum tilt", text: "tilt toward 52-week price strength" },
+      { label: "Quality tilt", text: "tilt heavily toward quality" },
+    ],
+  },
+];
+
+function b64url(s: string): string {
+  const b = typeof btoa === "function" ? btoa(s) : Buffer.from(s, "utf8").toString("base64");
+  return b.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export default function SwarmConfig({
+  portfolioId,
+  slug,
+  name,
+  mandate,
+  members,
+  screenConfig,
+  draftEnabled,
+}: Props) {
+  const [brief, setBrief] = useState(mandate);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [pending, start] = useTransition();
+
+  const buyers = members.filter((m) => m.role === "buyer");
+  const reviewers = members.filter((m) => m.role === "reviewer");
+  const topN = Number((screenConfig as { topN?: number } | null)?.topN ?? 40);
+  const screenHref = screenConfig
+    ? `/screener?config=${b64url(JSON.stringify(screenConfig))}`
+    : "/screener";
+
+  function flash(m: string) {
+    setMsg(m);
+    setTimeout(() => setMsg(null), 2500);
+  }
+
+  function saveBrief() {
+    start(async () => {
+      const r = await updatePortfolioDetails({ portfolioId, name, mandate: brief });
+      flash(r.ok ? "Mandate saved" : r.error);
+    });
+  }
+  function insertBlock(text: string) {
+    setBrief((b) => (b.trim() ? `${b.trim()}, ${text}` : text));
+  }
+  function toggleDraft(on: boolean) {
+    start(async () => {
+      const r = await setDraftConfig({
+        portfolioId,
+        draftConfig: on ? { order: "snake", cycle: "daily" } : null,
+      });
+      flash(r.ok ? (on ? "Swarm coordination on" : "Swarm coordination off") : r.error);
+    });
+  }
+
+  return (
+    <section className="space-y-6" aria-label="Portfolio configuration">
+      {/* Mandate */}
+      <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+        <h2 className="text-sm font-semibold text-text mb-1">Mandate</h2>
+        <p className="text-xs text-text-muted mb-2">
+          One plain-English brief — your portfolio&apos;s constitution. Its
+          selection rules compile into your screen.
+        </p>
+        <label htmlFor="mandate" className="sr-only">
+          Portfolio mandate
+        </label>
+        <textarea
+          id="mandate"
+          value={brief}
+          onChange={(e) => setBrief(e.target.value)}
+          rows={4}
+          className="w-full resize-y rounded-md bg-black/30 border border-white/10 px-3 py-2 text-sm text-text focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40"
+        />
+        <div className="mt-3 space-y-2">
+          {BLOCKS.map((g) => (
+            <div key={g.group} className="flex items-center gap-1.5 flex-wrap">
+              <span className="text-[10px] font-mono uppercase tracking-[0.1em] text-text-muted w-16">
+                {g.group}
+              </span>
+              {g.items.map((it) => (
+                <button
+                  key={it.label}
+                  type="button"
+                  onClick={() => insertBlock(it.text)}
+                  className="font-mono text-[11px] rounded-md border border-white/10 text-text-muted px-2 py-1 hover:text-text hover:border-green/40"
+                >
+                  {it.label}
+                </button>
+              ))}
+            </div>
+          ))}
+        </div>
+        <div className="mt-3 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={saveBrief}
+            disabled={pending}
+            className="font-mono text-[11px] rounded-md px-3 py-1.5 bg-green text-black disabled:opacity-40"
+          >
+            Save mandate
+          </button>
+          <Link href={screenHref} className="font-mono text-[11px] text-green hover:underline">
+            → your screen · top {topN} candidates · view screen
+          </Link>
+          {msg && <span className="font-mono text-[11px] text-text-muted">{msg}</span>}
+        </div>
+      </div>
+
+      {/* Draft toggle */}
+      <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4 flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-text">Swarm coordination</h2>
+          <p className="text-xs text-text-muted">
+            Snake-draft buying across your buyers (one name per turn, rotating
+            order, shared cash) + first-valid-sell across reviewers. Off = each
+            agent runs independently.
+          </p>
+        </div>
+        <label className="font-mono text-[11px] text-green inline-flex items-center gap-2 shrink-0">
+          <input
+            type="checkbox"
+            checked={draftEnabled}
+            onChange={(e) => toggleDraft(e.target.checked)}
+          />
+          Run as a swarm
+        </label>
+      </div>
+
+      {/* Buyers */}
+      <RosterEditor
+        title="Buyers"
+        role="buyer"
+        members={buyers}
+        portfolioId={portfolioId}
+        slug={slug}
+        onFlash={flash}
+      />
+
+      {/* Reviewers */}
+      <RosterEditor
+        title="Reviewers"
+        role="reviewer"
+        members={reviewers}
+        portfolioId={portfolioId}
+        slug={slug}
+        onFlash={flash}
+      />
+    </section>
+  );
+}
+
+function RosterEditor({
+  title,
+  role,
+  members,
+  portfolioId,
+  onFlash,
+}: {
+  title: string;
+  role: "buyer" | "reviewer";
+  members: Member[];
+  portfolioId: string;
+  slug: string;
+  onFlash: (m: string) => void;
+}) {
+  const [handle, setHandle] = useState("");
+  const [remit, setRemit] = useState("");
+  const [, start] = useTransition();
+
+  function add() {
+    if (!handle.trim()) return;
+    start(async () => {
+      const r = await addAgentToPortfolio({
+        portfolioId,
+        handle: handle.trim(),
+        role,
+        remit: remit.trim() || undefined,
+        config:
+          role === "buyer"
+            ? { convictionGate: 1, maxPerName: 0.08, cadence: "daily" }
+            : { cadence: "weekly" },
+      });
+      onFlash(r.ok ? `Added ${handle}` : r.error);
+      if (r.ok) {
+        setHandle("");
+        setRemit("");
+      }
+    });
+  }
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+      <h2 className="text-sm font-semibold text-text mb-2">
+        {title}{" "}
+        <span className="text-text-muted font-normal">({members.length})</span>
+      </h2>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {members.map((m) => (
+          <AgentCard
+            key={m.agent_id}
+            member={m}
+            role={role}
+            portfolioId={portfolioId}
+            onFlash={onFlash}
+          />
+        ))}
+        {members.length === 0 && (
+          <p className="text-xs text-text-muted">No {title.toLowerCase()} yet.</p>
+        )}
+      </div>
+
+      <div className="mt-3 flex items-end gap-2 flex-wrap">
+        <label className="text-[11px] text-text-muted">
+          Add a {role}
+          <input
+            value={handle}
+            onChange={(e) => setHandle(e.target.value)}
+            placeholder="agent handle"
+            className="block mt-1 w-40 bg-black/30 border border-white/10 rounded-md px-2 py-1 text-sm text-text"
+          />
+        </label>
+        <label className="text-[11px] text-text-muted">
+          Remit
+          <input
+            value={remit}
+            onChange={(e) => setRemit(e.target.value)}
+            placeholder={role === "buyer" ? "e.g. deep value" : "e.g. thesis-strict"}
+            className="block mt-1 w-44 bg-black/30 border border-white/10 rounded-md px-2 py-1 text-sm text-text"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={add}
+          className="font-mono text-[11px] rounded-md border border-white/10 text-text-muted px-3 py-1.5 hover:text-text"
+        >
+          + add
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function AgentCard({
+  member,
+  role,
+  portfolioId,
+  onFlash,
+}: {
+  member: Member;
+  role: "buyer" | "reviewer";
+  portfolioId: string;
+  onFlash: (m: string) => void;
+}) {
+  const cfg = (member.config ?? {}) as {
+    convictionGate?: number;
+    maxPerName?: number;
+    cadence?: string;
+  };
+  const [gate, setGate] = useState(Number(cfg.convictionGate ?? 1));
+  const [maxPct, setMaxPct] = useState(Number(cfg.maxPerName ?? 0.08) * 100);
+  const [cadence, setCadence] = useState(String(cfg.cadence ?? (role === "buyer" ? "daily" : "weekly")));
+  const [remit, setRemit] = useState(member.remit ?? "");
+  const [, start] = useTransition();
+
+  function save() {
+    start(async () => {
+      const r = await setMemberSwarmConfig({
+        portfolioId,
+        handle: member.handle,
+        remit,
+        config:
+          role === "buyer"
+            ? { convictionGate: gate, maxPerName: maxPct / 100, cadence }
+            : { cadence },
+      });
+      onFlash(r.ok ? `Saved ${member.handle}` : r.error);
+    });
+  }
+  function remove() {
+    start(async () => {
+      const r = await removeAgentFromPortfolio({ portfolioId, handle: member.handle });
+      onFlash(r.ok ? `Removed ${member.handle}` : r.error);
+    });
+  }
+
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <span className="text-sm text-text font-medium">{member.display_name}</span>
+          {member.powered_by && (
+            <span className="ml-2 text-[10px] font-mono text-green border border-green/30 rounded px-1.5 py-0.5">
+              {member.powered_by}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={remove}
+          aria-label={`Remove ${member.handle}`}
+          className="text-text-muted hover:text-text text-xs"
+        >
+          remove
+        </button>
+      </div>
+      <input
+        value={remit}
+        onChange={(e) => setRemit(e.target.value)}
+        placeholder={role === "buyer" ? "remit (e.g. deep value)" : "focus (e.g. drawdown)"}
+        className="mt-2 w-full bg-black/30 border border-white/10 rounded px-2 py-1 text-xs text-text"
+      />
+      <div className="mt-2 flex items-center gap-3 flex-wrap text-[11px] text-text-muted">
+        {role === "buyer" && (
+          <>
+            <label className="inline-flex items-center gap-1">
+              conviction ≥
+              <select
+                value={gate}
+                onChange={(e) => setGate(Number(e.target.value))}
+                className="bg-black/40 border border-white/10 rounded px-1 text-text"
+              >
+                {[1, 2, 3, 4, 5].map((n) => (
+                  <option key={n} value={n} className="bg-black">
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="inline-flex items-center gap-1">
+              max/name %
+              <input
+                type="number"
+                min={1}
+                max={100}
+                value={Math.round(maxPct)}
+                onChange={(e) => setMaxPct(Number(e.target.value))}
+                className="w-14 bg-black/40 border border-white/10 rounded px-1 text-text"
+              />
+            </label>
+          </>
+        )}
+        <label className="inline-flex items-center gap-1">
+          cadence
+          <select
+            value={cadence}
+            onChange={(e) => setCadence(e.target.value)}
+            className="bg-black/40 border border-white/10 rounded px-1 text-text"
+          >
+            {["daily", "weekly", "monthly"].map((c) => (
+              <option key={c} value={c} className="bg-black">
+                {c}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={save}
+          className="font-mono text-[11px] rounded border border-white/10 text-text-muted px-2 py-0.5 hover:text-text"
+        >
+          save
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/lib/portfolios-mutations.ts
+++ b/web/lib/portfolios-mutations.ts
@@ -359,6 +359,11 @@ async function resolveAgent(handle: string): Promise<ResolvedAgent | null> {
 export async function addAgentToPortfolio(input: {
   portfolioId: string;
   handle: string;
+  // Swarm membership (migration 041): scout an agent in as a buyer or
+  // reviewer with a free-text remit + per-member knobs.
+  role?: "buyer" | "reviewer";
+  remit?: string;
+  config?: Record<string, unknown>;
 }): Promise<ActionResult> {
   const { user } = await requireUser();
   const portfolio = await resolveOwnedPortfolio(input.portfolioId, user.id);
@@ -373,19 +378,83 @@ export async function addAgentToPortfolio(input: {
     };
   }
 
+  const row: Record<string, unknown> = {
+    portfolio_id: input.portfolioId,
+    agent_id: agent.id,
+  };
+  if (input.role) row.role = input.role;
+  if (input.remit !== undefined) row.remit = input.remit;
+  if (input.config !== undefined) row.config = input.config;
+
   const supabase = getSupabase();
+  // upsert (not ignoreDuplicates) so re-adding updates the role/remit/knobs.
   const { error } = await supabase
     .from("portfolio_agents")
-    .upsert(
-      { portfolio_id: input.portfolioId, agent_id: agent.id },
-      { onConflict: "portfolio_id,agent_id", ignoreDuplicates: true },
-    );
+    .upsert(row, { onConflict: "portfolio_id,agent_id" });
 
   if (error) {
     console.error("addAgentToPortfolio failed:", error);
     return { ok: false, error: "Could not add the agent. Try again." };
   }
 
+  revalidate(portfolio.slug);
+  return { ok: true };
+}
+
+/** Update a member's swarm role / remit / knobs (config-in-place). */
+export async function setMemberSwarmConfig(input: {
+  portfolioId: string;
+  handle: string;
+  role?: "buyer" | "reviewer" | null;
+  remit?: string | null;
+  config?: Record<string, unknown> | null;
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+  const portfolio = await resolveOwnedPortfolio(input.portfolioId, user.id);
+  if (!portfolio) return { ok: false, error: NOT_FOUND_ERROR };
+
+  const agent = await resolveAgent(input.handle);
+  if (!agent) return { ok: false, error: "That agent no longer exists." };
+
+  const patch: Record<string, unknown> = {};
+  if (input.role !== undefined) patch.role = input.role;
+  if (input.remit !== undefined) patch.remit = input.remit;
+  if (input.config !== undefined) patch.config = input.config;
+  if (Object.keys(patch).length === 0) return { ok: true };
+
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from("portfolio_agents")
+    .update(patch)
+    .eq("portfolio_id", input.portfolioId)
+    .eq("agent_id", agent.id);
+  if (error) {
+    console.error("setMemberSwarmConfig failed:", error);
+    return { ok: false, error: "Could not update the agent. Try again." };
+  }
+  revalidate(portfolio.slug);
+  return { ok: true };
+}
+
+/** Set (or clear) a portfolio's draft settings — the opt-in switch that turns
+ *  the swarm coordination engine on for this portfolio. */
+export async function setDraftConfig(input: {
+  portfolioId: string;
+  draftConfig: Record<string, unknown> | null;
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+  const portfolio = await resolveOwnedPortfolio(input.portfolioId, user.id);
+  if (!portfolio) return { ok: false, error: NOT_FOUND_ERROR };
+
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from("portfolios")
+    .update({ draft_config: input.draftConfig })
+    .eq("id", input.portfolioId);
+  if (error) {
+    console.error("setDraftConfig failed:", error);
+    return { ok: false, error: "Could not update draft settings. Try again." };
+  }
   revalidate(portfolio.slug);
   return { ok: true };
 }

--- a/web/lib/portfolios-query.ts
+++ b/web/lib/portfolios-query.ts
@@ -25,6 +25,10 @@ export interface Portfolio {
   is_public: boolean;
   created_at: string;
   updated_at: string;
+  /** The portfolio's selection recipe (migration 040). Non-secret. */
+  screen_config: Record<string, unknown> | null;
+  /** Swarm draft settings (migration 041); presence opts into the swarm. */
+  draft_config: Record<string, unknown> | null;
 }
 
 /**
@@ -34,7 +38,7 @@ export interface Portfolio {
  * server serializes to the browser. Read `mode` only via `getPortfolioMode`.
  */
 const PORTFOLIO_COLUMNS =
-  "id, slug, display_name, description, owner_agent_id, owner_user_id, is_public, created_at, updated_at";
+  "id, slug, display_name, description, owner_agent_id, owner_user_id, is_public, created_at, updated_at, screen_config, draft_config";
 
 /**
  * The owner-only paper/live mode of a portfolio (migration 036). Gated on a
@@ -92,6 +96,10 @@ export interface PortfolioMember {
   strategy: string | null;
   notes: string | null;
   joined_at: string;
+  /** Swarm membership (migration 041). */
+  role: "buyer" | "reviewer" | null;
+  remit: string | null;
+  config: Record<string, unknown> | null;
 }
 
 export interface PortfolioMembershipForAgent {
@@ -255,7 +263,7 @@ export async function getMembersForPortfolio(
   const { data, error } = await supabase
     .from("portfolio_agents")
     .select(
-      "agent_id, notes, joined_at, agents (handle, display_name, description, is_house_agent, powered_by, strategy)",
+      "agent_id, notes, joined_at, role, remit, config, agents (handle, display_name, description, is_house_agent, powered_by, strategy)",
     )
     .eq("portfolio_id", portfolioId)
     .order("joined_at", { ascending: true });
@@ -278,6 +286,9 @@ export async function getMembersForPortfolio(
     agent_id: string;
     notes: string | null;
     joined_at: string;
+    role: "buyer" | "reviewer" | null;
+    remit: string | null;
+    config: Record<string, unknown> | null;
     agents: EmbeddedAgent | EmbeddedAgent[] | null;
   };
   const rows = (data as unknown as Row[] | null) ?? [];
@@ -295,6 +306,9 @@ export async function getMembersForPortfolio(
         strategy: a.strategy,
         notes: r.notes,
         joined_at: r.joined_at,
+        role: r.role ?? null,
+        remit: r.remit ?? null,
+        config: r.config ?? null,
       };
     })
     .filter((m): m is PortfolioMember => m !== null);


### PR DESCRIPTION
## Portfolio swarm — multi-buyer / multi-reviewer coordination (portfolio page brief)

A portfolio becomes the **config-in-place** home for a swarm of specialist buyers + reviewers over one shared cash pool, coordinated per cycle (snake-draft buying, first-valid-sell).

> **Stacked on the screener PR (#1329).** Base is `claude/youthful-fermat-Gx5ct` so the diff is portfolio-only; it depends on `screen.py` / `portfolio_screen_candidates` from that PR. Retarget to `main` once #1329 merges.

### Backend engine (applied to live DB + tested)
- **migration 041**: `portfolio_agents.{role,remit,config}`, `portfolios.draft_config`, `portfolio_holdings.opened_by_agent_id`; role backfilled from each member's strategy.
- **`swarm.py`** — pure coordination core: `snake_draft_plan` (rotating/reversing draft order, per-buyer conviction gates, shared cash, one-name-per-turn, dupes resolved, per-pick attribution) + `first_valid_sell_plan` + `rank_to_conviction`. Decisions are injected → deterministic + unit-tested. **`test_swarm.py` (10 tests).**
- **`agent_heartbeat._run_portfolio_swarm`** — buys via the snake draft (`ctx.buy` → thesis-freeze + live routing), stamps `opened_by_agent_id`; sells by running each reviewer in order on the shared book (first-valid-sell by construction). **Opt-in**: runs only when a portfolio has a `draft_config` set AND role-tagged buyers — otherwise the legacy per-member loop is untouched (zero impact on existing portfolios).
- `db.get_portfolio_members` surfaces role/remit/config.

### Web — config-in-place (full `tsc --noEmit` clean)
- Owner section on `/portfolios/<slug>`: **mandate** textarea + grouped **building-block** chips (Quality/Value/Exclude/Rules) that insert into the brief; **buyers + reviewers rosters** as cards (brain chip, editable remit + per-member knobs: conviction gate, max %/name, cadence; add/remove); **"Run as a swarm"** toggle (sets `draft_config`); thin **→ your screen · top N** link. No selection stage on the page. Non-owners keep the read-only mandate + agents view.
- Server actions: `addAgentToPortfolio` (now takes role/remit/config), `setMemberSwarmConfig`, `setDraftConfig`. `portfolios-query` exposes the new member + portfolio fields.

### Acceptance criteria
All met except, per the agreed scope, the **Dashboard launchpad** (deferred to its own piece). Two honest gaps flagged for follow-up:
1. **Conviction source** is a deterministic screen-rank baseline (`rank_to_conviction`); per-brain LLM conviction is a one-function swap (populate the `convictions` map) but needs a live run to validate — the LLM path isn't exercised in this environment. The draft *mechanics* are real and tested.
2. **Agent cards** show the brain chip but not yet track-record figures (30d return / win rate); "add a buyer" is a handle input rather than a visual scouting picker.

The LLM-coupled heartbeat path can't be run-tested here, which is why the whole swarm path is gated behind opt-in `draft_config`.

https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN)_