### PR TITLE
Per-agent mandates with baked-in defaults (migration 046)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,22 @@ params live flat in `portfolio_agents.config` (merged into the strategy's
 agent stays on the roster but the heartbeat skips it). Action maps to the
 heartbeat role (`buy→buyer`, `sell→reviewer`, `manage→manager`); buy/sell run
 through the existing swarm engine, manage is inert until a manage engine is
-defined. The **library is the set of hireable agents with `action` set** — the
+defined.
+
+**Per-agent mandates (migration 046).** Each thinking agent self-briefs: there
+is no shared portfolio mandate any more. A library agent's baked-in brief lives
+in `agents.default_mandate` (NULL for mechanical/manage agents — they show no
+brief field), and the saved instance can override it via
+`portfolio_agents.mandate`. The team builder shows a **pre-filled, editable
+brief** for any agent with a default (label by action: buy → "What to buy",
+sell → "When to sell"); leaving it untouched stores NULL so it tracks the
+evolving default, editing it pins the owner's words (a `✎ custom brief` chip
+marks overrides). The heartbeat resolves `ctx.mandate` as
+`instance override ?? agent default ?? (legacy) portfolios.description`
+(`agent_heartbeat._resolve_member_mandate`), so `portfolios.description` is now
+only a fallback for legacy 1:1 agents. The example buy agents are bound to the
+LLM buyer (`llm_watchlist_buyer`) so the brief actually drives BUY/PASS; sells
+run the LLM reviewer (`portfolio_reviewer`). The **library is the set of hireable agents with `action` set** — the
 seeded roster (migration 045) is illustrative; the real roster is curated
 separately by inserting agent rows. Mutations (`saveTeamAgent`,
 `updateTeamAgentParams`, `setTeamAgentEnabled`) live in

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -293,6 +293,23 @@ def _portfolio_is_due(portfolio: dict, now: datetime) -> bool:
     return now >= last + timedelta(hours=PORTFOLIO_HEARTBEAT_INTERVAL_HOURS)
 
 
+def _resolve_member_mandate(member_row: dict, portfolio_mandate: str | None) -> str | None:
+    """The brief a member agent works to (migration 046).
+
+    Per-agent mandates replace the old single portfolio mandate: each thinking
+    agent self-briefs. Resolution mirrors params — the saved INSTANCE override
+    wins, else the agent's baked-in DEFAULT, else the portfolio brief as a
+    legacy fallback (for 1:1 agents that predate per-agent mandates).
+    """
+    override = (member_row.get("mandate") or "").strip()
+    if override:
+        return override
+    default = ((member_row.get("agent") or {}).get("default_mandate") or "").strip()
+    if default:
+        return default
+    return portfolio_mandate
+
+
 def _run_portfolio_swarm(
     db: SupabaseDB,
     pm: PortfolioManager,
@@ -387,7 +404,8 @@ def _run_portfolio_swarm(
         ctx = RebalanceContext(
             db=db, pm=pm, agent=m["agent"], dry_run=False,
             params=dict(m.get("config") or {}), portfolio_id=pid,
-            members=members, mandate=mandate, mode=mode, executor=executor,
+            members=members, mandate=_resolve_member_mandate(m, mandate),
+            mode=mode, executor=executor,
         )
         rationale = cand_map.get(pick.ticker)
         note = f"swarm draft (conviction {pick.conviction}/5): {rationale or ''}".strip()
@@ -434,7 +452,8 @@ def _run_portfolio_swarm(
         ctx = RebalanceContext(
             db=db, pm=pm, agent=agent, dry_run=dry_run,
             params=dict(m.get("config") or {}), portfolio_id=pid,
-            members=members, mandate=mandate, mode=mode, executor=executor,
+            members=members, mandate=_resolve_member_mandate(m, mandate),
+            mode=mode, executor=executor,
         )
         try:
             result = strategy(ctx)
@@ -517,11 +536,13 @@ def _run_portfolio(
 
     members = [m["agent"] for m in member_rows]
     mandate = portfolio.get("description")
+    run_rows = member_rows
     if handle_filter:
-        members = [m for m in members if m.get("handle") == handle_filter]
-    logger.info("  portfolio %-22s %d member(s)", slug, len(members))
+        run_rows = [mr for mr in member_rows if mr["agent"].get("handle") == handle_filter]
+    logger.info("  portfolio %-22s %d member(s)", slug, len(run_rows))
 
-    for member in members:
+    for member_row in run_rows:
+        member = member_row["agent"]
         handle = member.get("handle", member["id"][:8])
         strategy_name = member.get("strategy")
         started = _now_utc()
@@ -552,12 +573,16 @@ def _run_portfolio(
             continue
 
         mode, executor = _resolve_live_executor(portfolio, dry_run=dry_run)
+        # Per-instance params (portfolio_agents.config, migration 045) override
+        # the agent-level config; the membership-less legacy 1:1 agents fall
+        # back to their agents.config. Mandate is resolved per-agent (046).
+        params = {**(member.get("config") or {}), **(member_row.get("config") or {})}
         ctx = RebalanceContext(
             db=db, pm=pm, agent=member, dry_run=dry_run,
-            params=dict(member.get("config") or {}),
+            params=params,
             portfolio_id=portfolio["id"],
             members=members,
-            mandate=mandate,
+            mandate=_resolve_member_mandate(member_row, mandate),
             mode=mode,
             executor=executor,
         )

--- a/db.py
+++ b/db.py
@@ -588,6 +588,11 @@ class SupabaseDB:
                     "role": m.get("role"),
                     "remit": m.get("remit"),
                     "config": m.get("config"),
+                    # Per-instance mandate override (migration 046). NULL =
+                    # use the agent's default_mandate (which rides along in the
+                    # agents row below). Resolved at ctx-build time in the
+                    # heartbeat: override ?? agent default ?? portfolio brief.
+                    "mandate": m.get("mandate"),
                     # Per-instance Run/Stop switch (migration 045). A stopped
                     # team agent stays on the roster but is skipped by the
                     # heartbeat. Default True for legacy rows / new members.

--- a/migrations/046_agent_mandate.sql
+++ b/migrations/046_agent_mandate.sql
@@ -1,0 +1,79 @@
+-- Migration 046: per-agent individual mandates (team builder, brief v2).
+--
+-- In the old model every LLM-driven agent read one shared mandate
+-- (portfolios.description). The team-builder world makes the team *be* the
+-- strategy, so a single overall mandate no longer fits. Each thinking agent now
+-- carries its OWN brief, pre-filled with a sensible default, so a team works out
+-- of the box but each agent can be tuned individually.
+--
+-- Mirrors how params already work (migration 045): the DEFAULT lives on the
+-- agent definition, the saved INSTANCE can override. Resolution at heartbeat
+-- time is `instance override ?? agent default ?? (legacy) portfolio.description`.
+--
+-- Only "thinking" agents (those whose engine consumes a brief — the LLM buyer
+-- and the LLM reviewer) carry a default_mandate. Mechanical/manage agents leave
+-- it NULL and the UI shows no brief field for them.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+-- ============================================================
+-- 1. Columns
+-- ============================================================
+-- agents.default_mandate: the baked-in brief. Presence (NOT NULL) is what marks
+--   an agent as a thinking agent that shows a brief field.
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS default_mandate TEXT;
+
+-- portfolio_agents.mandate: the per-instance override. NULL = use the agent's
+--   default (and keep tracking it as the default evolves).
+ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS mandate TEXT;
+
+-- ============================================================
+-- 2. Re-seed the example library with default mandates
+-- ============================================================
+-- Buy agents move onto the thinking buyer (llm_watchlist_buyer) so the brief
+-- actually drives BUY/PASS; sell agents stay on the LLM reviewer; manage agents
+-- keep NULL default_mandate (no engine, no brief). Idempotent: extends the
+-- migration-045 seed in place.
+
+UPDATE agents SET strategy = 'llm_watchlist_buyer', default_mandate =
+    'Own elite Rule-of-40 compounders — durable revenue growth paired with strong free cash flow. Favour proven models over hype, and skip names already priced for perfection.'
+    WHERE handle = 'agent-quality-compounder';
+
+UPDATE agents SET strategy = 'llm_watchlist_buyer', default_mandate =
+    'Buy strength — names breaking out to new highs on improving fundamentals. Avoid breakouts riding deteriorating margins or fading growth.'
+    WHERE handle = 'agent-momentum-breakout';
+
+UPDATE agents SET strategy = 'llm_watchlist_buyer', default_mandate =
+    'Buy quality at a discount — sound businesses trading cheaply on sales. Demand a real margin of safety, not just a low multiple on a broken story.'
+    WHERE handle = 'agent-deep-value-sniper';
+
+UPDATE agents SET strategy = 'llm_watchlist_buyer', default_mandate =
+    'Buy quality on weakness — durable names that have pulled back, not falling knives. Confirm the thesis still holds before adding.'
+    WHERE handle = 'agent-dip-buyer';
+
+UPDATE agents SET strategy = 'llm_watchlist_buyer', default_mandate =
+    'Buy durable franchises trading well below their long-run trend, where the business is intact and the discount is sentiment rather than deterioration.'
+    WHERE handle = 'agent-200w-reversion';
+
+UPDATE agents SET default_mandate =
+    'Cut losers fast — exit any position that falls meaningfully below its entry price. Never average down a broken position.'
+    WHERE handle = 'agent-hard-stop-loss';
+
+UPDATE agents SET default_mandate =
+    'Let winners run but protect gains — exit when a position gives back a meaningful chunk from its peak since purchase.'
+    WHERE handle = 'agent-trailing-stop';
+
+UPDATE agents SET default_mandate =
+    'Bank gains into strength — take profits once a position has run, trimming back toward a core holding rather than exiting wholesale.'
+    WHERE handle = 'agent-target-trimmer';
+
+UPDATE agents SET default_mandate =
+    'Keep capital working — close positions that have been held past their intended horizon without delivering, freeing cash for fresher ideas.'
+    WHERE handle = 'agent-time-based-exit';
+
+UPDATE agents SET default_mandate =
+    'Exit on outsized adverse moves relative to a name''s normal volatility — a break well beyond its typical range signals a changed regime, not noise.'
+    WHERE handle = 'agent-volatility-stop';
+
+-- Manage agents (equal-weight balancer, risk-parity sizer) intentionally keep
+-- default_mandate NULL — mechanical, no brief.

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -886,3 +886,15 @@ ALTER TABLE agents ADD  CONSTRAINT agents_action_check
 CREATE INDEX IF NOT EXISTS idx_agents_library ON agents (action) WHERE action IS NOT NULL;
 
 ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE;  -- per-instance Run/Stop
+
+
+-- ============================================================
+-- Per-agent mandates (migration 046 — team builder, brief v2)
+--
+-- Each thinking agent (LLM buyer / reviewer) carries its OWN brief with a
+-- baked-in default; the saved instance can override it. Resolution at heartbeat
+-- time: instance override ?? agent default ?? (legacy) portfolios.description.
+-- Mechanical/manage agents leave default_mandate NULL (no brief field shown).
+-- ============================================================
+ALTER TABLE agents          ADD COLUMN IF NOT EXISTS default_mandate TEXT;  -- baked-in brief; NULL = mechanical (no brief)
+ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS mandate        TEXT;  -- per-instance override; NULL = use agent default

--- a/web/components/portfolio/team-builder.tsx
+++ b/web/components/portfolio/team-builder.tsx
@@ -18,7 +18,9 @@ import {
   type ParamSpec,
   type TeamAgent,
   defaultParams,
+  effectiveMandate,
   fillSentence,
+  hasCustomMandate,
   readiness,
   TRIGGER_LABELS,
 } from "@/lib/agents/types";
@@ -68,6 +70,30 @@ interface PendingItem {
   key: string;
   agent: LibraryAgent;
   params: Record<string, number | string>;
+  /** The editable brief, pre-filled from the agent's default mandate. */
+  mandate: string;
+}
+
+/** Action-aware label for an agent's brief field (brief = its mandate). */
+function briefLabel(action: AgentAction): string {
+  if (action === "buy") return "What to buy";
+  if (action === "sell") return "When to sell";
+  return "Brief";
+}
+
+/**
+ * The value to persist for a brief: null when it's empty or unchanged from the
+ * agent's default (so an untouched brief keeps tracking the evolving default),
+ * otherwise the trimmed text.
+ */
+function mandateOverride(
+  agent: Pick<LibraryAgent, "defaultMandate">,
+  text: string,
+): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  if (trimmed === (agent.defaultMandate ?? "").trim()) return null;
+  return trimmed;
 }
 
 // ----- Root ----------------------------------------------------------------
@@ -119,6 +145,7 @@ export default function TeamBuilder({
         key: `${agent.handle}-${seq.current}`,
         agent,
         params: defaultParams(agent.paramSchema),
+        mandate: agent.defaultMandate ?? "",
       },
     ]);
   }
@@ -128,6 +155,10 @@ export default function TeamBuilder({
     params: Record<string, number | string>,
   ) {
     setPending((p) => p.map((x) => (x.key === key ? { ...x, params } : x)));
+  }
+
+  function setPendingMandate(key: string, mandate: string) {
+    setPending((p) => p.map((x) => (x.key === key ? { ...x, mandate } : x)));
   }
 
   function discard(key: string) {
@@ -143,6 +174,8 @@ export default function TeamBuilder({
         portfolioId,
         handle: item.agent.handle,
         params: item.params,
+        // null when untouched from the default, so it keeps tracking it.
+        mandate: mandateOverride(item.agent, item.mandate),
       });
       if (!res.ok) {
         setError(res.error ?? "Could not save the agent.");
@@ -184,6 +217,7 @@ export default function TeamBuilder({
           if (agent) addAgent(agent);
         }}
         onPendingParams={setPendingParams}
+        onPendingMandate={setPendingMandate}
         onSavePending={savePending}
         onDiscard={discard}
         onToggleEnabled={(handle, enabled) =>
@@ -192,8 +226,10 @@ export default function TeamBuilder({
         onRemove={(handle) =>
           run(() => removeAgentFromPortfolio({ portfolioId, handle }))
         }
-        onSaveEdit={(handle, params) =>
-          run(() => updateTeamAgentParams({ portfolioId, handle, params }))
+        onSaveEdit={(handle, params, mandate) =>
+          run(() =>
+            updateTeamAgentParams({ portfolioId, handle, params, mandate }),
+          )
         }
         complete={read.buy && read.sell && read.manage}
       />
@@ -251,6 +287,7 @@ function TeamHopper({
   complete,
   onDropAgent,
   onPendingParams,
+  onPendingMandate,
   onSavePending,
   onDiscard,
   onToggleEnabled,
@@ -264,11 +301,16 @@ function TeamHopper({
   complete: boolean;
   onDropAgent: (handle: string) => void;
   onPendingParams: (key: string, params: Record<string, number | string>) => void;
+  onPendingMandate: (key: string, mandate: string) => void;
   onSavePending: (item: PendingItem) => void;
   onDiscard: (key: string) => void;
   onToggleEnabled: (handle: string, enabled: boolean) => void;
   onRemove: (handle: string) => void;
-  onSaveEdit: (handle: string, params: Record<string, number | string>) => void;
+  onSaveEdit: (
+    handle: string,
+    params: Record<string, number | string>,
+    mandate: string | null,
+  ) => void;
 }) {
   const [dragOver, setDragOver] = useState(false);
 
@@ -340,6 +382,7 @@ function TeamHopper({
                 item={item}
                 busy={busy}
                 onParams={(params) => onPendingParams(item.key, params)}
+                onMandate={(mandate) => onPendingMandate(item.key, mandate)}
                 onSave={() => onSavePending(item)}
                 onDiscard={() => onDiscard(item.key)}
               />
@@ -364,11 +407,18 @@ function TeamCard({
   busy: boolean;
   onToggleEnabled: (handle: string, enabled: boolean) => void;
   onRemove: (handle: string) => void;
-  onSaveEdit: (handle: string, params: Record<string, number | string>) => void;
+  onSaveEdit: (
+    handle: string,
+    params: Record<string, number | string>,
+    mandate: string | null,
+  ) => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(agent.params);
+  const [draftMandate, setDraftMandate] = useState(effectiveMandate(agent));
   const meta = ACTION_META[agent.action];
+  const hasBrief = agent.defaultMandate !== null;
+  const configurable = agent.paramSchema.length > 0 || hasBrief;
 
   return (
     <li className="px-4 py-4">
@@ -390,6 +440,14 @@ function TeamCard({
             <span className="text-[11px] font-mono text-text-muted">
               {agent.enabled ? "running" : "stopped"}
             </span>
+            {hasCustomMandate(agent) && (
+              <span
+                className="text-[10px] font-mono text-[var(--color-cyan)]"
+                title="Running a custom brief you set"
+              >
+                ✎ custom brief
+              </span>
+            )}
           </div>
           {agent.poweredBy && (
             <p className="text-[11px] font-mono text-text-muted mt-0.5">
@@ -417,12 +475,23 @@ function TeamCard({
               <p className="text-sm text-text-dim mt-3 italic">
                 {fillSentence(agent, draft)}
               </p>
+              {hasBrief && (
+                <BriefField
+                  action={agent.action}
+                  value={draftMandate}
+                  onChange={setDraftMandate}
+                />
+              )}
               <div className="mt-3 flex gap-2">
                 <button
                   type="button"
                   disabled={busy}
                   onClick={() => {
-                    onSaveEdit(agent.handle, draft);
+                    onSaveEdit(
+                      agent.handle,
+                      draft,
+                      mandateOverride(agent, draftMandate),
+                    );
                     setEditing(false);
                   }}
                   className="rounded-lg bg-[var(--color-green)]/15 border border-[var(--color-green)]/40 px-3 py-1.5 text-xs font-mono text-[var(--color-green)] hover:bg-[var(--color-green)]/25 transition-colors disabled:opacity-50"
@@ -433,6 +502,7 @@ function TeamCard({
                   type="button"
                   onClick={() => {
                     setDraft(agent.params);
+                    setDraftMandate(effectiveMandate(agent));
                     setEditing(false);
                   }}
                   className="rounded-lg border border-white/10 px-3 py-1.5 text-xs font-mono text-text-muted hover:text-text transition-colors"
@@ -456,11 +526,12 @@ function TeamCard({
             >
               {agent.enabled ? "Stop" : "Run"}
             </button>
-            {agent.paramSchema.length > 0 && (
+            {configurable && (
               <button
                 type="button"
                 onClick={() => {
                   setDraft(agent.params);
+                  setDraftMandate(effectiveMandate(agent));
                   setEditing(true);
                 }}
                 title="Configure"
@@ -493,12 +564,14 @@ function PendingCard({
   item,
   busy,
   onParams,
+  onMandate,
   onSave,
   onDiscard,
 }: {
   item: PendingItem;
   busy: boolean;
   onParams: (params: Record<string, number | string>) => void;
+  onMandate: (mandate: string) => void;
   onSave: () => void;
   onDiscard: () => void;
 }) {
@@ -533,6 +606,16 @@ function PendingCard({
       <p className="text-sm text-text-dim mt-3 italic leading-relaxed">
         {fillSentence(agent, params)}
       </p>
+
+      {/* Per-agent brief, pre-filled with the agent's default (migration 046).
+          Only thinking agents (default mandate set) get one. */}
+      {agent.defaultMandate !== null && (
+        <BriefField
+          action={agent.action}
+          value={item.mandate}
+          onChange={onMandate}
+        />
+      )}
       {agent.action === "sell" && agent.triggers.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1.5">
           {agent.triggers.map((t) => (
@@ -628,6 +711,37 @@ function ParamControls({
           )}
         </div>
       ))}
+    </div>
+  );
+}
+
+// ----- Brief (per-agent mandate) -------------------------------------------
+
+function BriefField({
+  action,
+  value,
+  onChange,
+}: {
+  action: AgentAction;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="mt-3">
+      <label className="text-xs font-mono text-text-muted block mb-1">
+        {briefLabel(action)}{" "}
+        <span className="text-text-muted/70">— this agent&apos;s brief</span>
+      </label>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={3}
+        className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-text-dim leading-relaxed focus:border-[var(--color-cyan)] outline-none resize-y"
+      />
+      <p className="text-[11px] font-mono text-text-muted mt-1">
+        Pre-filled with the agent&apos;s default. Tune it, or leave it to track
+        the default.
+      </p>
     </div>
   );
 }

--- a/web/lib/agents/library.ts
+++ b/web/lib/agents/library.ts
@@ -19,7 +19,7 @@ import {
 export * from "@/lib/agents/types";
 
 const LIBRARY_COLUMNS =
-  "handle, display_name, description, powered_by, action, triggers, param_schema, sentence_template";
+  "handle, display_name, description, powered_by, action, triggers, param_schema, sentence_template, default_mandate";
 
 function coerceParamSchema(raw: unknown): ParamSpec[] {
   if (!Array.isArray(raw)) return [];
@@ -38,6 +38,7 @@ type LibraryRow = {
   triggers: string[] | null;
   param_schema: unknown;
   sentence_template: string | null;
+  default_mandate: string | null;
 };
 
 function rowToLibraryAgent(r: LibraryRow): LibraryAgent {
@@ -50,6 +51,7 @@ function rowToLibraryAgent(r: LibraryRow): LibraryAgent {
     triggers: r.triggers ?? [],
     paramSchema: coerceParamSchema(r.param_schema),
     sentenceTemplate: r.sentence_template,
+    defaultMandate: r.default_mandate ?? null,
   };
 }
 
@@ -86,7 +88,11 @@ export async function getTeamForPortfolio(
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from("portfolio_agents")
-    .select("config, enabled, joined_at, agents!inner(" + LIBRARY_COLUMNS + ")")
+    .select(
+      "config, enabled, mandate, joined_at, agents!inner(" +
+        LIBRARY_COLUMNS +
+        ")",
+    )
     .eq("portfolio_id", portfolioId)
     .not("agents.action", "is", null)
     .order("joined_at", { ascending: true });
@@ -97,6 +103,7 @@ export async function getTeamForPortfolio(
   type Row = {
     config: Record<string, number | string> | null;
     enabled: boolean | null;
+    mandate: string | null;
     agents: LibraryRow | LibraryRow[] | null;
   };
   const rows = (data as unknown as Row[] | null) ?? [];
@@ -112,6 +119,7 @@ export async function getTeamForPortfolio(
         ...lib,
         params: withDefaults(lib.paramSchema, r.config ?? {}),
         enabled: r.enabled ?? true,
+        mandate: r.mandate ?? null,
       };
     })
     .filter((t): t is TeamAgent => t !== null);

--- a/web/lib/agents/types.ts
+++ b/web/lib/agents/types.ts
@@ -40,12 +40,32 @@ export interface LibraryAgent {
   triggers: string[];
   paramSchema: ParamSpec[];
   sentenceTemplate: string | null;
+  /**
+   * The agent's baked-in brief (migration 046). Non-null only for "thinking"
+   * agents (LLM buyer / reviewer) — the team builder shows a brief field iff
+   * this is set; mechanical/manage agents leave it null.
+   */
+  defaultMandate: string | null;
 }
 
 /** A configured copy of a library agent saved onto a portfolio. */
 export interface TeamAgent extends LibraryAgent {
   params: Record<string, number | string>;
   enabled: boolean;
+  /** Per-instance brief override; null = track the agent default. */
+  mandate: string | null;
+}
+
+/** Whether the owner has pinned a custom brief on this saved agent. */
+export function hasCustomMandate(agent: TeamAgent): boolean {
+  return (agent.mandate ?? "").trim().length > 0;
+}
+
+/** The brief actually in force for an agent: instance override ?? default. */
+export function effectiveMandate(
+  agent: Pick<LibraryAgent, "defaultMandate"> & { mandate?: string | null },
+): string {
+  return (agent.mandate ?? null)?.trim() || agent.defaultMandate || "";
 }
 
 /** Merge stored params over schema defaults, dropping unknown keys. */

--- a/web/lib/portfolios-mutations.ts
+++ b/web/lib/portfolios-mutations.ts
@@ -529,6 +529,9 @@ export async function saveTeamAgent(input: {
   portfolioId: string;
   handle: string;
   params: Record<string, number | string>;
+  /** Per-instance brief override (migration 046). null = track the agent
+   *  default; the client passes null when the text equals the default. */
+  mandate?: string | null;
 }): Promise<ActionResult> {
   const { user } = await requireUser();
   const portfolio = await resolveOwnedPortfolio(input.portfolioId, user.id);
@@ -553,6 +556,7 @@ export async function saveTeamAgent(input: {
       agent_id: agent.id,
       role: ROLE_FOR_ACTION[agent.action] ?? null,
       config: input.params ?? {},
+      mandate: normalizeMandate(input.mandate),
       enabled: true,
     },
     { onConflict: "portfolio_id,agent_id" },
@@ -566,11 +570,20 @@ export async function saveTeamAgent(input: {
   return { ok: true };
 }
 
-/** Live edit of a saved agent's params (no re-deploy — brief §4). */
+/** Trim a brief to null/text — empty string collapses to null (track default). */
+function normalizeMandate(mandate: string | null | undefined): string | null {
+  if (mandate === undefined || mandate === null) return null;
+  const trimmed = mandate.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** Live edit of a saved agent's params + brief (no re-deploy — brief §4). */
 export async function updateTeamAgentParams(input: {
   portfolioId: string;
   handle: string;
   params: Record<string, number | string>;
+  /** Per-instance brief override (migration 046). null = track the default. */
+  mandate?: string | null;
 }): Promise<ActionResult> {
   const { user } = await requireUser();
   const portfolio = await resolveOwnedPortfolio(input.portfolioId, user.id);
@@ -582,7 +595,7 @@ export async function updateTeamAgentParams(input: {
   const supabase = getSupabase();
   const { error } = await supabase
     .from("portfolio_agents")
-    .update({ config: input.params ?? {} })
+    .update({ config: input.params ?? {}, mandate: normalizeMandate(input.mandate) })
     .eq("portfolio_id", input.portfolioId)
     .eq("agent_id", agent.id);
   if (error) {


### PR DESCRIPTION
Stacked on the team-builder rebuild (#1414) — base is `claude/admiring-rubin-6nzTJ`, so this diff is just the per-agent mandate work.

## What

Each thinking agent now **self-briefs** instead of sharing one portfolio mandate. Mirrors how params already work: a **default on the agent definition**, an **override on the saved instance**, resolved `override ?? default`.

- **`agents.default_mandate`** — the agent's baked-in brief. Non-null only for "thinking" agents (LLM buyer / reviewer); mechanical/manage agents leave it NULL and show no brief field.
- **`portfolio_agents.mandate`** — the per-instance override. NULL = track the agent default as it evolves; a value pins the owner's words.
- The old shared `portfolios.description` is no longer the agents' brief — it survives only as a last-resort fallback for legacy 1:1 agents.

## How it shows up

In the team builder, dragging a thinking agent in shows the sliders + live sentence **and a brief textarea pre-filled with the agent's default** (labelled by action: "What to buy" / "When to sell"). Leaving it untouched stores NULL so it keeps tracking the default; editing it pins the text, flagged on the settled card with a `✎ custom brief` chip. Mechanical/manage agents stay params-only.

## Backend

`agent_heartbeat._resolve_member_mandate` resolves `ctx.mandate` at all three ctx-build sites (swarm buyer, swarm reviewer, legacy per-member) as `instance override ?? agent default ?? (legacy) portfolios.description`. The legacy per-member loop also now reads per-instance config + mandate from the membership (falling back to agent-level config) so team agents configure correctly off the swarm path too. Example buy agents rebind to the LLM buyer (`llm_watchlist_buyer`) so the brief actually drives BUY/PASS.

## Known limitation

The swarm **buy** path drafts deterministically and doesn't invoke a buyer's LLM, so a *buyer's* brief bites only on the non-swarm path today; *sells* (the LLM reviewer) honour the per-agent brief everywhere. Rewiring swarm buys to per-buyer LLM judgment is a separate engine change.

## Verification

`tsc` clean, `next build` compiles, swarm unit tests pass.

https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU)_