### PR TITLE
Display data freshness timestamp on screener page

### DIFF
--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -83,6 +83,26 @@ export async function generateMetadata({
   };
 }
 
+/**
+ * Format the screener's freshness stamp (the latest `price_asof` across the
+ * Tier 1 universe, i.e. when the daily matview last picked up prices). Parses a
+ * date-only `YYYY-MM-DD` in UTC to avoid an off-by-one from the server's
+ * timezone; falls back to a full timestamp parse otherwise.
+ */
+function formatAsOf(s: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(s);
+  const d = m
+    ? new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])))
+    : new Date(s);
+  if (Number.isNaN(d.getTime())) return s;
+  return d.toLocaleDateString("en-US", {
+    timeZone: "UTC",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
 export default async function ScreenerPage({
   searchParams,
 }: {
@@ -108,6 +128,11 @@ export default async function ScreenerPage({
               All US-listed equities (incl. ADRs), ranked by a composite you
               control · a research tool, not a recommendation.
             </p>
+            {initial.data_asof && (
+              <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.12em] text-text-muted">
+                Last refreshed {formatAsOf(initial.data_asof)}
+              </p>
+            )}
           </header>
 
           <ScreenerClient


### PR DESCRIPTION
## Summary
Add a "Last refreshed" timestamp display to the screener page header, showing when the Tier 1 universe prices were last updated (`data_asof`).

## Changes
- **New `formatAsOf()` utility function**: Parses date-only strings in `YYYY-MM-DD` format (UTC) to avoid timezone-related off-by-one errors, with fallback to full timestamp parsing. Returns formatted date in `en-US` locale with UTC timezone.
- **Screener header enhancement**: Display the freshness timestamp below the description text when `initial.data_asof` is available, styled as small monospace uppercase text matching the muted text color scheme.

## Implementation Details
- The formatter handles the common case of date-only strings from the daily matview by explicitly parsing them as UTC dates, preventing local timezone shifts
- Gracefully degrades to the original string if parsing fails
- Uses `toLocaleDateString()` with explicit UTC timezone to ensure consistent display regardless of server/client timezone
- Conditional rendering ensures the timestamp only appears when data is available

https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU