### PR TITLE
Cache screen facts fetch with 5-minute revalidation window

### DIFF
--- a/web/lib/screen/query.ts
+++ b/web/lib/screen/query.ts
@@ -1,79 +1,70 @@
 /**
  * Server-side data load for the screener (brief v2 §6 contract).
  *
- * Pulls the Level 0 facts (screen_facts()) for the whole Tier 1 universe,
- * merges the optional AI bull/bear overlay (screen_ai_overlay()), then hands
- * the rows to the pure scoring function. No scoring lives here — this module
- * only fetches; scoreScreen() ranks.
+ * Pulls the Level 0 facts (screen_facts(), which now folds in the AI bull/bear
+ * overlay — migration 042) and hands them to the pure scoring function. No
+ * scoring lives here — this module only fetches; scoreScreen() ranks.
+ *
+ * PERF: the facts are identical for every config (only filtering/scoring
+ * differs), so the fetch is wrapped in unstable_cache with a 5-minute window.
+ * That turns every page load + every /api/screen re-rank into a cheap cache
+ * read + in-memory scoring, instead of re-hitting Postgres each time. The
+ * function returns ~900 rankable rows (one PostgREST page) — no pagination.
  */
 
+import { unstable_cache } from "next/cache";
 import { getSupabase } from "@/lib/supabase";
 import { scoreScreen, type ScreenFacts, type ScreenResult } from "@/lib/screen/score";
 import type { ScreenConfig } from "@/lib/screen/config";
 
 const PAGE = 1000;
 
-/** Fetch every Tier 1 fact row (paginated past PostgREST's 1000-row cap). */
-export async function loadFacts(): Promise<ScreenFacts[]> {
+async function fetchFacts(): Promise<ScreenFacts[]> {
   const supabase = getSupabase();
-
-  const [factsRaw, overlay] = await Promise.all([
-    fetchAll(supabase, "screen_facts"),
-    fetchAll(supabase, "screen_ai_overlay"),
-  ]);
-
-  const ai = new Map<string, { bull: boolean | null; bear: boolean | null }>();
-  for (const r of overlay) {
-    ai.set(r.ticker as string, {
-      bull: (r.bull as boolean | null) ?? null,
-      bear: (r.bear as boolean | null) ?? null,
-    });
-  }
-
-  return factsRaw.map((r) => {
-    const verdict = ai.get(r.ticker as string);
-    return {
-      ticker: r.ticker as string,
-      name: (r.name as string) ?? null,
-      sector: (r.sector as string) ?? null,
-      industry: (r.industry as string) ?? null,
-      country: (r.country as string) ?? null,
-      price: num(r.price),
-      price_asof: (r.price_asof as string) ?? null,
-      rev_growth_ttm: num(r.rev_growth_ttm),
-      gross_margin: num(r.gross_margin),
-      fcf_margin: num(r.fcf_margin),
-      net_margin: num(r.net_margin),
-      operating_margin: num(r.operating_margin),
-      rule_of_40: num(r.rule_of_40),
-      ps: num(r.ps),
-      ps_median_12m: num(r.ps_median_12m),
-      ret_52w: num(r.ret_52w),
-      bull: verdict?.bull ?? null,
-      bear: verdict?.bear ?? null,
-    } satisfies ScreenFacts;
-  });
-}
-
-async function fetchAll(
-  supabase: ReturnType<typeof getSupabase>,
-  fn: string,
-): Promise<Record<string, unknown>[]> {
-  const out: Record<string, unknown>[] = [];
+  const rows: Record<string, unknown>[] = [];
+  // One page in practice (screen_facts returns the rankable set, < PAGE). The
+  // loop is just a safety net should the universe ever exceed a page.
   for (let page = 0; ; page++) {
     const { data, error } = await supabase
-      .rpc(fn)
+      .rpc("screen_facts")
       .range(page * PAGE, (page + 1) * PAGE - 1);
     if (error) {
-      console.error(`${fn} failed:`, error.message);
+      console.error("screen_facts failed:", error.message);
       break;
     }
     const batch = (data ?? []) as Record<string, unknown>[];
-    out.push(...batch);
+    rows.push(...batch);
     if (batch.length < PAGE) break;
   }
-  return out;
+
+  return rows.map((r) => ({
+    ticker: r.ticker as string,
+    name: (r.name as string) ?? null,
+    sector: (r.sector as string) ?? null,
+    industry: (r.industry as string) ?? null,
+    country: (r.country as string) ?? null,
+    price: num(r.price),
+    price_asof: (r.price_asof as string) ?? null,
+    rev_growth_ttm: num(r.rev_growth_ttm),
+    gross_margin: num(r.gross_margin),
+    fcf_margin: num(r.fcf_margin),
+    net_margin: num(r.net_margin),
+    operating_margin: num(r.operating_margin),
+    rule_of_40: num(r.rule_of_40),
+    ps: num(r.ps),
+    ps_median_12m: num(r.ps_median_12m),
+    ret_52w: num(r.ret_52w),
+    bull: (r.bull as boolean | null) ?? null,
+    bear: (r.bear as boolean | null) ?? null,
+  }) satisfies ScreenFacts);
 }
+
+// Shared across all configs + all requests for 5 minutes — the data refreshes
+// on the daily/intraday cadence, so a 5-minute window is well inside it.
+export const loadFacts = unstable_cache(fetchFacts, ["screen-facts-v2"], {
+  revalidate: 300,
+  tags: ["screen-facts"],
+});
 
 export interface ScreenResponse extends ScreenResult {
   data_asof: string | null;


### PR DESCRIPTION
## Summary
Refactors the screener data-loading pipeline to eliminate redundant database hits by wrapping the facts fetch in Next.js `unstable_cache` with a 5-minute revalidation window. Also simplifies the code by moving AI bull/bear overlay logic into the `screen_facts()` RPC (migration 042), eliminating the need for a separate merge step.

## Key Changes
- **Consolidate data fetch:** `screen_facts()` RPC now includes AI bull/bear overlay directly (migration 042), removing the separate `screen_ai_overlay()` call and manual merge logic
- **Add caching layer:** Wrap `fetchFacts()` in `unstable_cache()` with 300-second (5-minute) revalidation and `["screen-facts"]` tag, keyed on `["screen-facts-v2"]`
- **Simplify pagination:** Inline the generic `fetchAll()` helper into `fetchFacts()` since only one RPC is now called; add clarifying comment that the loop is a safety net (universe is ~900 rows, well under the 1000-row PostgREST page limit)
- **Update module docs:** Clarify that facts are now identical across all configs (only filtering/scoring differs), making caching safe and effective; note that every page load + `/api/screen` re-rank now hits the cache instead of Postgres

## Performance Impact
- **Before:** Every page load and every `/api/screen` re-rank hit Postgres twice (facts + overlay), then scored in-memory
- **After:** First request fetches from Postgres; subsequent requests within 5 minutes read from Next.js cache, then score in-memory. Turns repeated re-ranks into cheap cache reads + CPU-only scoring

## Implementation Details
- The 5-minute window aligns with the daily/intraday price refresh cadence (prices update every 15 minutes during market hours, fundamentals daily), so stale facts are not a concern
- Returns ~900 rankable rows (one PostgREST page); no pagination needed in practice
- Cache is shared across all screen configs and all requests, since the underlying facts are config-agnostic

https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN