### PR TITLE
Improve auth flow & UX messaging for live portfolios

### DIFF
--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -66,9 +66,16 @@ export default async function AccountPage() {
               spySeries={spySeries}
             />
           )}
-          <div className="mt-10">
-            <BetaDisclaimer />
-          </div>
+          {/* Live (real-money) risk acknowledgement — shown ONLY to users
+              who have actually been provisioned a live portfolio in the DB,
+              not to every signed-in visitor. A live follower exists only
+              after an operator runs the go-live flow, so its presence is the
+              gate. */}
+          {livePortfolio && (
+            <div className="mt-10">
+              <BetaDisclaimer />
+            </div>
+          )}
         </div>
       </main>
     </>

--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -172,7 +172,7 @@ export default function ScreenerClient({
   async function compile() {
     if (!brief.trim()) return;
     setCompiling(true);
-    setCompileStatus("Compiling…");
+    setCompileStatus("Building your screen…");
     try {
       const res = await fetch("/api/compile-brief", {
         method: "POST",
@@ -180,7 +180,7 @@ export default function ScreenerClient({
         body: JSON.stringify({ brief }),
       });
       if (!res.ok) {
-        setCompileStatus("Compile failed — tune the knobs directly.");
+        setCompileStatus("Couldn’t build the screen — tune the knobs directly.");
         return;
       }
       const { compiled } = await res.json();
@@ -194,7 +194,7 @@ export default function ScreenerClient({
       }));
       setBriefDirty(false);
       const fc = compiled.filters.length;
-      setCompileStatus(`compiled — ${fc} filter${fc === 1 ? "" : "s"} + a ${topWeight(compiled.weights)}-tilted weighting`);
+      setCompileStatus(`Built — ${fc} filter${fc === 1 ? "" : "s"} + a ${topWeight(compiled.weights)}-tilted weighting`);
     } finally {
       setCompiling(false);
     }
@@ -342,10 +342,10 @@ export default function ScreenerClient({
           disabled={compiling || !brief.trim()}
           className="font-mono text-[11px] rounded-md px-3 py-1.5 bg-green text-black disabled:opacity-40"
         >
-          {compiling ? "Compiling…" : briefDirty ? "Recompile ↻" : "Compile to screen"}
+          {compiling ? "Building…" : briefDirty ? "Update screen ↻" : "Build screen from brief"}
         </button>
         <span className="font-mono text-[10.5px] text-text-muted" aria-live="polite">
-          {compileStatus ?? "the brief is for humans; the compiled filters & weights are what drive the screener"}
+          {compileStatus ?? "turns your plain-English brief into the filters & weights that drive the screener below"}
         </span>
       </div>
 

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -8,6 +8,27 @@ import { NextResponse, type NextRequest } from "next/server";
 //
 // `proxy` is the Next 16 successor to the deprecated `middleware` convention.
 export async function proxy(request: NextRequest) {
+  const { pathname, searchParams } = request.nextUrl;
+
+  // Auth-code rescue. A magic-link sign-in redirects back with a PKCE
+  // `?code=` that must be exchanged for a session by /auth/callback. If
+  // Supabase falls back to the Site URL (e.g. /auth/callback isn't in the
+  // redirect allowlist) the code lands on some other path — most often the
+  // homepage — where nothing exchanges it, so the user sees the logged-out
+  // homepage despite a valid link. Funnel any stray code through the
+  // callback so the session is always established and first-login lands on
+  // the dashboard (callback's default next=/account).
+  const code = searchParams.get("code");
+  if (code && pathname !== "/auth/callback" && !pathname.startsWith("/api")) {
+    const callbackUrl = new URL("/auth/callback", request.url);
+    callbackUrl.searchParams.set("code", code);
+    const next = searchParams.get("next");
+    if (next && next.startsWith("/") && !next.startsWith("//")) {
+      callbackUrl.searchParams.set("next", next);
+    }
+    return NextResponse.redirect(callbackUrl);
+  }
+
   let response = NextResponse.next({ request });
 
   const supabase = createServerClient(


### PR DESCRIPTION
## Summary
Three targeted improvements to authentication, portfolio visibility, and user messaging:

1. **Auth code rescue in proxy middleware** — Supabase magic-link sign-ins that redirect with a PKCE `?code=` parameter now reliably land on `/auth/callback` even if the redirect allowlist falls back to the Site URL. Stray codes on other paths are funneled through the callback to establish the session and land first-time users on the dashboard.

2. **Gate live portfolio disclaimer** — The beta disclaimer (live risk acknowledgement) now only displays to users who have actually been provisioned a live portfolio in the database, not to every signed-in visitor. Presence of a `livePortfolio` is the gate.

3. **Clarify screener brief compilation UX** — Updated button labels and status messages to use more intuitive language ("Build screen from brief" instead of "Compile", "Building your screen…" instead of "Compiling…") and improved the helper text to explain the feature's purpose more clearly.

## Key Changes
- **web/proxy.ts**: Added auth-code rescue logic that detects stray PKCE codes and redirects them through `/auth/callback` with optional `next` parameter preservation
- **web/app/account/page.tsx**: Wrapped `BetaDisclaimer` in conditional render gated by `livePortfolio` presence; added explanatory comment about the gate
- **web/app/screener/screener-client.tsx**: Updated compile button text, status messages, and helper text for clarity and user-friendliness

## Implementation Details
- The auth rescue checks for `code` in search params and only redirects if not already on `/auth/callback` and not an API route
- The `next` parameter is validated (must start with `/` and not `//`) before being forwarded to the callback
- All messaging changes maintain the existing tone while being more descriptive of what the feature does

https://claude.ai/code/session_015aAUvzh8Pw2cNFEemhvY8F