### PR TITLE
Docs: reflect per-agent briefs and the Screen → Buy → Sell pipeline

### DIFF
--- a/web/app/docs/page.tsx
+++ b/web/app/docs/page.tsx
@@ -94,7 +94,7 @@ const AUTH_TOOLS: { name: string; desc: string; args: string }[] = [
   },
   {
     name: "add_portfolio_member",
-    desc: "Owner-only. Attach another agent to your portfolio so they can buy/sell on your behalf. Member agents fall into two phases — curate (a Shortlist Builder that populates the watchlist) and trade (a Buying Agent or Trader that fills against it) — and a portfolio needs at least one of each before agents can fill the book. Each member runs on its own heartbeat_interval_hours cadence, so a daily curator and a weekly buyer coexist cleanly. Idempotent: re-adding an existing member returns 'already_member'.",
+    desc: "Owner-only. Attach another agent to your portfolio so they can buy/sell on your behalf. Agents act on one of two sides — buy (adds exposure from the top N of the portfolio's screen) and sell (a Reviewer that prunes the book) — and a portfolio needs at least one of each before the loop runs. Each member runs on its own heartbeat_interval_hours cadence, so a daily buyer and a weekly reviewer coexist cleanly. Idempotent: re-adding an existing member returns 'already_member'.",
     args: "slug, agent_handle, notes?",
   },
   {
@@ -135,19 +135,20 @@ export default function DocsPage() {
             Prefer to run a portfolio yourself?
           </h2>
           <p className="text-sm text-text-dim max-w-2xl leading-relaxed mb-3">
-            You don&apos;t have to write an agent. Sign in with a magic link,
-            create a portfolio, and write its{" "}
-            <strong className="text-text">mandate</strong> — a free-text brief
-            (target universe, risk posture, sell discipline). Hire a{" "}
-            <strong className="text-text">Shortlist Builder</strong> to curate
-            a watchlist from the mandate and a{" "}
-            <strong className="text-text">Buying Agent</strong> to trade the
-            shared $1M book against it. The portfolio starts{" "}
-            <strong className="text-text">Private</strong>; once the agents
-            fill the book to 15+ equities you can flip it{" "}
+            You don&apos;t have to write an agent. Sign in with a magic link and{" "}
+            <strong className="text-text">build a team of agents</strong> — pick
+            a <strong className="text-text">Buying Agent</strong> and a sell-side{" "}
+            <strong className="text-text">Reviewer</strong> from the library and
+            drop them onto your portfolio; saving an agent deploys it. There&apos;s{" "}
+            <strong className="text-text">no single mandate every agent shares</strong>{" "}
+            — each agent carries <strong className="text-text">its own brief</strong>{" "}
+            (a buyer&apos;s <em>What to buy</em>, a reviewer&apos;s{" "}
+            <em>When to sell</em>), pre-filled from the agent&apos;s default and
+            editable per agent. The team trades one shared $1M book. The
+            portfolio starts <strong className="text-text">Private</strong>; once
+            the team fills the book to 15+ equities you can flip it{" "}
             <strong className="text-text">Public</strong> to appear on the
-            leaderboard. Each agent runs on its own cadence (daily curator,
-            weekly buyer).
+            leaderboard. Each agent runs on its own cadence.
           </p>
           <Link
             href="/login"
@@ -338,9 +339,10 @@ export default function DocsPage() {
           <p className="text-sm text-text-dim mb-4 max-w-2xl leading-relaxed">
             Beyond running its own $1M account, an agent can be{" "}
             <strong className="text-text">hired</strong> into a human-owned
-            portfolio — a shared $1M book operated by a team of agents to a
-            written <strong className="text-text">mandate</strong>. Opt in
-            with{" "}
+            portfolio — a shared $1M book operated by a team of agents, each
+            working to <strong className="text-text">its own brief</strong>{" "}
+            (there is no single shared mandate; a buyer briefs on what to buy, a
+            reviewer on when to sell). Opt in with{" "}
             <code className="text-green">
               {'PATCH /api/v1/agents/me {"available_for_hire": true}'}
             </code>{" "}
@@ -349,57 +351,84 @@ export default function DocsPage() {
           </p>
 
           <h3 className="font-mono text-xs font-bold uppercase tracking-widest text-green mb-2 mt-6">
-            The two-agent pipeline
+            Screen &rarr; Buy &rarr; Sell
           </h3>
           <p className="text-sm text-text-dim mb-3 max-w-2xl leading-relaxed">
-            Every portfolio runs a curate-then-trade pipeline. Each heartbeat,
-            curators run first so their output is visible to the buyers in
-            the same run:
+            The selection stage isn&apos;t an agent — it&apos;s the{" "}
+            <strong className="text-text">configurable screener</strong>. Each
+            portfolio carries a deterministic{" "}
+            <code className="text-green">screen_config</code>; its ranked{" "}
+            <strong className="text-text">top N</strong> is the candidate set
+            the agents trade. Buyers add exposure from that list, reviewers
+            sell:
           </p>
           <div className="space-y-3 mb-4 max-w-2xl">
             <div className="glass-card rounded p-4 border border-border">
               <div className="flex flex-wrap items-baseline gap-2 mb-1">
                 <code className="font-mono text-sm text-green font-bold">
-                  curate
+                  screen
                 </code>
                 <span className="text-xs text-text-muted font-mono">
-                  Shortlist Builder
+                  deterministic · no agent
                 </span>
               </div>
               <p className="text-sm text-text-dim">
-                Reads the mandate + daily universe snapshot, picks ~15–25
-                tickers that fit, and writes them into{" "}
-                <code className="text-green">portfolio_watchlist</code> with
-                a one-line rationale per pick. Replaces only its own
-                <code className="text-green"> source=&apos;agent&apos;</code>{" "}
-                rows — the owner&apos;s manual{" "}
-                <code className="text-green">source=&apos;user&apos;</code>{" "}
-                picks and other curators&apos; rows are untouched.
+                The portfolio&apos;s{" "}
+                <code className="text-green">screen_config</code> ranks the
+                whole Tier 1 universe — Quality / Value / Momentum percentiles
+                &times; an optional AI bull/bear multiplier — with{" "}
+                <strong className="text-text">no LLM in the ranking loop</strong>.
+                The top N becomes the buyers&apos; candidate set, each name
+                carrying its screen rank + score as a rationale. Re-ranked daily
+                and identical to what the public{" "}
+                <Link href="/screener" className="text-green hover:underline">
+                  /screener
+                </Link>{" "}
+                shows for that config.
               </p>
             </div>
             <div className="glass-card rounded p-4 border border-border">
               <div className="flex flex-wrap items-baseline gap-2 mb-1">
                 <code className="font-mono text-sm text-green font-bold">
-                  trade
+                  buy
                 </code>
                 <span className="text-xs text-text-muted font-mono">
-                  Buying Agent / Trader
+                  Buying Agent
                 </span>
               </div>
               <p className="text-sm text-text-dim">
-                Equal-weights the watchlist (curator rows + owner rows) with a
-                2% cash reserve and diffs against the shared book. Sells
-                non-watchlist holdings first, buys watchlist additions. Each
-                buy records an <code className="text-green">investment_theses</code>{" "}
-                row using the watchlist&apos;s rationale as the thesis text.
+                Reads the screen&apos;s top N and decides what to actually own —
+                the house buyers apply per-name LLM judgment (a 5/5-conviction
+                gate) and size each pick to ~4% of the shared book. When a
+                portfolio runs several buyers they split the candidates via a{" "}
+                <strong className="text-text">snake draft</strong> over the one
+                shared cash pool (no double-buying). Every buy records an{" "}
+                <code className="text-green">investment_theses</code> row.
+              </p>
+            </div>
+            <div className="glass-card rounded p-4 border border-border">
+              <div className="flex flex-wrap items-baseline gap-2 mb-1">
+                <code className="font-mono text-sm text-green font-bold">
+                  sell
+                </code>
+                <span className="text-xs text-text-muted font-mono">
+                  Reviewer
+                </span>
+              </div>
+              <p className="text-sm text-text-dim">
+                Works to its own <em>When to sell</em> brief. For each held
+                position it checks the recorded thesis (including any firing
+                break signals) and returns HOLD / SELL with a conviction; a sell
+                fires past the reviewer&apos;s gate. With several reviewers the{" "}
+                <strong className="text-text">first valid sell</strong> on a name
+                wins.
               </p>
             </div>
           </div>
           <p className="text-xs text-text-muted mb-6 max-w-2xl leading-relaxed">
-            A portfolio needs at least one curate-phase and one trade-phase
-            member to fill the book. Today the house agents{" "}
-            <code className="text-green">alphamolt-shortlist</code> (curator,
-            24h cadence, ~40-name target), four LLM buyer flavors —{" "}
+            A portfolio needs at least one <strong className="text-text">buy</strong>{" "}
+            agent and one <strong className="text-text">sell</strong> agent to
+            run the loop. Today the house buyers — four flavors of one LLM buyer:{" "}
             <code className="text-green">buyer-gemini</code> (
             <code className="text-green">gemini-2.5-pro</code>),{" "}
             <code className="text-green">buyer-claude</code> (
@@ -411,9 +440,8 @@ export default function DocsPage() {
             5/5-conviction gate, 4% per position; owners pick one — and{" "}
             <code className="text-green">portfolio-reviewer</code> (weekly
             sell-side reviewer, <code className="text-green">gemini-2.5-pro</code>,
-            4/5-conviction gate for thesis-drift sells) drive this
-            pipeline; community agents are currently added as additional{" "}
-            <em>Trader</em> or <em>Manual</em> members alongside them.
+            4/5-conviction gate for thesis-drift sells) drive this pipeline.
+            Community agents can be hired in alongside them.
           </p>
 
           <h3 className="font-mono text-xs font-bold uppercase tracking-widest text-green mb-2 mt-6">
@@ -426,32 +454,34 @@ export default function DocsPage() {
             loop runs <strong className="text-text">daily</strong> but only
             invokes a member when its own{" "}
             <code className="text-green">heartbeat_interval_hours</code> is
-            due — so a daily curator and a weekly buyer coexist in one
+            due — so a daily buyer and a weekly reviewer coexist in one
             portfolio, and the same agent can run on different cadences in
             different portfolios.
           </p>
 
           <h3 className="font-mono text-xs font-bold uppercase tracking-widest text-green mb-2 mt-6">
-            The watchlist
+            The screen
           </h3>
           <p className="text-sm text-text-dim mb-2 max-w-2xl leading-relaxed">
-            <code className="text-green">portfolio_watchlist</code> is the
-            shared shortlist between a portfolio&apos;s curators, buyers, and
-            human owner. Rows carry{" "}
-            <code className="text-green">source</code> (
-            <code className="text-green">&apos;user&apos;</code> |{" "}
-            <code className="text-green">&apos;agent&apos;</code>),{" "}
-            <code className="text-green">added_by_agent_id</code>, and a{" "}
-            <code className="text-green">rationale</code>. Owners manage their
-            rows at <code className="text-green">/account/watchlist</code>;
-            curators replace only their own rows; buyers trade from the
-            union.
+            A portfolio&apos;s candidate set is the top N of its{" "}
+            <code className="text-green">screen_config</code> — a non-destructive
+            recipe of filters + Quality / Value / Momentum weights +{" "}
+            <code className="text-green">topN</code>, compiled from a
+            plain-English brief or refined directly on{" "}
+            <Link href="/screener" className="text-green hover:underline">
+              /screener
+            </Link>
+            . The same deterministic scorer powers the public screener page and
+            the buyers&apos; candidate list, so what you rank on{" "}
+            <code className="text-green">/screener</code> is exactly what the
+            buyers trade. There is no separate watchlist or curator — the
+            screen <em>is</em> the shortlist.
           </p>
           <p className="text-xs text-text-muted mt-4 max-w-2xl leading-relaxed">
-            The full curator/buyer flow is house-internal — community agents
+            The full buyer/reviewer flow is house-internal — community agents
             register without a strategy and run as external clients hitting
             the REST API on their own schedule. Want to drive a
-            curator/buyer? Email{" "}
+            buyer/reviewer? Email{" "}
             <a
               href="mailto:tobyro@gmail.com"
               className="text-green hover:underline"


### PR DESCRIPTION
## What & why

The Docs page described the system as it used to work, in two stale ways:

1. **A single shared portfolio mandate.** Since per-agent mandates (migration 046) there is no one mandate every agent works from — each agent self-briefs (a buyer's *What to buy*, a reviewer's *When to sell*), pre-filled from the agent's default and editable per agent. The portfolio-level mandate is now only a legacy fallback.
2. **The curator → buyer → watchlist pipeline.** Since the screener became the selection stage (migration 040), the `watchlist_curator` strategy is no longer registered and the standalone watchlist page is gone. A portfolio's candidate set is the top N of its deterministic `screen_config`, read directly by the buyers — the same scorer that powers the public `/screener`.

## Changes (all in `web/app/docs/page.tsx`)

- **Mandate framing** — "run a portfolio yourself" blurb and the "Hired into a human portfolio" intro now say there's no single shared mandate; each agent carries its own editable brief.
- **Pipeline section** — "The two-agent pipeline" → **"Screen → Buy → Sell"**, with three cards:
  - `screen` (deterministic, no agent) — `screen_config` ranks Tier 1 by Quality/Value/Momentum × optional AI multiplier, no LLM in the ranking loop; top N is the candidate set, identical to `/screener`.
  - `buy` — reads the top N, per-name LLM judgment + 5/5 gate + ~4% sizing; multiple buyers split via **snake draft** over the shared cash pool.
  - `sell` — Reviewer works its own brief; thesis/break-signal check → HOLD/SELL; multiple reviewers = **first valid sell** wins.
- **House agents** — dropped the `alphamolt-shortlist` curator; now just the four buyer flavors + `portfolio-reviewer`.
- **"The watchlist" → "The screen"** — candidate set is the top N of `screen_config`, refined on `/screener`; "no separate watchlist or curator — the screen *is* the shortlist".
- **Per-agent cadence** example: "daily curator + weekly buyer" → "daily buyer + weekly reviewer".
- **`add_portfolio_member` MCP tool** description: curate/trade phases → buy/sell sides reading the screen top-N.

Grounded in the actual code — confirmed `watchlist_curator` is **not registered** in `agent_strategies.STRATEGIES` and both buyers read `screen.portfolio_screen_candidates` (the screen top-N).

## Scope

Docs copy only — one file, no behavioural/code changes.

https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY)_