### PR TITLE
Screener UX: friendly filter chips, inline adjuster, tune panel

### DIFF
--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { saveScreen } from "@/lib/screen/saved-mutations";
 import {
   FILTER_FIELDS,
   FILTER_OPS,
+  METRIC_META,
+  NAMED_FILTERS,
   PRESETS,
   TEXT_FIELDS,
   encodeConfig,
+  filterChipLabel,
+  newFilterFor,
   presetConfig,
   type Filter,
   type FilterField,
@@ -43,20 +47,6 @@ interface ScreenData {
   data_asof: string | null;
 }
 
-const FIELD_LABEL: Record<FilterField, string> = {
-  sector: "Sector",
-  country: "Country",
-  ps: "P/S",
-  rev_growth_ttm: "Rev growth %",
-  gross_margin: "Gross margin %",
-  fcf_margin: "FCF margin %",
-  net_margin: "Net margin %",
-  operating_margin: "Op margin %",
-  rule_of_40: "Rule of 40",
-  ret_52w: "52w return %",
-  price: "Price $",
-};
-
 function fmt(v: number | null, opts?: { pct?: boolean; mult?: boolean; dp?: number }): string {
   if (v == null || !Number.isFinite(v)) return "—";
   const dp = opts?.dp ?? (opts?.pct ? 1 : opts?.mult ? 1 : 2);
@@ -66,24 +56,50 @@ function fmt(v: number | null, opts?: { pct?: boolean; mult?: boolean; dp?: numb
   return s;
 }
 
+// Default + optional table columns (UX follow-up §4): lead with ~5, the rest
+// behind "columns ▾".
+interface Col {
+  key: string;
+  label: string;
+  green?: boolean;
+  render: (r: Row) => string;
+}
+const BASE_COLS: Col[] = [
+  { key: "score", label: "Score", green: true, render: (r) => fmt(r.score, { dp: 1 }) },
+  { key: "ps", label: "P/S", render: (r) => fmt(r.ps, { mult: true }) },
+  { key: "rev_growth_ttm", label: "Rev gr%", green: true, render: (r) => fmt(r.rev_growth_ttm, { pct: true }) },
+  { key: "gross_margin", label: "GM%", green: true, render: (r) => fmt(r.gross_margin, { pct: true }) },
+  { key: "rule_of_40", label: "R40", green: true, render: (r) => fmt(r.rule_of_40, { dp: 0 }) },
+];
+const EXTRA_COLS: Col[] = [
+  { key: "fcf_margin", label: "FCF M%", green: true, render: (r) => fmt(r.fcf_margin, { pct: true }) },
+  { key: "ret_52w", label: "52w%", render: (r) => fmt(r.ret_52w, { pct: true, dp: 0 }) },
+];
+
 export default function ScreenerClient({
   initialConfig,
   initialData,
-  defaultEncoded,
 }: {
   initialConfig: ScreenConfig;
   initialData: ScreenData;
-  defaultEncoded: string;
+  defaultEncoded?: string;
 }) {
   const [config, setConfig] = useState<ScreenConfig>(initialConfig);
   const [data, setData] = useState<ScreenData>(initialData);
   const [loading, setLoading] = useState(false);
   const [brief, setBrief] = useState(initialConfig.brief ?? "");
+  const [briefDirty, setBriefDirty] = useState(false);
   const [compileStatus, setCompileStatus] = useState<string | null>(null);
   const [compiling, setCompiling] = useState(false);
   const [signedIn, setSignedIn] = useState(false);
   const [saveLink, setSaveLink] = useState<string | null>(null);
   const [shareMsg, setShareMsg] = useState<string | null>(null);
+  const [editingFilter, setEditingFilter] = useState<number | null>(null);
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
+  const [colMenuOpen, setColMenuOpen] = useState(false);
+  const [extraCols, setExtraCols] = useState<Set<string>>(new Set());
+  const [tuneOpen, setTuneOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const firstRender = useRef(true);
 
   useEffect(() => {
@@ -91,8 +107,7 @@ export default function ScreenerClient({
     supabase.auth.getSession().then(({ data }) => setSignedIn(!!data.session));
   }, []);
 
-  // Live re-rank: whenever the compiled config changes, re-fetch /api/screen
-  // (debounced) and sync the URL. Skips the initial mount (SSR already paid).
+  // Live re-rank on config change (debounced) + URL sync. Skips initial mount.
   useEffect(() => {
     if (firstRender.current) {
       firstRender.current = false;
@@ -103,14 +118,10 @@ export default function ScreenerClient({
       const encoded = encodeConfig(config);
       try {
         const res = await fetch(`/api/screen?config=${encoded}`, { cache: "no-store" });
-        if (res.ok) {
-          const json = await res.json();
-          setData(json as ScreenData);
-        }
+        if (res.ok) setData((await res.json()) as ScreenData);
       } finally {
         setLoading(false);
       }
-      // Clean URL for an unmodified preset, else the encoded config.
       const isClean = encoded === encodeConfig(presetConfig(config.preset ?? ""));
       const url =
         isClean && config.preset && config.preset !== "custom"
@@ -129,7 +140,8 @@ export default function ScreenerClient({
   function selectPreset(id: string) {
     const c = presetConfig(id);
     setConfig(c);
-    setBrief("");
+    setBrief(c.brief ?? ""); // preset fills the brief (UX §2)
+    setBriefDirty(false);
     setCompileStatus(null);
     setSaveLink(null);
   }
@@ -145,7 +157,7 @@ export default function ScreenerClient({
         body: JSON.stringify({ brief }),
       });
       if (!res.ok) {
-        setCompileStatus("Compile failed — edit the knobs directly.");
+        setCompileStatus("Compile failed — tune the knobs directly.");
         return;
       }
       const { compiled } = await res.json();
@@ -157,9 +169,9 @@ export default function ScreenerClient({
         weights: compiled.weights,
         aiMultiplier: compiled.aiMultiplier,
       }));
+      setBriefDirty(false);
       const fc = compiled.filters.length;
-      const tilt = topWeight(compiled.weights);
-      setCompileStatus(`compiled — ${fc} filter${fc === 1 ? "" : "s"} + a ${tilt}-tilted weighting`);
+      setCompileStatus(`compiled — ${fc} filter${fc === 1 ? "" : "s"} + a ${topWeight(compiled.weights)}-tilted weighting`);
     } finally {
       setCompiling(false);
     }
@@ -167,97 +179,91 @@ export default function ScreenerClient({
 
   async function onSave() {
     if (!signedIn) {
-      setSaveLink(null);
       setShareMsg("Sign in to save — viewing & sharing stay open.");
       return;
     }
-    const name = config.preset && config.preset !== "custom"
-      ? PRESETS[config.preset]?.label ?? "My screen"
-      : "Custom screen";
+    const name =
+      config.preset && config.preset !== "custom"
+        ? PRESETS[config.preset]?.label ?? "My screen"
+        : "Custom screen";
     const res = await saveScreen({ name, config });
     if (res.ok) setSaveLink(`/screener?screen=${res.slug}`);
     else setShareMsg(res.error);
   }
-
   async function onShare() {
-    const encoded = encodeConfig(config);
-    const url = `${window.location.origin}/screener?config=${encoded}`;
+    const url = `${window.location.origin}/screener?config=${encodeConfig(config)}`;
     try {
       await navigator.clipboard.writeText(url);
-      setShareMsg("Link copied to clipboard");
+      setShareMsg("Link copied");
     } catch {
       setShareMsg(url);
     }
   }
 
-  function addFilter() {
-    const used = new Set(config.filters.map((f) => f.field));
-    const field = FILTER_FIELDS.find((f) => !used.has(f)) ?? "ps";
-    const isText = TEXT_FIELDS.has(field);
-    patch({
-      filters: [
-        ...config.filters,
-        { field, op: isText ? "==" : "<=", value: isText ? "" : 0 } as Filter,
-      ],
-    });
-  }
-  function updateFilter(i: number, p: Partial<Filter>) {
-    const next = config.filters.map((f, idx) => (idx === i ? { ...f, ...p } : f));
-    patch({ filters: next as Filter[] });
+  function setFilter(i: number, p: Partial<Filter>) {
+    patch({ filters: config.filters.map((f, idx) => (idx === i ? { ...f, ...p } : f)) as Filter[] });
   }
   function removeFilter(i: number) {
+    setEditingFilter(null);
     patch({ filters: config.filters.filter((_, idx) => idx !== i) });
   }
+  function addNamedFilter(field: FilterField) {
+    setAddMenuOpen(false);
+    patch({ filters: [...config.filters, newFilterFor(field)] });
+    setEditingFilter(config.filters.length); // open the new chip's slider
+  }
 
-  const rows = data.rows;
+  const usedFields = useMemo(() => new Set(config.filters.map((f) => f.field)), [config.filters]);
+  const cols = useMemo(
+    () => [...BASE_COLS, ...EXTRA_COLS.filter((c) => extraCols.has(c.key))],
+    [extraCols],
+  );
 
   return (
     <div>
-      {/* ---- Brief panel ---- */}
-      <section
-        className="rounded-xl border border-white/10 bg-white/[0.02] p-4 mb-3"
-        aria-label="Screen brief"
-      >
-        <div className="flex items-center gap-2 flex-wrap mb-2">
-          <span className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted mr-1">
-            Preset
-          </span>
-          {Object.values(PRESETS).map((p) => (
-            <button
-              key={p.id}
-              type="button"
-              onClick={() => selectPreset(p.id)}
-              aria-pressed={config.preset === p.id}
-              className={`font-mono text-[11px] rounded-md px-2.5 py-1.5 border transition-colors ${
-                config.preset === p.id
-                  ? "text-green border-green/50 bg-green/10"
-                  : "text-text-muted border-white/10 hover:text-text"
-              }`}
-            >
-              {p.label}
-            </button>
-          ))}
-          <span
-            className={`font-mono text-[11px] rounded-md px-2.5 py-1.5 border ${
-              config.preset === "custom"
+      {/* Preset chips */}
+      <div className="flex items-center gap-2 flex-wrap mb-3">
+        <span className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted mr-1">
+          Preset
+        </span>
+        {Object.values(PRESETS).map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => selectPreset(p.id)}
+            aria-pressed={config.preset === p.id}
+            title={p.description}
+            className={`font-mono text-[11px] rounded-full px-3 py-1.5 border transition-colors ${
+              config.preset === p.id
                 ? "text-green border-green/50 bg-green/10"
-                : "text-text-muted/60 border-white/10"
+                : "text-text-muted border-white/10 hover:text-text hover:border-white/25"
             }`}
           >
+            {p.label}
+          </button>
+        ))}
+        {config.preset === "custom" && (
+          <span className="font-mono text-[11px] rounded-full px-3 py-1.5 border text-green border-green/50 bg-green/10">
             Custom
           </span>
-        </div>
+        )}
+      </div>
 
+      {/* Compact brief */}
+      <div className="rounded-xl border border-white/10 bg-white/[0.02] p-3 mb-3">
         <label htmlFor="brief" className="sr-only">
           Plain-English screen brief
         </label>
         <textarea
           id="brief"
           value={brief}
-          onChange={(e) => setBrief(e.target.value)}
+          onChange={(e) => {
+            setBrief(e.target.value);
+            setBriefDirty(true);
+          }}
           rows={2}
-          placeholder="e.g. Rule of 40 winners, no biotech, P/S under 15, lean quality-tilted…"
-          className="w-full resize-y rounded-md bg-black/30 border border-white/10 px-3 py-2 text-sm text-text placeholder:text-text-muted/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40"
+          placeholder="Describe the stocks you want — e.g. Rule of 40 winners, no biotech, P/S under 15…"
+          className="w-full resize-none rounded-md bg-black/30 border border-white/10 px-3 py-2 text-sm text-text placeholder:text-text-muted/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-green/40"
         />
         <div className="flex items-center gap-3 mt-2 flex-wrap">
           <button
@@ -266,214 +272,169 @@ export default function ScreenerClient({
             disabled={compiling || !brief.trim()}
             className="font-mono text-[11px] rounded-md px-3 py-1.5 bg-green text-black disabled:opacity-40"
           >
-            {compiling ? "Compiling…" : "Compile to screen"}
+            {compiling ? "Compiling…" : briefDirty ? "Recompile ↻" : "Compile to screen"}
           </button>
           {compileStatus && (
             <span className="font-mono text-[11px] text-text-muted" aria-live="polite">
               {compileStatus}
             </span>
           )}
-          <span className="font-mono text-[10px] text-text-muted/70">
-            the brief is for humans; the compiled knobs below are what the buyer
-            reads
-          </span>
         </div>
-      </section>
+      </div>
 
-      {/* ---- Compiled screen panel ---- */}
-      <details className="rounded-xl border border-white/10 bg-white/[0.02] p-4 mb-3" open>
-        <summary className="cursor-pointer text-green font-mono text-[11px] select-none">
-          Compiled screen — filters &amp; score weighting
-        </summary>
-
-        <div className="flex items-center gap-2 flex-wrap mt-3 pb-3 border-b border-white/10">
-          <span className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted mr-1">
-            Filters
-          </span>
-          {config.filters.map((f, i) => (
+      {/* Friendly filter bar */}
+      <div className="flex items-center gap-2 flex-wrap mb-2">
+        <span className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted mr-1">
+          Filters
+        </span>
+        {config.filters.map((f, i) => (
+          <button
+            key={`${f.field}-${i}`}
+            type="button"
+            onClick={() => setEditingFilter(editingFilter === i ? null : i)}
+            aria-expanded={editingFilter === i}
+            className={`inline-flex items-center gap-1.5 font-mono text-[11px] rounded-full px-3 py-1.5 border transition-colors ${
+              editingFilter === i
+                ? "text-green border-green/50 bg-green/10"
+                : "text-text border-green/25 bg-black/20 hover:border-green/40"
+            }`}
+          >
+            {filterChipLabel(f)}
             <span
-              key={i}
-              className="inline-flex items-center gap-1 font-mono text-[11px] rounded-md border border-green/30 bg-black/30 px-2 py-1"
+              role="button"
+              tabIndex={0}
+              aria-label="Remove filter"
+              onClick={(e) => {
+                e.stopPropagation();
+                removeFilter(i);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.stopPropagation();
+                  removeFilter(i);
+                }
+              }}
+              className="text-text-muted hover:text-text"
             >
-              <select
-                aria-label="Filter field"
-                value={f.field}
-                onChange={(e) => {
-                  const field = e.target.value as FilterField;
-                  const isText = TEXT_FIELDS.has(field);
-                  updateFilter(i, {
-                    field,
-                    op: isText ? "==" : f.op,
-                    value: isText ? String(f.value ?? "") : Number(f.value) || 0,
-                  });
-                }}
-                className="bg-transparent text-text focus:outline-none"
-              >
-                {FILTER_FIELDS.map((ff) => (
-                  <option key={ff} value={ff} className="bg-black">
-                    {FIELD_LABEL[ff]}
-                  </option>
-                ))}
-              </select>
-              <select
-                aria-label="Filter operator"
-                value={f.op}
-                onChange={(e) => updateFilter(i, { op: e.target.value as FilterOp })}
-                className="bg-transparent text-text focus:outline-none"
-              >
-                {FILTER_OPS.map((op) => (
-                  <option key={op} value={op} className="bg-black">
-                    {op}
-                  </option>
-                ))}
-              </select>
-              {TEXT_FIELDS.has(f.field) ? (
-                <input
-                  aria-label="Filter value"
-                  value={String(f.value ?? "")}
-                  onChange={(e) => updateFilter(i, { value: e.target.value })}
-                  className="w-28 bg-transparent text-text focus:outline-none border-b border-white/10"
-                />
-              ) : (
-                <input
-                  aria-label="Filter value"
-                  type="number"
-                  value={Number(f.value)}
-                  onChange={(e) => updateFilter(i, { value: Number(e.target.value) })}
-                  className="w-16 bg-transparent text-text focus:outline-none border-b border-white/10"
-                />
-              )}
-              <button
-                type="button"
-                aria-label="Remove filter"
-                onClick={() => removeFilter(i)}
-                className="text-text-muted hover:text-text"
-              >
-                ✕
-              </button>
+              ✕
             </span>
-          ))}
+          </button>
+        ))}
+
+        {/* + add filter (named-filter menu) */}
+        <div className="relative">
           <button
             type="button"
-            onClick={addFilter}
-            className="font-mono text-[11px] rounded-md border border-dashed border-white/20 text-text-muted px-2 py-1 hover:text-text"
+            onClick={() => setAddMenuOpen((v) => !v)}
+            aria-expanded={addMenuOpen}
+            className="font-mono text-[11px] rounded-full border border-dashed border-white/25 text-text-muted px-3 py-1.5 hover:text-text"
           >
             + add filter
           </button>
-          <span className="font-mono text-[11px] text-text-muted ml-auto" aria-live="polite">
-            {data.match_count} match{data.match_count === 1 ? "" : "es"}
-            {loading ? " · …" : ""}
-          </span>
-        </div>
-
-        <div className="flex items-center justify-between mt-3 mb-2">
-          <span className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted">
-            Score weighting — this screen&apos;s own ranking
-          </span>
-          <label className="font-mono text-[11px] text-green inline-flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={config.aiMultiplier}
-              onChange={(e) => patch({ aiMultiplier: e.target.checked })}
-            />
-            AI bull/bear ×
-          </label>
-        </div>
-        <div className="flex gap-5 flex-wrap">
-          {(["quality", "value", "momentum"] as const).map((k) => (
-            <label key={k} className="flex-1 min-w-[150px]">
-              <span className="font-mono text-[11px] text-text-muted flex justify-between capitalize">
-                <span>{k}</span>
-                <span className="text-text">{config.weights[k]}</span>
-              </span>
-              <input
-                type="range"
-                min={0}
-                max={100}
-                value={config.weights[k]}
-                onChange={(e) =>
-                  patch({ weights: { ...config.weights, [k]: Number(e.target.value) } })
-                }
-                className="w-full accent-green"
-                aria-label={`${k} weight`}
-              />
-            </label>
-          ))}
-          <label className="min-w-[110px]">
-            <span className="font-mono text-[11px] text-text-muted flex justify-between">
-              <span>Top N → buyer</span>
-              <span className="text-text">{config.topN}</span>
-            </span>
-            <input
-              type="number"
-              min={1}
-              max={200}
-              value={config.topN}
-              onChange={(e) => patch({ topN: Math.max(1, Math.min(200, Number(e.target.value))) })}
-              className="w-full bg-black/30 border border-white/10 rounded-md px-2 py-1 text-sm text-text mt-1"
-            />
-          </label>
-        </div>
-
-        <div className="flex gap-2 mt-3">
-          <button
-            type="button"
-            onClick={onShare}
-            className="font-mono text-[11px] rounded-md border border-white/10 text-text-muted px-3 py-1.5 hover:text-text"
-          >
-            Share ↗
-          </button>
-          <button
-            type="button"
-            onClick={onSave}
-            className="font-mono text-[11px] rounded-md border border-white/10 text-text-muted px-3 py-1.5 hover:text-text"
-          >
-            Save
-          </button>
-          {saveLink && (
-            <Link href={saveLink} className="font-mono text-[11px] text-green px-2 py-1.5 underline">
-              saved → {saveLink}
-            </Link>
-          )}
-          {shareMsg && (
-            <span className="font-mono text-[11px] text-text-muted px-2 py-1.5" aria-live="polite">
-              {shareMsg}
-            </span>
+          {addMenuOpen && (
+            <div className="absolute z-20 mt-1 w-52 rounded-lg border border-white/10 bg-[#0b0b0b] p-1 shadow-xl">
+              {NAMED_FILTERS.filter((nf) => !usedFields.has(nf.field)).map((nf) => (
+                <button
+                  key={nf.field}
+                  type="button"
+                  onClick={() => addNamedFilter(nf.field)}
+                  className="block w-full text-left text-sm text-text-dim hover:text-text hover:bg-white/5 rounded px-2 py-1.5"
+                >
+                  {nf.label}
+                </button>
+              ))}
+              {NAMED_FILTERS.every((nf) => usedFields.has(nf.field)) && (
+                <p className="text-xs text-text-muted px-2 py-1.5">All filters added.</p>
+              )}
+            </div>
           )}
         </div>
-      </details>
 
-      <div className="font-mono text-[10.5px] text-text-muted mb-2 flex justify-between flex-wrap gap-1.5">
+        <span className="font-mono text-[11px] text-text-muted ml-auto" aria-live="polite">
+          {data.match_count} match{data.match_count === 1 ? "" : "es"}
+          {loading ? " · …" : ""}
+        </span>
+      </div>
+
+      {/* Inline chip adjuster (slider / value) */}
+      {editingFilter != null && config.filters[editingFilter] && (
+        <FilterAdjuster
+          filter={config.filters[editingFilter]}
+          onChange={(p) => setFilter(editingFilter, p)}
+          onClose={() => setEditingFilter(null)}
+        />
+      )}
+
+      <div className="font-mono text-[10.5px] text-text-muted my-2 flex justify-between flex-wrap gap-1.5">
         <span>
-          {data.match_count} companies · top {Math.min(config.topN, data.match_count)} feed your
-          buyer · re-ranks live · {data.total_universe} in universe
+          {data.match_count} companies · top {Math.min(config.topN, data.match_count)} feed the
+          buyer · {data.total_universe} in universe
         </span>
         <span className="text-green">filters &amp; weights live in this URL</span>
       </div>
 
-      {/* ---- Results ---- */}
+      {/* Results — lead with the table */}
+      <div className="flex items-center justify-end mb-1.5">
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setColMenuOpen((v) => !v)}
+            aria-expanded={colMenuOpen}
+            className="font-mono text-[11px] text-text-muted hover:text-text border border-white/10 rounded-md px-2 py-1"
+          >
+            columns ▾
+          </button>
+          {colMenuOpen && (
+            <div className="absolute right-0 z-20 mt-1 w-44 rounded-lg border border-white/10 bg-[#0b0b0b] p-1 shadow-xl">
+              {EXTRA_COLS.map((c) => (
+                <label
+                  key={c.key}
+                  className="flex items-center gap-2 text-sm text-text-dim hover:bg-white/5 rounded px-2 py-1.5 cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={extraCols.has(c.key)}
+                    onChange={(e) =>
+                      setExtraCols((prev) => {
+                        const next = new Set(prev);
+                        if (e.target.checked) next.add(c.key);
+                        else next.delete(c.key);
+                        return next;
+                      })
+                    }
+                  />
+                  {c.label}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
       <div className="rounded-xl border border-white/10 overflow-hidden">
         <table className="w-full border-collapse" aria-label="Screened equities, ranked by your composite score">
           <thead>
             <tr className="bg-white/[0.02]">
               <Th className="text-left w-8">#</Th>
               <Th className="text-left">Ticker</Th>
-              <Th>Score</Th>
-              <Th>P/S</Th>
-              <Th>Rev gr%</Th>
-              <Th>GM%</Th>
-              <Th>FCF M%</Th>
-              <Th>R40</Th>
-              <Th>52w%</Th>
+              {cols.map((c) => (
+                <Th key={c.key}>{c.label}</Th>
+              ))}
             </tr>
           </thead>
           <tbody>
-            {rows.map((r, i) => (
-              <RowView key={r.ticker} r={r} cut={i === data.cut_index && data.cut_index < rows.length} dim={i >= data.cut_index} />
+            {data.rows.map((r, i) => (
+              <RowView
+                key={r.ticker}
+                r={r}
+                cols={cols}
+                cut={i === data.cut_index && data.cut_index < data.rows.length}
+                dim={i >= data.cut_index}
+              />
             ))}
-            {rows.length === 0 && (
+            {data.rows.length === 0 && (
               <tr>
-                <td colSpan={9} className="p-6 text-center text-sm text-text-muted">
+                <td colSpan={2 + cols.length} className="p-6 text-center text-sm text-text-muted">
                   No matches — loosen your filters.
                 </td>
               </tr>
@@ -481,6 +442,163 @@ export default function ScreenerClient({
           </tbody>
         </table>
       </div>
+
+      {/* Tune ranking — collapsed by default */}
+      <details
+        className="mt-3 rounded-xl border border-white/10 bg-white/[0.02]"
+        open={tuneOpen}
+        onToggle={(e) => setTuneOpen((e.target as HTMLDetailsElement).open)}
+      >
+        <summary className="cursor-pointer select-none px-4 py-3 text-sm text-text font-medium list-none flex items-center gap-2">
+          <span className="text-green">⚙</span> Tune ranking
+          <span className="text-text-muted font-normal text-xs">
+            — weighting, AI multiplier, top N
+          </span>
+        </summary>
+        <div className="px-4 pb-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted">
+              Score weighting
+            </span>
+            <label className="font-mono text-[11px] text-green inline-flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={config.aiMultiplier}
+                onChange={(e) => patch({ aiMultiplier: e.target.checked })}
+              />
+              AI bull/bear ×
+            </label>
+          </div>
+          <div className="flex gap-5 flex-wrap">
+            {(["quality", "value", "momentum"] as const).map((k) => (
+              <label key={k} className="flex-1 min-w-[150px]">
+                <span className="font-mono text-[11px] text-text-muted flex justify-between capitalize">
+                  <span>{k}</span>
+                  <span className="text-text">{config.weights[k]}</span>
+                </span>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={config.weights[k]}
+                  onChange={(e) => patch({ weights: { ...config.weights, [k]: Number(e.target.value) } })}
+                  className="w-full accent-green"
+                  aria-label={`${k} weight, ${config.weights[k]} of 100`}
+                />
+              </label>
+            ))}
+            <label className="min-w-[110px]">
+              <span className="font-mono text-[11px] text-text-muted flex justify-between">
+                <span>Top N → buyer</span>
+                <span className="text-text">{config.topN}</span>
+              </span>
+              <input
+                type="number"
+                min={1}
+                max={200}
+                value={config.topN}
+                onChange={(e) => patch({ topN: Math.max(1, Math.min(200, Number(e.target.value))) })}
+                className="w-full bg-black/30 border border-white/10 rounded-md px-2 py-1 text-sm text-text mt-1"
+              />
+            </label>
+          </div>
+
+          <div className="flex gap-2 mt-4 flex-wrap items-center">
+            <button
+              type="button"
+              onClick={onShare}
+              className="font-mono text-[11px] rounded-md border border-white/10 text-text-muted px-3 py-1.5 hover:text-text"
+            >
+              Share ↗
+            </button>
+            <button
+              type="button"
+              onClick={onSave}
+              className="font-mono text-[11px] rounded-md border border-white/10 text-text-muted px-3 py-1.5 hover:text-text"
+            >
+              Save
+            </button>
+            {saveLink && (
+              <Link href={saveLink} className="font-mono text-[11px] text-green underline">
+                saved → {saveLink}
+              </Link>
+            )}
+            {shareMsg && (
+              <span className="font-mono text-[11px] text-text-muted" aria-live="polite">
+                {shareMsg}
+              </span>
+            )}
+          </div>
+
+          {/* Advanced raw filter editor (power users) */}
+          <details
+            className="mt-4 border-t border-white/10 pt-3"
+            open={advancedOpen}
+            onToggle={(e) => setAdvancedOpen((e.target as HTMLDetailsElement).open)}
+          >
+            <summary className="cursor-pointer select-none text-[11px] font-mono text-text-muted">
+              Advanced filters (field · operator · value)
+            </summary>
+            <div className="mt-2 space-y-2">
+              {config.filters.map((f, i) => (
+                <div key={`adv-${i}`} className="flex items-center gap-2 flex-wrap">
+                  <select
+                    aria-label="Filter field"
+                    value={f.field}
+                    onChange={(e) => {
+                      const field = e.target.value as FilterField;
+                      const isText = TEXT_FIELDS.has(field);
+                      setFilter(i, {
+                        field,
+                        op: isText ? "==" : f.op,
+                        value: isText ? String(f.value ?? "") : Number(f.value) || 0,
+                      });
+                    }}
+                    className="bg-black/40 border border-white/10 rounded px-1.5 py-1 text-xs text-text"
+                  >
+                    {FILTER_FIELDS.map((ff) => (
+                      <option key={ff} value={ff} className="bg-black">{ff}</option>
+                    ))}
+                  </select>
+                  <select
+                    aria-label="Filter operator"
+                    value={f.op}
+                    onChange={(e) => setFilter(i, { op: e.target.value as FilterOp })}
+                    className="bg-black/40 border border-white/10 rounded px-1.5 py-1 text-xs text-text"
+                  >
+                    {FILTER_OPS.map((op) => (
+                      <option key={op} value={op} className="bg-black">{op}</option>
+                    ))}
+                  </select>
+                  {TEXT_FIELDS.has(f.field) ? (
+                    <input
+                      aria-label="Filter value"
+                      value={String(f.value ?? "")}
+                      onChange={(e) => setFilter(i, { value: e.target.value })}
+                      className="w-32 bg-black/40 border border-white/10 rounded px-1.5 py-1 text-xs text-text"
+                    />
+                  ) : (
+                    <input
+                      aria-label="Filter value"
+                      type="number"
+                      value={Number(f.value)}
+                      onChange={(e) => setFilter(i, { value: Number(e.target.value) })}
+                      className="w-20 bg-black/40 border border-white/10 rounded px-1.5 py-1 text-xs text-text"
+                    />
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => removeFilter(i)}
+                    className="text-text-muted hover:text-text text-xs"
+                  >
+                    remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          </details>
+        </div>
+      </details>
 
       <footer className="border-t border-white/10 mt-5 pt-4">
         <p className="font-mono text-[10.5px] text-text-muted">
@@ -492,22 +610,64 @@ export default function ScreenerClient({
   );
 }
 
+function FilterAdjuster({
+  filter,
+  onChange,
+  onClose,
+}: {
+  filter: Filter;
+  onChange: (p: Partial<Filter>) => void;
+  onClose: () => void;
+}) {
+  const isText = TEXT_FIELDS.has(filter.field);
+  const m = METRIC_META[filter.field];
+  return (
+    <div className="rounded-xl border border-green/30 bg-black/30 p-3 mb-2 flex items-center gap-3 flex-wrap">
+      <span className="font-mono text-[11px] text-text">{filterChipLabel(filter)}</span>
+      {isText ? (
+        <input
+          aria-label={`${filter.field} value`}
+          value={String(filter.value ?? "")}
+          onChange={(e) => onChange({ value: e.target.value })}
+          className="flex-1 min-w-[160px] bg-black/40 border border-white/10 rounded px-2 py-1 text-sm text-text"
+        />
+      ) : m ? (
+        <input
+          type="range"
+          min={m.min}
+          max={m.max}
+          step={m.step}
+          value={Number(filter.value)}
+          onChange={(e) => onChange({ value: Number(e.target.value) })}
+          aria-label={`${m.label} ${m.op === "<=" ? "at most" : "at least"} ${filter.value}${m.unit}`}
+          className="flex-1 min-w-[200px] accent-green"
+        />
+      ) : null}
+      <button
+        type="button"
+        onClick={onClose}
+        className="font-mono text-[11px] text-text-muted hover:text-text"
+      >
+        done
+      </button>
+    </div>
+  );
+}
+
 function Th({ children, className = "" }: { children: React.ReactNode; className?: string }) {
   return (
-    <th
-      className={`font-mono text-[10px] tracking-[0.04em] text-text-muted font-normal px-2.5 py-2 text-right ${className}`}
-    >
+    <th className={`font-mono text-[10px] tracking-[0.04em] text-text-muted font-normal px-3 py-2.5 text-right ${className}`}>
       {children}
     </th>
   );
 }
 
-function RowView({ r, cut, dim }: { r: Row; cut: boolean; dim: boolean }) {
+function RowView({ r, cols, cut, dim }: { r: Row; cols: Col[]; cut: boolean; dim: boolean }) {
   return (
     <>
       {cut && (
         <tr aria-hidden>
-          <td colSpan={9} className="px-2.5 py-1 bg-green/[0.06] border-t border-green/30">
+          <td colSpan={2 + cols.length} className="px-3 py-1 bg-green/[0.06] border-t border-green/30">
             <span className="font-mono text-[10px] text-green">
               ── cut line: above feeds your buyer · below is ranked, not bought ──
             </span>
@@ -515,29 +675,28 @@ function RowView({ r, cut, dim }: { r: Row; cut: boolean; dim: boolean }) {
         </tr>
       )}
       <tr className={dim ? "opacity-45" : ""}>
-        <td className="px-2.5 py-2 text-left font-mono text-text-muted text-xs border-t border-white/10">
+        <td className="px-3 py-2.5 text-left font-mono text-text-muted text-xs border-t border-white/10">
           {r.rank}
         </td>
-        <td className="px-2.5 py-2 text-left border-t border-white/10">
+        <td className="px-3 py-2.5 text-left border-t border-white/10">
           <Link href={`/company/${r.ticker}`} className="hover:text-green">
             <span className="font-mono text-text text-[12.5px]">{r.ticker}</span>{" "}
             <span className="text-[11px] text-text-muted">{r.name}</span>
           </Link>
         </td>
-        <Td className="text-green font-mono">{fmt(r.score, { dp: 1 })}</Td>
-        <Td className="font-mono">{fmt(r.ps, { mult: true })}</Td>
-        <Td className="font-mono text-green">{fmt(r.rev_growth_ttm, { pct: true })}</Td>
-        <Td className="font-mono text-green">{fmt(r.gross_margin, { pct: true })}</Td>
-        <Td className="font-mono text-green">{fmt(r.fcf_margin, { pct: true })}</Td>
-        <Td className="font-mono text-green">{fmt(r.rule_of_40, { dp: 0 })}</Td>
-        <Td className="font-mono">{fmt(r.ret_52w, { pct: true, dp: 0 })}</Td>
+        {cols.map((c) => (
+          <td
+            key={c.key}
+            className={`px-3 py-2.5 text-right text-[12.5px] font-mono border-t border-white/10 ${
+              c.green ? "text-green" : "text-text"
+            }`}
+          >
+            {c.render(r)}
+          </td>
+        ))}
       </tr>
     </>
   );
-}
-
-function Td({ children, className = "" }: { children: React.ReactNode; className?: string }) {
-  return <td className={`px-2.5 py-2 text-right text-[12.5px] border-t border-white/10 ${className}`}>{children}</td>;
 }
 
 function topWeight(w: { quality: number; value: number; momentum: number }): string {

--- a/web/lib/screen/config.ts
+++ b/web/lib/screen/config.ts
@@ -89,6 +89,8 @@ export const PRESETS: Record<string, Preset> = {
       "Durable compounders — Rule of 40, fat FCF and gross margins, valuation kept sane.",
     config: {
       ...base,
+      brief:
+        "Durable quality compounders: high Rule of 40, fat free cash flow and gross margins, with the valuation kept sane — P/S under 15.",
       filters: [{ field: "ps", op: "<=", value: 15 }],
       weights: { quality: 60, value: 25, momentum: 15 },
     },
@@ -99,6 +101,8 @@ export const PRESETS: Record<string, Preset> = {
     description: "Cheap on sales relative to their own history; quality is secondary.",
     config: {
       ...base,
+      brief:
+        "Cheap on sales relative to their own 12-month history. I'll tolerate weaker quality for the discount — P/S under 8.",
       filters: [{ field: "ps", op: "<=", value: 8 }],
       weights: { quality: 20, value: 60, momentum: 20 },
     },
@@ -109,6 +113,8 @@ export const PRESETS: Record<string, Preset> = {
     description: "Leaders by trailing 52-week price strength, quality as a sanity check.",
     config: {
       ...base,
+      brief:
+        "Market leaders by trailing 52-week price strength, with quality as a sanity check so I'm not just chasing junk.",
       filters: [],
       weights: { quality: 25, value: 15, momentum: 60 },
     },
@@ -119,6 +125,8 @@ export const PRESETS: Record<string, Preset> = {
     description: "Cash machines — free-cash-flow margin and Rule of 40 lead the score.",
     config: {
       ...base,
+      brief:
+        "Cash machines: strong free-cash-flow margin (10%+) and Rule of 40 lead the ranking; valuation is secondary.",
       filters: [{ field: "fcf_margin", op: ">=", value: 10 }],
       weights: { quality: 65, value: 20, momentum: 15 },
     },
@@ -183,4 +191,74 @@ export function isHousePreset(config: ScreenConfig): boolean {
   if (!p) return false;
   const a = screenConfigSchema.parse({ ...p.config, preset: p.id });
   return JSON.stringify({ ...a, brief: undefined }) === JSON.stringify({ ...config, brief: undefined });
+}
+
+// ---- Friendly filters (screener UX follow-up §3) --------------------------
+//
+// A filter is presented as a readable chip with the operator IMPLIED by the
+// metric — P/S / price are "at most" (≤), growth / margins / R40 / return are
+// "at least" (≥). Tapping a chip reveals a slider over the metric's range. The
+// raw field+op+value editor stays available under "advanced".
+
+export interface MetricMeta {
+  field: FilterField;
+  label: string; // friendly name, e.g. "Revenue growth"
+  unit: "%" | "×" | "$" | "";
+  op: FilterOp; // implied operator
+  min: number;
+  max: number;
+  step: number;
+  default: number;
+}
+
+// Numeric metrics only — text fields (sector/country) get a different control.
+export const METRIC_META: Record<string, MetricMeta> = {
+  ps: { field: "ps", label: "P/S", unit: "×", op: "<=", min: 0, max: 30, step: 0.5, default: 15 },
+  rev_growth_ttm: { field: "rev_growth_ttm", label: "Revenue growth", unit: "%", op: ">=", min: 0, max: 100, step: 5, default: 20 },
+  gross_margin: { field: "gross_margin", label: "Gross margin", unit: "%", op: ">=", min: 0, max: 100, step: 5, default: 60 },
+  fcf_margin: { field: "fcf_margin", label: "FCF margin", unit: "%", op: ">=", min: -20, max: 60, step: 5, default: 10 },
+  net_margin: { field: "net_margin", label: "Net margin", unit: "%", op: ">=", min: -40, max: 60, step: 5, default: 0 },
+  operating_margin: { field: "operating_margin", label: "Operating margin", unit: "%", op: ">=", min: -40, max: 60, step: 5, default: 0 },
+  rule_of_40: { field: "rule_of_40", label: "Rule of 40", unit: "", op: ">=", min: 0, max: 120, step: 5, default: 40 },
+  ret_52w: { field: "ret_52w", label: "52-week return", unit: "%", op: ">=", min: -50, max: 150, step: 10, default: 0 },
+  price: { field: "price", label: "Price", unit: "$", op: ">=", min: 0, max: 500, step: 5, default: 5 },
+};
+
+/** The natural operator for a metric (implied — no operator dropdown). */
+export function impliedOp(field: FilterField): FilterOp {
+  return METRIC_META[field]?.op ?? ">=";
+}
+
+/** A readable chip label for a filter, e.g. "P/S ≤ 15" / "Rev growth ≥ 20%". */
+export function filterChipLabel(f: Filter): string {
+  if (TEXT_FIELDS.has(f.field)) {
+    const verb = f.op === "!=" ? "exclude" : "only";
+    return `${verb} ${f.value}`;
+  }
+  const m = METRIC_META[f.field];
+  const sym = f.op === "<=" || f.op === "<" ? "≤" : f.op === ">=" || f.op === ">" ? "≥" : f.op;
+  const label = m?.label ?? f.field;
+  const unit = m?.unit ?? "";
+  return `${label} ${sym} ${f.value}${unit}`;
+}
+
+// The "+ add filter" menu — named, friendly filters (not a blank field/op/value
+// row). Each seeds a chip with its implied operator + default value.
+export const NAMED_FILTERS: { field: FilterField; label: string }[] = [
+  { field: "ps", label: "P/S multiple" },
+  { field: "rev_growth_ttm", label: "Revenue growth" },
+  { field: "gross_margin", label: "Gross margin" },
+  { field: "fcf_margin", label: "FCF margin" },
+  { field: "rule_of_40", label: "Rule of 40" },
+  { field: "ret_52w", label: "52-week return" },
+  { field: "net_margin", label: "Net margin" },
+  { field: "operating_margin", label: "Operating margin" },
+  { field: "price", label: "Share price" },
+];
+
+/** Build a default filter for a metric, ready to drop into the bar as a chip. */
+export function newFilterFor(field: FilterField): Filter {
+  if (TEXT_FIELDS.has(field)) return { field, op: "!=", value: "" };
+  const m = METRIC_META[field];
+  return { field, op: impliedOp(field), value: m?.default ?? 0 };
 }


### PR DESCRIPTION
## Summary

Refactors the screener's filter UI from a dense inline editor to a friendly chip-based interface with an inline slider adjuster. Moves ranking tuning (weights, AI multiplier, top N) into a collapsible "Tune ranking" panel, and adds a columns menu for optional metrics. Introduces `METRIC_META` and helper functions (`filterChipLabel`, `newFilterFor`, `impliedOp`) to centralize metric definitions and friendly labeling.

## Key Changes

- **Filter chips**: Filters now display as readable chips (e.g., "P/S ≤ 15") with implied operators baked into the metric definition. Tapping a chip opens an inline slider adjuster (`FilterAdjuster` component) for numeric metrics or text input for text fields.

- **Metric metadata**: New `METRIC_META` record in `config.ts` centralizes friendly names, units, implied operators, and slider ranges for all numeric metrics. Replaces the old `FIELD_LABEL` constant.

- **Named filters menu**: "+ add filter" now opens a dropdown of available filters (excluding already-used fields), seeded with sensible defaults via `newFilterFor()`.

- **Tune ranking panel**: Weights, AI multiplier, top N, share, and save controls moved into a collapsible `<details>` section (collapsed by default). Advanced raw filter editor (field · operator · value) nested inside as a second `<details>`.

- **Columns menu**: Optional extra columns (FCF margin, 52-week return) behind a "columns ▾" dropdown. Base columns (Score, P/S, Rev growth, Gross margin, Rule of 40) always visible.

- **Brief dirty tracking**: Added `briefDirty` state to show "Recompile ↻" button when the brief has unseen changes.

- **Preset briefs**: Each house preset now includes a `brief` field that auto-fills when selected (UX §2).

- **Simplified layout**: Removed the old "Compiled screen" section header; filters and brief are now more compact and front-and-center.

- **Helper functions**: 
  - `filterChipLabel(f)` — renders a readable filter label
  - `newFilterFor(field)` — creates a new filter with sensible defaults
  - `impliedOp(field)` — returns the natural operator for a metric

## Notable Details

- Filter state is managed via `editingFilter` (which chip is open) and `addMenuOpen` / `colMenuOpen` for dropdowns.
- The `FilterAdjuster` component handles both numeric (range slider) and text (input) filters inline.
- Columns are defined as `Col` objects with a `render` function, making it easy to add/remove metrics.
- The advanced filter editor remains available for power users but is hidden by default.
- Preset selection now resets `briefDirty` to false and populates the brief from the preset config.

https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN