### PR TITLE
Fix portfolio page server error after applying a screen (btoa em-dash crash)

### DIFF
--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -29,6 +29,7 @@ import {
   type InvestmentThesis,
 } from "@/lib/theses-query";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { b64urlEncode } from "@/lib/screen/config";
 
 export const revalidate = 300;
 
@@ -243,7 +244,7 @@ export default async function PortfolioPage({ params }: PageParams) {
   // SCREEN node links to this portfolio's own compiled screen (same encoding
   // as SwarmConfig's "→ your screen" link), or the bare screener as fallback.
   const screenHref = portfolio.screen_config
-    ? `/screener?config=${b64url(JSON.stringify(portfolio.screen_config))}`
+    ? `/screener?config=${b64urlEncode(JSON.stringify(portfolio.screen_config))}`
     : "/screener";
 
   return (
@@ -548,16 +549,6 @@ function Stat({
       </p>
     </div>
   );
-}
-
-// URL-safe base64 of the screen config — same encoding as SwarmConfig's
-// "→ your screen" link, so the graphic's SCREEN node opens the same screen.
-function b64url(s: string): string {
-  const b =
-    typeof btoa === "function"
-      ? btoa(s)
-      : Buffer.from(s, "utf8").toString("base64");
-  return b.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
 function formatUsd(n: number): string {

--- a/web/components/portfolio/swarm-config.tsx
+++ b/web/components/portfolio/swarm-config.tsx
@@ -16,6 +16,7 @@ import {
   setMemberSwarmConfig,
   setDraftConfig,
 } from "@/lib/portfolios-mutations";
+import { b64urlEncode } from "@/lib/screen/config";
 
 interface Member {
   agent_id: string;
@@ -71,11 +72,6 @@ const BLOCKS: { group: string; items: { label: string; text: string; star?: bool
   },
 ];
 
-function b64url(s: string): string {
-  const b = typeof btoa === "function" ? btoa(s) : Buffer.from(s, "utf8").toString("base64");
-  return b.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
 export default function SwarmConfig({
   portfolioId,
   slug,
@@ -93,7 +89,7 @@ export default function SwarmConfig({
   const reviewers = members.filter((m) => m.role === "reviewer");
   const topN = Number((screenConfig as { topN?: number } | null)?.topN ?? 40);
   const screenHref = screenConfig
-    ? `/screener?config=${b64url(JSON.stringify(screenConfig))}`
+    ? `/screener?config=${b64urlEncode(JSON.stringify(screenConfig))}`
     : "/screener";
 
   function flash(m: string) {

--- a/web/lib/screen/config.ts
+++ b/web/lib/screen/config.ts
@@ -150,7 +150,7 @@ export function presetConfig(id: string): ScreenConfig {
 // (InvalidCharacterError) on any non-ASCII char — and a brief routinely
 // contains an em-dash, "≤", curly quotes, etc. Use Buffer on the server (UTF-8
 // native) and TextEncoder/TextDecoder on the browser.
-function b64urlEncode(s: string): string {
+export function b64urlEncode(s: string): string {
   let b: string;
   if (typeof Buffer !== "undefined") {
     b = Buffer.from(s, "utf8").toString("base64");


### PR DESCRIPTION
## The bug

Clicking **Run this screen as a portfolio** (or the **Portfolio** signpost link) redirected to `/portfolios/<slug>?screen=applied`, which rendered **"This page couldn't load — a server error occurred."**

## Root cause

The same `btoa()` UTF-8 bug we already fixed in the screener. `/screener/run` writes the compiled `screen_config` to `portfolios.screen_config`, and that config **includes the prose `brief`** — every house preset's brief contains an em-dash (`—`). The portfolio page then builds the SCREEN-node link with a local `b64url()` that calls `btoa(JSON.stringify(screen_config))`. `btoa` is Latin1-only and throws `InvalidCharacterError` on the em-dash, crashing the Server Component render.

The same broken `b64url` lived in the client-side `SwarmConfig` (browser `btoa`, same Latin1 limitation), so the owner's "→ your screen" link would have hit it too.

## Fix

- Export the already-UTF-8-safe `b64urlEncode` from `web/lib/screen/config.ts` (prefers `Buffer`, falls back to `TextEncoder`+`btoa` over raw bytes) as the single source of truth.
- Delete the duplicated, broken local `b64url` in `web/app/portfolios/[slug]/page.tsx` and `web/components/portfolio/swarm-config.tsx`; both now import the shared encoder.

The decode side (`configFromParams` → `b64urlDecode`) was already UTF-8-safe, so the round-trip back into `/screener?config=` is fine.

`npx tsc --noEmit` is clean.

https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN)_