### PR TITLE
Dashboard: header label + pulse chart period selector

### DIFF
--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -10,7 +10,12 @@ import NeedsAttention, {
   type AttentionItem,
 } from "@/components/dashboard/needs-attention";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
-import { getDashboardData, type DashPortfolio, type DashTrade } from "@/lib/dashboard-query";
+import {
+  getDashboardData,
+  type DashPortfolio,
+  type DashTrade,
+  type DashValuePoint,
+} from "@/lib/dashboard-query";
 import { getHouseTicker, type HouseTick } from "@/lib/house-activity-query";
 import { PRESETS, DEFAULT_PRESET } from "@/lib/screen/config";
 
@@ -50,7 +55,7 @@ export default async function AccountPage() {
     /* ignore — greeting falls back to the email local-part */
   }
 
-  const { portfolios, livePortfolio, activity, spySeries } =
+  const { portfolios, livePortfolio, activity, spyValues } =
     await getDashboardData(user.id);
 
   return (
@@ -66,7 +71,7 @@ export default async function AccountPage() {
               portfolios={portfolios}
               livePortfolio={livePortfolio}
               activity={activity}
-              spySeries={spySeries}
+              spyValues={spyValues}
             />
           )}
           {/* Live (real-money) risk acknowledgement — shown ONLY to users
@@ -90,13 +95,13 @@ function Dashboard({
   portfolios,
   livePortfolio,
   activity,
-  spySeries,
+  spyValues,
 }: {
   displayName: string;
   portfolios: DashPortfolio[];
   livePortfolio: DashPortfolio | null;
   activity: DashTrade[];
-  spySeries: { date: string; pct: number }[];
+  spyValues: DashValuePoint[];
 }) {
   const best = [...portfolios].sort(
     (a, b) => (b.pnlPct ?? -1e9) - (a.pnlPct ?? -1e9),
@@ -132,7 +137,7 @@ function Dashboard({
       </header>
 
       {/* Pulse */}
-      <PulseSection portfolios={portfolios} spy={spySeries} />
+      <PulseSection portfolios={portfolios} spyValues={spyValues} />
 
       {/* Needs attention */}
       {items.length > 0 && <NeedsAttention items={items} />}

--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -107,7 +107,10 @@ function Dashboard({
     <div className="space-y-8">
       {/* Header + standing line */}
       <header>
-        <h1 className="text-[26px] sm:text-[30px] font-bold tracking-[-0.02em] text-text">
+        <p className="text-[11px] font-mono uppercase tracking-[0.14em] text-text-muted">
+          Dashboard
+        </p>
+        <h1 className="mt-1 text-[26px] sm:text-[30px] font-bold tracking-[-0.02em] text-text">
           Hi {displayName}
         </h1>
         <p className="mt-1 text-sm text-text-muted">

--- a/web/components/dashboard/pulse-section.tsx
+++ b/web/components/dashboard/pulse-section.tsx
@@ -2,7 +2,11 @@
 
 import { useMemo, useState } from "react";
 import PulseChart from "@/components/dashboard/pulse-chart";
-import type { DashPortfolio, DashSeriesPoint } from "@/lib/dashboard-query";
+import type {
+  DashPortfolio,
+  DashSeriesPoint,
+  DashValuePoint,
+} from "@/lib/dashboard-query";
 
 function fmtUsd(v: number | null): string {
   if (v == null) return "—";
@@ -13,73 +17,133 @@ function fmtPct(v: number | null): string {
   return `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
 }
 
-/** Average the per-portfolio normalised % series by date (an "All" proxy). */
-function aggregate(portfolios: DashPortfolio[]): DashSeriesPoint[] {
-  const byDate = new Map<string, { sum: number; n: number }>();
+// Period selector. Each maps to a lookback in days; `null` = all history.
+const PERIODS = [
+  { key: "1W", label: "1W", days: 7 },
+  { key: "1M", label: "1M", days: 30 },
+  { key: "3M", label: "3M", days: 90 },
+  { key: "1Y", label: "1Y", days: 365 },
+  { key: "ALL", label: "All", days: null },
+] as const;
+type PeriodKey = (typeof PERIODS)[number]["key"];
+
+/** Sum each date's raw value across portfolios (the "All" total-value series). */
+function aggregateValues(portfolios: DashPortfolio[]): DashValuePoint[] {
+  const byDate = new Map<string, number>();
   for (const p of portfolios) {
-    for (const pt of p.series) {
-      const e = byDate.get(pt.date) ?? { sum: 0, n: 0 };
-      e.sum += pt.pct;
-      e.n += 1;
-      byDate.set(pt.date, e);
+    for (const pt of p.valueSeries) {
+      byDate.set(pt.date, (byDate.get(pt.date) ?? 0) + pt.value);
     }
   }
   return [...byDate.entries()]
     .sort((a, b) => (a[0] < b[0] ? -1 : 1))
-    .map(([date, e]) => ({ date, pct: e.sum / e.n }));
+    .map(([date, value]) => ({ date, value }));
+}
+
+/** Slice a raw value series to the period and re-normalise to its first point,
+ *  so the % return is measured from the start of the *selected* window. */
+function periodSeries(
+  raw: DashValuePoint[],
+  cutoff: string | null,
+): DashSeriesPoint[] {
+  const win = cutoff ? raw.filter((r) => r.date >= cutoff) : raw;
+  if (win.length === 0) return [];
+  const base = win[0].value;
+  if (!base) return win.map((r) => ({ date: r.date, pct: 0 }));
+  return win.map((r) => ({ date: r.date, pct: (r.value / base - 1) * 100 }));
 }
 
 export default function PulseSection({
   portfolios,
-  spy,
+  spyValues,
 }: {
   portfolios: DashPortfolio[];
-  spy: DashSeriesPoint[];
+  spyValues: DashValuePoint[];
 }) {
   const multi = portfolios.length > 1;
   const [sel, setSel] = useState<string>(multi ? "all" : portfolios[0]?.id ?? "all");
+  const [period, setPeriod] = useState<PeriodKey>("1M");
+
+  const cutoff = useMemo(() => {
+    const days = PERIODS.find((p) => p.key === period)?.days ?? null;
+    return days == null
+      ? null
+      : new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
+  }, [period]);
 
   const current = useMemo(() => {
-    if (sel === "all") {
-      const series = aggregate(portfolios);
-      const value = portfolios.reduce((s, p) => s + (p.value ?? 0), 0);
-      const pnlPct = series.length ? series[series.length - 1].pct : null;
-      return { name: "All portfolios", value, pnlPct, series };
-    }
-    const p = portfolios.find((x) => x.id === sel) ?? portfolios[0];
-    return { name: p.name, value: p.value, pnlPct: p.pnlPct, series: p.series };
-  }, [sel, portfolios]);
+    const rawValues =
+      sel === "all"
+        ? aggregateValues(portfolios)
+        : (portfolios.find((x) => x.id === sel) ?? portfolios[0])?.valueSeries ??
+          [];
+    const name =
+      sel === "all"
+        ? "All portfolios"
+        : (portfolios.find((x) => x.id === sel) ?? portfolios[0])?.name ??
+          "Portfolio";
+    const value =
+      sel === "all"
+        ? portfolios.reduce((s, p) => s + (p.value ?? 0), 0)
+        : (portfolios.find((x) => x.id === sel) ?? portfolios[0])?.value ?? null;
+    const series = periodSeries(rawValues, cutoff);
+    const periodPct = series.length ? series[series.length - 1].pct : null;
+    return { name, value, periodPct, series };
+  }, [sel, portfolios, cutoff]);
 
-  const spyFinal = spy.length ? spy[spy.length - 1].pct : 0;
-  const youFinal = current.series.length ? current.series[current.series.length - 1].pct : 0;
+  const spySeries = useMemo(
+    () => periodSeries(spyValues, cutoff),
+    [spyValues, cutoff],
+  );
+
+  const periodLabel = PERIODS.find((p) => p.key === period)?.label ?? "";
+  const spyFinal = spySeries.length ? spySeries[spySeries.length - 1].pct : 0;
+  const youFinal = current.series.length
+    ? current.series[current.series.length - 1].pct
+    : 0;
   const vsSpy = youFinal - spyFinal;
 
   return (
-    <section aria-label="Performance pulse" className="rounded-xl border border-white/10 bg-white/[0.02] p-4">
+    <section
+      aria-label="Performance pulse"
+      className="rounded-xl border border-white/10 bg-white/[0.02] p-4"
+    >
       <div className="flex items-start justify-between gap-3 flex-wrap mb-3">
         <div className="flex gap-6">
           <Stat label="Total value" value={fmtUsd(current.value)} />
-          <Stat label="P/L" value={fmtPct(current.pnlPct)} tone={current.pnlPct} />
-          <Stat label="vs SPY (30d)" value={fmtPct(vsSpy)} tone={vsSpy} />
+          <Stat label={`P/L (${periodLabel})`} value={fmtPct(current.periodPct)} tone={current.periodPct} />
+          <Stat label={`vs SPY (${periodLabel})`} value={fmtPct(vsSpy)} tone={vsSpy} />
         </div>
-        {multi && (
-          <div className="flex items-center gap-1 flex-wrap">
-            <SwitchChip active={sel === "all"} onClick={() => setSel("all")} label="All" />
-            {portfolios.map((p) => (
-              <SwitchChip
-                key={p.id}
-                active={sel === p.id}
-                onClick={() => setSel(p.id)}
-                label={p.name}
-              />
-            ))}
-          </div>
-        )}
+        {/* Period selector. */}
+        <div className="flex items-center gap-1 flex-wrap" role="group" aria-label="Chart period">
+          {PERIODS.map((p) => (
+            <SwitchChip
+              key={p.key}
+              active={period === p.key}
+              onClick={() => setPeriod(p.key)}
+              label={p.label}
+            />
+          ))}
+        </div>
       </div>
-      <PulseChart portfolio={current.series} spy={spy} />
+      {/* Per-portfolio selector (when the user runs more than one book). */}
+      {multi && (
+        <div className="flex items-center gap-1 flex-wrap mb-3">
+          <SwitchChip active={sel === "all"} onClick={() => setSel("all")} label="All" />
+          {portfolios.map((p) => (
+            <SwitchChip
+              key={p.id}
+              active={sel === p.id}
+              onClick={() => setSel(p.id)}
+              label={p.name}
+            />
+          ))}
+        </div>
+      )}
+      <PulseChart portfolio={current.series} spy={spySeries} />
       <p className="sr-only">
-        {current.name} is {fmtPct(current.pnlPct)} over the last 30 days,{" "}
-        {vsSpy >= 0 ? "ahead of" : "behind"} the S&amp;P 500 by{" "}
+        {current.name} is {fmtPct(current.periodPct)} over the selected period
+        ({periodLabel}), {vsSpy >= 0 ? "ahead of" : "behind"} the S&amp;P 500 by{" "}
         {Math.abs(vsSpy).toFixed(2)} percentage points.
       </p>
     </section>

--- a/web/lib/dashboard-query.ts
+++ b/web/lib/dashboard-query.ts
@@ -13,6 +13,12 @@ export interface DashSeriesPoint {
   pct: number; // % return from the window start
 }
 
+/** Raw daily value point — the pulse re-normalises these per selected period. */
+export interface DashValuePoint {
+  date: string; // YYYY-MM-DD
+  value: number;
+}
+
 export interface DashPortfolio {
   id: string;
   slug: string;
@@ -21,7 +27,11 @@ export interface DashPortfolio {
   value: number | null;
   pnlPct: number | null;
   numPositions: number;
+  /** Last 30 trading days, normalised — feeds the compact card sparkline. */
   series: DashSeriesPoint[];
+  /** Raw daily value over the full lookback — feeds the period-selectable
+   *  pulse chart, which re-normalises to whichever window is selected. */
+  valueSeries: DashValuePoint[];
   hasBuyer: boolean;
   hasReviewer: boolean;
   mandateEmpty: boolean;
@@ -56,10 +66,14 @@ export interface DashboardData {
   /** The private real-money Alpaca follower, if the owner has one. */
   livePortfolio: DashPortfolio | null;
   activity: DashTrade[];
-  spySeries: DashSeriesPoint[];
+  /** Raw SPY closes over the full lookback; the pulse normalises per period. */
+  spyValues: DashValuePoint[];
 }
 
+// Card sparkline window vs the pulse-chart lookback. The pulse fetches up to a
+// year so its period selector (1W … 1Y/All) has data to re-base against.
 const WINDOW_DAYS = 30;
+const LOOKBACK_DAYS = 370;
 
 function normalize(
   rows: { date: string; value: number }[],
@@ -72,7 +86,7 @@ function normalize(
 
 export async function getDashboardData(userId: string): Promise<DashboardData> {
   const supabase = getSupabase();
-  const since = new Date(Date.now() - (WINDOW_DAYS + 5) * 86400000)
+  const since = new Date(Date.now() - (LOOKBACK_DAYS + 5) * 86400000)
     .toISOString()
     .slice(0, 10);
 
@@ -93,7 +107,7 @@ export async function getDashboardData(userId: string): Promise<DashboardData> {
   const ids = portfolios.map((p) => p.id);
 
   if (ids.length === 0) {
-    return { portfolios: [], livePortfolio: null, activity: [], spySeries: [] };
+    return { portfolios: [], livePortfolio: null, activity: [], spyValues: [] };
   }
 
   // Fan out the shared reads. The live-follower lookup is filtered on
@@ -167,16 +181,14 @@ export async function getDashboardData(userId: string): Promise<DashboardData> {
     roleByPA.set(`${m.portfolio_id}:${m.agent_id}`, m.role ?? null);
   }
 
-  const spySeries = normalize(
-    ((spyRes.data ?? []) as Array<{ price_date: string; close: number | string }>).map((r) => ({
-      date: r.price_date,
-      value: Number(r.close) || 0,
-    })),
-  );
+  const spyValues: DashValuePoint[] = (
+    (spyRes.data ?? []) as Array<{ price_date: string; close: number | string }>
+  ).map((r) => ({ date: r.price_date, value: Number(r.close) || 0 }));
 
   const dashAll: DashPortfolio[] = portfolios.map((p) => {
-    const hist = (histByP.get(p.id) ?? []).slice(-WINDOW_DAYS);
-    const latest = hist.length ? hist[hist.length - 1] : null;
+    const fullHist = histByP.get(p.id) ?? [];
+    const recent = fullHist.slice(-WINDOW_DAYS);
+    const latest = fullHist.length ? fullHist[fullHist.length - 1] : null;
     const roles = rolesByP.get(p.id) ?? { buyer: false, reviewer: false };
     return {
       id: p.id,
@@ -186,7 +198,8 @@ export async function getDashboardData(userId: string): Promise<DashboardData> {
       value: latest ? latest.value : null,
       pnlPct: latest ? latest.pnl : null,
       numPositions: latest ? latest.pos : 0,
-      series: normalize(hist.map((h) => ({ date: h.date, value: h.value }))),
+      series: normalize(recent.map((h) => ({ date: h.date, value: h.value }))),
+      valueSeries: fullHist.map((h) => ({ date: h.date, value: h.value })),
       hasBuyer: roles.buyer,
       hasReviewer: roles.reviewer,
       mandateEmpty: !(p.description && p.description.trim()),
@@ -242,5 +255,5 @@ export async function getDashboardData(userId: string): Promise<DashboardData> {
     };
   });
 
-  return { portfolios: dashPortfolios, livePortfolio, activity, spySeries };
+  return { portfolios: dashPortfolios, livePortfolio, activity, spyValues };
 }


### PR DESCRIPTION
Two Dashboard (`/account`) polish items:

1. **"Dashboard" header label** — the page jumped straight to "Hi {name}" with no page label, unlike Screener ("Stock screener") and Portfolio ("Portfolio") which carry an eyebrow above their h1. Adds the matching "Dashboard" eyebrow so the page self-identifies consistently.

2. **Period selector on the pulse chart** — the pulse was locked to a 30-day window. The dashboard query now fetches up to a year of raw daily values (keeping the 30d normalised series for the card sparklines), and the pulse gets a **1W / 1M / 3M / 1Y / All** selector that re-normalises the portfolio + SPY series to the start of the chosen window. P/L and vs-SPY read for the selected period and the chart redraws accordingly.

`tsc` clean, `next build` compiles.

https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU)_