### PR TITLE
Screener: How-this-works signpost + cut banner, opaque menus, tooltips

### DIFF
--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -57,6 +57,22 @@ function fmt(v: number | null, opts?: { pct?: boolean; mult?: boolean; dp?: numb
 }
 const PAGE_SIZE = 250;
 
+// Hover explanations for the (jargon-y) ranking controls.
+const WEIGHT_HELP: Record<"quality" | "value" | "momentum", string> = {
+  quality:
+    "Quality — how strong the business is: 0.60×Rule of 40 + 0.25×free-cash-flow margin + 0.15×gross margin, scored as percentiles within the filtered set. Raise it to favour profitable, efficient compounders.",
+  value:
+    "Value — how cheap it is on sales versus the stock's own 12-month median P/S (not an absolute P/S). Raise it to favour names trading below their usual valuation.",
+  momentum:
+    "Momentum — trailing 52-week price return, collared so falling knives and blow-off tops don't dominate. Raise it to favour recent leaders.",
+};
+const RANKING_HELP =
+  "Each name's Score is a percentile blend of Quality, Value and Momentum, weighted by these sliders, relative to the names matching your filters — so it's this screen's own ranking, not a fixed house score.";
+const AI_HELP =
+  "Multiply each Score by the AI bull/bear verdict: dual-positive ×1.30, story-but-red-flags ×0.70, avoid ×0.40, sound-or-unrated ×1.00. Uncheck to ignore the AI overlay.";
+const TOPN_HELP =
+  "The top N ranked names become your buyer's candidate pool — the cut line in the table. Only these feed the swarm.";
+
 function topWeight(w: { quality: number; value: number; momentum: number }): string {
   const e = Object.entries(w) as [string, number][];
   e.sort((a, b) => b[1] - a[1]);
@@ -221,6 +237,9 @@ export default function ScreenerClient({
   const usedFields = useMemo(() => new Set(config.filters.map((f) => f.field)), [config.filters]);
   const cols = useMemo(() => [...BASE_COLS, ...EXTRA_COLS.filter((c) => extraCols.has(c.key))], [extraCols]);
   const metricColCount = 1 + cols.length; // Score + metric cols
+  // "Run as a portfolio" carries the current screen config into the portfolio
+  // home, where it becomes the portfolio's selection recipe (screen_config).
+  const runHref = `/account?from=screen&config=${encodeConfig(config)}`;
 
   const card = "rounded-xl border border-white/10 bg-white/[0.02]";
 
@@ -311,7 +330,7 @@ export default function ScreenerClient({
           <summary className="list-none cursor-pointer font-mono text-[10.5px] text-text-muted border border-dashed border-white/20 rounded-md px-2.5 py-1.5 hover:text-text marker:hidden [&::-webkit-details-marker]:hidden">
             + add filter
           </summary>
-          <div className={`absolute z-20 mt-1.5 w-52 ${card} p-1.5`}>
+          <div className="absolute z-30 mt-1.5 w-52 rounded-xl border border-white/10 bg-[#0b1214] shadow-2xl p-1.5">
             {NAMED_FILTERS.filter((nf) => !usedFields.has(nf.field)).map((nf) => (
               <button
                 key={nf.field}
@@ -341,15 +360,25 @@ export default function ScreenerClient({
         <details
           className={`ml-auto min-w-[280px] ${card}`}
         >
-          <summary className="list-none cursor-pointer font-mono text-[11px] text-[var(--color-cyan)] px-3 py-2 marker:hidden [&::-webkit-details-marker]:hidden">
+          <summary
+            title="Adjust how the Score is computed — the balance of Quality, Value and Momentum, the AI multiplier, and how many top names feed your buyer."
+            className="list-none cursor-pointer font-mono text-[11px] text-[var(--color-cyan)] px-3 py-2 marker:hidden [&::-webkit-details-marker]:hidden"
+          >
             ⚙ Tune ranking ▸
           </summary>
           <div className="px-3 pb-3">
-            <div className="flex items-center justify-between mt-1.5">
-              <span className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted">
-                This screen&apos;s own ranking
+            <div className="flex items-center justify-between mt-1.5 gap-2">
+              <span
+                title={RANKING_HELP}
+                className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted cursor-help underline decoration-dotted decoration-white/25 underline-offset-2"
+              >
+                This screen&apos;s own ranking{" "}
+                <span aria-hidden className="text-text-muted/50 no-underline">ⓘ</span>
               </span>
-              <label className="font-mono text-[10.5px] text-[var(--color-cyan)] inline-flex items-center gap-1.5">
+              <label
+                title={AI_HELP}
+                className="font-mono text-[10.5px] text-[var(--color-cyan)] inline-flex items-center gap-1.5 cursor-help shrink-0"
+              >
                 <input
                   type="checkbox"
                   checked={config.aiMultiplier}
@@ -362,7 +391,12 @@ export default function ScreenerClient({
             {(["quality", "value", "momentum"] as const).map((k) => (
               <div key={k} className="mt-2.5">
                 <div className="flex justify-between font-mono text-[11px] text-text-muted capitalize">
-                  <span>{k}</span>
+                  <span
+                    title={WEIGHT_HELP[k]}
+                    className="cursor-help underline decoration-dotted decoration-white/25 underline-offset-2"
+                  >
+                    {k} <span aria-hidden className="text-text-muted/50 no-underline">ⓘ</span>
+                  </span>
                   <span className="text-text">{config.weights[k]}</span>
                 </div>
                 <input
@@ -373,12 +407,18 @@ export default function ScreenerClient({
                   onChange={(e) => patch({ weights: { ...config.weights, [k]: Number(e.target.value) } })}
                   className="w-full accent-[var(--color-cyan)]"
                   aria-label={`${k} weight, ${config.weights[k]} of 100`}
+                  title={WEIGHT_HELP[k]}
                 />
               </div>
             ))}
             <div className="mt-3">
               <div className="flex justify-between font-mono text-[11px] text-text-muted">
-                <span>Top N → buyer</span>
+                <span
+                  title={TOPN_HELP}
+                  className="cursor-help underline decoration-dotted decoration-white/25 underline-offset-2"
+                >
+                  Top N → buyer <span aria-hidden className="text-text-muted/50 no-underline">ⓘ</span>
+                </span>
                 <span className="text-[var(--color-cyan)]">{config.topN}</span>
               </div>
               <input
@@ -389,6 +429,7 @@ export default function ScreenerClient({
                 onChange={(e) => patch({ topN: Math.max(1, Math.min(200, Number(e.target.value))) })}
                 className="w-full accent-[var(--color-cyan)]"
                 aria-label={`Top N candidates, ${config.topN}`}
+                title={TOPN_HELP}
               />
             </div>
           </div>
@@ -405,11 +446,51 @@ export default function ScreenerClient({
         />
       )}
 
+      {/* How this works — Screen → top N → Portfolio (one bridge, not a pipeline) */}
+      <div className="mt-4 mb-4">
+        <div className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted mb-2">
+          How this works
+        </div>
+        <div className="flex items-stretch gap-0 flex-wrap">
+          <div className="flex-1 min-w-[200px] rounded-xl border border-[var(--color-cyan)]/45 bg-[var(--color-cyan)]/[0.06] p-3.5">
+            <div className="font-mono text-[12px] text-[var(--color-cyan)]">
+              ● THIS SCREEN{" "}
+              <span className="text-[9px] text-text-muted tracking-[0.05em]">YOU ARE HERE</span>
+            </div>
+            <div className="text-[11px] text-text-muted mt-1.5 leading-relaxed">
+              Ranks every US equity by your config. Re-ranks live.
+            </div>
+          </div>
+          <div className="flex-[0_0_130px] min-w-[120px] flex flex-col items-center justify-center px-1">
+            <div className="font-mono text-[10px] text-green">top {config.topN}</div>
+            <div
+              className="w-full h-px my-1.5 relative"
+              style={{ background: "linear-gradient(90deg,rgba(38,224,240,.5),rgba(55,219,128,.5))" }}
+            >
+              <span className="absolute -right-0.5 -top-[5px] text-green text-[11px]">▶</span>
+            </div>
+            <div className="font-mono text-[9px] text-text-muted">candidates</div>
+          </div>
+          <Link
+            href={runHref}
+            className="flex-1 min-w-[200px] rounded-xl border border-green/45 bg-green/[0.06] p-3.5 hover:bg-green/[0.1] transition-colors"
+          >
+            <div className="font-mono text-[12px] text-green">PORTFOLIO →</div>
+            <div className="text-[11px] text-text-muted mt-1.5 leading-relaxed">
+              Your <span className="text-text">swarm</span> drafts &amp; trades them — marked to
+              market, daily.
+            </div>
+            <div className="font-mono text-[10px] text-green mt-2">
+              Run this screen as a portfolio →
+            </div>
+          </Link>
+        </div>
+      </div>
+
       {/* Count + actions */}
       <div className="font-mono text-[10.5px] text-text-muted flex justify-between flex-wrap gap-1.5 mb-2">
         <span>
-          {data.match_count} of {data.total_universe} · top {Math.min(config.topN, data.match_count)} feed your
-          buyer · re-ranks live{loading ? " · …" : ""}
+          {data.match_count} of {data.total_universe} · re-ranks live{loading ? " · …" : ""}
         </span>
         <span className="flex gap-3 items-center" aria-live="polite">
           <button type="button" onClick={onShare} className="text-[var(--color-cyan)] hover:underline">
@@ -451,7 +532,8 @@ export default function ScreenerClient({
                   cols ▾
                 </button>
                 {colsOpen && (
-                  <div className={`absolute right-0 z-20 mt-1 w-40 ${card} p-1 text-left`}>
+                  <div className="absolute right-0 z-30 mt-1 w-40 rounded-xl border border-white/10 bg-[#0b1214] shadow-2xl p-1 text-left">
+
                     {EXTRA_COLS.map((c) => (
                       <label
                         key={c.key}
@@ -486,6 +568,8 @@ export default function ScreenerClient({
                 cut={i === data.cut_index && data.cut_index < data.rows.length}
                 dim={i >= data.cut_index}
                 spanCols={metricColCount + 3}
+                topN={config.topN}
+                runHref={runHref}
               />
             ))}
             {data.rows.length === 0 && (
@@ -669,19 +753,30 @@ function RowView({
   cut,
   dim,
   spanCols,
+  topN,
+  runHref,
 }: {
   r: Row;
   cols: Col[];
   cut: boolean;
   dim: boolean;
   spanCols: number;
+  topN: number;
+  runHref: string;
 }) {
   return (
     <>
       {cut && (
-        <tr aria-hidden>
-          <td colSpan={spanCols} className="p-0">
-            <div className="h-px bg-[var(--color-cyan)]/40" />
+        <tr>
+          <td colSpan={spanCols} className="p-0 border-t border-green/45">
+            <div className="flex justify-between items-center gap-2 flex-wrap bg-green/[0.07] px-2.5 py-1.5">
+              <span className="font-mono text-[10px] text-green tracking-[0.05em]">
+                ▲ TOP {topN} — what flows to a portfolio
+              </span>
+              <Link href={runHref} className="font-mono text-[10px] text-green hover:underline">
+                Run as a portfolio →
+              </Link>
+            </div>
           </td>
         </tr>
       )}


### PR DESCRIPTION
## Screener: "How this works" signpost + cut banner (+ menu/tooltip polish)

These three `screener-client.tsx` improvements landed after #1345 merged (which took only the crash fix), so they need their own PR. Single-file diff off the current `main` (which already has the reference design).

### Signpost + funnel (the new reference v2)
- A **"How this works"** signpost between the filter bar and the table: two nodes — **THIS SCREEN** (cyan, "you are here") → a **top-N bridge** arrow → **PORTFOLIO** (green, clickable). Not a 4-step pipeline: the top-N rides the arrow (it's the screen's output), the swarm lives in the Portfolio node.
- The table cut line becomes a banner: **`▲ TOP {N} — what flows to a portfolio · Run as a portfolio →`**; below-cut rows stay dimmed.
- Both the Portfolio card and the cut-banner link carry the **encoded screen config** to `/account?from=screen&config=…`.
- Count line simplified to `{n} of {N} · re-ranks live`.

### Polish (the earlier asks)
- **Opaque backgrounds** (+ shadow, higher z-index) for the "+ add filter" and "cols ▾" dropdowns — they were bleeding over the table.
- **Hover tooltips** (dotted-underline + `ⓘ`) on every Tune-ranking control — Quality / Value / Momentum / Top N / AI bull-bear / "this screen's own ranking" — explaining the jargon. Native `title`, keyboard/screen-reader friendly.

`tsc --noEmit` clean.

### Follow-up (noted, not in this PR)
The "Run as a portfolio" links **carry** the config but `/account` doesn't yet **consume** it (apply it as the portfolio's `screen_config`). Wiring that consume-side is a small follow-up — happy to do it next.

https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN)_