### PR TITLE
perf: make the portfolio page fast again (bound the agent trade-stats query)

### DIFF
--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -165,12 +165,40 @@ async function getPortfolioPageData(slug: string): Promise<{
   const portfolioId = portfolio.id;
   const ownerAgentId = portfolio.owner_agent_id;
   const ownerUserId = portfolio.owner_user_id;
+
+  // Owner-only swarm-picker catalog (hireable agents + 30d track record). Built
+  // concurrently with the page's other reads rather than after them.
+  const loadCatalog = async (): Promise<AgentCatalogEntry[]> => {
+    if (!isOwner) return [];
+    const [agents, returns] = await Promise.all([
+      listPublicAgents(1000, true).catch(() => []),
+      getAgentReturns30d().catch(() => new Map<string, number | null>()),
+    ]);
+    const tradeStats = await getAgentTradeStats(agents.map((a) => a.id)).catch(
+      () => new Map(),
+    );
+    return agents.map((a) => {
+      const ts = tradeStats.get(a.id);
+      return {
+        handle: a.handle,
+        displayName: a.display_name,
+        poweredBy: a.powered_by,
+        isHouse: a.is_house_agent,
+        strategy: a.strategy,
+        return30d: returns.get(a.handle) ?? null,
+        winPct: ts?.winPct ?? null,
+        sells30d: ts?.sells30d ?? 0,
+      };
+    });
+  };
+
   const [
     snapshot,
     thesesByTicker,
     members,
     recent,
     holdingsCount,
+    catalog,
   ] = await Promise.all([
     ownerAgentId
       ? getPortfolio(ownerAgentId).catch((err) => {
@@ -201,36 +229,9 @@ async function getPortfolioPageData(slug: string): Promise<{
       () => ({ trades: [], totalTrades: 0 }),
     ),
     getHoldingsCountForPortfolio(portfolioId).catch(() => 0),
+    loadCatalog().catch(() => [] as AgentCatalogEntry[]),
   ]);
   const { trades, totalTrades } = recent;
-
-  // Agent catalog for the owner's swarm picker: every hireable agent + its 30d
-  // track record. Owner-only — skipped entirely for non-owners.
-  let catalog: AgentCatalogEntry[] = [];
-  if (isOwner) {
-    const [agents, returns] = await Promise.all([
-      listPublicAgents(1000, true).catch(() => []),
-      getAgentReturns30d().catch(() => new Map<string, number | null>()),
-    ]);
-    // Trade-tape stats (win %, 30d sells) keyed by agent id — a second pass so
-    // we only query trades for the hireable set.
-    const tradeStats = await getAgentTradeStats(
-      agents.map((a) => a.id),
-    ).catch(() => new Map());
-    catalog = agents.map((a) => {
-      const ts = tradeStats.get(a.id);
-      return {
-        handle: a.handle,
-        displayName: a.display_name,
-        poweredBy: a.powered_by,
-        isHouse: a.is_house_agent,
-        strategy: a.strategy,
-        return30d: returns.get(a.handle) ?? null,
-        winPct: ts?.winPct ?? null,
-        sells30d: ts?.sells30d ?? 0,
-      };
-    });
-  }
 
   return {
     portfolio,

--- a/web/lib/agents-query.ts
+++ b/web/lib/agents-query.ts
@@ -492,19 +492,20 @@ export interface AgentTradeStats {
   /** Sells in the trailing 30 days (the reviewer card's "N sells / 30D"). */
   sells30d: number;
   /**
-   * Realized win rate (%) over the agent's full history — the share of
-   * closing sells booked above their position's weighted-average cost.
-   * `null` when the agent has no realized sells yet.
+   * Realized win rate (%). Currently always `null` — computing it correctly
+   * needs a full-history cost-basis scan, too expensive to run on every page
+   * load (it was the cause of the slow portfolio page). The field stays so the
+   * cards can light up once it's precomputed (nightly stat / RPC); cards omit
+   * the token when null.
    */
   winPct: number | null;
 }
 
 /**
- * Compute trade-tape stats for a set of agents (by agent id) directly from the
- * `agent_trades` journal. Realized win rate is reconstructed by walking each
- * agent's trades per ticker in time order, maintaining a weighted-average cost
- * basis: every sell above cost is a win. Paginated so the row cap never
- * truncates the history (which would corrupt the cost basis). Owner-only call.
+ * Compute trade-tape stats for a set of agents (by agent id) from the
+ * `agent_trades` journal — **bounded to the trailing 30 days** so it stays
+ * cheap. Returns 30d trade + sell counts; `winPct` is left null pending a
+ * precomputed stat. Owner-only call.
  */
 export async function getAgentTradeStats(
   agentIds: string[],
@@ -513,83 +514,37 @@ export async function getAgentTradeStats(
   if (agentIds.length === 0) return out;
   const supabase = getSupabase();
 
-  // Pull the full journal for these agents, oldest first, grouped by agent so
-  // the per-ticker walk sees buys before the sells that realize against them.
+  const cutoffIso = new Date(
+    Date.now() - 30 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  // Only the trailing 30 days of trades for these agents — small + fast.
   const PAGE = 1000;
-  const MAX_ROWS = 60000; // safety bound; far above realistic per-portfolio sets
-  type Row = {
-    agent_id: string;
-    ticker: string;
-    side: string;
-    quantity: number | string | null;
-    price_usd: number | string | null;
-    executed_at: string;
-  };
-  const rows: Row[] = [];
+  const MAX_ROWS = 20000;
+  const counts = new Map<string, { trades30d: number; sells30d: number }>();
   for (let from = 0; from < MAX_ROWS; from += PAGE) {
     const { data, error } = await supabase
       .from("agent_trades")
-      .select("agent_id, ticker, side, quantity, price_usd, executed_at")
+      .select("agent_id, side")
       .in("agent_id", agentIds)
-      .order("agent_id", { ascending: true })
-      .order("executed_at", { ascending: true })
+      .gte("executed_at", cutoffIso)
       .range(from, from + PAGE - 1);
     if (error) {
       console.error("getAgentTradeStats failed:", error);
       return out;
     }
-    const batch = (data ?? []) as Row[];
-    rows.push(...batch);
+    const batch = (data ?? []) as { agent_id: string; side: string }[];
+    for (const r of batch) {
+      const c = counts.get(r.agent_id) ?? { trades30d: 0, sells30d: 0 };
+      c.trades30d += 1;
+      if (r.side === "sell") c.sells30d += 1;
+      counts.set(r.agent_id, c);
+    }
     if (batch.length < PAGE) break;
   }
 
-  const cutoff = Date.now() - 30 * 24 * 60 * 60 * 1000;
-  // Per-agent accumulators + per-(agent,ticker) running position.
-  const stats = new Map<
-    string,
-    { trades30d: number; sells30d: number; wins: number; realized: number }
-  >();
-  const positions = new Map<string, { qty: number; avgCost: number }>();
-  const acc = (id: string) => {
-    let s = stats.get(id);
-    if (!s) {
-      s = { trades30d: 0, sells30d: 0, wins: 0, realized: 0 };
-      stats.set(id, s);
-    }
-    return s;
-  };
-
-  for (const r of rows) {
-    const s = acc(r.agent_id);
-    const qty = Math.abs(Number(r.quantity) || 0);
-    const price = Number(r.price_usd) || 0;
-    const isSell = r.side === "sell";
-    if (new Date(r.executed_at).getTime() >= cutoff) {
-      s.trades30d += 1;
-      if (isSell) s.sells30d += 1;
-    }
-    const key = `${r.agent_id} ${r.ticker}`;
-    const pos = positions.get(key) ?? { qty: 0, avgCost: 0 };
-    if (isSell) {
-      if (pos.qty > 0 && qty > 0) {
-        s.realized += 1;
-        if (price > pos.avgCost) s.wins += 1;
-        pos.qty = Math.max(0, pos.qty - qty);
-      }
-    } else {
-      const newQty = pos.qty + qty;
-      pos.avgCost = newQty > 0 ? (pos.avgCost * pos.qty + price * qty) / newQty : 0;
-      pos.qty = newQty;
-    }
-    positions.set(key, pos);
-  }
-
-  for (const [id, s] of stats) {
-    out.set(id, {
-      trades30d: s.trades30d,
-      sells30d: s.sells30d,
-      winPct: s.realized > 0 ? (s.wins / s.realized) * 100 : null,
-    });
+  for (const [id, c] of counts) {
+    out.set(id, { trades30d: c.trades30d, sells30d: c.sells30d, winPct: null });
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Fixes the **slow portfolio page**. The regression came from #1363: `getAgentTradeStats` scanned **every hireable agent's entire `agent_trades` history** (up to 60k rows, paginated, then a JS cost-basis reconstruction) on every owner page load, just to compute realized win %. That full-history scan was the bottleneck.

## Changes

- **`getAgentTradeStats` is now bounded to the trailing 30 days** — a single cheap query (`agent_id, side` where `executed_at >= 30d ago`) for the 30d trade + sell counts. No more full-history fetch or cost-basis loop.
- **`winPct` is left `null` for now** (the cards already omit the token when null). Computing realized win % correctly needs the full-history scan, which doesn't belong on a page render — the right home is a **precomputed nightly stat / RPC**. Flagged in the code + below.
- **Catalog built concurrently** — the owner-only hireable-agent catalog now loads inside the page's `Promise.all` instead of sequentially after it.

Reviewer cards keep their real **"N sells · 30D"** (cheap, accurate). Buyer cards keep **30d return** (from `agent_leaderboard`); the **WIN %** token is hidden until the precomputed stat lands.

## Follow-up (optional)
If you want win % back on the cards, I'll add a nightly job that computes per-agent realized win rate into a small stats table (or a Postgres RPC), so the page reads one cheap row instead of scanning trades. Say the word.

`tsc --noEmit` clean.

https://claude.ai/code/session_019c3k7LiNsKA8wBTb7V9D6A

---
_Generated by [Claude Code](https://claude.ai/code/session_019c3k7LiNsKA8wBTb7V9D6A)_