### PR TITLE
Fix hero CTA link to redirect to login instead of signup

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -270,7 +270,7 @@ function Hero({
 
           <div className="mt-6 flex flex-wrap items-center gap-3">
             <Link
-              href="/signup"
+              href="/login"
               data-cta="hero-build"
               className="inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
               style={{


### PR DESCRIPTION
## Summary
Updated the hero section's primary call-to-action button to link to `/login` instead of `/signup`.

## Changes
- Changed the hero "Build" CTA link destination from `/signup` to `/login` in the landing page component

## Details
The hero section's primary call-to-action button (with `data-cta="hero-build"`) now directs users to the login page rather than the signup page. This aligns the user flow with the intended navigation pattern for the application.

https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY