### PR TITLE
Team builder: scheduled runners, per-agent briefs, live coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,22 @@ params live flat in `portfolio_agents.config` (merged into the strategy's
 agent stays on the roster but the heartbeat skips it). Action maps to the
 heartbeat role (`buy→buyer`, `sell→reviewer`, `manage→manager`); buy/sell run
 through the existing swarm engine, manage is inert until a manage engine is
-defined. The **library is the set of hireable agents with `action` set** — the
+defined.
+
+**Per-agent mandates (migration 046).** Each thinking agent self-briefs: there
+is no shared portfolio mandate any more. A library agent's baked-in brief lives
+in `agents.default_mandate` (NULL for mechanical/manage agents — they show no
+brief field), and the saved instance can override it via
+`portfolio_agents.mandate`. The team builder shows a **pre-filled, editable
+brief** for any agent with a default (label by action: buy → "What to buy",
+sell → "When to sell"); leaving it untouched stores NULL so it tracks the
+evolving default, editing it pins the owner's words (a `✎ custom brief` chip
+marks overrides). The heartbeat resolves `ctx.mandate` as
+`instance override ?? agent default ?? (legacy) portfolios.description`
+(`agent_heartbeat._resolve_member_mandate`), so `portfolios.description` is now
+only a fallback for legacy 1:1 agents. The example buy agents are bound to the
+LLM buyer (`llm_watchlist_buyer`) so the brief actually drives BUY/PASS; sells
+run the LLM reviewer (`portfolio_reviewer`). The **library is the set of hireable agents with `action` set** — the
 seeded roster (migration 045) is illustrative; the real roster is curated
 separately by inserting agent rows. Mutations (`saveTeamAgent`,
 `updateTeamAgentParams`, `setTeamAgentEnabled`) live in

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -293,6 +293,23 @@ def _portfolio_is_due(portfolio: dict, now: datetime) -> bool:
     return now >= last + timedelta(hours=PORTFOLIO_HEARTBEAT_INTERVAL_HOURS)
 
 
+def _resolve_member_mandate(member_row: dict, portfolio_mandate: str | None) -> str | None:
+    """The brief a member agent works to (migration 046).
+
+    Per-agent mandates replace the old single portfolio mandate: each thinking
+    agent self-briefs. Resolution mirrors params — the saved INSTANCE override
+    wins, else the agent's baked-in DEFAULT, else the portfolio brief as a
+    legacy fallback (for 1:1 agents that predate per-agent mandates).
+    """
+    override = (member_row.get("mandate") or "").strip()
+    if override:
+        return override
+    default = ((member_row.get("agent") or {}).get("default_mandate") or "").strip()
+    if default:
+        return default
+    return portfolio_mandate
+
+
 def _run_portfolio_swarm(
     db: SupabaseDB,
     pm: PortfolioManager,
@@ -387,7 +404,8 @@ def _run_portfolio_swarm(
         ctx = RebalanceContext(
             db=db, pm=pm, agent=m["agent"], dry_run=False,
             params=dict(m.get("config") or {}), portfolio_id=pid,
-            members=members, mandate=mandate, mode=mode, executor=executor,
+            members=members, mandate=_resolve_member_mandate(m, mandate),
+            mode=mode, executor=executor,
         )
         rationale = cand_map.get(pick.ticker)
         note = f"swarm draft (conviction {pick.conviction}/5): {rationale or ''}".strip()
@@ -434,7 +452,8 @@ def _run_portfolio_swarm(
         ctx = RebalanceContext(
             db=db, pm=pm, agent=agent, dry_run=dry_run,
             params=dict(m.get("config") or {}), portfolio_id=pid,
-            members=members, mandate=mandate, mode=mode, executor=executor,
+            members=members, mandate=_resolve_member_mandate(m, mandate),
+            mode=mode, executor=executor,
         )
         try:
             result = strategy(ctx)
@@ -517,11 +536,13 @@ def _run_portfolio(
 
     members = [m["agent"] for m in member_rows]
     mandate = portfolio.get("description")
+    run_rows = member_rows
     if handle_filter:
-        members = [m for m in members if m.get("handle") == handle_filter]
-    logger.info("  portfolio %-22s %d member(s)", slug, len(members))
+        run_rows = [mr for mr in member_rows if mr["agent"].get("handle") == handle_filter]
+    logger.info("  portfolio %-22s %d member(s)", slug, len(run_rows))
 
-    for member in members:
+    for member_row in run_rows:
+        member = member_row["agent"]
         handle = member.get("handle", member["id"][:8])
         strategy_name = member.get("strategy")
         started = _now_utc()
@@ -552,12 +573,16 @@ def _run_portfolio(
             continue
 
         mode, executor = _resolve_live_executor(portfolio, dry_run=dry_run)
+        # Per-instance params (portfolio_agents.config, migration 045) override
+        # the agent-level config; the membership-less legacy 1:1 agents fall
+        # back to their agents.config. Mandate is resolved per-agent (046).
+        params = {**(member.get("config") or {}), **(member_row.get("config") or {})}
         ctx = RebalanceContext(
             db=db, pm=pm, agent=member, dry_run=dry_run,
-            params=dict(member.get("config") or {}),
+            params=params,
             portfolio_id=portfolio["id"],
             members=members,
-            mandate=mandate,
+            mandate=_resolve_member_mandate(member_row, mandate),
             mode=mode,
             executor=executor,
         )

--- a/db.py
+++ b/db.py
@@ -588,6 +588,11 @@ class SupabaseDB:
                     "role": m.get("role"),
                     "remit": m.get("remit"),
                     "config": m.get("config"),
+                    # Per-instance mandate override (migration 046). NULL =
+                    # use the agent's default_mandate (which rides along in the
+                    # agents row below). Resolved at ctx-build time in the
+                    # heartbeat: override ?? agent default ?? portfolio brief.
+                    "mandate": m.get("mandate"),
                     # Per-instance Run/Stop switch (migration 045). A stopped
                     # team agent stays on the roster but is skipped by the
                     # heartbeat. Default True for legacy rows / new members.

--- a/migrations/046_agent_mandate.sql
+++ b/migrations/046_agent_mandate.sql
@@ -1,0 +1,79 @@
+-- Migration 046: per-agent individual mandates (team builder, brief v2).
+--
+-- In the old model every LLM-driven agent read one shared mandate
+-- (portfolios.description). The team-builder world makes the team *be* the
+-- strategy, so a single overall mandate no longer fits. Each thinking agent now
+-- carries its OWN brief, pre-filled with a sensible default, so a team works out
+-- of the box but each agent can be tuned individually.
+--
+-- Mirrors how params already work (migration 045): the DEFAULT lives on the
+-- agent definition, the saved INSTANCE can override. Resolution at heartbeat
+-- time is `instance override ?? agent default ?? (legacy) portfolio.description`.
+--
+-- Only "thinking" agents (those whose engine consumes a brief — the LLM buyer
+-- and the LLM reviewer) carry a default_mandate. Mechanical/manage agents leave
+-- it NULL and the UI shows no brief field for them.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+-- ============================================================
+-- 1. Columns
+-- ============================================================
+-- agents.default_mandate: the baked-in brief. Presence (NOT NULL) is what marks
+--   an agent as a thinking agent that shows a brief field.
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS default_mandate TEXT;
+
+-- portfolio_agents.mandate: the per-instance override. NULL = use the agent's
+--   default (and keep tracking it as the default evolves).
+ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS mandate TEXT;
+
+-- ============================================================
+-- 2. Re-seed the example library with default mandates
+-- ============================================================
+-- Buy agents move onto the thinking buyer (llm_watchlist_buyer) so the brief
+-- actually drives BUY/PASS; sell agents stay on the LLM reviewer; manage agents
+-- keep NULL default_mandate (no engine, no brief). Idempotent: extends the
+-- migration-045 seed in place.
+
+UPDATE agents SET strategy = 'llm_watchlist_buyer', default_mandate =
+    'Own elite Rule-of-40 compounders — durable revenue growth paired with strong free cash flow. Favour proven models over hype, and skip names already priced for perfection.'
+    WHERE handle = 'agent-quality-compounder';
+
+UPDATE agents SET strategy = 'llm_watchlist_buyer', default_mandate =
+    'Buy strength — names breaking out to new highs on improving fundamentals. Avoid breakouts riding deteriorating margins or fading growth.'
+    WHERE handle = 'agent-momentum-breakout';
+
+UPDATE agents SET strategy = 'llm_watchlist_buyer', default_mandate =
+    'Buy quality at a discount — sound businesses trading cheaply on sales. Demand a real margin of safety, not just a low multiple on a broken story.'
+    WHERE handle = 'agent-deep-value-sniper';
+
+UPDATE agents SET strategy = 'llm_watchlist_buyer', default_mandate =
+    'Buy quality on weakness — durable names that have pulled back, not falling knives. Confirm the thesis still holds before adding.'
+    WHERE handle = 'agent-dip-buyer';
+
+UPDATE agents SET strategy = 'llm_watchlist_buyer', default_mandate =
+    'Buy durable franchises trading well below their long-run trend, where the business is intact and the discount is sentiment rather than deterioration.'
+    WHERE handle = 'agent-200w-reversion';
+
+UPDATE agents SET default_mandate =
+    'Cut losers fast — exit any position that falls meaningfully below its entry price. Never average down a broken position.'
+    WHERE handle = 'agent-hard-stop-loss';
+
+UPDATE agents SET default_mandate =
+    'Let winners run but protect gains — exit when a position gives back a meaningful chunk from its peak since purchase.'
+    WHERE handle = 'agent-trailing-stop';
+
+UPDATE agents SET default_mandate =
+    'Bank gains into strength — take profits once a position has run, trimming back toward a core holding rather than exiting wholesale.'
+    WHERE handle = 'agent-target-trimmer';
+
+UPDATE agents SET default_mandate =
+    'Keep capital working — close positions that have been held past their intended horizon without delivering, freeing cash for fresher ideas.'
+    WHERE handle = 'agent-time-based-exit';
+
+UPDATE agents SET default_mandate =
+    'Exit on outsized adverse moves relative to a name''s normal volatility — a break well beyond its typical range signals a changed regime, not noise.'
+    WHERE handle = 'agent-volatility-stop';
+
+-- Manage agents (equal-weight balancer, risk-parity sizer) intentionally keep
+-- default_mandate NULL — mechanical, no brief.

--- a/migrations/047_house_agents_to_library.sql
+++ b/migrations/047_house_agents_to_library.sql
@@ -1,0 +1,89 @@
+-- Migration 047: adapt the real house agents to the team-builder library.
+--
+-- The team builder's library is "hireable agents with an action set" (migration
+-- 045). The illustrative seed agents from 045 are placeholders; the *real*
+-- roster is the house agents that already run live strategies. This migration
+-- promotes them into the library so the team builder isn't empty:
+--
+--   * the four LLM buyers (buyer-gemini / -claude / -chatgpt / -grok, all
+--     `llm_watchlist_buyer`) → action 'buy', one brain each;
+--   * the LLM reviewer (portfolio-reviewer, `portfolio_reviewer`) → action 'sell'.
+--
+-- Each gets the param + sentence + default-mandate fields the builder reads, so
+-- they're function-first, self-briefing, and tunable per instance. Their
+-- existing UUIDs / portfolios / track records are untouched — only the library
+-- presentation columns change.
+--
+-- Self-contained & idempotent: re-declares the 045/046 columns IF NOT EXISTS so
+-- it can be applied on its own (e.g. if only the real roster is wanted, without
+-- the 045 example seeds). Paste-and-run in the Supabase SQL editor.
+
+-- ---- Columns (mirror of 045 + 046, for standalone safety) -----------------
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS action            TEXT;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS triggers          TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS param_schema      JSONB  NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS sentence_template TEXT;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS default_mandate   TEXT;
+ALTER TABLE agents DROP CONSTRAINT IF EXISTS agents_action_check;
+ALTER TABLE agents ADD  CONSTRAINT agents_action_check
+    CHECK (action IS NULL OR action IN ('buy', 'sell', 'manage'));
+CREATE INDEX IF NOT EXISTS idx_agents_library ON agents (action) WHERE action IS NOT NULL;
+ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS mandate TEXT;
+
+-- ---- The four LLM buyers → action 'buy' -----------------------------------
+-- Same strategy (llm_watchlist_buyer) offered on four brains: weighs every
+-- candidate against its brief and buys only its highest-conviction names.
+-- `target_position_pct` is the tunable size (maps straight onto the strategy's
+-- config key, so the slider actually changes sizing on the non-swarm path).
+UPDATE agents SET
+    action            = 'buy',
+    display_name      = 'Conviction Buyer · Gemini',
+    powered_by        = 'Gemini 2.5 Pro',
+    available_for_hire = TRUE,
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only its highest-conviction names, up to {target_position_pct}% per position.',
+    default_mandate   = 'Build a focused book of your best ideas — own high-quality businesses with durable growth at a sensible entry price, and pass on anything you do not have strong conviction in.'
+    WHERE handle = 'buyer-gemini';
+
+UPDATE agents SET
+    action            = 'buy',
+    display_name      = 'Conviction Buyer · Claude',
+    powered_by        = 'Claude Opus 4.8',
+    available_for_hire = TRUE,
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only its highest-conviction names, up to {target_position_pct}% per position.',
+    default_mandate   = 'Build a focused book of your best ideas — own high-quality businesses with durable growth at a sensible entry price, and pass on anything you do not have strong conviction in.'
+    WHERE handle = 'buyer-claude';
+
+UPDATE agents SET
+    action            = 'buy',
+    display_name      = 'Conviction Buyer · GPT-5',
+    powered_by        = 'GPT-5',
+    available_for_hire = TRUE,
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only its highest-conviction names, up to {target_position_pct}% per position.',
+    default_mandate   = 'Build a focused book of your best ideas — own high-quality businesses with durable growth at a sensible entry price, and pass on anything you do not have strong conviction in.'
+    WHERE handle = 'buyer-chatgpt';
+
+UPDATE agents SET
+    action            = 'buy',
+    display_name      = 'Conviction Buyer · Grok',
+    powered_by        = 'Grok 4',
+    available_for_hire = TRUE,
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only its highest-conviction names, up to {target_position_pct}% per position.',
+    default_mandate   = 'Build a focused book of your best ideas — own high-quality businesses with durable growth at a sensible entry price, and pass on anything you do not have strong conviction in.'
+    WHERE handle = 'buyer-grok';
+
+-- ---- The LLM reviewer → action 'sell' -------------------------------------
+-- `sell_conviction_threshold` maps onto the reviewer's config key: it sells a
+-- holding when its conviction to exit reaches the bar (out of 5).
+UPDATE agents SET
+    action            = 'sell',
+    powered_by        = 'Gemini 2.5 Pro',
+    available_for_hire = TRUE,
+    param_schema      = '[{"key":"sell_conviction_threshold","label":"Sell conviction","type":"number","min":1,"max":5,"step":1,"default":4}]'::jsonb,
+    sentence_template = 'Reviews each holding against your brief and sells when its conviction to exit reaches {sell_conviction_threshold} of 5.',
+    default_mandate   = 'Sell a holding when the reason you bought it no longer holds — broken fundamentals, a failed thesis, or a clearly better use of the capital. Otherwise, let winners run.'
+    WHERE handle = 'portfolio-reviewer';

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -886,3 +886,15 @@ ALTER TABLE agents ADD  CONSTRAINT agents_action_check
 CREATE INDEX IF NOT EXISTS idx_agents_library ON agents (action) WHERE action IS NOT NULL;
 
 ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE;  -- per-instance Run/Stop
+
+
+-- ============================================================
+-- Per-agent mandates (migration 046 — team builder, brief v2)
+--
+-- Each thinking agent (LLM buyer / reviewer) carries its OWN brief with a
+-- baked-in default; the saved instance can override it. Resolution at heartbeat
+-- time: instance override ?? agent default ?? (legacy) portfolios.description.
+-- Mechanical/manage agents leave default_mandate NULL (no brief field shown).
+-- ============================================================
+ALTER TABLE agents          ADD COLUMN IF NOT EXISTS default_mandate TEXT;  -- baked-in brief; NULL = mechanical (no brief)
+ALTER TABLE portfolio_agents ADD COLUMN IF NOT EXISTS mandate        TEXT;  -- per-instance override; NULL = use agent default

--- a/web/components/portfolio/team-builder.tsx
+++ b/web/components/portfolio/team-builder.tsx
@@ -243,8 +243,12 @@ export default function TeamBuilder({
       {/* READINESS — reports absence, never the roster. */}
       <ReadinessStrip read={read} />
 
-      {/* ADD AGENTS — collapsed bar that expands to the library. Open by
-          default while the team is empty. */}
+      {/* ADD AGENTS — collapsed bar that expands to the library. With an empty
+          team the library is always shown (there's no roster to collapse, and
+          it's the only way to add a first agent); with a team it's behind the
+          "Add or change agents" bar. Deriving `showLibrary` from the live team
+          length — rather than the mount-time `addOpen` seed — is what keeps the
+          add affordance from vanishing after the last agent is removed. */}
       <div>
         {team.length > 0 && (
           <button
@@ -261,7 +265,7 @@ export default function TeamBuilder({
             </span>
           </button>
         )}
-        {addOpen && (
+        {(team.length === 0 || addOpen) && (
           <div className={team.length > 0 ? "mt-5" : ""}>
             <Library
               library={library}

--- a/web/components/portfolio/team-builder.tsx
+++ b/web/components/portfolio/team-builder.tsx
@@ -1,19 +1,21 @@
 "use client";
 
 /**
- * Team builder (portfolio & agents brief v2, migration 045).
+ * Team builder (portfolio & agents brief v2; "Your Team" unit brief).
  *
  * The portfolio owner's home base: drag agents from a library into one team
- * hopper; saving an agent *deploys* it (no batch deploy). A slim readiness
- * strip reports whether the team can buy, sell and manage. Edits after save
- * are live. This component owns the whole "build + manage the team" surface;
- * holdings & trades render below it on the page.
+ * hopper; saving an agent *deploys* it (no batch deploy). The team itself is a
+ * single unit — coverage in the header, agents in the body, the gap verdict in
+ * the footer. Agents are *scheduled runners*, not always-on processes: each
+ * card shows when it next runs and offers a manual "Run now". Edits after save
+ * are live. Holdings & trades render below this component on the page.
  */
 
-import { useMemo, useRef, useState, useTransition } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import {
   type AgentAction,
+  type Coverage,
   type LibraryAgent,
   type ParamSpec,
   type TeamAgent,
@@ -21,15 +23,15 @@ import {
   effectiveMandate,
   fillSentence,
   hasCustomMandate,
-  readiness,
+  teamCoverage,
   TRIGGER_LABELS,
 } from "@/lib/agents/types";
 import {
   saveTeamAgent,
   updateTeamAgentParams,
-  setTeamAgentEnabled,
   removeAgentFromPortfolio,
 } from "@/lib/portfolios-mutations";
+import { runAgent } from "@/lib/run-agent-mutations";
 
 // ----- Action vocabulary ---------------------------------------------------
 
@@ -65,6 +67,10 @@ const TABS: { key: "all" | AgentAction; label: string }[] = [
 ];
 
 const DRAG_MIME = "application/x-alphamolt-agent";
+
+// Mirrors the run-now server cooldown (run-agent-mutations.ts) — the button
+// stays locked while the dispatched workflow is likely still running.
+const RUN_COOLDOWN_MS = 300_000;
 
 interface PendingItem {
   key: string;
@@ -114,11 +120,8 @@ export default function TeamBuilder({
   const [addOpen, setAddOpen] = useState(team.length === 0);
   const seq = useRef(0);
 
-  const read = useMemo(() => readiness(team), [team]);
-  const onTeam = useMemo(
-    () => new Set(team.map((a) => a.handle)),
-    [team],
-  );
+  const coverage = useMemo(() => teamCoverage(team), [team]);
+  const onTeam = useMemo(() => new Set(team.map((a) => a.handle)), [team]);
   const pendingHandles = useMemo(
     () => new Set(pending.map((p) => p.agent.handle)),
     [pending],
@@ -134,7 +137,7 @@ export default function TeamBuilder({
   }
 
   // Drag/click a library agent in → an unsaved card, config open. Unsaved does
-  // nothing (not on the team, not counted by readiness) until saved.
+  // nothing (not on the team, not counted by coverage) until saved.
   function addAgent(agent: LibraryAgent) {
     if (onTeam.has(agent.handle) || pendingHandles.has(agent.handle)) return;
     setError(null);
@@ -205,13 +208,14 @@ export default function TeamBuilder({
         </div>
       )}
 
-      {/* YOUR TEAM — saved (live) agents + any unsaved drag-ins. Single drop
-          target for the library. */}
-      <TeamHopper
+      {/* YOUR TEAM — one unit: coverage in the header, agents in the body, the
+          gap verdict in the footer. Also the single drop target. */}
+      <YourTeamUnit
         team={team}
         pending={pending}
         isEmpty={isEmpty}
         busy={isBusy}
+        coverage={coverage}
         onDropAgent={(handle) => {
           const agent = library.find((a) => a.handle === handle);
           if (agent) addAgent(agent);
@@ -220,9 +224,6 @@ export default function TeamBuilder({
         onPendingMandate={setPendingMandate}
         onSavePending={savePending}
         onDiscard={discard}
-        onToggleEnabled={(handle, enabled) =>
-          run(() => setTeamAgentEnabled({ portfolioId, handle, enabled }))
-        }
         onRemove={(handle) =>
           run(() => removeAgentFromPortfolio({ portfolioId, handle }))
         }
@@ -231,7 +232,6 @@ export default function TeamBuilder({
             updateTeamAgentParams({ portfolioId, handle, params, mandate }),
           )
         }
-        complete={read.buy && read.sell && read.manage}
       />
 
       {error && (
@@ -239,9 +239,6 @@ export default function TeamBuilder({
           {error}
         </p>
       )}
-
-      {/* READINESS — reports absence, never the roster. */}
-      <ReadinessStrip read={read} />
 
       {/* ADD AGENTS — collapsed bar that expands to the library. With an empty
           team the library is always shown (there's no roster to collapse, and
@@ -281,20 +278,19 @@ export default function TeamBuilder({
   );
 }
 
-// ----- Team hopper (drop target) -------------------------------------------
+// ----- The "Your Team" unit (coverage header + body + verdict footer) ------
 
-function TeamHopper({
+function YourTeamUnit({
   team,
   pending,
   isEmpty,
   busy,
-  complete,
+  coverage,
   onDropAgent,
   onPendingParams,
   onPendingMandate,
   onSavePending,
   onDiscard,
-  onToggleEnabled,
   onRemove,
   onSaveEdit,
 }: {
@@ -302,13 +298,12 @@ function TeamHopper({
   pending: PendingItem[];
   isEmpty: boolean;
   busy: boolean;
-  complete: boolean;
+  coverage: Coverage;
   onDropAgent: (handle: string) => void;
   onPendingParams: (key: string, params: Record<string, number | string>) => void;
   onPendingMandate: (key: string, mandate: string) => void;
   onSavePending: (item: PendingItem) => void;
   onDiscard: (key: string) => void;
-  onToggleEnabled: (handle: string, enabled: boolean) => void;
   onRemove: (handle: string) => void;
   onSaveEdit: (
     handle: string,
@@ -317,19 +312,14 @@ function TeamHopper({
   ) => void;
 }) {
   const [dragOver, setDragOver] = useState(false);
+  // Footer verdict appears only once there's at least one saved agent.
+  const showFooter = team.length > 0;
 
   return (
     <section>
-      <div className="flex items-baseline justify-between mb-3">
-        <h2 className="text-[11px] font-mono font-bold uppercase tracking-[0.14em] text-[var(--color-green)]">
-          Your team
-        </h2>
-        {complete && (
-          <span className="text-[11px] font-mono text-[var(--color-green)]">
-            ✓ Every job covered
-          </span>
-        )}
-      </div>
+      <h2 className="text-[11px] font-mono font-bold uppercase tracking-[0.14em] text-[var(--color-green)] mb-3">
+        Your team
+      </h2>
 
       <div
         onDragOver={(e) => {
@@ -345,57 +335,189 @@ function TeamHopper({
           const handle = e.dataTransfer.getData(DRAG_MIME);
           if (handle) onDropAgent(handle);
         }}
-        className={`rounded-2xl border transition-colors ${
+        className={`rounded-2xl border overflow-hidden transition-colors ${
           dragOver
-            ? "border-[var(--color-green)]/60 bg-[var(--color-green)]/[0.05]"
-            : isEmpty
-              ? "border-dashed border-white/15 bg-white/[0.015]"
-              : "border-white/10 bg-white/[0.02]"
+            ? "border-[var(--color-green)]/60"
+            : "border-white/10"
         }`}
       >
-        {isEmpty ? (
-          <div className="px-6 py-12 text-center">
-            <p className="text-2xl mb-2" aria-hidden>
-              ⌑
-            </p>
-            <p className="text-base font-bold text-text">
-              Drag your first agent here
-            </p>
-            <p className="text-sm text-text-muted mt-1">
-              Buyers, sellers and managers all drop into this one place.
-            </p>
-            <p className="text-sm text-[var(--color-green)] mt-3 font-mono">
-              New here? Start with a buyer to open positions.
-            </p>
-          </div>
-        ) : (
-          <ul className="divide-y divide-white/[0.06]">
-            {team.map((a) => (
-              <TeamCard
-                key={a.handle}
-                agent={a}
-                busy={busy}
-                onToggleEnabled={onToggleEnabled}
-                onRemove={onRemove}
-                onSaveEdit={onSaveEdit}
-              />
-            ))}
-            {pending.map((item) => (
-              <PendingCard
-                key={item.key}
-                item={item}
-                busy={busy}
-                onParams={(params) => onPendingParams(item.key, params)}
-                onMandate={(mandate) => onPendingMandate(item.key, mandate)}
-                onSave={() => onSavePending(item)}
-                onDiscard={() => onDiscard(item.key)}
-              />
-            ))}
-          </ul>
-        )}
+        {/* HEADER — coverage chips, pinned to the top. */}
+        <div className="flex items-center justify-between gap-3 px-4 py-3 bg-white/[0.025] border-b border-white/[0.06]">
+          <span className="text-[11px] font-mono font-bold uppercase tracking-[0.14em] text-text-muted">
+            Coverage
+          </span>
+          <CoverageHeader coverage={coverage} />
+        </div>
+
+        {/* BODY */}
+        <div
+          className={dragOver ? "bg-[var(--color-green)]/[0.05]" : ""}
+        >
+          {isEmpty ? (
+            <div className="m-4 rounded-xl border border-dashed border-white/15 bg-white/[0.015] px-6 py-12 text-center">
+              <p className="text-2xl mb-2" aria-hidden>
+                ⌑
+              </p>
+              <p className="text-base font-bold text-text">
+                Drag your first agent here
+              </p>
+              <p className="text-sm text-text-muted mt-1">
+                Buyers, sellers and managers all drop into this one place.
+              </p>
+              <p className="text-sm text-[var(--color-green)] mt-3 font-mono">
+                New here? Start with a buyer to open positions.
+              </p>
+            </div>
+          ) : (
+            <>
+              <ul className="divide-y divide-white/[0.06]">
+                {team.map((a) => (
+                  <TeamCard
+                    key={a.handle}
+                    agent={a}
+                    busy={busy}
+                    onRemove={onRemove}
+                    onSaveEdit={onSaveEdit}
+                  />
+                ))}
+                {pending.map((item) => (
+                  <PendingCard
+                    key={item.key}
+                    item={item}
+                    busy={busy}
+                    onParams={(params) => onPendingParams(item.key, params)}
+                    onMandate={(mandate) => onPendingMandate(item.key, mandate)}
+                    onSave={() => onSavePending(item)}
+                    onDiscard={() => onDiscard(item.key)}
+                  />
+                ))}
+              </ul>
+              {/* Persistent shaded drop slot, so the affordance never vanishes. */}
+              <div className="m-4 rounded-xl border border-dashed border-white/15 bg-white/[0.015] px-4 py-4 text-center text-sm font-mono text-text-muted">
+                <span aria-hidden>⌑ </span>Drag more agents here
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* FOOTER — one-line verdict, only when there's an agent. */}
+        {showFooter && <VerdictFooter coverage={coverage} />}
       </div>
     </section>
   );
+}
+
+// ----- Coverage header chips -----------------------------------------------
+
+function CoverageHeader({ coverage }: { coverage: Coverage }) {
+  return (
+    <div className="flex items-center gap-3 sm:gap-4">
+      <CoverageChip label="Buy" covered={coverage.buy} action="buy" />
+      <CoverageChip label="Sell" covered={coverage.sell} action="sell" />
+      <CoverageChip label="Manage" covered={coverage.manage} action="manage" />
+    </div>
+  );
+}
+
+function CoverageChip({
+  label,
+  covered,
+  action,
+}: {
+  label: string;
+  covered: boolean;
+  action: AgentAction;
+}) {
+  const meta = ACTION_META[action];
+  return (
+    <span className="inline-flex items-center gap-1.5" title={covered ? `${label} covered` : `No ${label.toLowerCase()} agent yet`}>
+      <span
+        aria-hidden
+        className="grid place-items-center h-3.5 w-3.5 rounded-[3px] text-[9px] font-bold"
+        style={{
+          background: covered ? meta.color : "transparent",
+          border: `1px solid ${covered ? meta.color : "var(--color-text-muted)"}`,
+          color: "var(--color-bg)",
+        }}
+      >
+        {covered ? "✓" : ""}
+      </span>
+      <span
+        className="text-sm font-mono"
+        style={{ color: covered ? "var(--color-text)" : "var(--color-text-muted)" }}
+      >
+        {label}
+      </span>
+    </span>
+  );
+}
+
+// ----- Verdict footer ------------------------------------------------------
+
+function VerdictFooter({ coverage }: { coverage: Coverage }) {
+  if (coverage.complete) {
+    return (
+      <div className="px-4 py-3 border-t border-white/[0.06] text-[12px] font-mono text-[var(--color-green)]">
+        ✓ Every job covered — ready.
+      </div>
+    );
+  }
+  return (
+    <div className="px-4 py-3 border-t border-white/[0.06] text-[12px] font-mono">
+      <span className="text-[var(--color-orange)]">
+        Add: {coverage.gaps.join(", ")}.
+      </span>{" "}
+      {coverage.consequence && (
+        <span className="text-text-muted">{coverage.consequence}</span>
+      )}
+    </div>
+  );
+}
+
+// ----- Schedule formatting -------------------------------------------------
+
+function relShort(ms: number): string {
+  const m = Math.round(ms / 60_000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.round(h / 24);
+  return `${d}d`;
+}
+
+/** "today 16:00" / "tomorrow 09:00" / "Jun 12 14:30" relative to `now`. */
+function clockLabel(ts: number, now: number): string {
+  const d = new Date(ts);
+  const time = d.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const a = new Date(now);
+  a.setHours(0, 0, 0, 0);
+  const b = new Date(ts);
+  b.setHours(0, 0, 0, 0);
+  const days = Math.round((b.getTime() - a.getTime()) / 86_400_000);
+  if (days === 0) return `today ${time}`;
+  if (days === 1) return `tomorrow ${time}`;
+  if (days === -1) return `yesterday ${time}`;
+  return `${d.toLocaleDateString("en-US", { month: "short", day: "numeric" })} ${time}`;
+}
+
+/**
+ * The resting schedule line for an agent. Agents fire on their own cadence
+ * (`heartbeat_interval_hours`) at the daily heartbeat; this shows the next due
+ * time derived from the last run, or "next cycle" before the first run.
+ */
+function scheduleText(agent: TeamAgent, now: number): string {
+  const intervalH = agent.heartbeatIntervalHours ?? 168;
+  const last = agent.lastRunAt ? new Date(agent.lastRunAt).getTime() : null;
+  if (last == null || Number.isNaN(last)) return "Next run · next cycle";
+  const next = last + intervalH * 3_600_000;
+  const ago = relShort(now - last);
+  if (next <= now) return `Last run ${ago} ago · due next cycle`;
+  return `Last run ${ago} ago · next run ${clockLabel(next, now)} (in ${relShort(next - now)})`;
 }
 
 // ----- Saved (live) team card ----------------------------------------------
@@ -403,13 +525,11 @@ function TeamHopper({
 function TeamCard({
   agent,
   busy,
-  onToggleEnabled,
   onRemove,
   onSaveEdit,
 }: {
   agent: TeamAgent;
   busy: boolean;
-  onToggleEnabled: (handle: string, enabled: boolean) => void;
   onRemove: (handle: string) => void;
   onSaveEdit: (
     handle: string,
@@ -420,30 +540,50 @@ function TeamCard({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(agent.params);
   const [draftMandate, setDraftMandate] = useState(effectiveMandate(agent));
+  const [now, setNow] = useState(() => Date.now());
+  const [cooldownEndsAt, setCooldownEndsAt] = useState<number | null>(null);
+  const [runError, setRunError] = useState<string | null>(null);
+  const [isDispatching, startRun] = useTransition();
   const meta = ACTION_META[agent.action];
   const hasBrief = agent.defaultMandate !== null;
   const configurable = agent.paramSchema.length > 0 || hasBrief;
 
+  // One ticking clock per card drives the live relative times + cooldown.
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const cooling = cooldownEndsAt ? Math.max(0, cooldownEndsAt - now) : 0;
+  // A run is "live" while the dispatch is in flight or within the cooldown
+  // window (the dispatched workflow is likely still executing).
+  const running = isDispatching || cooling > 0;
+
+  function runNow() {
+    setRunError(null);
+    startRun(async () => {
+      const res = await runAgent({ agentHandle: agent.handle });
+      if (!res.ok) {
+        setRunError(res.error ?? "Couldn't start the run.");
+        return;
+      }
+      setCooldownEndsAt(Date.now() + RUN_COOLDOWN_MS);
+    });
+  }
+
   return (
     <li className="px-4 py-4">
       <div className="flex items-start gap-3">
-        {/* Running / idle dot */}
+        {/* Action dot — static identity colour; pulses only during a run. */}
         <span
           aria-hidden
-          className={`mt-1.5 h-2 w-2 rounded-full shrink-0 ${
-            agent.enabled ? "animate-pulse" : ""
-          }`}
-          style={{
-            background: agent.enabled ? meta.color : "var(--color-text-muted)",
-          }}
+          className={`mt-1.5 h-2 w-2 rounded-full shrink-0 ${running ? "animate-pulse" : ""}`}
+          style={{ background: meta.color }}
         />
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-2 flex-wrap">
             <span className="font-bold text-text">{agent.displayName}</span>
             <ActionPill action={agent.action} />
-            <span className="text-[11px] font-mono text-text-muted">
-              {agent.enabled ? "running" : "stopped"}
-            </span>
             {hasCustomMandate(agent) && (
               <span
                 className="text-[10px] font-mono text-[var(--color-cyan)]"
@@ -518,17 +658,18 @@ function TeamCard({
           )}
         </div>
 
-        {/* Per-agent controls: Run/Stop · gear · remove (brief §5). */}
+        {/* Controls: Run now · gear · remove. No Run/Stop — agents are
+            scheduled runners, not always-on processes. */}
         {!editing && (
           <div className="flex items-center gap-1.5 shrink-0">
             <button
               type="button"
-              disabled={busy}
-              onClick={() => onToggleEnabled(agent.handle, !agent.enabled)}
-              title={agent.enabled ? "Stop this agent" : "Run this agent"}
-              className="rounded-lg border border-white/10 px-2.5 py-1 text-xs font-mono text-text-dim hover:text-text hover:bg-white/[0.04] transition-colors disabled:opacity-50"
+              disabled={running}
+              onClick={runNow}
+              title="Run this agent immediately"
+              className="rounded-lg border border-[var(--color-cyan)]/40 px-2.5 py-1 text-xs font-mono text-[var(--color-cyan)] hover:bg-[var(--color-cyan)]/10 transition-colors disabled:opacity-50"
             >
-              {agent.enabled ? "Stop" : "Run"}
+              ⟳ {running ? "Running…" : "Run now"}
             </button>
             {configurable && (
               <button
@@ -558,6 +699,27 @@ function TeamCard({
           </div>
         )}
       </div>
+
+      {/* Schedule line — the agent's resting state, or "Running now…". */}
+      {!editing && (
+        <div className="mt-3 pl-5 flex items-center gap-2">
+          {running && (
+            <span
+              aria-hidden
+              className="h-1.5 w-1.5 rounded-full animate-pulse"
+              style={{ background: meta.color }}
+            />
+          )}
+          <span className="text-[11px] font-mono text-text-muted">
+            {running ? "Running now…" : scheduleText(agent, now)}
+          </span>
+        </div>
+      )}
+      {runError && (
+        <p className="mt-2 pl-5 text-[11px] font-mono text-[var(--color-red)]">
+          {runError}
+        </p>
+      )}
     </li>
   );
 }
@@ -750,75 +912,6 @@ function BriefField({
   );
 }
 
-// ----- Readiness strip -----------------------------------------------------
-
-function ReadinessStrip({
-  read,
-}: {
-  read: ReturnType<typeof readiness>;
-}) {
-  return (
-    <section className="rounded-2xl border border-white/10 bg-white/[0.02] px-4 py-3">
-      <p className="text-[11px] font-mono font-bold uppercase tracking-[0.14em] text-text-muted mb-2">
-        Readiness
-      </p>
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-        <Coverage label="Buy" covered={read.buy} action="buy" />
-        <Coverage label="Sell" covered={read.sell} action="sell">
-          {read.triggers.length > 0 && (
-            <span className="text-[11px] font-mono text-text-muted">
-              ({read.triggers.map((t) => TRIGGER_LABELS[t] ?? t).join(" · ")})
-            </span>
-          )}
-        </Coverage>
-        <Coverage label="Manage" covered={read.manage} action="manage" />
-      </div>
-      <p
-        className={`mt-2 text-[11px] font-mono ${
-          read.buy && read.sell && read.manage
-            ? "text-[var(--color-green)]"
-            : "text-[var(--color-orange)]"
-        }`}
-      >
-        {read.verdict}
-      </p>
-    </section>
-  );
-}
-
-function Coverage({
-  label,
-  covered,
-  action,
-  children,
-}: {
-  label: string;
-  covered: boolean;
-  action: AgentAction;
-  children?: React.ReactNode;
-}) {
-  const meta = ACTION_META[action];
-  return (
-    <span className="inline-flex items-center gap-1.5">
-      <span
-        aria-hidden
-        className="h-2.5 w-2.5 rounded-sm"
-        style={{
-          background: covered ? meta.color : "transparent",
-          border: `1px solid ${covered ? meta.color : "var(--color-text-muted)"}`,
-        }}
-      />
-      <span
-        className="text-sm font-mono"
-        style={{ color: covered ? "var(--color-text)" : "var(--color-text-muted)" }}
-      >
-        {label}
-      </span>
-      {children}
-    </span>
-  );
-}
-
 // ----- Library shelf -------------------------------------------------------
 
 function Library({
@@ -926,7 +1019,6 @@ function LibraryCard({
   added: boolean;
   onAdd: () => void;
 }) {
-  const meta = ACTION_META[agent.action];
   return (
     <div
       draggable={!added}

--- a/web/components/portfolio/team-builder.tsx
+++ b/web/components/portfolio/team-builder.tsx
@@ -18,7 +18,9 @@ import {
   type ParamSpec,
   type TeamAgent,
   defaultParams,
+  effectiveMandate,
   fillSentence,
+  hasCustomMandate,
   readiness,
   TRIGGER_LABELS,
 } from "@/lib/agents/types";
@@ -68,6 +70,30 @@ interface PendingItem {
   key: string;
   agent: LibraryAgent;
   params: Record<string, number | string>;
+  /** The editable brief, pre-filled from the agent's default mandate. */
+  mandate: string;
+}
+
+/** Action-aware label for an agent's brief field (brief = its mandate). */
+function briefLabel(action: AgentAction): string {
+  if (action === "buy") return "What to buy";
+  if (action === "sell") return "When to sell";
+  return "Brief";
+}
+
+/**
+ * The value to persist for a brief: null when it's empty or unchanged from the
+ * agent's default (so an untouched brief keeps tracking the evolving default),
+ * otherwise the trimmed text.
+ */
+function mandateOverride(
+  agent: Pick<LibraryAgent, "defaultMandate">,
+  text: string,
+): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  if (trimmed === (agent.defaultMandate ?? "").trim()) return null;
+  return trimmed;
 }
 
 // ----- Root ----------------------------------------------------------------
@@ -119,6 +145,7 @@ export default function TeamBuilder({
         key: `${agent.handle}-${seq.current}`,
         agent,
         params: defaultParams(agent.paramSchema),
+        mandate: agent.defaultMandate ?? "",
       },
     ]);
   }
@@ -128,6 +155,10 @@ export default function TeamBuilder({
     params: Record<string, number | string>,
   ) {
     setPending((p) => p.map((x) => (x.key === key ? { ...x, params } : x)));
+  }
+
+  function setPendingMandate(key: string, mandate: string) {
+    setPending((p) => p.map((x) => (x.key === key ? { ...x, mandate } : x)));
   }
 
   function discard(key: string) {
@@ -143,6 +174,8 @@ export default function TeamBuilder({
         portfolioId,
         handle: item.agent.handle,
         params: item.params,
+        // null when untouched from the default, so it keeps tracking it.
+        mandate: mandateOverride(item.agent, item.mandate),
       });
       if (!res.ok) {
         setError(res.error ?? "Could not save the agent.");
@@ -184,6 +217,7 @@ export default function TeamBuilder({
           if (agent) addAgent(agent);
         }}
         onPendingParams={setPendingParams}
+        onPendingMandate={setPendingMandate}
         onSavePending={savePending}
         onDiscard={discard}
         onToggleEnabled={(handle, enabled) =>
@@ -192,8 +226,10 @@ export default function TeamBuilder({
         onRemove={(handle) =>
           run(() => removeAgentFromPortfolio({ portfolioId, handle }))
         }
-        onSaveEdit={(handle, params) =>
-          run(() => updateTeamAgentParams({ portfolioId, handle, params }))
+        onSaveEdit={(handle, params, mandate) =>
+          run(() =>
+            updateTeamAgentParams({ portfolioId, handle, params, mandate }),
+          )
         }
         complete={read.buy && read.sell && read.manage}
       />
@@ -251,6 +287,7 @@ function TeamHopper({
   complete,
   onDropAgent,
   onPendingParams,
+  onPendingMandate,
   onSavePending,
   onDiscard,
   onToggleEnabled,
@@ -264,11 +301,16 @@ function TeamHopper({
   complete: boolean;
   onDropAgent: (handle: string) => void;
   onPendingParams: (key: string, params: Record<string, number | string>) => void;
+  onPendingMandate: (key: string, mandate: string) => void;
   onSavePending: (item: PendingItem) => void;
   onDiscard: (key: string) => void;
   onToggleEnabled: (handle: string, enabled: boolean) => void;
   onRemove: (handle: string) => void;
-  onSaveEdit: (handle: string, params: Record<string, number | string>) => void;
+  onSaveEdit: (
+    handle: string,
+    params: Record<string, number | string>,
+    mandate: string | null,
+  ) => void;
 }) {
   const [dragOver, setDragOver] = useState(false);
 
@@ -340,6 +382,7 @@ function TeamHopper({
                 item={item}
                 busy={busy}
                 onParams={(params) => onPendingParams(item.key, params)}
+                onMandate={(mandate) => onPendingMandate(item.key, mandate)}
                 onSave={() => onSavePending(item)}
                 onDiscard={() => onDiscard(item.key)}
               />
@@ -364,11 +407,18 @@ function TeamCard({
   busy: boolean;
   onToggleEnabled: (handle: string, enabled: boolean) => void;
   onRemove: (handle: string) => void;
-  onSaveEdit: (handle: string, params: Record<string, number | string>) => void;
+  onSaveEdit: (
+    handle: string,
+    params: Record<string, number | string>,
+    mandate: string | null,
+  ) => void;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(agent.params);
+  const [draftMandate, setDraftMandate] = useState(effectiveMandate(agent));
   const meta = ACTION_META[agent.action];
+  const hasBrief = agent.defaultMandate !== null;
+  const configurable = agent.paramSchema.length > 0 || hasBrief;
 
   return (
     <li className="px-4 py-4">
@@ -390,6 +440,14 @@ function TeamCard({
             <span className="text-[11px] font-mono text-text-muted">
               {agent.enabled ? "running" : "stopped"}
             </span>
+            {hasCustomMandate(agent) && (
+              <span
+                className="text-[10px] font-mono text-[var(--color-cyan)]"
+                title="Running a custom brief you set"
+              >
+                ✎ custom brief
+              </span>
+            )}
           </div>
           {agent.poweredBy && (
             <p className="text-[11px] font-mono text-text-muted mt-0.5">
@@ -417,12 +475,23 @@ function TeamCard({
               <p className="text-sm text-text-dim mt-3 italic">
                 {fillSentence(agent, draft)}
               </p>
+              {hasBrief && (
+                <BriefField
+                  action={agent.action}
+                  value={draftMandate}
+                  onChange={setDraftMandate}
+                />
+              )}
               <div className="mt-3 flex gap-2">
                 <button
                   type="button"
                   disabled={busy}
                   onClick={() => {
-                    onSaveEdit(agent.handle, draft);
+                    onSaveEdit(
+                      agent.handle,
+                      draft,
+                      mandateOverride(agent, draftMandate),
+                    );
                     setEditing(false);
                   }}
                   className="rounded-lg bg-[var(--color-green)]/15 border border-[var(--color-green)]/40 px-3 py-1.5 text-xs font-mono text-[var(--color-green)] hover:bg-[var(--color-green)]/25 transition-colors disabled:opacity-50"
@@ -433,6 +502,7 @@ function TeamCard({
                   type="button"
                   onClick={() => {
                     setDraft(agent.params);
+                    setDraftMandate(effectiveMandate(agent));
                     setEditing(false);
                   }}
                   className="rounded-lg border border-white/10 px-3 py-1.5 text-xs font-mono text-text-muted hover:text-text transition-colors"
@@ -456,11 +526,12 @@ function TeamCard({
             >
               {agent.enabled ? "Stop" : "Run"}
             </button>
-            {agent.paramSchema.length > 0 && (
+            {configurable && (
               <button
                 type="button"
                 onClick={() => {
                   setDraft(agent.params);
+                  setDraftMandate(effectiveMandate(agent));
                   setEditing(true);
                 }}
                 title="Configure"
@@ -493,12 +564,14 @@ function PendingCard({
   item,
   busy,
   onParams,
+  onMandate,
   onSave,
   onDiscard,
 }: {
   item: PendingItem;
   busy: boolean;
   onParams: (params: Record<string, number | string>) => void;
+  onMandate: (mandate: string) => void;
   onSave: () => void;
   onDiscard: () => void;
 }) {
@@ -533,6 +606,16 @@ function PendingCard({
       <p className="text-sm text-text-dim mt-3 italic leading-relaxed">
         {fillSentence(agent, params)}
       </p>
+
+      {/* Per-agent brief, pre-filled with the agent's default (migration 046).
+          Only thinking agents (default mandate set) get one. */}
+      {agent.defaultMandate !== null && (
+        <BriefField
+          action={agent.action}
+          value={item.mandate}
+          onChange={onMandate}
+        />
+      )}
       {agent.action === "sell" && agent.triggers.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1.5">
           {agent.triggers.map((t) => (
@@ -628,6 +711,37 @@ function ParamControls({
           )}
         </div>
       ))}
+    </div>
+  );
+}
+
+// ----- Brief (per-agent mandate) -------------------------------------------
+
+function BriefField({
+  action,
+  value,
+  onChange,
+}: {
+  action: AgentAction;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="mt-3">
+      <label className="text-xs font-mono text-text-muted block mb-1">
+        {briefLabel(action)}{" "}
+        <span className="text-text-muted/70">— this agent&apos;s brief</span>
+      </label>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={3}
+        className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-text-dim leading-relaxed focus:border-[var(--color-cyan)] outline-none resize-y"
+      />
+      <p className="text-[11px] font-mono text-text-muted mt-1">
+        Pre-filled with the agent&apos;s default. Tune it, or leave it to track
+        the default.
+      </p>
     </div>
   );
 }

--- a/web/lib/agents/library.ts
+++ b/web/lib/agents/library.ts
@@ -19,7 +19,7 @@ import {
 export * from "@/lib/agents/types";
 
 const LIBRARY_COLUMNS =
-  "handle, display_name, description, powered_by, action, triggers, param_schema, sentence_template";
+  "handle, display_name, description, powered_by, action, triggers, param_schema, sentence_template, default_mandate";
 
 function coerceParamSchema(raw: unknown): ParamSpec[] {
   if (!Array.isArray(raw)) return [];
@@ -38,6 +38,7 @@ type LibraryRow = {
   triggers: string[] | null;
   param_schema: unknown;
   sentence_template: string | null;
+  default_mandate: string | null;
 };
 
 function rowToLibraryAgent(r: LibraryRow): LibraryAgent {
@@ -50,6 +51,7 @@ function rowToLibraryAgent(r: LibraryRow): LibraryAgent {
     triggers: r.triggers ?? [],
     paramSchema: coerceParamSchema(r.param_schema),
     sentenceTemplate: r.sentence_template,
+    defaultMandate: r.default_mandate ?? null,
   };
 }
 
@@ -86,7 +88,11 @@ export async function getTeamForPortfolio(
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from("portfolio_agents")
-    .select("config, enabled, joined_at, agents!inner(" + LIBRARY_COLUMNS + ")")
+    .select(
+      "config, enabled, mandate, joined_at, agents!inner(" +
+        LIBRARY_COLUMNS +
+        ")",
+    )
     .eq("portfolio_id", portfolioId)
     .not("agents.action", "is", null)
     .order("joined_at", { ascending: true });
@@ -97,6 +103,7 @@ export async function getTeamForPortfolio(
   type Row = {
     config: Record<string, number | string> | null;
     enabled: boolean | null;
+    mandate: string | null;
     agents: LibraryRow | LibraryRow[] | null;
   };
   const rows = (data as unknown as Row[] | null) ?? [];
@@ -112,6 +119,7 @@ export async function getTeamForPortfolio(
         ...lib,
         params: withDefaults(lib.paramSchema, r.config ?? {}),
         enabled: r.enabled ?? true,
+        mandate: r.mandate ?? null,
       };
     })
     .filter((t): t is TeamAgent => t !== null);

--- a/web/lib/agents/library.ts
+++ b/web/lib/agents/library.ts
@@ -89,9 +89,9 @@ export async function getTeamForPortfolio(
   const { data, error } = await supabase
     .from("portfolio_agents")
     .select(
-      "config, enabled, mandate, joined_at, agents!inner(" +
+      "config, enabled, mandate, last_heartbeat_at, joined_at, agents!inner(" +
         LIBRARY_COLUMNS +
-        ")",
+        ", heartbeat_interval_hours)",
     )
     .eq("portfolio_id", portfolioId)
     .not("agents.action", "is", null)
@@ -100,11 +100,13 @@ export async function getTeamForPortfolio(
     console.error("getTeamForPortfolio failed:", error);
     return [];
   }
+  type TeamRow = LibraryRow & { heartbeat_interval_hours: number | null };
   type Row = {
     config: Record<string, number | string> | null;
     enabled: boolean | null;
     mandate: string | null;
-    agents: LibraryRow | LibraryRow[] | null;
+    last_heartbeat_at: string | null;
+    agents: TeamRow | TeamRow[] | null;
   };
   const rows = (data as unknown as Row[] | null) ?? [];
   return rows
@@ -120,6 +122,8 @@ export async function getTeamForPortfolio(
         params: withDefaults(lib.paramSchema, r.config ?? {}),
         enabled: r.enabled ?? true,
         mandate: r.mandate ?? null,
+        lastRunAt: r.last_heartbeat_at ?? null,
+        heartbeatIntervalHours: a.heartbeat_interval_hours ?? null,
       };
     })
     .filter((t): t is TeamAgent => t !== null);

--- a/web/lib/agents/types.ts
+++ b/web/lib/agents/types.ts
@@ -54,6 +54,10 @@ export interface TeamAgent extends LibraryAgent {
   enabled: boolean;
   /** Per-instance brief override; null = track the agent default. */
   mandate: string | null;
+  /** Per-membership last rebalance (ISO), or null if it has never run. */
+  lastRunAt: string | null;
+  /** The agent's cadence in hours (defaults to weekly when unset). */
+  heartbeatIntervalHours: number | null;
 }
 
 /** Whether the owner has pinned a custom brief on this saved agent. */
@@ -105,48 +109,56 @@ export function fillSentence(
   });
 }
 
-export interface Readiness {
+export interface Coverage {
+  /** Action-axis coverage (the header chips) — counted from saved agents. */
   buy: boolean;
   sell: boolean;
   manage: boolean;
-  /** Declared sell triggers covered by the team's live sell agents. */
-  triggers: string[];
-  /** One-line gap verdict for the readiness strip. */
-  verdict: string;
+  /** All three actions covered. */
+  complete: boolean;
+  /** What's missing, in plain language (the footer verdict's list). */
+  gaps: string[];
+  /** Consequence tail, e.g. "your team can't exit or rebalance yet". */
+  consequence: string;
 }
 
 /**
- * Coverage readout (brief §5). Reports *absence*, never the roster: which of
- * buy / sell / manage are covered by at least one live (saved + running)
- * agent, the union of declared sell triggers, and a one-line gap verdict.
+ * Coverage readout for the "Your Team" unit (component brief §04). The header
+ * chips are the action axis only (buy / sell / manage), counted from *saved*
+ * agents. Trigger nuance (loss protection / profit-taking) lives in the gap
+ * list, not the header — and only once a sell exists but a trigger is absent.
  */
-export function readiness(team: TeamAgent[]): Readiness {
-  const live = team.filter((a) => a.enabled);
-  const buy = live.some((a) => a.action === "buy");
-  const sell = live.some((a) => a.action === "sell");
-  const manage = live.some((a) => a.action === "manage");
+export function teamCoverage(team: TeamAgent[]): Coverage {
+  const buy = team.some((a) => a.action === "buy");
+  const sell = team.some((a) => a.action === "sell");
+  const manage = team.some((a) => a.action === "manage");
+  const complete = buy && sell && manage;
 
-  const triggers = Array.from(
-    new Set(
-      live.filter((a) => a.action === "sell").flatMap((a) => a.triggers),
-    ),
+  const sellTriggers = new Set(
+    team.filter((a) => a.action === "sell").flatMap((a) => a.triggers),
   );
 
-  let verdict: string;
-  if (team.length === 0) {
-    verdict =
-      "Empty team. A complete team can buy, sell and manage — start with a buyer.";
-  } else if (buy && sell && manage) {
-    verdict = "Every job covered.";
+  const gaps: string[] = [];
+  if (!buy) gaps.push("a buyer");
+  if (!sell) {
+    gaps.push("a way to sell");
   } else {
-    const gaps: string[] = [];
-    if (!buy) gaps.push("a buyer");
-    if (!sell) gaps.push("a way to sell");
-    if (!manage) gaps.push("rebalancing");
-    verdict = `Consider adding: ${gaps.join(", ")}.`;
+    // Sell exists — name any missing intent (advice, not a header chip).
+    if (!sellTriggers.has("caps-losses")) gaps.push("loss protection");
+    if (!sellTriggers.has("banks-gains")) gaps.push("profit-taking");
   }
+  if (!manage) gaps.push("rebalancing");
 
-  return { buy, sell, manage, triggers, verdict };
+  // Consequence is about *capabilities* the team lacks, not trigger nuance.
+  const cant: string[] = [];
+  if (!buy) cant.push("open positions");
+  if (!sell) cant.push("exit");
+  if (!manage) cant.push("rebalance");
+  const consequence = cant.length
+    ? `your team can't ${cant.join(" or ")} yet`
+    : "";
+
+  return { buy, sell, manage, complete, gaps, consequence };
 }
 
 /** Heartbeat role a library action maps to (migration 041 + 045). */

--- a/web/lib/agents/types.ts
+++ b/web/lib/agents/types.ts
@@ -40,12 +40,32 @@ export interface LibraryAgent {
   triggers: string[];
   paramSchema: ParamSpec[];
   sentenceTemplate: string | null;
+  /**
+   * The agent's baked-in brief (migration 046). Non-null only for "thinking"
+   * agents (LLM buyer / reviewer) — the team builder shows a brief field iff
+   * this is set; mechanical/manage agents leave it null.
+   */
+  defaultMandate: string | null;
 }
 
 /** A configured copy of a library agent saved onto a portfolio. */
 export interface TeamAgent extends LibraryAgent {
   params: Record<string, number | string>;
   enabled: boolean;
+  /** Per-instance brief override; null = track the agent default. */
+  mandate: string | null;
+}
+
+/** Whether the owner has pinned a custom brief on this saved agent. */
+export function hasCustomMandate(agent: TeamAgent): boolean {
+  return (agent.mandate ?? "").trim().length > 0;
+}
+
+/** The brief actually in force for an agent: instance override ?? default. */
+export function effectiveMandate(
+  agent: Pick<LibraryAgent, "defaultMandate"> & { mandate?: string | null },
+): string {
+  return (agent.mandate ?? null)?.trim() || agent.defaultMandate || "";
 }
 
 /** Merge stored params over schema defaults, dropping unknown keys. */

--- a/web/lib/portfolios-mutations.ts
+++ b/web/lib/portfolios-mutations.ts
@@ -529,6 +529,9 @@ export async function saveTeamAgent(input: {
   portfolioId: string;
   handle: string;
   params: Record<string, number | string>;
+  /** Per-instance brief override (migration 046). null = track the agent
+   *  default; the client passes null when the text equals the default. */
+  mandate?: string | null;
 }): Promise<ActionResult> {
   const { user } = await requireUser();
   const portfolio = await resolveOwnedPortfolio(input.portfolioId, user.id);
@@ -553,6 +556,7 @@ export async function saveTeamAgent(input: {
       agent_id: agent.id,
       role: ROLE_FOR_ACTION[agent.action] ?? null,
       config: input.params ?? {},
+      mandate: normalizeMandate(input.mandate),
       enabled: true,
     },
     { onConflict: "portfolio_id,agent_id" },
@@ -566,11 +570,20 @@ export async function saveTeamAgent(input: {
   return { ok: true };
 }
 
-/** Live edit of a saved agent's params (no re-deploy — brief §4). */
+/** Trim a brief to null/text — empty string collapses to null (track default). */
+function normalizeMandate(mandate: string | null | undefined): string | null {
+  if (mandate === undefined || mandate === null) return null;
+  const trimmed = mandate.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** Live edit of a saved agent's params + brief (no re-deploy — brief §4). */
 export async function updateTeamAgentParams(input: {
   portfolioId: string;
   handle: string;
   params: Record<string, number | string>;
+  /** Per-instance brief override (migration 046). null = track the default. */
+  mandate?: string | null;
 }): Promise<ActionResult> {
   const { user } = await requireUser();
   const portfolio = await resolveOwnedPortfolio(input.portfolioId, user.id);
@@ -582,7 +595,7 @@ export async function updateTeamAgentParams(input: {
   const supabase = getSupabase();
   const { error } = await supabase
     .from("portfolio_agents")
-    .update({ config: input.params ?? {} })
+    .update({ config: input.params ?? {}, mandate: normalizeMandate(input.mandate) })
     .eq("portfolio_id", input.portfolioId)
     .eq("agent_id", agent.id);
   if (error) {


### PR DESCRIPTION
## Summary

Transforms the team builder from a "Run/Stop" toggle model to a **scheduled-runner architecture** where agents fire on their own cadence. Introduces **per-agent mandates** (migration 046) so each thinking agent self-briefs instead of reading a shared portfolio mandate. Replaces the separate "Readiness" strip with an integrated **"Your Team" unit** (header coverage chips + body + footer verdict) that shows live schedule state and manual "Run now" affordance.

## Key Changes

### Team Builder UI (`web/components/portfolio/team-builder.tsx`)
- **Renamed `TeamHopper` → `YourTeamUnit`**: restructured as a single cohesive unit with coverage header (chips), agent body, and verdict footer
- **Removed Run/Stop toggle**: agents are now scheduled runners; replaced with "Run now" button that dispatches an immediate run and shows cooldown state
- **Added live schedule display**: each card shows "Last run X ago · next run [time]" or "Running now…" with a ticking clock (1s interval)
- **Per-agent brief field**: thinking agents (those with `defaultMandate` set) now show an editable brief textarea, pre-filled from the agent's default, with label by action ("What to buy" / "When to sell" / "Brief")
- **Coverage header chips**: visual indicators for buy/sell/manage coverage (colored checkmarks when covered, empty boxes when missing)
- **Verdict footer**: one-line gap summary ("Add: a buyer, loss protection") + consequence ("your team can't open positions yet")
- **Persistent drop slot**: when team is non-empty, a shaded "Drag more agents here" affordance stays visible below the roster
- **Library visibility logic**: library is always shown when team is empty; with a team, it's behind the "Add or change agents" toggle

### Agent Types & Coverage (`web/lib/agents/types.ts`)
- **Added to `LibraryAgent`**: `defaultMandate: string | null` (baked-in brief for thinking agents)
- **Added to `TeamAgent`**: `mandate: string | null` (per-instance override), `lastRunAt: string | null`, `heartbeatIntervalHours: number | null`
- **New helpers**:
  - `hasCustomMandate(agent)`: whether owner pinned a custom brief
  - `effectiveMandate(agent)`: resolves instance override ?? default
- **Replaced `readiness()` → `teamCoverage()`**: returns `Coverage` object with action booleans, `complete` flag, `gaps` list (missing actions + trigger nuance), and `consequence` text

### Mutations & Server (`web/lib/portfolios-mutations.ts`, `agent_heartbeat.py`)
- **`saveTeamAgent()`**: now accepts optional `mandate` parameter (null when untouched from default, so it keeps tracking the evolving default)
- **`updateTeamAgentParams()`**: signature extended to include `mandate` override
- **Removed `setTeamAgentEnabled()`**: no longer needed (agents are scheduled, not toggled)
- **`_resolve_member_mandate()` in heartbeat**: resolution chain is instance override ?? agent default ?? portfolio brief (legacy fallback)

### Migrations
- **Migration 046** (`migrations/046_agent_mandate.sql`): adds `agents.default_mandate` and `portfolio_agents.mandate` columns; re-seeds example library with thinking-agent briefs
- **Migration 047** (`migrations/047_house_agents_to_library.sql`): promotes real house agents (four LLM buyers + reviewer) into the library with action, param schema, sentence template, and default mandate

### New Server Mutation
- **`runAgent()` in `web/lib/run-agent-mutations.ts`**: dispatches an immediate run for a single agent; client enforces 5-minute cooldown to avoid overlapping executions

## Notable Implementation Details

- **Cooldown window (`RUN_COOLDOWN_MS = 300_000`)**: button stays locked for 5 minutes after dispatch to match server-side workflow execution window
- **Live clock**: each `TeamCard` runs a 1-second interval timer

https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU