### PR TITLE
Fix ZeroDivisionError in screen scoring (crashes heartbeat buyers)

### DIFF
--- a/screen.py
+++ b/screen.py
@@ -123,7 +123,11 @@ def score_screen(facts: list[dict], config: dict) -> list[dict]:
     for r in subset:
         ps = _f(r.get("ps"))
         med = _f(r.get("ps_median_12m"))
-        ps_ratio.append(None if ps is None else ps / (med if med and med > 0 else ps))
+        # P/S relative to its own 12-mo median; fall back to a neutral 1.0
+        # (ps/ps) when the median is missing. Guard the denominator so a
+        # ps of 0 (or 0 fallback) doesn't divide by zero — just unscoreable.
+        denom = med if (med and med > 0) else ps
+        ps_ratio.append(ps / denom if (ps is not None and denom) else None)
         ret = _f(r.get("ret_52w"))
         mom.append(None if ret is None else max(MOM_FLOOR, min(MOM_CAP, ret)))
 

--- a/test_screen.py
+++ b/test_screen.py
@@ -124,6 +124,18 @@ class TestScoring(unittest.TestCase):
         # equal scores → AAA before ZZZ
         self.assertEqual([r["ticker"] for r in out], ["AAA", "ZZZ"])
 
+    def test_zero_ps_without_median_does_not_crash(self):
+        # A P/S of 0 with no recorded median used to divide 0/0 and crash the
+        # whole screen (ZeroDivisionError). It must score as unscoreable-on-value
+        # and rank alongside the rest, not blow up.
+        rows = facts(
+            {"ticker": "ZERO", "ps": 0, "ps_median_12m": None, "rule_of_40": 10, "fcf_margin": 1, "gross_margin": 1, "ret_52w": 1},
+            {"ticker": "NORM", "ps": 5, "ps_median_12m": 4, "rule_of_40": 20, "fcf_margin": 1, "gross_margin": 1, "ret_52w": 1},
+        )
+        cfg = {"weights": {"quality": 45, "value": 25, "momentum": 20}, "aiMultiplier": False}
+        out = screen.score_screen(rows, cfg)
+        self.assertEqual(len(out), 2)
+
     def test_topn_helper_via_run(self):
         rows = facts(
             {"ticker": "A", "rule_of_40": 90, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},

--- a/web/lib/screen/score.ts
+++ b/web/lib/screen/score.ts
@@ -136,10 +136,13 @@ export function scoreScreen(
   const subset = applyFilters(facts, config.filters);
 
   // Value driver: P/S relative to the stock's own 12-month median (cheaper =
-  // better). Falls back to raw P/S when no median is recorded.
-  const psRatio = subset.map((r) =>
-    r.ps == null ? null : r.ps / (r.ps_median_12m && r.ps_median_12m > 0 ? r.ps_median_12m : r.ps),
-  );
+  // better). Falls back to raw P/S when no median is recorded; guards the
+  // denominator so a P/S of 0 yields null (unscoreable) instead of NaN.
+  const psRatio = subset.map((r) => {
+    if (r.ps == null) return null;
+    const denom = r.ps_median_12m && r.ps_median_12m > 0 ? r.ps_median_12m : r.ps;
+    return denom ? r.ps / denom : null;
+  });
   const mom = subset.map((r) =>
     r.ret_52w == null ? null : Math.max(MOM_FLOOR, Math.min(MOM_CAP, r.ret_52w)),
   );


### PR DESCRIPTION
## Problem

`agent_heartbeat` buyers (`llm_watchlist_buyer`, `watchlist_buyer`) rank candidates through the screen scorer, and that scorer crashed the entire run:

```
ZeroDivisionError: float division by zero
  screen.py:126  ps_ratio.append(None if ps is None else ps / (med if med and med > 0 else ps))
```

The Value component scores each stock's P/S relative to its own 12-month median. When `ps_median_12m` is missing it falls back to dividing `ps / ps` (neutral 1.0) — but a candidate with **P/S = 0** makes that `0 / 0` and throws. A single such row in the Tier-1 universe takes down every buyer that ranks candidates, surfacing as a fully failed heartbeat (`error=1`).

## Fix

- **`screen.py`** — guard the denominator; a P/S of 0 with no median becomes `None` (unscoreable on the value axis, handled neutrally by the percentile step) instead of crashing.
- **`web/lib/screen/score.ts`** — the TS mirror had the same flaw, where `0/0` silently produced `NaN` and poisoned the value percentiles. Same guard applied, keeping the two scorers in lockstep (CLAUDE.md parity requirement).
- **`test_screen.py`** — regression test `test_zero_ps_without_median_does_not_crash`. All 14 tests pass.

## Scope

Independent of the CTA fix (#1367) and the auth-email/Resend work (#1391).

https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY)_