### PR TITLE
Fix screener crash: UTF-8-safe base64url config encoding

### DIFF
--- a/web/lib/screen/config.ts
+++ b/web/lib/screen/config.ts
@@ -146,14 +146,31 @@ export function presetConfig(id: string): ScreenConfig {
 // arbitrary custom screen round-trips losslessly and shareably. A bare
 // `?preset=` or `?sector=` shortcut yields the clean, indexable URLs.
 
+// UTF-8 safe base64url. NOTE: `btoa`/`atob` only handle Latin1, so they THROW
+// (InvalidCharacterError) on any non-ASCII char — and a brief routinely
+// contains an em-dash, "≤", curly quotes, etc. Use Buffer on the server (UTF-8
+// native) and TextEncoder/TextDecoder on the browser.
 function b64urlEncode(s: string): string {
-  const b = typeof btoa === "function" ? btoa(s) : Buffer.from(s, "utf8").toString("base64");
+  let b: string;
+  if (typeof Buffer !== "undefined") {
+    b = Buffer.from(s, "utf8").toString("base64");
+  } else {
+    const bytes = new TextEncoder().encode(s);
+    let bin = "";
+    for (const byte of bytes) bin += String.fromCharCode(byte);
+    b = btoa(bin);
+  }
   return b.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 function b64urlDecode(s: string): string {
   const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
   const b = s.replace(/-/g, "+").replace(/_/g, "/") + pad;
-  return typeof atob === "function" ? atob(b) : Buffer.from(b, "base64").toString("utf8");
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(b, "base64").toString("utf8");
+  }
+  const bin = atob(b);
+  const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
 }
 
 export function encodeConfig(config: ScreenConfig): string {


### PR DESCRIPTION
## Fix the screener crash — UTF-8-safe config encoding

**This is the real root cause** (found by reproducing the build and serving it against the live DB, not guessing).

### The bug
`b64urlEncode` in `lib/screen/config.ts` used **`btoa()`**, which only handles Latin1 and **throws `InvalidCharacterError` on any non-ASCII character**. The preset briefs I added contain an **em-dash** (e.g. "…valuation kept sane **—** P/S under 15"), and the **default** preset (quality-growth) has one — so **every default `/screener` load** encoded that config and threw, producing the "A server error occurred" digest. Any user-typed brief with Unicode (em-dash, curly quotes, `≤`, accents) would have crashed too.

The intended `Buffer` fallback never ran because `btoa` *is* defined on Node — so the broken branch always won.

### The fix
Encode/decode via **`Buffer` on the server** and **`TextEncoder`/`TextDecoder` on the browser**, so the URL config round-trips any UTF-8 string. One file (`config.ts`).

### Verified (not assumed)
- Reproduced the exact error by `next build` + `next start` against the live DB: `InvalidCharacterError` at `lib/screen/config.ts`, digest.
- After the fix, rebuilt + served against the live DB: **`/screener` → HTTP 200**, no server errors, HTML renders "Stock Screener / Score / Tune ranking".
- Round-trip unit-checked with `— ≤ "curly quotes"`. `tsc --noEmit` clean.

Merge this to clear the live error. (This supersedes my earlier `unstable_cache` and timeout guesses — those reduced load but weren't the throw; this is.)

https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN)_