### PR TITLE
Repoint /api/v1 equities at the Level 0 universe (full ~3.2k Tier 1, incl. mega-caps)

### DIFF
--- a/migrations/043_api_universe_facts.sql
+++ b/migrations/043_api_universe_facts.sql
@@ -1,0 +1,96 @@
+-- 043_api_universe_facts.sql
+--
+-- Level 0-backed read for the public REST API (/api/v1/equities + /equities/{ticker})
+-- and the MCP equity tools. The legacy endpoints read the curated `companies`
+-- table (~1k growth-screen names, mega-caps excluded by the TradingView screen),
+-- which is why NVDA/AAPL/MSFT 404 and the count is capped near 1,029. This RPC
+-- exposes the real universe the screener UI uses: every active Tier 1 security
+-- (~3.2k liquid US equities incl. mega-caps) with its latest fundamentals /
+-- valuation / price folded in.
+--
+-- Modelled on screen_facts() (migration 042) but:
+--   * LEFT JOIN fundamentals/valuation (not INNER) so the FULL Tier 1 set comes
+--     back — a name with prices but not-yet-backfilled fundamentals still lists,
+--     just with null metrics.
+--   * adds identity columns (exchange, security_type, status, ipo_date).
+--   * output columns named to match the legacy `companies` field names where they
+--     map (company_name, sector, ps_now, rev_growth_ttm_pct, gross_margin_pct, …)
+--     so existing REST clients keep parsing, now over the full universe.
+
+CREATE OR REPLACE FUNCTION public.api_universe_facts()
+RETURNS TABLE(
+  ticker text, company_name text, exchange text, security_type text,
+  sector text, industry text, country text, status text, ipo_date date,
+  is_tier1 boolean,
+  price numeric, price_asof date,
+  rev_growth_ttm_pct numeric, rev_growth_qoq_pct numeric, rev_cagr_pct numeric,
+  gross_margin_pct numeric, operating_margin_pct numeric, net_margin_pct numeric,
+  fcf_margin_pct numeric, rule_of_40 numeric, eps_only numeric,
+  fundamentals_asof date,
+  ps_now numeric, ps_median_12m numeric, ps_high_52w numeric, ps_low_52w numeric,
+  ps_pct_of_ath numeric, valuation_asof date,
+  ret_52w numeric, bull boolean, bear boolean
+)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+    SELECT
+        s.ticker,
+        s.name,
+        s.exchange,
+        s.security_type,
+        s.gics_sector,
+        s.gics_industry,
+        s.country,
+        s.status,
+        s.ipo_date,
+        s.is_tier1,
+        lp.close,
+        lp.date,
+        f.rev_growth_ttm,
+        f.rev_growth_qoq,
+        f.rev_cagr,
+        f.gross_margin,
+        f.operating_margin,
+        f.net_margin,
+        f.fcf_margin,
+        f.rule_of_40,
+        f.eps,
+        f.period_end,
+        v.ps,
+        v.ps_median_12m,
+        v.ps_high_52w,
+        v.ps_low_52w,
+        v.ps_pct_of_ath,
+        v.date,
+        CASE WHEN p52.close IS NOT NULL AND p52.close > 0
+             THEN (lp.close / p52.close - 1) * 100 END,
+        CASE WHEN left(c.bull_eval, 1) = '✅' THEN true
+             WHEN left(c.bull_eval, 1) = '❌' THEN false END,
+        CASE WHEN left(c.bear_eval, 1) = '✅' THEN true
+             WHEN left(c.bear_eval, 1) = '❌' THEN false END
+    FROM securities s
+    LEFT JOIN LATERAL (
+        SELECT * FROM fundamentals fd
+        WHERE fd.ticker = s.ticker ORDER BY fd.period_end DESC LIMIT 1
+    ) f ON true
+    LEFT JOIN LATERAL (
+        SELECT close, date FROM prices_daily pd
+        WHERE pd.ticker = s.ticker ORDER BY pd.date DESC LIMIT 1
+    ) lp ON true
+    LEFT JOIN LATERAL (
+        SELECT close FROM prices_daily pd
+        WHERE pd.ticker = s.ticker AND pd.date <= (CURRENT_DATE - INTERVAL '52 weeks')
+        ORDER BY pd.date DESC LIMIT 1
+    ) p52 ON true
+    LEFT JOIN LATERAL (
+        SELECT * FROM valuation vl
+        WHERE vl.ticker = s.ticker ORDER BY vl.date DESC LIMIT 1
+    ) v ON true
+    LEFT JOIN companies c ON c.ticker = s.ticker
+    WHERE s.is_tier1 AND s.status = 'active'
+    ORDER BY s.ticker;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.api_universe_facts() TO anon, authenticated, service_role;

--- a/web/lib/equities-query.ts
+++ b/web/lib/equities-query.ts
@@ -1,117 +1,45 @@
 /**
- * Shared Supabase query logic for equities.
+ * Shared equity query logic for the REST v1 API routes and the MCP tool
+ * handlers, so the two surfaces return identical shapes.
  *
- * Used by both the REST v1 API routes and the MCP tool handlers so the
- * two surfaces return identical shapes and respect identical limits.
+ * As of migration 043 these read **Level 0** (the full ~3.2k Tier 1 universe of
+ * liquid US equities, incl. mega-caps) via `level0-query`, NOT the legacy
+ * curated `companies` table. This is what fixed the public-API/UI mismatch:
+ * `/api/v1/equities` now lists the same universe the screener shows, and
+ * `/equities/{ticker}` resolves names like NVDA/AAPL/MSFT that never existed in
+ * `companies`. The function names are kept for back-compat with existing
+ * importers; the row shape is `Level0Equity`.
  */
 
-import { getSupabase } from "@/lib/supabase";
-import { Company, PriceSales, SCREENER_COLUMNS } from "@/lib/types";
+import {
+  listEquitiesL0,
+  getEquityL0,
+  searchEquitiesL0,
+  type Level0Equity,
+  type Level0ListResult,
+  type Level0ListFilters,
+  DEFAULT_LIMIT,
+  MAX_LIMIT,
+} from "@/lib/level0-query";
 
-export interface EquityListFilters {
-  status?: string | null;
-  sector?: string | null;
-  country?: string | null;
-  limit?: number | null;
-  offset?: number | null;
-}
+export type Equity = Level0Equity;
+export type EquityListFilters = Level0ListFilters;
+export type EquityListResult = Level0ListResult;
+export { DEFAULT_LIMIT, MAX_LIMIT };
 
-export const DEFAULT_LIMIT = 1000;
-export const MAX_LIMIT = 1000;
-
-export interface EquityListResult {
-  equities: Partial<Company>[];
-  count: number;
-  limit: number;
-  offset: number;
-}
-
-export async function listEquities(
+export function listEquities(
   filters: EquityListFilters = {},
 ): Promise<EquityListResult> {
-  const limit = Math.min(
-    Math.max(Number(filters.limit ?? DEFAULT_LIMIT) || DEFAULT_LIMIT, 1),
-    MAX_LIMIT,
-  );
-  const offset = Math.max(Number(filters.offset ?? 0) || 0, 0);
-
-  const supabase = getSupabase();
-  let query = supabase
-    .from("companies")
-    .select(SCREENER_COLUMNS)
-    .order("sort_order", { ascending: true, nullsFirst: false });
-
-  if (filters.status) {
-    query = query.ilike("status", `%${filters.status}%`);
-  }
-  if (filters.sector) {
-    query = query.eq("sector", filters.sector);
-  }
-  if (filters.country) {
-    query = query.eq("country", filters.country);
-  }
-
-  query = query.range(offset, offset + limit - 1);
-
-  const { data, error } = await query;
-  if (error) {
-    throw new Error(`Supabase query failed: ${error.message}`);
-  }
-
-  const rows = (data ?? []) as unknown as Partial<Company>[];
-  return {
-    equities: rows,
-    count: rows.length,
-    limit,
-    offset,
-  };
+  return listEquitiesL0(filters);
 }
 
-export interface EquityDetailResult {
-  company: Company;
-  price_sales: PriceSales | null;
+export function getEquity(ticker: string): Promise<Equity | null> {
+  return getEquityL0(ticker);
 }
 
-export async function getEquity(
-  ticker: string,
-): Promise<EquityDetailResult | null> {
-  const normalized = ticker.trim().toUpperCase();
-  if (!normalized) return null;
-
-  const supabase = getSupabase();
-  const [companyRes, psRes] = await Promise.all([
-    supabase.from("companies").select("*").eq("ticker", normalized).maybeSingle(),
-    supabase.from("price_sales").select("*").eq("ticker", normalized).maybeSingle(),
-  ]);
-
-  if (companyRes.error) {
-    throw new Error(`Supabase query failed: ${companyRes.error.message}`);
-  }
-  if (!companyRes.data) return null;
-
-  return {
-    company: companyRes.data as Company,
-    price_sales: (psRes.data as PriceSales | null) ?? null,
-  };
-}
-
-export async function searchEquities(
+export function searchEquities(
   query: string,
   limit = 25,
-): Promise<Partial<Company>[]> {
-  const q = query.trim();
-  if (!q) return [];
-
-  const supabase = getSupabase();
-  const { data, error } = await supabase
-    .from("companies")
-    .select(SCREENER_COLUMNS)
-    .or(`ticker.ilike.%${q}%,company_name.ilike.%${q}%`)
-    .order("sort_order", { ascending: true, nullsFirst: false })
-    .limit(Math.min(Math.max(limit, 1), 100));
-
-  if (error) {
-    throw new Error(`Supabase query failed: ${error.message}`);
-  }
-  return (data ?? []) as unknown as Partial<Company>[];
+): Promise<Equity[]> {
+  return searchEquitiesL0(query, limit);
 }

--- a/web/lib/level0-query.ts
+++ b/web/lib/level0-query.ts
@@ -1,0 +1,215 @@
+/**
+ * Level 0-backed equity reads for the public REST API (/api/v1/equities +
+ * /equities/{ticker}) and the MCP equity tools.
+ *
+ * The legacy `companies` table (curated TradingView growth screen, ~1k names,
+ * mega-caps excluded) used to back these surfaces — which is why NVDA/AAPL/MSFT
+ * 404'd and the count capped near 1,029. This module reads the real universe
+ * instead: every active Tier 1 security (~3.2k liquid US equities incl.
+ * mega-caps) with latest fundamentals / valuation / price, via the
+ * `api_universe_facts()` RPC (migration 043).
+ *
+ * The full set (~3.2k rows) is loaded once and held in a 5-minute process cache
+ * — the same pattern the screener uses (see web/lib/screen/query.ts) — so list
+ * / detail / search are in-memory filters over a single cached snapshot rather
+ * than a Postgres round-trip each.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+
+export interface Level0Equity {
+  ticker: string;
+  company_name: string | null;
+  exchange: string | null;
+  security_type: string | null;
+  sector: string | null;
+  industry: string | null;
+  country: string | null;
+  /** Tier 0 listing status — 'active' (delisted names are excluded here). */
+  status: string | null;
+  ipo_date: string | null;
+  is_tier1: boolean;
+  price: number | null;
+  price_asof: string | null;
+  rev_growth_ttm_pct: number | null;
+  rev_growth_qoq_pct: number | null;
+  rev_cagr_pct: number | null;
+  gross_margin_pct: number | null;
+  operating_margin_pct: number | null;
+  net_margin_pct: number | null;
+  fcf_margin_pct: number | null;
+  rule_of_40: number | null;
+  eps_only: number | null;
+  /** period_end of the latest fundamentals row (null if not yet enriched). */
+  fundamentals_asof: string | null;
+  ps_now: number | null;
+  ps_median_12m: number | null;
+  ps_high_52w: number | null;
+  ps_low_52w: number | null;
+  ps_pct_of_ath: number | null;
+  valuation_asof: string | null;
+  /** Trailing 52-week price return, % (raw, not vs SPY). */
+  ret_52w: number | null;
+  /** Folded AI verdict: true = ✅, false = ❌, null = no eval. */
+  bull: boolean | null;
+  bear: boolean | null;
+}
+
+export interface Level0ListFilters {
+  status?: string | null;
+  sector?: string | null;
+  country?: string | null;
+  limit?: number | null;
+  offset?: number | null;
+}
+
+export interface Level0ListResult {
+  equities: Level0Equity[];
+  /** Rows returned in this page. */
+  count: number;
+  /** Total rows matching the filters (across all pages). */
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export const DEFAULT_LIMIT = 1000;
+// The full Tier 1 universe is ~3.2k, so allow a single call to fetch all of it.
+export const MAX_LIMIT = 5000;
+
+const PAGE = 1000;
+const TTL_MS = 5 * 60 * 1000;
+
+let cache: { at: number; data: Level0Equity[] } | null = null;
+let inflight: Promise<Level0Equity[]> | null = null;
+
+function num(v: unknown): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function mapRow(r: Record<string, unknown>): Level0Equity {
+  return {
+    ticker: r.ticker as string,
+    company_name: (r.company_name as string) ?? null,
+    exchange: (r.exchange as string) ?? null,
+    security_type: (r.security_type as string) ?? null,
+    sector: (r.sector as string) ?? null,
+    industry: (r.industry as string) ?? null,
+    country: (r.country as string) ?? null,
+    status: (r.status as string) ?? null,
+    ipo_date: (r.ipo_date as string) ?? null,
+    is_tier1: Boolean(r.is_tier1),
+    price: num(r.price),
+    price_asof: (r.price_asof as string) ?? null,
+    rev_growth_ttm_pct: num(r.rev_growth_ttm_pct),
+    rev_growth_qoq_pct: num(r.rev_growth_qoq_pct),
+    rev_cagr_pct: num(r.rev_cagr_pct),
+    gross_margin_pct: num(r.gross_margin_pct),
+    operating_margin_pct: num(r.operating_margin_pct),
+    net_margin_pct: num(r.net_margin_pct),
+    fcf_margin_pct: num(r.fcf_margin_pct),
+    rule_of_40: num(r.rule_of_40),
+    eps_only: num(r.eps_only),
+    fundamentals_asof: (r.fundamentals_asof as string) ?? null,
+    ps_now: num(r.ps_now),
+    ps_median_12m: num(r.ps_median_12m),
+    ps_high_52w: num(r.ps_high_52w),
+    ps_low_52w: num(r.ps_low_52w),
+    ps_pct_of_ath: num(r.ps_pct_of_ath),
+    valuation_asof: (r.valuation_asof as string) ?? null,
+    ret_52w: num(r.ret_52w),
+    bull: (r.bull as boolean | null) ?? null,
+    bear: (r.bear as boolean | null) ?? null,
+  };
+}
+
+async function fetchUniverse(): Promise<Level0Equity[]> {
+  const supabase = getSupabase();
+  const rows: Record<string, unknown>[] = [];
+  // ~3.2k rows = 4 PostgREST pages.
+  for (let page = 0; ; page++) {
+    const { data, error } = await supabase
+      .rpc("api_universe_facts")
+      .range(page * PAGE, (page + 1) * PAGE - 1);
+    if (error) {
+      console.error("api_universe_facts failed:", error.message);
+      break;
+    }
+    const batch = (data ?? []) as Record<string, unknown>[];
+    rows.push(...batch);
+    if (batch.length < PAGE) break;
+  }
+  return rows.map(mapRow);
+}
+
+/** Cached full-universe load — fresh within TTL, concurrent calls share a fetch. */
+export async function loadUniverse(): Promise<Level0Equity[]> {
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.data;
+  if (inflight) return inflight;
+  inflight = (async () => {
+    try {
+      const data = await fetchUniverse();
+      if (data.length) cache = { at: Date.now(), data };
+      return data.length ? data : (cache?.data ?? []);
+    } catch (err) {
+      console.error("loadUniverse failed:", err);
+      return cache?.data ?? [];
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+function clampLimit(limit?: number | null): number {
+  return Math.min(Math.max(Number(limit ?? DEFAULT_LIMIT) || DEFAULT_LIMIT, 1), MAX_LIMIT);
+}
+
+export async function listEquitiesL0(
+  filters: Level0ListFilters = {},
+): Promise<Level0ListResult> {
+  const limit = clampLimit(filters.limit);
+  const offset = Math.max(Number(filters.offset ?? 0) || 0, 0);
+
+  let rows = await loadUniverse();
+  if (filters.status) {
+    const s = filters.status.toLowerCase();
+    rows = rows.filter((r) => (r.status ?? "").toLowerCase().includes(s));
+  }
+  if (filters.sector) {
+    rows = rows.filter((r) => r.sector === filters.sector);
+  }
+  if (filters.country) {
+    rows = rows.filter((r) => r.country === filters.country);
+  }
+
+  const total = rows.length;
+  const page = rows.slice(offset, offset + limit);
+  return { equities: page, count: page.length, total, limit, offset };
+}
+
+export async function getEquityL0(ticker: string): Promise<Level0Equity | null> {
+  const normalized = ticker.trim().toUpperCase();
+  if (!normalized) return null;
+  const rows = await loadUniverse();
+  return rows.find((r) => r.ticker.toUpperCase() === normalized) ?? null;
+}
+
+export async function searchEquitiesL0(
+  query: string,
+  limit = 25,
+): Promise<Level0Equity[]> {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  const cap = Math.min(Math.max(limit, 1), 100);
+  const rows = await loadUniverse();
+  return rows
+    .filter(
+      (r) =>
+        r.ticker.toLowerCase().includes(q) ||
+        (r.company_name ?? "").toLowerCase().includes(q),
+    )
+    .slice(0, cap);
+}

--- a/web/lib/openapi-spec.ts
+++ b/web/lib/openapi-spec.ts
@@ -28,7 +28,7 @@ export const OPENAPI_SPEC = {
       get: {
         summary: "Get the daily universe snapshot",
         description:
-          "Returns the latest daily universe snapshot — the same JSON the internal LLM agents read at heartbeat time. One bulk fetch instead of N /equities calls. CDN-cached for 24h since snapshots are immutable per (date, detail). Use this for stage-1 shortlists or any agent that wants the whole universe in a single call.",
+          "Returns the latest daily snapshot of the curated growth screen (~900 names from the legacy `companies` pipeline) — the JSON the internal LLM narrative agents read at heartbeat time. CDN-cached 24h (immutable per date+detail). NOTE: this is the narrow curated set, NOT the full universe; for every liquid US equity (~3,200, incl. mega-caps) use GET /equities instead.",
         operationId: "getUniverse",
         parameters: [
           {
@@ -76,7 +76,7 @@ export const OPENAPI_SPEC = {
       get: {
         summary: "List equities",
         description:
-          "Returns companies in the AlphaMolt screener, ordered by sort_order (best rank first). Supports filtering by status, sector, and country.",
+          "Lists the full Level 0 universe — every active Tier 1 liquid US equity (~3,200 names, including mega-caps like NVDA/AAPL/MSFT), one row per security with its latest fundamentals, valuation (P/S) and price folded in. This is the same universe the screener UI ranks. Ordered by ticker. Names not yet enriched return null metrics but still list. Supports filtering by status, sector, and country, and offset/limit pagination — read `total` to know how many pages to fetch.",
         operationId: "listEquities",
         parameters: [
           {
@@ -85,7 +85,7 @@ export const OPENAPI_SPEC = {
             required: false,
             schema: { type: "string" },
             description:
-              "Filter by screener status (case-insensitive substring match). Examples: 'Discount', 'Excluded'. Default-eligible rows have empty status.",
+              "Filter by Tier 0 listing status (case-insensitive substring). Only 'active' securities are returned, so this is rarely needed.",
           },
           {
             name: "sector",
@@ -105,7 +105,9 @@ export const OPENAPI_SPEC = {
             name: "limit",
             in: "query",
             required: false,
-            schema: { type: "integer", minimum: 1, maximum: 1000, default: 1000 },
+            schema: { type: "integer", minimum: 1, maximum: 5000, default: 1000 },
+            description:
+              "Max rows to return (default 1000, max 5000 — large enough to fetch the whole universe in one call).",
           },
           {
             name: "offset",
@@ -341,7 +343,7 @@ export const OPENAPI_SPEC = {
       get: {
         summary: "Get equity detail",
         description:
-          "Returns full company record including AI narrative, agent evaluations, flags, and P/S history for the given ticker.",
+          "Returns the Level 0 universe record for a ticker — identity plus latest fundamentals, valuation (P/S) and price. Resolves any active Tier 1 US equity, including mega-caps (NVDA, AAPL, MSFT, …). 404 if the ticker is not an active Tier 1 security.",
         operationId: "getEquity",
         parameters: [
           {
@@ -405,46 +407,80 @@ export const OPENAPI_SPEC = {
       EquitySummary: {
         type: "object",
         description:
-          "Lightweight equity row returned by the list endpoint. A subset of the full Equity schema.",
+          "A Level 0 universe equity: identity + latest fundamentals, valuation (P/S) and price. Returned by both the list endpoint and GET /equities/{ticker}. Metric fields are null for names not yet enriched.",
         properties: {
           ticker: { type: "string" },
-          exchange: { type: "string" },
-          company_name: { type: "string" },
-          sector: { type: "string" },
-          country: { type: "string" },
-          status: { type: "string" },
-          composite_score: { type: ["number", "null"] },
+          company_name: { type: ["string", "null"] },
+          exchange: { type: ["string", "null"] },
+          security_type: {
+            type: ["string", "null"],
+            description: "Common Stock | ADR | REIT.",
+          },
+          sector: { type: ["string", "null"], description: "GICS sector." },
+          industry: { type: ["string", "null"], description: "GICS industry." },
+          country: { type: ["string", "null"] },
+          status: {
+            type: ["string", "null"],
+            description: "Tier 0 listing status — always 'active' in this feed.",
+          },
+          ipo_date: { type: ["string", "null"], format: "date" },
+          is_tier1: { type: "boolean" },
           price: {
             type: ["number", "null"],
-            description:
-              "15-minute-delayed quote from EODHD, refreshed every 15 min during US market hours. Outside market hours, equals the prior trading day's last intraday tick (~21:45 UTC).",
+            description: "Latest Level 0 daily close (prices_daily).",
           },
           price_asof: {
             type: ["string", "null"],
-            format: "date-time",
-            description:
-              "ISO-8601 timestamp of the last price refresh. Pair with `price` to display freshness.",
+            format: "date",
+            description: "Date of the latest price.",
+          },
+          rev_growth_ttm_pct: { type: ["number", "null"] },
+          rev_growth_qoq_pct: { type: ["number", "null"] },
+          rev_cagr_pct: { type: ["number", "null"] },
+          gross_margin_pct: { type: ["number", "null"] },
+          operating_margin_pct: { type: ["number", "null"] },
+          net_margin_pct: { type: ["number", "null"] },
+          fcf_margin_pct: { type: ["number", "null"] },
+          rule_of_40: { type: ["number", "null"] },
+          eps_only: { type: ["number", "null"] },
+          fundamentals_asof: {
+            type: ["string", "null"],
+            format: "date",
+            description: "period_end of the latest fundamentals row, or null if not yet enriched.",
           },
           ps_now: { type: ["number", "null"] },
-          rev_growth_ttm_pct: { type: ["number", "null"] },
-          gross_margin_pct: { type: ["number", "null"] },
-          rating: { type: ["number", "null"] },
-          sort_order: { type: ["integer", "null"] },
-          bear_eval: { type: ["string", "null"] },
-          bull_eval: { type: ["string", "null"] },
-          perf_52w_vs_spy: { type: ["number", "null"] },
-          short_outlook: { type: ["string", "null"] },
+          ps_median_12m: { type: ["number", "null"] },
+          ps_high_52w: { type: ["number", "null"] },
+          ps_low_52w: { type: ["number", "null"] },
+          ps_pct_of_ath: { type: ["number", "null"] },
+          valuation_asof: { type: ["string", "null"], format: "date" },
+          ret_52w: {
+            type: ["number", "null"],
+            description: "Trailing 52-week price return, % (raw, not relative to SPY).",
+          },
+          bull: {
+            type: ["boolean", "null"],
+            description: "Folded AI bull verdict: true = ✅, false = ❌, null = no eval.",
+          },
+          bear: {
+            type: ["boolean", "null"],
+            description: "Folded AI bear verdict: true = ✅, false = ❌, null = no eval.",
+          },
         },
       },
       EquityList: {
         type: "object",
-        required: ["equities", "count", "limit", "offset"],
+        required: ["equities", "count", "total", "limit", "offset"],
         properties: {
           equities: {
             type: "array",
             items: { $ref: "#/components/schemas/EquitySummary" },
           },
-          count: { type: "integer" },
+          count: { type: "integer", description: "Rows in this page." },
+          total: {
+            type: "integer",
+            description: "Total rows matching the filters across all pages (~3,200 unfiltered).",
+          },
           limit: { type: "integer" },
           offset: { type: "integer" },
         },
@@ -721,17 +757,9 @@ export const OPENAPI_SPEC = {
         },
       },
       EquityDetail: {
-        type: "object",
-        required: ["company"],
-        properties: {
-          company: { $ref: "#/components/schemas/Company" },
-          price_sales: {
-            anyOf: [
-              { $ref: "#/components/schemas/PriceSales" },
-              { type: "null" },
-            ],
-          },
-        },
+        description:
+          "A single Level 0 universe equity (same shape as the list rows).",
+        allOf: [{ $ref: "#/components/schemas/EquitySummary" }],
       },
     },
   },


### PR DESCRIPTION
Closes the public-API / UI universe mismatch reported by a developer (chuckyegg/deathwatchbeetles): `/api/v1/equities` returned only the legacy curated `companies` set (~1,029, mega-caps 404'd), while the screener UI shows the full Level 0 Tier 1 universe (~3,200). This repoints the public REST API (and the MCP equity tools, which share the same query layer) at Level 0.

## Root cause
`/api/v1/equities`, `/equities/{ticker}` and the MCP tools all read `companies` via `equities-query.ts`. `companies` is the TradingView growth screen — market-cap band $500M–$500B + growth/sector filters — so NVDA/AAPL/MSFT never enter it (genuine 404), and the whole table is only ~1,029 rows (the "limit max=1000" cap was incidental).

## What changed
- **Migration 043** — new `api_universe_facts()` RPC (applied live). Modelled on `screen_facts()` but **LEFT JOIN**s fundamentals/valuation (so the *full* ~3,200 active Tier 1 set returns, enriched where available) and adds identity columns (exchange, security_type, status, ipo_date). Output columns named to match the legacy `companies` fields where they map (`company_name`, `sector`, `ps_now`, `rev_growth_ttm_pct`, `gross_margin_pct`, `rule_of_40`, …) so existing clients keep parsing.
- **`web/lib/level0-query.ts`** (new) — loads the universe once into a 5-min process cache (same pattern as the screener) and serves list / detail / search as in-memory filters. Adds `total` to the list result and lifts the limit cap to 5000 (one call can fetch the whole universe).
- **`web/lib/equities-query.ts`** — now a thin delegator to `level0-query` (same function names: `listEquities` / `getEquity` / `searchEquities`), so the REST routes **and** MCP tools migrate together with no route changes.
- **OpenAPI (`openapi-spec.ts`)** — updated `EquitySummary` to the Level 0 shape, `EquityList` gains `total`, `EquityDetail` is now the flat equity, `/equities` limit max→5000 + new descriptions, and `/universe` is relabelled as the *curated* agent snapshot with a pointer to `/equities` for the full set.

## Result
- `GET /api/v1/equities` → ~3,200 names (verified 3,223 from the RPC), incl. mega-caps, paginated with `total`.
- `GET /api/v1/equities/{ticker}` → resolves NVDA/AAPL/MSFT (all confirmed `is_tier1, active`, enriched).
- `/universe` stays the legacy agent snapshot by design, now documented as such.

## Shape change (breaking, intended)
The equity row is now the Level 0 shape — drops `companies`-only fields (`composite_score`, `sort_order`, `rating`, `short_outlook`, narrative, `bear_eval`/`bull_eval` strings) and adds `security_type`, `industry`, `ipo_date`, `ret_52w`, `fundamentals_asof`, `valuation_asof`, boolean `bull`/`bear`, and the P/S detail. `/equities/{ticker}` returns the flat equity (was `{company, price_sales}`). Metric fields are null for names not yet enriched (the Tier 1 fundamentals/valuation backfill is still completing).

`tsc --noEmit` clean. RPC verified live (3,223 rows; mega-caps present).

https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPD8JmN87bpqfB73LT5aPN)_