### PR TITLE
Fix first-time sign-in email + route auth mail through Resend

### DIFF
--- a/supabase/email-templates/README.md
+++ b/supabase/email-templates/README.md
@@ -14,11 +14,30 @@ template → replace the body with the file's contents → **Save**.
 
 | File | Dashboard template | Supabase variables used |
 |---|---|---|
-| `magic-link.html` | Magic Link | `{{ .ConfirmationURL }}` |
+| `magic-link.html` | Magic Link | `{{ .SiteURL }}`, `{{ .TokenHash }}` |
+| `confirm-signup.html` | Confirm signup | `{{ .SiteURL }}`, `{{ .TokenHash }}` |
 
-Only the **Magic Link** template is in use — the app's sole auth path is
-`signInWithOtp` (`web/components/login-form.tsx`). The other templates
-(Confirm signup, Reset password, etc.) are left on Supabase defaults.
+The app's sole auth path is `signInWithOtp` (`web/components/login-form.tsx`),
+but it fires **two** templates depending on the address:
+
+- **Returning** address → **Magic Link**.
+- **First-time** address → **Confirm signup** (Supabase sends this, not Magic
+  Link, when `signInWithOtp` creates the user). Leaving it on the Supabase
+  default is why first-time sign-ins got an unbranded, dead link — so both
+  templates must be deployed.
+
+Both link straight back to the app's own `/auth/callback` with a
+`token_hash` (`?token_hash={{ .TokenHash }}&type=magiclink|signup`) rather
+than `{{ .ConfirmationURL }}`. The callback route
+(`web/app/auth/callback/route.ts`) verifies the hash via `verifyOtp`, so the
+session is established without depending on Supabase's legacy
+`/auth/v1/verify` redirect. The callback still accepts a PKCE `?code=` link
+for backward compatibility.
+
+**Dashboard URL config (required):** Authentication → URL Configuration →
+set **Site URL** to `https://www.alphamolt.ai` (substituted into
+`{{ .SiteURL }}`) and add `https://www.alphamolt.ai/auth/callback` to the
+**Redirect URLs** allow-list.
 
 ## Notes
 

--- a/supabase/email-templates/README.md
+++ b/supabase/email-templates/README.md
@@ -7,7 +7,31 @@ are not picked up from this directory automatically. These files exist so
 the templates are version-controlled, reviewable, and recoverable. When a
 template here changes, paste the new HTML into the dashboard by hand.
 
-## Deploy
+## Delivery — Resend via Custom SMTP
+
+Auth emails are delivered by **Resend** (not Supabase's built-in sender),
+wired as a Custom SMTP relay. Supabase still renders these templates and
+mints the token links; Resend only delivers. No app code is involved — it
+is dashboard + DNS config:
+
+1. **Resend → Domains** — add `alphamolt.ai` and publish the SPF/DKIM DNS
+   records it gives you. Wait for "Verified".
+2. **Resend → API Keys** — create a key (`re_…`) with send permission.
+3. **Supabase dashboard → Authentication → Emails → SMTP Settings** →
+   enable **Custom SMTP**:
+   - **Sender email**: `login@alphamolt.ai` (must be on the verified domain)
+   - **Sender name**: `AlphaMolt`
+   - **Host**: `smtp.resend.com`
+   - **Port**: `465`
+   - **Username**: `resend`
+   - **Password**: the Resend API key from step 2
+4. Raise **Authentication → Rate Limits → Emails** above the tiny default
+   that applies while using the built-in sender.
+
+Send a magic link to a fresh address to confirm it arrives from
+`login@alphamolt.ai` via Resend (check the Resend dashboard's Emails log).
+
+## Deploy templates
 
 Supabase dashboard → **Authentication → Email Templates** → select the
 template → replace the body with the file's contents → **Save**.

--- a/supabase/email-templates/confirm-signup.html
+++ b/supabase/email-templates/confirm-signup.html
@@ -1,8 +1,10 @@
 <!--
-  AlphaMolt — magic-link sign-in email.
-  Source of truth for the Supabase Auth "Magic Link" template.
-  Paste into: Supabase dashboard -> Authentication -> Email Templates -> Magic Link.
-  Supabase substitutes {{ .ConfirmationURL }} with the one-time sign-in link.
+  AlphaMolt — confirm-signup email.
+  Source of truth for the Supabase Auth "Confirm signup" template.
+  Paste into: Supabase dashboard -> Authentication -> Email Templates -> Confirm signup.
+  Supabase sends THIS template (not Magic Link) the first time signInWithOtp is
+  called for a new email address. The link points back at the app's own
+  /auth/callback with a token_hash, which the route verifies via verifyOtp.
   All CSS is inline (email clients drop <style> blocks); table-based layout.
 -->
 <!DOCTYPE html>
@@ -17,7 +19,7 @@
 <body style="margin:0; padding:0; background-color:#0A0A0A; -webkit-text-size-adjust:100%;">
   <!-- preheader: shown in inbox preview, hidden in the body -->
   <div style="display:none; max-height:0; overflow:hidden; opacity:0; color:#0A0A0A;">
-    Your one-time sign-in link for AlphaMolt. It works once and expires shortly.
+    Confirm your email to start your AlphaMolt portfolio. This link works once and expires shortly.
   </div>
 
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#0A0A0A" style="background-color:#0A0A0A;">
@@ -43,21 +45,22 @@
                   <td style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">
 
                     <h1 style="margin:0 0 16px 0; font-size:22px; line-height:1.3; font-weight:700; color:#EDEDED;">
-                      Sign in to AlphaMolt
+                      Confirm your email
                     </h1>
 
                     <p style="margin:0 0 28px 0; font-size:15px; line-height:1.6; color:#A1A1AA;">
-                      Click the button below to sign in. This link works once and
-                      expires shortly &mdash; no password needed.
+                      Click the button below to confirm your email and sign in to
+                      AlphaMolt. This link works once and expires shortly
+                      &mdash; no password needed.
                     </p>
 
                     <!-- CTA button -->
                     <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 28px 0;">
                       <tr>
                         <td align="center" bgcolor="#00FF41" style="background-color:#00FF41; border-radius:6px;">
-                          <a href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&amp;type=magiclink" target="_blank"
+                          <a href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&amp;type=signup" target="_blank"
                              style="display:inline-block; padding:14px 34px; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; font-size:15px; font-weight:700; color:#0A0A0A; text-decoration:none; border-radius:6px;">
-                            Sign in to AlphaMolt
+                            Confirm &amp; sign in
                           </a>
                         </td>
                       </tr>
@@ -67,7 +70,7 @@
                       Button not working? Paste this link into your browser:
                     </p>
                     <p style="margin:0 0 4px 0; font-size:13px; line-height:1.5; word-break:break-all;">
-                      <a href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&amp;type=magiclink" target="_blank" style="color:#00CC33; text-decoration:underline;">{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&amp;type=magiclink</a>
+                      <a href="{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&amp;type=signup" target="_blank" style="color:#00CC33; text-decoration:underline;">{{ .SiteURL }}/auth/callback?token_hash={{ .TokenHash }}&amp;type=signup</a>
                     </p>
 
                   </td>

--- a/web/app/auth/callback/route.ts
+++ b/web/app/auth/callback/route.ts
@@ -1,13 +1,22 @@
 import { NextResponse, type NextRequest } from "next/server";
+import type { EmailOtpType } from "@supabase/supabase-js";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
-// Magic-link landing route. Supabase emails a link back here with a `code`;
-// we exchange it for a session (sets the auth cookies) and redirect on.
+// Magic-link / email-confirmation landing route. Supabase emails a link back
+// here in one of two shapes, depending on which template fired:
+//   • PKCE link        ?code=<uuid>                 → exchangeCodeForSession
+//   • token-hash link  ?token_hash=<hash>&type=<t>  → verifyOtp
+// We handle both. A first-time address gets the "Confirm signup" template
+// (type=signup), returning addresses get "Magic Link" (type=magiclink); the
+// token-hash form lands the user in a session without depending on the
+// legacy /auth/v1/verify redirect, so both work identically.
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
+  const tokenHash = searchParams.get("token_hash");
+  const type = searchParams.get("type") as EmailOtpType | null;
 
   // Guard against open redirects — only same-origin relative paths.
   const nextParam = searchParams.get("next");
@@ -16,12 +25,13 @@ export async function GET(request: NextRequest) {
       ? nextParam
       : "/account";
 
-  if (!code) {
-    return NextResponse.redirect(`${origin}/login?error=missing_code`);
-  }
-
   const supabase = await createSupabaseServerClient();
-  const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+  const { error } = code
+    ? await supabase.auth.exchangeCodeForSession(code)
+    : tokenHash && type
+      ? await supabase.auth.verifyOtp({ token_hash: tokenHash, type })
+      : { error: { message: "missing_code" } };
 
   if (error) {
     return NextResponse.redirect(


### PR DESCRIPTION
## Problem

First-time sign-ups got the **unbranded default Supabase "Confirm signup"** email, and its link dead-ended. `signInWithOtp` sends the *Confirm signup* template (not *Magic Link*) when it creates a brand-new user, and that link's shape wasn't handled by `/auth/callback` — which only accepted the PKCE `?code=` param.

## Changes

- **`web/app/auth/callback/route.ts`** — now also verifies a `token_hash` + `type` link via `verifyOtp`, keeping the `?code=` (PKCE) path for backward compatibility. Both email shapes now establish a session.
- **`supabase/email-templates/confirm-signup.html`** (new) — branded version of the first-time signup email.
- **`supabase/email-templates/magic-link.html`** — both templates now link straight to `/auth/callback?token_hash=…&type=…` instead of relying on Supabase's legacy `/auth/v1/verify` redirect.
- **`supabase/email-templates/README.md`** — documents the second template plus the **Resend Custom SMTP** delivery setup (Supabase renders the templates; Resend delivers).

## Manual follow-up (dashboard + DNS — no app code)

1. Verify `alphamolt.ai` in Resend (SPF/DKIM), create a send API key.
2. Supabase → Authentication → Emails → **Custom SMTP**: host `smtp.resend.com`, port `465`, user `resend`, password = Resend API key, sender `login@alphamolt.ai`.
3. Paste both templates into Authentication → Email Templates.
4. Authentication → URL Configuration: Site URL `https://www.alphamolt.ai`, add `/auth/callback` to the redirect allow-list.

Split out from #1367 (which now contains only the homepage CTA fix).

https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY)_