### PR TITLE
Portfolio add-agent: registry-backed gallery + rich seated cards (no free-text)

### DIFF
--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -6,9 +6,12 @@ import HoldingsList from "@/components/holdings-list";
 import { AgentMonogram } from "@/components/agent-monogram";
 import { TradeTape, type Trade } from "@/components/trade-tape";
 import VisibilityToggle from "@/components/portfolio/visibility-toggle";
-import SwarmConfig from "@/components/portfolio/swarm-config";
+import SwarmConfig, {
+  type AgentCatalogEntry,
+} from "@/components/portfolio/swarm-config";
 import PortfolioSignpost from "@/components/portfolio/portfolio-signpost";
 import SwarmLoop from "@/components/portfolio/swarm-loop";
+import { listPublicAgents, getAgentReturns30d } from "@/lib/agents-query";
 import BetaDisclaimer from "@/components/beta-disclaimer";
 import {
   getPortfolio,
@@ -120,6 +123,9 @@ async function getPortfolioPageData(slug: string): Promise<{
   trades: Trade[];
   totalTrades: number;
   holdingsCount: number;
+  /** Registry of hireable agents + 30d track record — owner-only (the swarm
+   *  picker). Empty for non-owners. */
+  catalog: AgentCatalogEntry[];
 }> {
   const portfolio = await resolveVisiblePortfolio(slug);
   if (!portfolio) {
@@ -133,6 +139,7 @@ async function getPortfolioPageData(slug: string): Promise<{
       trades: [],
       totalTrades: 0,
       holdingsCount: 0,
+      catalog: [],
     };
   }
   const isOwner = await isViewerOwner(portfolio);
@@ -194,6 +201,24 @@ async function getPortfolioPageData(slug: string): Promise<{
   ]);
   const { trades, totalTrades } = recent;
 
+  // Agent catalog for the owner's swarm picker: every hireable agent + its 30d
+  // track record. Owner-only — skipped entirely for non-owners.
+  let catalog: AgentCatalogEntry[] = [];
+  if (isOwner) {
+    const [agents, returns] = await Promise.all([
+      listPublicAgents(1000, true).catch(() => []),
+      getAgentReturns30d().catch(() => new Map<string, number | null>()),
+    ]);
+    catalog = agents.map((a) => ({
+      handle: a.handle,
+      displayName: a.display_name,
+      poweredBy: a.powered_by,
+      isHouse: a.is_house_agent,
+      strategy: a.strategy,
+      return30d: returns.get(a.handle) ?? null,
+    }));
+  }
+
   return {
     portfolio,
     isOwner,
@@ -204,6 +229,7 @@ async function getPortfolioPageData(slug: string): Promise<{
     trades,
     totalTrades,
     holdingsCount,
+    catalog,
   };
 }
 
@@ -223,6 +249,7 @@ export default async function PortfolioPage({ params }: PageParams) {
     trades,
     totalTrades,
     holdingsCount,
+    catalog,
   } = await getPortfolioPageData(slug);
   if (!portfolio) notFound();
 
@@ -340,10 +367,12 @@ export default async function PortfolioPage({ params }: PageParams) {
                   handle: m.handle,
                   display_name: m.display_name,
                   powered_by: m.powered_by,
+                  strategy: m.strategy,
                   role: m.role,
                   remit: m.remit,
                   config: m.config,
                 }))}
+                catalog={catalog}
                 screenConfig={portfolio.screen_config}
                 draftEnabled={!!portfolio.draft_config}
                 bookCount={bookCount}

--- a/web/components/portfolio/swarm-config.tsx
+++ b/web/components/portfolio/swarm-config.tsx
@@ -1,15 +1,23 @@
 "use client";
 
 /**
- * Config-in-place home for a portfolio (portfolio page brief). Owner-only:
- * the mandate (brief + building blocks), the swarm roster (buyers + reviewers
- * with per-member remit/knobs), the snake-draft toggle, and a thin link to the
- * portfolio's screen. Nothing here lives on the Dashboard.
+ * Config-in-place home for a portfolio (portfolio page brief + agent-selection
+ * follow-up). Owner-only: the mandate (brief + building blocks), the swarm
+ * coordination toggle, the engine loop, and the swarm roster (buyers +
+ * reviewers as rich cards). A thin link to the portfolio's screen.
+ *
+ * Agent selection is a registry-backed GALLERY — you pick a real registered
+ * agent by its track record; you never type a "brain" (that was the bug that
+ * kept regressing). remit + knobs are membership config set on top, per
+ * portfolio. Every mutation calls router.refresh() so the roster updates
+ * immediately.
  */
 
-import { useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import SwarmLoop from "@/components/portfolio/swarm-loop";
+import { roleFor } from "@/lib/agent-roles";
 import {
   updatePortfolioDetails,
   addAgentToPortfolio,
@@ -19,14 +27,26 @@ import {
 } from "@/lib/portfolios-mutations";
 import { b64urlEncode } from "@/lib/screen/config";
 
+type Role = "buyer" | "reviewer";
+
 interface Member {
   agent_id: string;
   handle: string;
   display_name: string;
   powered_by: string | null;
-  role: "buyer" | "reviewer" | null;
+  strategy: string | null;
+  role: Role | null;
   remit: string | null;
   config: Record<string, unknown> | null;
+}
+
+export interface AgentCatalogEntry {
+  handle: string;
+  displayName: string;
+  poweredBy: string | null;
+  isHouse: boolean;
+  strategy: string | null;
+  return30d: number | null;
 }
 
 interface Props {
@@ -35,19 +55,18 @@ interface Props {
   name: string;
   mandate: string;
   members: Member[];
+  catalog: AgentCatalogEntry[];
   screenConfig: Record<string, unknown> | null;
   draftEnabled: boolean;
   /** Current holdings count — feeds the swarm-loop "YOUR BOOK" live count. */
   bookCount: number;
 }
 
-// Curated building blocks (brief §2). Clicking inserts the phrase into the
-// brief; popular ones marked ★. A data-driven popularity list can come later.
-const BLOCKS: { group: string; items: { label: string; text: string; star?: boolean }[] }[] = [
+const BLOCKS: { group: string; items: { label: string; text: string }[] }[] = [
   {
     group: "Quality",
     items: [
-      { label: "★ Rule of 40 winners", text: "Rule of 40 winners", star: true },
+      { label: "★ Rule of 40 winners", text: "Rule of 40 winners" },
       { label: "Fat gross margins", text: "gross margin > 60%" },
       { label: "Strong FCF", text: "FCF margin > 10%" },
     ],
@@ -55,14 +74,14 @@ const BLOCKS: { group: string; items: { label: string; text: string; star?: bool
   {
     group: "Value",
     items: [
-      { label: "★ Cheap on sales", text: "P/S below its own 12-month median", star: true },
+      { label: "★ Cheap on sales", text: "P/S below its own 12-month median" },
       { label: "P/S < 15", text: "P/S < 15" },
     ],
   },
   {
     group: "Exclude",
     items: [
-      { label: "★ No biotech", text: "exclude Health Technology", star: true },
+      { label: "★ No biotech", text: "exclude Health Technology" },
       { label: "No finance", text: "exclude Finance" },
     ],
   },
@@ -75,22 +94,43 @@ const BLOCKS: { group: string; items: { label: string; text: string; star?: bool
   },
 ];
 
+/** The role a registered agent can fill, from its strategy (registry truth). */
+function strategyRole(strategy: string | null): Role | null {
+  const r = roleFor(strategy).role;
+  if (r === "Buying Agent") return "buyer";
+  if (r === "Reviewer") return "reviewer";
+  return null;
+}
+
+/** A seated member's effective role — explicit role, else inferred from
+ *  strategy so a buyer is never hidden just because role wasn't stamped. */
+function memberRole(m: Member): Role | null {
+  return m.role ?? strategyRole(m.strategy);
+}
+
+function fmtReturn(v: number | null): string {
+  if (v == null) return "—";
+  return `${v >= 0 ? "+" : ""}${v.toFixed(1)}%`;
+}
+
 export default function SwarmConfig({
   portfolioId,
   slug,
   name,
   mandate,
   members,
+  catalog,
   screenConfig,
   draftEnabled,
   bookCount,
 }: Props) {
+  const router = useRouter();
   const [brief, setBrief] = useState(mandate);
   const [msg, setMsg] = useState<string | null>(null);
   const [pending, start] = useTransition();
 
-  const buyers = members.filter((m) => m.role === "buyer");
-  const reviewers = members.filter((m) => m.role === "reviewer");
+  const buyers = members.filter((m) => memberRole(m) === "buyer");
+  const reviewers = members.filter((m) => memberRole(m) === "reviewer");
   const topN = Number((screenConfig as { topN?: number } | null)?.topN ?? 40);
   const screenHref = screenConfig
     ? `/screener?config=${b64urlEncode(JSON.stringify(screenConfig))}`
@@ -100,11 +140,15 @@ export default function SwarmConfig({
     setMsg(m);
     setTimeout(() => setMsg(null), 2500);
   }
+  function refresh() {
+    router.refresh();
+  }
 
   function saveBrief() {
     start(async () => {
       const r = await updatePortfolioDetails({ portfolioId, name, mandate: brief });
       flash(r.ok ? "Mandate saved" : r.error);
+      if (r.ok) refresh();
     });
   }
   function insertBlock(text: string) {
@@ -117,8 +161,14 @@ export default function SwarmConfig({
         draftConfig: on ? { order: "snake", cycle: "daily" } : null,
       });
       flash(r.ok ? (on ? "Swarm coordination on" : "Swarm coordination off") : r.error);
+      if (r.ok) refresh();
     });
   }
+
+  const seatedHandles = useMemo(
+    () => new Set(members.map((m) => m.handle)),
+    [members],
+  );
 
   return (
     <section className="space-y-6" aria-label="Portfolio configuration">
@@ -158,7 +208,7 @@ export default function SwarmConfig({
             </div>
           ))}
         </div>
-        <div className="mt-3 flex items-center gap-3">
+        <div className="mt-3 flex items-center gap-3 flex-wrap">
           <button
             type="button"
             onClick={saveBrief}
@@ -175,27 +225,41 @@ export default function SwarmConfig({
       </div>
 
       {/* Draft toggle */}
-      <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4 flex items-center justify-between">
-        <div>
-          <h2 className="text-sm font-semibold text-text">Swarm coordination</h2>
-          <p className="text-xs text-text-muted">
-            Snake-draft buying across your buyers (one name per turn, rotating
-            order, shared cash) + first-valid-sell across reviewers. Off = each
-            agent runs independently.
-          </p>
+      <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold text-text">Swarm coordination</h2>
+            <p className="text-xs text-text-muted">
+              Snake-draft buying across your buyers (one name per turn, rotating
+              order, shared cash) + first-valid-sell across reviewers. Off = each
+              agent runs independently.
+            </p>
+          </div>
+          <label className="font-mono text-[11px] text-green inline-flex items-center gap-2 shrink-0">
+            <input
+              type="checkbox"
+              checked={draftEnabled}
+              onChange={(e) => toggleDraft(e.target.checked)}
+            />
+            Run as a swarm
+          </label>
         </div>
-        <label className="font-mono text-[11px] text-green inline-flex items-center gap-2 shrink-0">
-          <input
-            type="checkbox"
-            checked={draftEnabled}
-            onChange={(e) => toggleDraft(e.target.checked)}
-          />
-          Run as a swarm
-        </label>
+        {draftEnabled && buyers.length > 0 && (
+          <p className="mt-2 font-mono text-[11px] text-text-muted">
+            draft order:{" "}
+            {buyers.map((b, i) => (
+              <span key={b.agent_id}>
+                {i > 0 && " → "}
+                <span className="text-text">{b.display_name}</span>
+              </span>
+            ))}{" "}
+            <span className="text-text-muted/60">(reverses each round)</span>
+          </p>
+        )}
       </div>
 
-      {/* How the swarm runs — the engine loop, shown right above the roster
-          you configure (brief §3). Spacing handled by the parent space-y-6. */}
+      {/* How the swarm runs — the engine loop, right above the roster you
+          configure (brief §3). Spacing handled by the parent space-y-6. */}
       <SwarmLoop
         buyers={buyers.length}
         reviewers={reviewers.length}
@@ -204,55 +268,78 @@ export default function SwarmConfig({
         className=""
       />
 
-      {/* Buyers */}
+      {/* Rosters — registry-backed gallery, no free-text brain. */}
       <RosterEditor
         title="Buyers"
         role="buyer"
-        members={buyers}
+        seated={buyers}
+        catalog={catalog}
+        seatedHandles={seatedHandles}
         portfolioId={portfolioId}
-        slug={slug}
         onFlash={flash}
+        onRefresh={refresh}
       />
-
-      {/* Reviewers */}
       <RosterEditor
         title="Reviewers"
         role="reviewer"
-        members={reviewers}
+        seated={reviewers}
+        catalog={catalog}
+        seatedHandles={seatedHandles}
         portfolioId={portfolioId}
-        slug={slug}
         onFlash={flash}
+        onRefresh={refresh}
       />
     </section>
+  );
+}
+
+function BrainBadge({ label }: { label: string | null }) {
+  if (!label) return null;
+  return (
+    <span className="text-[9px] font-mono uppercase tracking-[0.1em] text-green border border-green/30 rounded px-1.5 py-0.5">
+      {label}
+    </span>
   );
 }
 
 function RosterEditor({
   title,
   role,
-  members,
+  seated,
+  catalog,
+  seatedHandles,
   portfolioId,
   onFlash,
+  onRefresh,
 }: {
   title: string;
-  role: "buyer" | "reviewer";
-  members: Member[];
+  role: Role;
+  seated: Member[];
+  catalog: AgentCatalogEntry[];
+  seatedHandles: Set<string>;
   portfolioId: string;
-  slug: string;
   onFlash: (m: string) => void;
+  onRefresh: () => void;
 }) {
-  const [handle, setHandle] = useState("");
-  const [remit, setRemit] = useState("");
+  const [picking, setPicking] = useState(false);
   const [, start] = useTransition();
 
-  function add() {
-    if (!handle.trim()) return;
+  // Registry agents that can fill this role and aren't already seated, best
+  // track record first (the hero metric — people pick the winner).
+  const available = useMemo(
+    () =>
+      catalog
+        .filter((a) => strategyRole(a.strategy) === role && !seatedHandles.has(a.handle))
+        .sort((x, y) => (y.return30d ?? -1e9) - (x.return30d ?? -1e9)),
+    [catalog, role, seatedHandles],
+  );
+
+  function addAgent(handle: string) {
     start(async () => {
       const r = await addAgentToPortfolio({
         portfolioId,
-        handle: handle.trim(),
+        handle,
         role,
-        remit: remit.trim() || undefined,
         config:
           role === "buyer"
             ? { convictionGate: 1, maxPerName: 0.08, cadence: "daily" }
@@ -260,74 +347,239 @@ function RosterEditor({
       });
       onFlash(r.ok ? `Added ${handle}` : r.error);
       if (r.ok) {
-        setHandle("");
-        setRemit("");
+        setPicking(false);
+        onRefresh();
       }
     });
   }
 
+  const subtitle =
+    role === "buyer" ? "opens positions" : "manages & sells";
+
   return (
     <div className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
-      <h2 className="text-sm font-semibold text-text mb-2">
-        {title}{" "}
-        <span className="text-text-muted font-normal">({members.length})</span>
-      </h2>
-      <div className="grid gap-2 sm:grid-cols-2">
-        {members.map((m) => (
-          <AgentCard
-            key={m.agent_id}
-            member={m}
-            role={role}
-            portfolioId={portfolioId}
-            onFlash={onFlash}
-          />
-        ))}
-        {members.length === 0 && (
-          <p className="text-xs text-text-muted">No {title.toLowerCase()} yet.</p>
-        )}
-      </div>
-
-      <div className="mt-3 flex items-end gap-2 flex-wrap">
-        <label className="text-[11px] text-text-muted">
-          Add a {role}
-          <input
-            value={handle}
-            onChange={(e) => setHandle(e.target.value)}
-            placeholder="agent handle"
-            className="block mt-1 w-40 bg-black/30 border border-white/10 rounded-md px-2 py-1 text-sm text-text"
-          />
-        </label>
-        <label className="text-[11px] text-text-muted">
-          Remit
-          <input
-            value={remit}
-            onChange={(e) => setRemit(e.target.value)}
-            placeholder={role === "buyer" ? "e.g. deep value" : "e.g. thesis-strict"}
-            className="block mt-1 w-44 bg-black/30 border border-white/10 rounded-md px-2 py-1 text-sm text-text"
-          />
-        </label>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold text-text">
+          {title}{" "}
+          <span className="text-text-muted font-normal text-xs">· {subtitle}</span>{" "}
+          <span className="text-text-muted font-normal">({seated.length})</span>
+        </h2>
         <button
           type="button"
-          onClick={add}
+          onClick={() => setPicking((v) => !v)}
           className="font-mono text-[11px] rounded-md border border-white/10 text-text-muted px-3 py-1.5 hover:text-text"
         >
-          + add
+          {picking ? "Close" : seated.length > 0 ? "Swap in another brain" : `+ Add a ${role}`}
         </button>
       </div>
+
+      {/* Seated roster */}
+      {seated.length > 0 ? (
+        <div className="grid gap-2 sm:grid-cols-2">
+          {seated.map((m) => (
+            <SeatedCard
+              key={m.agent_id}
+              member={m}
+              role={role}
+              return30d={catalog.find((c) => c.handle === m.handle)?.return30d ?? null}
+              portfolioId={portfolioId}
+              onFlash={onFlash}
+              onRefresh={onRefresh}
+            />
+          ))}
+        </div>
+      ) : (
+        !picking && (
+          <EmptyRoster
+            role={role}
+            recommended={available.slice(0, 4)}
+            onAdd={addAgent}
+            onBrowse={() => setPicking(true)}
+          />
+        )
+      )}
+
+      {/* Gallery picker */}
+      {picking && (
+        <AgentGallery role={role} agents={available} onAdd={addAgent} />
+      )}
     </div>
   );
 }
 
-function AgentCard({
+function EmptyRoster({
+  role,
+  recommended,
+  onAdd,
+  onBrowse,
+}: {
+  role: Role;
+  recommended: AgentCatalogEntry[];
+  onAdd: (handle: string) => void;
+  onBrowse: () => void;
+}) {
+  return (
+    <div className="rounded-lg border border-dashed border-white/15 p-4">
+      <p className="text-sm text-text-muted mb-3">
+        No {role}s yet. {role === "buyer" ? "Buyers draft names from your screen." : "Reviewers decide what to sell."}{" "}
+        Add one to get started:
+      </p>
+      {recommended.length > 0 ? (
+        <div className="grid gap-2 sm:grid-cols-2">
+          {recommended.map((a) => (
+            <GalleryCard key={a.handle} agent={a} onAdd={onAdd} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-text-muted">No agents available to add.</p>
+      )}
+      <button
+        type="button"
+        onClick={onBrowse}
+        className="mt-3 font-mono text-[11px] text-green hover:underline"
+      >
+        Browse all {role}s →
+      </button>
+    </div>
+  );
+}
+
+function AgentGallery({
+  role,
+  agents,
+  onAdd,
+}: {
+  role: Role;
+  agents: AgentCatalogEntry[];
+  onAdd: (handle: string) => void;
+}) {
+  const [tab, setTab] = useState<"all" | "house" | "community">("all");
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<"return" | "handle">("return");
+
+  const shown = useMemo(() => {
+    let list = agents;
+    if (tab === "house") list = list.filter((a) => a.isHouse);
+    if (tab === "community") list = list.filter((a) => !a.isHouse);
+    const q = query.trim().toLowerCase();
+    if (q) list = list.filter((a) => a.handle.toLowerCase().includes(q) || a.displayName.toLowerCase().includes(q));
+    return [...list].sort((x, y) =>
+      sort === "return"
+        ? (y.return30d ?? -1e9) - (x.return30d ?? -1e9)
+        : x.handle.localeCompare(y.handle),
+    );
+  }, [agents, tab, query, sort]);
+
+  return (
+    <div className="mt-3 rounded-lg border border-white/10 bg-black/20 p-3" role="dialog" aria-label={`Choose a ${role}`}>
+      <div className="flex items-center gap-2 flex-wrap mb-2">
+        <div className="flex gap-1" role="tablist" aria-label="Source">
+          {(["all", "house", "community"] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              role="tab"
+              aria-selected={tab === t}
+              onClick={() => setTab(t)}
+              className={`font-mono text-[10px] uppercase tracking-[0.1em] rounded px-2 py-1 border ${
+                tab === t ? "text-green border-green/50 bg-green/10" : "text-text-muted border-white/10"
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="search handle…"
+          aria-label="Search agents"
+          className="flex-1 min-w-[120px] bg-black/30 border border-white/10 rounded px-2 py-1 text-xs text-text"
+        />
+        <label className="text-[10px] font-mono text-text-muted inline-flex items-center gap-1">
+          sort
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as "return" | "handle")}
+            className="bg-black/40 border border-white/10 rounded px-1 text-text"
+          >
+            <option value="return" className="bg-black">30d return</option>
+            <option value="handle" className="bg-black">handle</option>
+          </select>
+        </label>
+      </div>
+      {shown.length > 0 ? (
+        <div className="grid gap-2 sm:grid-cols-2 max-h-[360px] overflow-y-auto">
+          {shown.map((a) => (
+            <GalleryCard key={a.handle} agent={a} onAdd={onAdd} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-text-muted py-3 text-center">No matching agents.</p>
+      )}
+    </div>
+  );
+}
+
+function GalleryCard({
+  agent,
+  onAdd,
+}: {
+  agent: AgentCatalogEntry;
+  onAdd: (handle: string) => void;
+}) {
+  const up = (agent.return30d ?? 0) >= 0;
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/30 p-3 flex flex-col gap-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="text-sm text-text font-medium truncate">{agent.displayName}</span>
+            <BrainBadge label={agent.poweredBy} />
+          </div>
+          <span className="font-mono text-[11px] text-text-muted">@{agent.handle}</span>
+        </div>
+        <span className="text-[9px] font-mono uppercase tracking-[0.1em] text-text-muted shrink-0">
+          {agent.isHouse ? "House" : "Community"}
+        </span>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] font-mono uppercase tracking-[0.1em] text-text-muted">
+          30d return
+        </span>
+        <span
+          className="text-sm font-mono"
+          style={{ color: up ? "var(--color-green,#00FF41)" : "var(--color-red,#FF3333)" }}
+          aria-label={`30-day return ${fmtReturn(agent.return30d)}`}
+        >
+          {fmtReturn(agent.return30d)}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={() => onAdd(agent.handle)}
+        className="font-mono text-[11px] rounded-md bg-green text-black px-3 py-1.5 hover:opacity-90"
+      >
+        Add
+      </button>
+    </div>
+  );
+}
+
+function SeatedCard({
   member,
   role,
+  return30d,
   portfolioId,
   onFlash,
+  onRefresh,
 }: {
   member: Member;
-  role: "buyer" | "reviewer";
+  role: Role;
+  return30d: number | null;
   portfolioId: string;
   onFlash: (m: string) => void;
+  onRefresh: () => void;
 }) {
   const cfg = (member.config ?? {}) as {
     convictionGate?: number;
@@ -339,6 +591,8 @@ function AgentCard({
   const [cadence, setCadence] = useState(String(cfg.cadence ?? (role === "buyer" ? "daily" : "weekly")));
   const [remit, setRemit] = useState(member.remit ?? "");
   const [, start] = useTransition();
+  const up = (return30d ?? 0) >= 0;
+  const accent = role === "buyer" ? "var(--color-green)" : "var(--color-red)";
 
   function save() {
     start(async () => {
@@ -352,55 +606,68 @@ function AgentCard({
             : { cadence },
       });
       onFlash(r.ok ? `Saved ${member.handle}` : r.error);
+      if (r.ok) onRefresh();
     });
   }
   function remove() {
     start(async () => {
       const r = await removeAgentFromPortfolio({ portfolioId, handle: member.handle });
       onFlash(r.ok ? `Removed ${member.handle}` : r.error);
+      if (r.ok) onRefresh();
     });
   }
 
   return (
-    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
-      <div className="flex items-center justify-between">
-        <div>
-          <span className="text-sm text-text font-medium">{member.display_name}</span>
-          {member.powered_by && (
-            <span className="ml-2 text-[10px] font-mono text-green border border-green/30 rounded px-1.5 py-0.5">
-              {member.powered_by}
+    <div
+      className="rounded-lg border bg-black/20 p-3"
+      style={{ borderColor: `color-mix(in srgb, ${accent} 35%, transparent)` }}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="text-sm text-text font-medium truncate">{member.display_name}</span>
+            <span
+              className="text-[9px] font-mono uppercase tracking-[0.1em] rounded px-1.5 py-0.5"
+              style={{ color: accent, border: `1px solid color-mix(in srgb, ${accent} 40%, transparent)` }}
+            >
+              ✓ on your team
             </span>
-          )}
+          </div>
+          <span className="font-mono text-[11px] text-text-muted">
+            @{member.handle}
+            {member.powered_by && <> · brain: {member.powered_by}</>}
+          </span>
         </div>
-        <button
-          type="button"
-          onClick={remove}
-          aria-label={`Remove ${member.handle}`}
-          className="text-text-muted hover:text-text text-xs"
-        >
-          remove
-        </button>
+        <div className="text-right shrink-0">
+          <div className="text-[9px] font-mono uppercase tracking-[0.1em] text-text-muted">30d</div>
+          <div
+            className="text-sm font-mono"
+            style={{ color: up ? "var(--color-green,#00FF41)" : "var(--color-red,#FF3333)" }}
+          >
+            {fmtReturn(return30d)}
+          </div>
+        </div>
       </div>
       <input
         value={remit}
         onChange={(e) => setRemit(e.target.value)}
-        placeholder={role === "buyer" ? "remit (e.g. deep value)" : "focus (e.g. drawdown)"}
+        placeholder={role === "buyer" ? "style / remit (e.g. high-conviction growth)" : "style / focus (e.g. thesis-strict)"}
+        aria-label="Remit"
         className="mt-2 w-full bg-black/30 border border-white/10 rounded px-2 py-1 text-xs text-text"
       />
       <div className="mt-2 flex items-center gap-3 flex-wrap text-[11px] text-text-muted">
         {role === "buyer" && (
           <>
             <label className="inline-flex items-center gap-1">
-              conviction ≥
+              conv ≥
               <select
                 value={gate}
                 onChange={(e) => setGate(Number(e.target.value))}
+                aria-label="Conviction gate"
                 className="bg-black/40 border border-white/10 rounded px-1 text-text"
               >
                 {[1, 2, 3, 4, 5].map((n) => (
-                  <option key={n} value={n} className="bg-black">
-                    {n}
-                  </option>
+                  <option key={n} value={n} className="bg-black">{n}</option>
                 ))}
               </select>
             </label>
@@ -412,6 +679,7 @@ function AgentCard({
                 max={100}
                 value={Math.round(maxPct)}
                 onChange={(e) => setMaxPct(Number(e.target.value))}
+                aria-label="Max percent per name"
                 className="w-14 bg-black/40 border border-white/10 rounded px-1 text-text"
               />
             </label>
@@ -422,22 +690,31 @@ function AgentCard({
           <select
             value={cadence}
             onChange={(e) => setCadence(e.target.value)}
+            aria-label="Cadence"
             className="bg-black/40 border border-white/10 rounded px-1 text-text"
           >
             {["daily", "weekly", "monthly"].map((c) => (
-              <option key={c} value={c} className="bg-black">
-                {c}
-              </option>
+              <option key={c} value={c} className="bg-black">{c}</option>
             ))}
           </select>
         </label>
-        <button
-          type="button"
-          onClick={save}
-          className="font-mono text-[11px] rounded border border-white/10 text-text-muted px-2 py-0.5 hover:text-text"
-        >
-          save
-        </button>
+        <div className="ml-auto flex gap-2">
+          <button
+            type="button"
+            onClick={save}
+            className="font-mono text-[11px] rounded border border-white/10 text-text-muted px-2 py-0.5 hover:text-text"
+          >
+            save
+          </button>
+          <button
+            type="button"
+            onClick={remove}
+            aria-label={`Remove ${member.handle}`}
+            className="font-mono text-[11px] rounded border border-white/10 text-text-muted px-2 py-0.5 hover:text-[var(--color-red,#FF3333)]"
+          >
+            remove
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Fixes **Component 2** from the correction brief: the portfolio add-agent UI was rendering the **bare handle/remit form** (free-text "agent handle" + "+ add", agents as form rows). That's the version that kept regressing — and the free-text brain is why adding kept failing.

This restores the **registry-backed gallery** (from the never-merged agent-selection follow-up `09f2030`), adapted to the current page and the "Your team" design you shared.

## What changed (`SwarmConfig`)

- **No free-text brain anywhere.** You pick a real registered agent by its **30d track record**. Gallery with **All / House / Community** tabs, search, sort-by-return; only role-appropriate candidates (buyer picker → buyers), already-seated excluded, dupes prevented.
- **Seated buyers/reviewers are rich cards:** brain badge, name + @handle, **✓ on your team**, 30d return, editable remit/style, per-member knobs (buyer: conviction ≥ / max %/name / cadence; reviewer: cadence), remove. Role-tinted border (green buyers / red reviewers).
- **Inviting empty state:** top-track-record recommendations + "browse all".
- **Reliable add:** every mutation calls `router.refresh()`, so an added/removed agent shows in the right roster immediately (the "doesn't reliably add" bug).
- The seated-roster action reads **"Swap in another brain"** (nods to the design mock); the engine loop still renders above the roster.
- Page passes the hireable-agent **catalog** (`listPublicAgents` + `getAgentReturns30d`), owner-only.

## Acceptance criteria
- ✅ Add-agent is a gallery of cards; **no free-text agent-handle input** anywhere on the page.
- ✅ Seated agents are rich cards (brain, editable remit, track record, knobs, remove).
- ✅ Top is the slim balanced bridge; perf strip in the header; engine loop is a separate section above the roster (shipped in #1358, on `main`).
- ✅ Mandate / building blocks / holdings / trades / coordination toggle unchanged.

## Honest gap
The design mock shows **win %** and a **sell count** ("14 sells / 30D") on the cards. **30d return is real**; win-rate and per-agent trade/sell counts **don't exist in the data layer yet**, so they're not wired (no fabricated numbers). I can add a backend pass to compute them from `agent_trades` if you want those tokens — say the word.

`tsc --noEmit` clean. (No ESLint config in the repo — Vercel build is the CI gate.)

https://claude.ai/code/session_019c3k7LiNsKA8wBTb7V9D6A

---
_Generated by [Claude Code](https://claude.ai/code/session_019c3k7LiNsKA8wBTb7V9D6A)_