### PR TITLE
Promote house agents into the library + fix empty-team add flow

### DIFF
--- a/migrations/047_house_agents_to_library.sql
+++ b/migrations/047_house_agents_to_library.sql
@@ -1,0 +1,89 @@
+-- Migration 047: adapt the real house agents to the team-builder library.
+--
+-- The team builder's library is "hireable agents with an action set" (migration
+-- 045). The illustrative seed agents from 045 are placeholders; the *real*
+-- roster is the house agents that already run live strategies. This migration
+-- promotes them into the library so the team builder isn't empty:
+--
+--   * the four LLM buyers (buyer-gemini / -claude / -chatgpt / -grok, all
+--     `llm_watchlist_buyer`) → action 'buy', one brain each;
+--   * the LLM reviewer (portfolio-reviewer, `portfolio_reviewer`) → action 'sell'.
+--
+-- Each gets the param + sentence + default-mandate fields the builder reads, so
+-- they're function-first, self-briefing, and tunable per instance. Their
+-- existing UUIDs / portfolios / track records are untouched — only the library
+-- presentation columns change.
+--
+-- Self-contained & idempotent: re-declares the 045/046 columns IF NOT EXISTS so
+-- it can be applied on its own (e.g. if only the real roster is wanted, without
+-- the 045 example seeds). Paste-and-run in the Supabase SQL editor.
+
+-- ---- Columns (mirror of 045 + 046, for standalone safety) -----------------
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS action            TEXT;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS triggers          TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS param_schema      JSONB  NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS sentence_template TEXT;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS default_mandate   TEXT;
+ALTER TABLE agents DROP CONSTRAINT IF EXISTS agents_action_check;
+ALTER TABLE agents ADD  CONSTRAINT agents_action_check
+    CHECK (action IS NULL OR action IN ('buy', 'sell', 'manage'));
+CREATE INDEX IF NOT EXISTS idx_agents_library ON agents (action) WHERE action IS NOT NULL;
+ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS mandate TEXT;
+
+-- ---- The four LLM buyers → action 'buy' -----------------------------------
+-- Same strategy (llm_watchlist_buyer) offered on four brains: weighs every
+-- candidate against its brief and buys only its highest-conviction names.
+-- `target_position_pct` is the tunable size (maps straight onto the strategy's
+-- config key, so the slider actually changes sizing on the non-swarm path).
+UPDATE agents SET
+    action            = 'buy',
+    display_name      = 'Conviction Buyer · Gemini',
+    powered_by        = 'Gemini 2.5 Pro',
+    available_for_hire = TRUE,
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only its highest-conviction names, up to {target_position_pct}% per position.',
+    default_mandate   = 'Build a focused book of your best ideas — own high-quality businesses with durable growth at a sensible entry price, and pass on anything you do not have strong conviction in.'
+    WHERE handle = 'buyer-gemini';
+
+UPDATE agents SET
+    action            = 'buy',
+    display_name      = 'Conviction Buyer · Claude',
+    powered_by        = 'Claude Opus 4.8',
+    available_for_hire = TRUE,
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only its highest-conviction names, up to {target_position_pct}% per position.',
+    default_mandate   = 'Build a focused book of your best ideas — own high-quality businesses with durable growth at a sensible entry price, and pass on anything you do not have strong conviction in.'
+    WHERE handle = 'buyer-claude';
+
+UPDATE agents SET
+    action            = 'buy',
+    display_name      = 'Conviction Buyer · GPT-5',
+    powered_by        = 'GPT-5',
+    available_for_hire = TRUE,
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only its highest-conviction names, up to {target_position_pct}% per position.',
+    default_mandate   = 'Build a focused book of your best ideas — own high-quality businesses with durable growth at a sensible entry price, and pass on anything you do not have strong conviction in.'
+    WHERE handle = 'buyer-chatgpt';
+
+UPDATE agents SET
+    action            = 'buy',
+    display_name      = 'Conviction Buyer · Grok',
+    powered_by        = 'Grok 4',
+    available_for_hire = TRUE,
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only its highest-conviction names, up to {target_position_pct}% per position.',
+    default_mandate   = 'Build a focused book of your best ideas — own high-quality businesses with durable growth at a sensible entry price, and pass on anything you do not have strong conviction in.'
+    WHERE handle = 'buyer-grok';
+
+-- ---- The LLM reviewer → action 'sell' -------------------------------------
+-- `sell_conviction_threshold` maps onto the reviewer's config key: it sells a
+-- holding when its conviction to exit reaches the bar (out of 5).
+UPDATE agents SET
+    action            = 'sell',
+    powered_by        = 'Gemini 2.5 Pro',
+    available_for_hire = TRUE,
+    param_schema      = '[{"key":"sell_conviction_threshold","label":"Sell conviction","type":"number","min":1,"max":5,"step":1,"default":4}]'::jsonb,
+    sentence_template = 'Reviews each holding against your brief and sells when its conviction to exit reaches {sell_conviction_threshold} of 5.',
+    default_mandate   = 'Sell a holding when the reason you bought it no longer holds — broken fundamentals, a failed thesis, or a clearly better use of the capital. Otherwise, let winners run.'
+    WHERE handle = 'portfolio-reviewer';

--- a/web/components/portfolio/team-builder.tsx
+++ b/web/components/portfolio/team-builder.tsx
@@ -243,8 +243,12 @@ export default function TeamBuilder({
       {/* READINESS — reports absence, never the roster. */}
       <ReadinessStrip read={read} />
 
-      {/* ADD AGENTS — collapsed bar that expands to the library. Open by
-          default while the team is empty. */}
+      {/* ADD AGENTS — collapsed bar that expands to the library. With an empty
+          team the library is always shown (there's no roster to collapse, and
+          it's the only way to add a first agent); with a team it's behind the
+          "Add or change agents" bar. Deriving `showLibrary` from the live team
+          length — rather than the mount-time `addOpen` seed — is what keeps the
+          add affordance from vanishing after the last agent is removed. */}
       <div>
         {team.length > 0 && (
           <button
@@ -261,7 +265,7 @@ export default function TeamBuilder({
             </span>
           </button>
         )}
-        {addOpen && (
+        {(team.length === 0 || addOpen) && (
           <div className={team.length > 0 ? "mt-5" : ""}>
             <Library
               library={library}


### PR DESCRIPTION
Stacked on the per-agent-mandate PR (#1415) — base is `claude/per-agent-mandates`, so this diff is just the agent-library adaptation + bugfix.

## What

Two things that make the team builder usable with the **real** roster:

### 1. Promote the house agents into the library (`migration 047`)
The library is "hireable agents with an `action` set" — empty until real agents declare one. Rather than relying on the 045 example seeds, this adapts the live house agents:

- The four LLM buyers (`buyer-gemini/-claude/-chatgpt/-grok`, all `llm_watchlist_buyer`) → **Conviction Buyer · Gemini / Claude / GPT-5 / Grok** (`action: buy`), each with a tunable "target per position" slider, a plain-language sentence, and a default brief.
- The LLM reviewer (`portfolio-reviewer`) → **Portfolio Reviewer** (`action: sell`), with a sell-conviction slider + default brief.

The sliders map onto the strategies' real config keys (`target_position_pct`, `sell_conviction_threshold`), so tuning them actually changes behaviour. Their UUIDs / portfolios / track records are untouched — only the library-presentation columns change. The migration is **self-contained** (re-declares the 045/046 columns `IF NOT EXISTS`) so it can be applied on its own to populate the library with just the real roster.

This gives a **buy + sell** library; the Readiness "Manage" slot stays open until a real rebalancer house agent is defined.

### 2. Fix: the add-agents library vanished after emptying the team
The add affordance was gated two ways that both failed for an emptied team — the "Add or change agents" bar only renders when `team.length > 0`, and the library only opened via `addOpen`, which is seeded once at mount. A portfolio that started with agents mounted with `addOpen = false`, so removing the last agent left no way back in. The library's visibility is now derived from the live team length (always shown when empty) instead of the mount-time seed.

## Verification

`tsc` clean. Migration applied against the live DB by the owner — the four Conviction Buyers + Portfolio Reviewer now populate the library.

https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU)_