### PR TITLE
Your Agent Team unit: next-run date, cash split cards, drop verdict footer

### DIFF
--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -6,6 +6,7 @@ import HoldingsList from "@/components/holdings-list";
 import { TradeTape, type Trade } from "@/components/trade-tape";
 import VisibilityToggle from "@/components/portfolio/visibility-toggle";
 import TeamBuilder from "@/components/portfolio/team-builder";
+import TeamScheduleNote from "@/components/portfolio/team-schedule-note";
 import BetaDisclaimer from "@/components/beta-disclaimer";
 import {
   getPortfolio,
@@ -215,15 +216,17 @@ export default async function PortfolioPage({ params }: PageParams) {
   if (!portfolio) notFound();
 
   const bookCount = snapshot?.holdings.length ?? holdingsCount;
-  const runningCount = team.filter((a) => a.enabled).length;
   const unrealized =
     snapshot?.holdings.reduce((s, h) => s + (h.unrealized_pnl_usd ?? 0), 0) ??
     snapshot?.pnl_usd ??
     0;
-  const cashPct =
-    snapshot && snapshot.total_value_usd > 0
-      ? Math.round((snapshot.cash_usd / snapshot.total_value_usd) * 100)
-      : null;
+  // Equity (positions at market) vs cash split, and the unrealized return on
+  // account equity (= total paper value).
+  const totalValue = snapshot?.total_value_usd ?? 0;
+  const equityValue = snapshot?.holdings_value_usd ?? 0;
+  const cashValue = snapshot?.cash_usd ?? 0;
+  const equityPct = totalValue > 0 ? (equityValue / totalValue) * 100 : 0;
+  const pnlPct = totalValue > 0 ? (unrealized / totalValue) * 100 : 0;
 
   return (
     <>
@@ -275,27 +278,35 @@ export default async function PortfolioPage({ params }: PageParams) {
           {/* SUMMARY — paper value, unrealized P&L, holdings, team (brief §5).
               Honest: no invented alpha. */}
           {snapshot && (
-            <section className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-10 sm:mb-12">
-              <SummaryCard label="Paper value" value={formatUsd(snapshot.total_value_usd)} />
+            <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-10 sm:mb-12">
+              <PaperValueCard
+                total={totalValue}
+                equity={equityValue}
+                cash={cashValue}
+                equityPct={equityPct}
+              />
               <SummaryCard
                 label="Unrealized P&L"
                 value={`${unrealized >= 0 ? "+" : "-"}$${Math.abs(unrealized).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
                 tone={unrealized > 0 ? "positive" : unrealized < 0 ? "negative" : "neutral"}
+                sub={`${unrealized >= 0 ? "+" : "-"}${Math.abs(pnlPct).toFixed(2)}% on equity`}
               />
               <SummaryCard
                 label="Holdings"
                 value={String(bookCount)}
-                sub={cashPct !== null ? `${cashPct}% cash` : undefined}
+                sub="open positions"
               />
               <SummaryCard
                 label="Team"
                 value={`${team.length} agent${team.length === 1 ? "" : "s"}`}
                 sub={
-                  team.length === 0
-                    ? "none yet"
-                    : runningCount === team.length
-                      ? "all running"
-                      : `${runningCount} running`
+                  team.length === 0 ? (
+                    "none yet"
+                  ) : (
+                    <span className="text-[var(--color-green)]">
+                      <TeamScheduleNote />
+                    </span>
+                  )
                 }
               />
             </section>
@@ -385,7 +396,7 @@ function SummaryCard({
 }: {
   label: string;
   value: string;
-  sub?: string;
+  sub?: React.ReactNode;
   tone?: "positive" | "negative" | "neutral";
 }) {
   const color =
@@ -405,6 +416,57 @@ function SummaryCard({
       {sub && (
         <p className="text-[11px] font-mono text-text-muted mt-0.5">{sub}</p>
       )}
+    </div>
+  );
+}
+
+/**
+ * Paper-value card with an equity/cash split bar (component mockup) — so the
+ * owner can see how much capital is invested vs sitting in cash.
+ */
+function PaperValueCard({
+  total,
+  equity,
+  cash,
+  equityPct,
+}: {
+  total: number;
+  equity: number;
+  cash: number;
+  equityPct: number;
+}) {
+  const pct = Math.max(0, Math.min(100, equityPct));
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.02] px-4 py-3.5">
+      <p className="text-[10px] font-mono uppercase tracking-[0.14em] text-text-muted">
+        Paper value
+      </p>
+      <p className="font-mono text-xl sm:text-2xl font-bold tabular-nums text-text mt-1">
+        {formatUsd(total)}
+      </p>
+      <div
+        className="mt-2.5 h-1.5 w-full rounded-full bg-white/10 overflow-hidden"
+        role="img"
+        aria-label={`${pct.toFixed(0)}% invested in equities, the rest in cash`}
+      >
+        <div
+          className="h-full rounded-full bg-[var(--color-green)]"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="text-[11px] font-mono text-text-muted mt-1.5 leading-relaxed">
+        <span
+          aria-hidden
+          className="inline-block h-2 w-2 rounded-[2px] bg-[var(--color-green)] mr-1 align-middle"
+        />
+        Equity <span className="text-text">{formatUsd0(equity)}</span>
+        <span className="mx-1.5 text-text-dim">·</span>
+        <span
+          aria-hidden
+          className="inline-block h-2 w-2 rounded-[2px] bg-white/30 mr-1 align-middle"
+        />
+        Cash <span className="text-text">{formatUsd0(cash)}</span>
+      </p>
     </div>
   );
 }
@@ -456,4 +518,10 @@ function formatUsd(n: number): string {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   })}`;
+}
+
+/** Whole-dollar USD, e.g. "$535,140" (used in the equity/cash legend). */
+function formatUsd0(n: number): string {
+  const sign = n < 0 ? "-" : "";
+  return `${sign}$${Math.round(Math.abs(n)).toLocaleString("en-US")}`;
 }

--- a/web/components/portfolio/team-builder.tsx
+++ b/web/components/portfolio/team-builder.tsx
@@ -32,6 +32,7 @@ import {
   removeAgentFromPortfolio,
 } from "@/lib/portfolios-mutations";
 import { runAgent } from "@/lib/run-agent-mutations";
+import { scheduleText } from "@/lib/agents/schedule";
 
 // ----- Action vocabulary ---------------------------------------------------
 
@@ -318,7 +319,7 @@ function YourTeamUnit({
   return (
     <section>
       <h2 className="text-[11px] font-mono font-bold uppercase tracking-[0.14em] text-[var(--color-green)] mb-3">
-        Your team
+        Your agent team
       </h2>
 
       <div
@@ -475,72 +476,8 @@ function VerdictFooter({ coverage }: { coverage: Coverage }) {
 }
 
 // ----- Schedule formatting -------------------------------------------------
-
-// The rebalance automation runs on a fixed weekly cron — Sunday 07:00 UTC
-// (.github/workflows/agent-heartbeat.yml: "0 7 * * 0"). Each agent acts on that
-// tick once its own cadence (heartbeat_interval_hours) has elapsed, so the next
-// run is deterministic: the next Sunday-07:00-UTC at/after the agent's due time.
-const HEARTBEAT_UTC_DAY = 0; // Sunday
-const HEARTBEAT_UTC_HOUR = 7; // 07:00 UTC
-
-function relShort(ms: number): string {
-  const m = Math.round(ms / 60_000);
-  if (m < 1) return "just now";
-  if (m < 60) return `${m}m`;
-  const h = Math.round(m / 60);
-  if (h < 24) return `${h}h`;
-  const d = Math.round(h / 24);
-  return `${d}d`;
-}
-
-/** Local-time label for an instant, e.g. "Sun, Jun 15, 08:00". */
-function dateTimeLabel(ts: number): string {
-  return new Date(ts).toLocaleString(undefined, {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
-/** The smallest Sunday-07:00-UTC instant at or after `after`. */
-function nextHeartbeatTick(after: number): number {
-  const d = new Date(after);
-  let cand = Date.UTC(
-    d.getUTCFullYear(),
-    d.getUTCMonth(),
-    d.getUTCDate(),
-    HEARTBEAT_UTC_HOUR,
-    0,
-    0,
-    0,
-  );
-  for (let i = 0; i < 8; i++) {
-    if (new Date(cand).getUTCDay() === HEARTBEAT_UTC_DAY && cand >= after) {
-      return cand;
-    }
-    cand += 86_400_000;
-  }
-  return cand;
-}
-
-/**
- * The schedule line for an agent. The next run is the next weekly heartbeat
- * (Sunday 07:00 UTC, shown in the viewer's local time) at or after the agent's
- * due time — `last run + cadence`, or now for an agent that hasn't run yet.
- */
-function scheduleText(agent: TeamAgent, now: number): string {
-  const intervalH = agent.heartbeatIntervalHours ?? 168;
-  const last = agent.lastRunAt ? Date.parse(agent.lastRunAt) : NaN;
-  const hasRun = !Number.isNaN(last);
-  const due = hasRun ? last + intervalH * 3_600_000 : now;
-  const next = nextHeartbeatTick(Math.max(now, due));
-  const nextLabel = `${dateTimeLabel(next)} (in ${relShort(next - now)})`;
-  return hasRun
-    ? `Last run ${relShort(now - last)} ago · next run ${nextLabel}`
-    : `Next run ${nextLabel}`;
-}
+// Cron-aware next-run helpers live in the shared, client-safe schedule module
+// (single source of the weekly-heartbeat constant).
 
 // ----- Saved (live) team card ----------------------------------------------
 
@@ -733,7 +670,9 @@ function TeamCard({
             />
           )}
           <span className="text-[11px] font-mono text-text-muted">
-            {running ? "Running now…" : scheduleText(agent, now)}
+            {running
+              ? "Running now…"
+              : scheduleText(agent.lastRunAt, agent.heartbeatIntervalHours, now)}
           </span>
         </div>
       )}

--- a/web/components/portfolio/team-builder.tsx
+++ b/web/components/portfolio/team-builder.tsx
@@ -476,6 +476,13 @@ function VerdictFooter({ coverage }: { coverage: Coverage }) {
 
 // ----- Schedule formatting -------------------------------------------------
 
+// The rebalance automation runs on a fixed weekly cron — Sunday 07:00 UTC
+// (.github/workflows/agent-heartbeat.yml: "0 7 * * 0"). Each agent acts on that
+// tick once its own cadence (heartbeat_interval_hours) has elapsed, so the next
+// run is deterministic: the next Sunday-07:00-UTC at/after the agent's due time.
+const HEARTBEAT_UTC_DAY = 0; // Sunday
+const HEARTBEAT_UTC_HOUR = 7; // 07:00 UTC
+
 function relShort(ms: number): string {
   const m = Math.round(ms / 60_000);
   if (m < 1) return "just now";
@@ -486,38 +493,53 @@ function relShort(ms: number): string {
   return `${d}d`;
 }
 
-/** "today 16:00" / "tomorrow 09:00" / "Jun 12 14:30" relative to `now`. */
-function clockLabel(ts: number, now: number): string {
-  const d = new Date(ts);
-  const time = d.toLocaleTimeString("en-US", {
+/** Local-time label for an instant, e.g. "Sun, Jun 15, 08:00". */
+function dateTimeLabel(ts: number): string {
+  return new Date(ts).toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
-    hour12: false,
   });
-  const a = new Date(now);
-  a.setHours(0, 0, 0, 0);
-  const b = new Date(ts);
-  b.setHours(0, 0, 0, 0);
-  const days = Math.round((b.getTime() - a.getTime()) / 86_400_000);
-  if (days === 0) return `today ${time}`;
-  if (days === 1) return `tomorrow ${time}`;
-  if (days === -1) return `yesterday ${time}`;
-  return `${d.toLocaleDateString("en-US", { month: "short", day: "numeric" })} ${time}`;
+}
+
+/** The smallest Sunday-07:00-UTC instant at or after `after`. */
+function nextHeartbeatTick(after: number): number {
+  const d = new Date(after);
+  let cand = Date.UTC(
+    d.getUTCFullYear(),
+    d.getUTCMonth(),
+    d.getUTCDate(),
+    HEARTBEAT_UTC_HOUR,
+    0,
+    0,
+    0,
+  );
+  for (let i = 0; i < 8; i++) {
+    if (new Date(cand).getUTCDay() === HEARTBEAT_UTC_DAY && cand >= after) {
+      return cand;
+    }
+    cand += 86_400_000;
+  }
+  return cand;
 }
 
 /**
- * The resting schedule line for an agent. Agents fire on their own cadence
- * (`heartbeat_interval_hours`) at the daily heartbeat; this shows the next due
- * time derived from the last run, or "next cycle" before the first run.
+ * The schedule line for an agent. The next run is the next weekly heartbeat
+ * (Sunday 07:00 UTC, shown in the viewer's local time) at or after the agent's
+ * due time — `last run + cadence`, or now for an agent that hasn't run yet.
  */
 function scheduleText(agent: TeamAgent, now: number): string {
   const intervalH = agent.heartbeatIntervalHours ?? 168;
-  const last = agent.lastRunAt ? new Date(agent.lastRunAt).getTime() : null;
-  if (last == null || Number.isNaN(last)) return "Next run · next cycle";
-  const next = last + intervalH * 3_600_000;
-  const ago = relShort(now - last);
-  if (next <= now) return `Last run ${ago} ago · due next cycle`;
-  return `Last run ${ago} ago · next run ${clockLabel(next, now)} (in ${relShort(next - now)})`;
+  const last = agent.lastRunAt ? Date.parse(agent.lastRunAt) : NaN;
+  const hasRun = !Number.isNaN(last);
+  const due = hasRun ? last + intervalH * 3_600_000 : now;
+  const next = nextHeartbeatTick(Math.max(now, due));
+  const nextLabel = `${dateTimeLabel(next)} (in ${relShort(next - now)})`;
+  return hasRun
+    ? `Last run ${relShort(now - last)} ago · next run ${nextLabel}`
+    : `Next run ${nextLabel}`;
 }
 
 // ----- Saved (live) team card ----------------------------------------------

--- a/web/components/portfolio/team-builder.tsx
+++ b/web/components/portfolio/team-builder.tsx
@@ -313,8 +313,6 @@ function YourTeamUnit({
   ) => void;
 }) {
   const [dragOver, setDragOver] = useState(false);
-  // Footer verdict appears only once there's at least one saved agent.
-  const showFooter = team.length > 0;
 
   return (
     <section>
@@ -400,9 +398,6 @@ function YourTeamUnit({
             </>
           )}
         </div>
-
-        {/* FOOTER — one-line verdict, only when there's an agent. */}
-        {showFooter && <VerdictFooter coverage={coverage} />}
       </div>
     </section>
   );
@@ -454,26 +449,6 @@ function CoverageChip({
 }
 
 // ----- Verdict footer ------------------------------------------------------
-
-function VerdictFooter({ coverage }: { coverage: Coverage }) {
-  if (coverage.complete) {
-    return (
-      <div className="px-4 py-3 border-t border-white/[0.06] text-[12px] font-mono text-[var(--color-green)]">
-        ✓ Every job covered — ready.
-      </div>
-    );
-  }
-  return (
-    <div className="px-4 py-3 border-t border-white/[0.06] text-[12px] font-mono">
-      <span className="text-[var(--color-orange)]">
-        Add: {coverage.gaps.join(", ")}.
-      </span>{" "}
-      {coverage.consequence && (
-        <span className="text-text-muted">{coverage.consequence}</span>
-      )}
-    </div>
-  );
-}
 
 // ----- Schedule formatting -------------------------------------------------
 // Cron-aware next-run helpers live in the shared, client-safe schedule module

--- a/web/components/portfolio/team-schedule-note.tsx
+++ b/web/components/portfolio/team-schedule-note.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+/**
+ * The summary "Team" card's status line: "scheduled · next run Sun 08:00".
+ * The next run is the next weekly heartbeat tick, shown in the viewer's local
+ * time. Computed after mount (Date.now()) so server and first client render
+ * agree — avoiding a hydration mismatch on a time value.
+ */
+
+import { useEffect, useState } from "react";
+import { nextHeartbeatTick, shortRunLabel } from "@/lib/agents/schedule";
+
+export default function TeamScheduleNote() {
+  const [now, setNow] = useState<number | null>(null);
+  useEffect(() => setNow(Date.now()), []);
+  if (now == null) return <>scheduled</>;
+  return <>scheduled · next run {shortRunLabel(nextHeartbeatTick(now))}</>;
+}

--- a/web/lib/agents/schedule.ts
+++ b/web/lib/agents/schedule.ts
@@ -1,0 +1,86 @@
+/**
+ * Heartbeat-schedule helpers — client-safe, no server imports.
+ *
+ * The rebalance automation runs on a fixed weekly cron: Sunday 07:00 UTC
+ * (.github/workflows/agent-heartbeat.yml: "0 7 * * 0"). Each agent acts on that
+ * tick once its own cadence (heartbeat_interval_hours) has elapsed, so the next
+ * run is deterministic — the next Sunday-07:00-UTC at/after the agent's due
+ * time. Keep this the single source of the cron constant; if the workflow
+ * schedule changes, change it here.
+ */
+
+export const HEARTBEAT_UTC_DAY = 0; // Sunday
+export const HEARTBEAT_UTC_HOUR = 7; // 07:00 UTC
+
+/** Coarse relative duration: "just now" / "5m" / "3h" / "5d". */
+export function relShort(ms: number): string {
+  const m = Math.round(ms / 60_000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.round(h / 24);
+  return `${d}d`;
+}
+
+/** Local-time label for an instant, e.g. "Sun, Jun 15, 08:00". */
+export function dateTimeLabel(ts: number): string {
+  return new Date(ts).toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** Compact local label for tight spots, e.g. "Sun 08:00". */
+export function shortRunLabel(ts: number): string {
+  return new Date(ts).toLocaleString(undefined, {
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** The smallest Sunday-07:00-UTC instant at or after `after`. */
+export function nextHeartbeatTick(after: number): number {
+  const d = new Date(after);
+  let cand = Date.UTC(
+    d.getUTCFullYear(),
+    d.getUTCMonth(),
+    d.getUTCDate(),
+    HEARTBEAT_UTC_HOUR,
+    0,
+    0,
+    0,
+  );
+  for (let i = 0; i < 8; i++) {
+    if (new Date(cand).getUTCDay() === HEARTBEAT_UTC_DAY && cand >= after) {
+      return cand;
+    }
+    cand += 86_400_000;
+  }
+  return cand;
+}
+
+/**
+ * The schedule line for an agent: its next weekly run (Sunday 07:00 UTC, in the
+ * viewer's local time) at/after its due time — `last run + cadence`, or now for
+ * an agent that hasn't run yet.
+ */
+export function scheduleText(
+  lastRunAt: string | null,
+  intervalHours: number | null,
+  now: number,
+): string {
+  const intervalH = intervalHours ?? 168;
+  const last = lastRunAt ? Date.parse(lastRunAt) : NaN;
+  const hasRun = !Number.isNaN(last);
+  const due = hasRun ? last + intervalH * 3_600_000 : now;
+  const next = nextHeartbeatTick(Math.max(now, due));
+  const nextLabel = `${dateTimeLabel(next)} (in ${relShort(next - now)})`;
+  return hasRun
+    ? `Last run ${relShort(now - last)} ago · next run ${nextLabel}`
+    : `Next run ${nextLabel}`;
+}


### PR DESCRIPTION
These three follow-ups landed on `claude/your-team-unit` **after** #1424 merged to `main` (and #1425 merged into the branch rather than into `main`), so they're not yet on `main` and had no open PR. This lands them.

## What's in here

- **Real next-run date** (`5ba2106`) — the schedule line shows the next weekly heartbeat (Sunday 07:00 UTC, in the viewer's local time) with a countdown, instead of "next cycle". Single-source the cron in a shared client-safe `web/lib/agents/schedule.ts`.
- **Summary cards: equity/cash split** (`76182c3`) — Paper value card gains an equity/cash bar + legend so uninvested cash is visible; P&L card adds "% on equity"; Holdings shows "open positions"; Team card shows "scheduled · next run …". Also renames the unit header to **"Your agent team"**.
- **Remove the verdict footer** (`0a682e5`) — drop the "Add: … your team can't … yet" line; the header coverage chips already convey gaps.

## Verification

`tsc` clean, `next build` compiles.

## Note

The schedule reflects the **real weekly cron** (Sunday 07:00 UTC). The stale CLAUDE.md "daily" note vs the weekly workflow cron is still worth reconciling — separate decision.

https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU)_