### PR TITLE
Screener: working "Run as a portfolio" + scoring panel next to the table

### DIFF
--- a/web/app/screener/run/route.ts
+++ b/web/app/screener/run/route.ts
@@ -1,0 +1,73 @@
+/**
+ * GET /screener/run?config={encoded}
+ *
+ * "Run this screen as a portfolio" from the screener signpost / cut banner.
+ * Applies the screen as the signed-in owner's portfolio selection recipe
+ * (portfolios.screen_config) and redirects to that portfolio's page — NOT the
+ * old /account control room.
+ *
+ * - Not signed in → /login?next=… so the apply completes after auth.
+ * - Signed in, no portfolio yet → /account (the create flow), carrying the
+ *   config so it can be applied once a portfolio exists.
+ * - Signed in with a paper portfolio → set screen_config (owner-gated), then
+ *   land on /portfolios/<slug>.
+ */
+
+import { NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { getSupabase } from "@/lib/supabase";
+import { getPortfolioForUser } from "@/lib/portfolios-query";
+import { screenConfigSchema } from "@/lib/screen/config";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function decodeConfig(encoded: string): unknown | null {
+  try {
+    const pad = encoded.length % 4 === 0 ? "" : "=".repeat(4 - (encoded.length % 4));
+    const b64 = encoded.replace(/-/g, "+").replace(/_/g, "/") + pad;
+    return JSON.parse(Buffer.from(b64, "base64").toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const encoded = url.searchParams.get("config") ?? "";
+  const self = `/screener/run?config=${encoded}`;
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.redirect(
+      new URL(`/login?next=${encodeURIComponent(self)}`, req.url),
+    );
+  }
+
+  const portfolio = await getPortfolioForUser(user.id);
+  if (!portfolio) {
+    // No portfolio yet — send to the create flow, keeping the config around.
+    return NextResponse.redirect(
+      new URL(`/account?from=screen&config=${encoded}`, req.url),
+    );
+  }
+
+  // Validate before writing; a bad/hand-edited param just skips the apply.
+  const parsed = screenConfigSchema.safeParse(decodeConfig(encoded));
+  if (parsed.success) {
+    const svc = getSupabase();
+    const { error } = await svc
+      .from("portfolios")
+      .update({ screen_config: parsed.data })
+      .eq("id", portfolio.id)
+      .eq("owner_user_id", user.id);
+    if (error) console.error("apply screen_config failed:", error.message);
+  }
+
+  return NextResponse.redirect(
+    new URL(`/portfolios/${portfolio.slug}?screen=applied`, req.url),
+  );
+}

--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -237,9 +237,10 @@ export default function ScreenerClient({
   const usedFields = useMemo(() => new Set(config.filters.map((f) => f.field)), [config.filters]);
   const cols = useMemo(() => [...BASE_COLS, ...EXTRA_COLS.filter((c) => extraCols.has(c.key))], [extraCols]);
   const metricColCount = 1 + cols.length; // Score + metric cols
-  // "Run as a portfolio" carries the current screen config into the portfolio
-  // home, where it becomes the portfolio's selection recipe (screen_config).
-  const runHref = `/account?from=screen&config=${encodeConfig(config)}`;
+  // "Run as a portfolio" applies this screen as the portfolio's selection
+  // recipe (screen_config) and lands on the portfolio page — see
+  // app/screener/run/route.ts.
+  const runHref = `/screener/run?config=${encodeConfig(config)}`;
 
   const card = "rounded-xl border border-white/10 bg-white/[0.02]";
 
@@ -302,7 +303,7 @@ export default function ScreenerClient({
           {compiling ? "Compiling…" : briefDirty ? "Recompile ↻" : "Compile to screen"}
         </button>
         <span className="font-mono text-[10.5px] text-text-muted" aria-live="polite">
-          {compileStatus ?? "the brief is for humans; the compiled knobs are what the buyer reads"}
+          {compileStatus ?? "the brief is for humans; the compiled filters & weights are what drive the screener"}
         </span>
       </div>
 
@@ -356,84 +357,6 @@ export default function ScreenerClient({
           </div>
         </details>
 
-        {/* Tune ranking — pushed right, collapsed */}
-        <details
-          className={`ml-auto min-w-[280px] ${card}`}
-        >
-          <summary
-            title="Adjust how the Score is computed — the balance of Quality, Value and Momentum, the AI multiplier, and how many top names feed your buyer."
-            className="list-none cursor-pointer font-mono text-[11px] text-[var(--color-cyan)] px-3 py-2 marker:hidden [&::-webkit-details-marker]:hidden"
-          >
-            ⚙ Tune ranking ▸
-          </summary>
-          <div className="px-3 pb-3">
-            <div className="flex items-center justify-between mt-1.5 gap-2">
-              <span
-                title={RANKING_HELP}
-                className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted cursor-help underline decoration-dotted decoration-white/25 underline-offset-2"
-              >
-                This screen&apos;s own ranking{" "}
-                <span aria-hidden className="text-text-muted/50 no-underline">ⓘ</span>
-              </span>
-              <label
-                title={AI_HELP}
-                className="font-mono text-[10.5px] text-[var(--color-cyan)] inline-flex items-center gap-1.5 cursor-help shrink-0"
-              >
-                <input
-                  type="checkbox"
-                  checked={config.aiMultiplier}
-                  onChange={(e) => patch({ aiMultiplier: e.target.checked })}
-                  className="accent-[var(--color-cyan)]"
-                />
-                AI bull/bear ×
-              </label>
-            </div>
-            {(["quality", "value", "momentum"] as const).map((k) => (
-              <div key={k} className="mt-2.5">
-                <div className="flex justify-between font-mono text-[11px] text-text-muted capitalize">
-                  <span
-                    title={WEIGHT_HELP[k]}
-                    className="cursor-help underline decoration-dotted decoration-white/25 underline-offset-2"
-                  >
-                    {k} <span aria-hidden className="text-text-muted/50 no-underline">ⓘ</span>
-                  </span>
-                  <span className="text-text">{config.weights[k]}</span>
-                </div>
-                <input
-                  type="range"
-                  min={0}
-                  max={100}
-                  value={config.weights[k]}
-                  onChange={(e) => patch({ weights: { ...config.weights, [k]: Number(e.target.value) } })}
-                  className="w-full accent-[var(--color-cyan)]"
-                  aria-label={`${k} weight, ${config.weights[k]} of 100`}
-                  title={WEIGHT_HELP[k]}
-                />
-              </div>
-            ))}
-            <div className="mt-3">
-              <div className="flex justify-between font-mono text-[11px] text-text-muted">
-                <span
-                  title={TOPN_HELP}
-                  className="cursor-help underline decoration-dotted decoration-white/25 underline-offset-2"
-                >
-                  Top N → buyer <span aria-hidden className="text-text-muted/50 no-underline">ⓘ</span>
-                </span>
-                <span className="text-[var(--color-cyan)]">{config.topN}</span>
-              </div>
-              <input
-                type="range"
-                min={10}
-                max={100}
-                value={config.topN}
-                onChange={(e) => patch({ topN: Math.max(1, Math.min(200, Number(e.target.value))) })}
-                className="w-full accent-[var(--color-cyan)]"
-                aria-label={`Top N candidates, ${config.topN}`}
-                title={TOPN_HELP}
-              />
-            </div>
-          </div>
-        </details>
       </div>
 
       {/* Advanced raw add row */}
@@ -445,47 +368,6 @@ export default function ScreenerClient({
           }}
         />
       )}
-
-      {/* How this works — Screen → top N → Portfolio (one bridge, not a pipeline) */}
-      <div className="mt-4 mb-4">
-        <div className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted mb-2">
-          How this works
-        </div>
-        <div className="flex items-stretch gap-0 flex-wrap">
-          <div className="flex-1 min-w-[200px] rounded-xl border border-[var(--color-cyan)]/45 bg-[var(--color-cyan)]/[0.06] p-3.5">
-            <div className="font-mono text-[12px] text-[var(--color-cyan)]">
-              ● THIS SCREEN{" "}
-              <span className="text-[9px] text-text-muted tracking-[0.05em]">YOU ARE HERE</span>
-            </div>
-            <div className="text-[11px] text-text-muted mt-1.5 leading-relaxed">
-              Ranks every US equity by your config. Re-ranks live.
-            </div>
-          </div>
-          <div className="flex-[0_0_130px] min-w-[120px] flex flex-col items-center justify-center px-1">
-            <div className="font-mono text-[10px] text-green">top {config.topN}</div>
-            <div
-              className="w-full h-px my-1.5 relative"
-              style={{ background: "linear-gradient(90deg,rgba(38,224,240,.5),rgba(55,219,128,.5))" }}
-            >
-              <span className="absolute -right-0.5 -top-[5px] text-green text-[11px]">▶</span>
-            </div>
-            <div className="font-mono text-[9px] text-text-muted">candidates</div>
-          </div>
-          <Link
-            href={runHref}
-            className="flex-1 min-w-[200px] rounded-xl border border-green/45 bg-green/[0.06] p-3.5 hover:bg-green/[0.1] transition-colors"
-          >
-            <div className="font-mono text-[12px] text-green">PORTFOLIO →</div>
-            <div className="text-[11px] text-text-muted mt-1.5 leading-relaxed">
-              Your <span className="text-text">swarm</span> drafts &amp; trades them — marked to
-              market, daily.
-            </div>
-            <div className="font-mono text-[10px] text-green mt-2">
-              Run this screen as a portfolio →
-            </div>
-          </Link>
-        </div>
-      </div>
 
       {/* Count + actions */}
       <div className="font-mono text-[10.5px] text-text-muted flex justify-between flex-wrap gap-1.5 mb-2">
@@ -510,6 +392,87 @@ export default function ScreenerClient({
           )}
         </span>
       </div>
+
+      {/* Configure scoring — sits right above the table it drives */}
+      <details className={`mb-2 ${card}`}>
+        <summary
+          title="Configure how the Score is computed — the balance of Quality, Value and Momentum, the AI multiplier, and how many top names flow to a portfolio."
+          className="list-none cursor-pointer font-mono text-[11px] text-[var(--color-cyan)] px-3 py-2 marker:hidden [&::-webkit-details-marker]:hidden flex items-center justify-between"
+        >
+          <span>⚙ Configure scoring</span>
+          <span className="text-text-muted/60">
+            Q {config.weights.quality} · V {config.weights.value} · M {config.weights.momentum}
+            {config.aiMultiplier ? " · AI×" : ""} · top {config.topN} ▾
+          </span>
+        </summary>
+        <div className="px-3 pb-3 sm:max-w-[520px]">
+          <div className="flex items-center justify-between mt-1.5 gap-2">
+            <span
+              title={RANKING_HELP}
+              className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted cursor-help underline decoration-dotted decoration-white/25 underline-offset-2"
+            >
+              This screen&apos;s own ranking{" "}
+              <span aria-hidden className="text-text-muted/50 no-underline">ⓘ</span>
+            </span>
+            <label
+              title={AI_HELP}
+              className="font-mono text-[10.5px] text-[var(--color-cyan)] inline-flex items-center gap-1.5 cursor-help shrink-0"
+            >
+              <input
+                type="checkbox"
+                checked={config.aiMultiplier}
+                onChange={(e) => patch({ aiMultiplier: e.target.checked })}
+                className="accent-[var(--color-cyan)]"
+              />
+              AI bull/bear ×
+            </label>
+          </div>
+          {(["quality", "value", "momentum"] as const).map((k) => (
+            <div key={k} className="mt-2.5">
+              <div className="flex justify-between font-mono text-[11px] text-text-muted capitalize">
+                <span
+                  title={WEIGHT_HELP[k]}
+                  className="cursor-help underline decoration-dotted decoration-white/25 underline-offset-2"
+                >
+                  {k} <span aria-hidden className="text-text-muted/50 no-underline">ⓘ</span>
+                </span>
+                <span className="text-text">{config.weights[k]}</span>
+              </div>
+              <input
+                type="range"
+                min={0}
+                max={100}
+                value={config.weights[k]}
+                onChange={(e) => patch({ weights: { ...config.weights, [k]: Number(e.target.value) } })}
+                className="w-full accent-[var(--color-cyan)]"
+                aria-label={`${k} weight, ${config.weights[k]} of 100`}
+                title={WEIGHT_HELP[k]}
+              />
+            </div>
+          ))}
+          <div className="mt-3">
+            <div className="flex justify-between font-mono text-[11px] text-text-muted">
+              <span
+                title={TOPN_HELP}
+                className="cursor-help underline decoration-dotted decoration-white/25 underline-offset-2"
+              >
+                Top N → portfolio <span aria-hidden className="text-text-muted/50 no-underline">ⓘ</span>
+              </span>
+              <span className="text-[var(--color-cyan)]">{config.topN}</span>
+            </div>
+            <input
+              type="range"
+              min={10}
+              max={100}
+              value={config.topN}
+              onChange={(e) => patch({ topN: Math.max(1, Math.min(200, Number(e.target.value))) })}
+              className="w-full accent-[var(--color-cyan)]"
+              aria-label={`Top N candidates, ${config.topN}`}
+              title={TOPN_HELP}
+            />
+          </div>
+        </div>
+      </details>
 
       {/* Results */}
       <div className={`${card} overflow-hidden`}>
@@ -597,6 +560,48 @@ export default function ScreenerClient({
           </span>
         </div>
       )}
+
+      {/* How this works — below the table so the graphic doesn't separate the
+          controls from the list they drive. Screen → top N → Portfolio. */}
+      <div className="mt-6 mb-2">
+        <div className="text-[10px] font-mono uppercase tracking-[0.12em] text-text-muted mb-2">
+          How this works
+        </div>
+        <div className="flex items-stretch gap-0 flex-wrap">
+          <div className="flex-1 min-w-[200px] rounded-xl border border-[var(--color-cyan)]/45 bg-[var(--color-cyan)]/[0.06] p-3.5">
+            <div className="font-mono text-[12px] text-[var(--color-cyan)]">
+              ● THIS SCREEN{" "}
+              <span className="text-[9px] text-text-muted tracking-[0.05em]">YOU ARE HERE</span>
+            </div>
+            <div className="text-[11px] text-text-muted mt-1.5 leading-relaxed">
+              Ranks every US equity by your config. Re-ranks live.
+            </div>
+          </div>
+          <div className="flex-[0_0_130px] min-w-[120px] flex flex-col items-center justify-center px-1">
+            <div className="font-mono text-[10px] text-green">top {config.topN}</div>
+            <div
+              className="w-full h-px my-1.5 relative"
+              style={{ background: "linear-gradient(90deg,rgba(38,224,240,.5),rgba(55,219,128,.5))" }}
+            >
+              <span className="absolute -right-0.5 -top-[5px] text-green text-[11px]">▶</span>
+            </div>
+            <div className="font-mono text-[9px] text-text-muted">candidates</div>
+          </div>
+          <Link
+            href={runHref}
+            className="flex-1 min-w-[200px] rounded-xl border border-green/45 bg-green/[0.06] p-3.5 hover:bg-green/[0.1] transition-colors"
+          >
+            <div className="font-mono text-[12px] text-green">PORTFOLIO →</div>
+            <div className="text-[11px] text-text-muted mt-1.5 leading-relaxed">
+              Your <span className="text-text">swarm</span> drafts &amp; trades them — marked to
+              market, daily.
+            </div>
+            <div className="font-mono text-[10px] text-green mt-2">
+              Run this screen as a portfolio →
+            </div>
+          </Link>
+        </div>
+      </div>
 
       {/* Related screens */}
       <nav className="mt-5 flex gap-4 flex-wrap text-[12px] text-text-muted" aria-label="Related screens">


### PR DESCRIPTION
## Screener: working "Run as a portfolio" + scoring panel next to the table

The two screener changes that landed after #1346 merged (so they weren't in it). Single clean diff off current `main` — `screener-client.tsx` + a new route.

### "Run this screen as a portfolio" actually works now
Previously the CTA pointed at `/account?from=screen`, which is the **deprecated control-room page** and never consumed the config. New behaviour: it hits **`GET /screener/run?config=…`** which:
- applies the screen as the owner's portfolio selection recipe (`portfolios.screen_config`, owner-gated), then
- redirects to **`/portfolios/<slug>`** (the real portfolio page).
- Not signed in → `/login?next=…` so it completes after auth; no portfolio yet → `/account` create flow carrying the config.

### Scoring controls sit next to the table they drive
- Brief helper reworded: **"the compiled filters & weights are what drive the screener"** (was the misleading "what the buyer reads").
- **"Tune ranking" → "⚙ Configure scoring"**, moved from the far-right of the filter bar to **directly above the table**, with a live `Q·V·M · top N` summary in the collapsed header.
- The **"How this works" signpost moved below the table**, so the graphic no longer wedges between the controls (filters + scoring) and the list.

`tsc --noEmit` clean.

https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN)_