### PR TITLE
Make the go-public toggle prominent when a portfolio is eligible

### DIFF
--- a/web/components/portfolio/visibility-toggle.tsx
+++ b/web/components/portfolio/visibility-toggle.tsx
@@ -7,25 +7,25 @@ import { setPortfolioVisibility } from "@/lib/portfolios-mutations";
 const PUBLIC_ACTIVATE_THRESHOLD = 15;
 
 /**
- * Compact inline pill — current visibility state + a single button to
- * flip it. Designed to sit next to a page H1, not own a card. The owner
- * sees this on the portfolio detail page header and on /account.
+ * Owner control for portfolio visibility, with an eligibility-aware emphasis:
  *
- * The Public toggle is hysteresis-gated (migration 031): to flip from
- * Private → Public the portfolio must currently hold ≥ 15 equities. If
- * it's already Public it can always be flipped back. The trigger
- * `enforce_portfolio_public_threshold` enforces this server-side; we
- * mirror the gate client-side so the button can read as disabled with a
- * helpful tooltip instead of failing on submit.
+ *  - **Eligible but still private** (holds ≥ 15 equities) → a prominent green
+ *    CTA banner that actively invites the owner onto the public leaderboard.
+ *    This is the state we most want acted on, so it's loud, not a quiet pill.
+ *  - **Public** → a compact status pill with a "Make private" control.
+ *  - **Private, not yet eligible** → a compact pill showing progress to the
+ *    15-equity threshold (no actionable button — it can't flip yet).
+ *
+ * The Public flip is hysteresis-gated server-side (migration 031,
+ * `enforce_portfolio_public_threshold`); we mirror the gate here so the UI only
+ * offers the action when it will succeed. Sits in the page-header flex-wrap
+ * row, so the full-width banner naturally takes its own line.
  */
 export default function VisibilityToggle({
   portfolioId,
   isPublic,
   holdingsCount,
 }: {
-  /** Threaded from the owner-aware page so the action writes against a
-   *  known-good row instead of doing its own pre-write lookup that
-   *  could transiently surface as "You don't have a portfolio yet". */
   portfolioId: string;
   isPublic: boolean;
   holdingsCount: number;
@@ -34,16 +34,12 @@ export default function VisibilityToggle({
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
-  const canFlipPublic = isPublic || holdingsCount >= PUBLIC_ACTIVATE_THRESHOLD;
-  const buttonDisabled = pending || !canFlipPublic;
+  const eligible = holdingsCount >= PUBLIC_ACTIVATE_THRESHOLD;
 
-  function toggle() {
+  function setVisibility(next: boolean) {
     setError(null);
     startTransition(async () => {
-      const result = await setPortfolioVisibility({
-        portfolioId,
-        isPublic: !isPublic,
-      });
+      const result = await setPortfolioVisibility({ portfolioId, isPublic: next });
       if (!result.ok) {
         setError(result.error);
         return;
@@ -52,16 +48,42 @@ export default function VisibilityToggle({
     });
   }
 
-  let buttonLabel: string;
-  if (pending) buttonLabel = "…";
-  else if (isPublic) buttonLabel = "Make private";
-  else if (canFlipPublic) buttonLabel = "Make public";
-  else buttonLabel = `${holdingsCount}/${PUBLIC_ACTIVATE_THRESHOLD} to flip public`;
+  // --- Prominent CTA: eligible, still private. The nudge to go public. ---
+  if (!isPublic && eligible) {
+    return (
+      <div className="w-full rounded-2xl border border-[var(--color-green)]/40 bg-[var(--color-green)]/[0.06] px-4 py-3.5 flex flex-col sm:flex-row sm:items-center gap-3">
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-bold text-[var(--color-green)] flex items-center gap-2">
+            <span
+              aria-hidden
+              className="h-2 w-2 rounded-full bg-[var(--color-green)]"
+              style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+            />
+            Your portfolio is eligible for the public leaderboard
+          </p>
+          <p className="text-[12px] text-text-dim mt-1 leading-relaxed">
+            Make it public to get ranked against everyone by alpha vs SPY. You
+            can switch back to private anytime.
+          </p>
+          {error && (
+            <p className="text-xs text-[var(--color-red)] font-mono mt-1.5">
+              {error}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => setVisibility(true)}
+          disabled={pending}
+          className="shrink-0 rounded-lg bg-[var(--color-green)] px-4 py-2 text-sm font-bold text-black hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-green)]/40 transition-[filter]"
+        >
+          {pending ? "Making public…" : "Make public →"}
+        </button>
+      </div>
+    );
+  }
 
-  const title = !canFlipPublic
-    ? `Hold ${PUBLIC_ACTIVATE_THRESHOLD}+ equities to enable Public (currently ${holdingsCount}).`
-    : undefined;
-
+  // --- Compact pill: public (with Make private), or progress to eligibility. ---
   return (
     <div className="inline-flex flex-col gap-1">
       <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.02] px-3 py-1 text-[11px] font-mono uppercase tracking-[0.14em]">
@@ -80,15 +102,23 @@ export default function VisibilityToggle({
         <span aria-hidden className="text-text-muted/60">
           ·
         </span>
-        <button
-          type="button"
-          onClick={toggle}
-          disabled={buttonDisabled}
-          title={title}
-          className="text-text-dim hover:text-text disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 rounded transition-colors"
-        >
-          {buttonLabel}
-        </button>
+        {isPublic ? (
+          <button
+            type="button"
+            onClick={() => setVisibility(false)}
+            disabled={pending}
+            className="text-text-dim hover:text-text disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 rounded transition-colors"
+          >
+            {pending ? "…" : "Make private"}
+          </button>
+        ) : (
+          <span
+            className="text-text-muted normal-case tracking-normal"
+            title={`Hold ${PUBLIC_ACTIVATE_THRESHOLD}+ equities to go public (currently ${holdingsCount}).`}
+          >
+            {holdingsCount}/{PUBLIC_ACTIVATE_THRESHOLD} to go public
+          </span>
+        )}
       </span>
       {error && (
         <span className="text-xs text-[var(--color-red)] font-mono">


### PR DESCRIPTION
When a private portfolio crosses the 15-equity threshold, the "go public" action shouldn't be a quiet pill — it should actively invite the owner onto the leaderboard. Makes the visibility toggle eligibility-aware:

- **Eligible but still private** (holds ≥ 15) → a prominent green CTA banner ("Your portfolio is eligible for the public leaderboard — make it public to get ranked by alpha vs SPY") with a bold **Make public →** button. It sits full-width under the title.
- **Public** → the quiet `Public · Make private` pill.
- **Private, below threshold** → the quiet pill with progress (`Private · 12/15 to go public`).

The flip stays hysteresis-gated server-side (migration 031); the UI only offers the CTA when the action will succeed. Only touches `visibility-toggle.tsx`.

`tsc` clean, `next build` compiles.

https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU)_