### PR TITLE
Screener Momentum ranks on alpha vs SPY, and the page shows it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,8 @@ ranks the whole Tier 1 universe for a given config. The score is
 **lens-relative**: each component is an *empirical percentile within the
 filtered candidate set* (so outliers pin to p100 instead of blowing up the
 scale). Composite = weighted blend of Quality (0.60·R40 + 0.25·FCF + 0.15·GM),
-Value (inverse P/S ÷ 12-mo median) and Momentum (collared 52-week return),
+Value (inverse P/S ÷ 12-mo median) and Momentum (collared 52-week return vs
+SPY — `perf_52w_vs_spy`, derived from `benchmark_prices`),
 ×optional AI bull/bear multiplier. Implemented once in TS
 (`web/lib/screen/score.ts`) and mirrored in Python (`screen.py`) so the buyer's
 top N is identical to the page's.

--- a/screen.py
+++ b/screen.py
@@ -132,7 +132,10 @@ def score_screen(facts: list[dict], config: dict) -> list[dict]:
         # ps of 0 (or 0 fallback) doesn't divide by zero — just unscoreable.
         denom = med if (med and med > 0) else ps
         ps_ratio.append(ps / denom if (ps is not None and denom) else None)
-        ret = _f(r.get("ret_52w"))
+        # Momentum is alpha vs SPY (perf_52w_vs_spy = ret_52w − SPY's 52w
+        # return, derived in load_facts), collared — so a name that only rode
+        # the market up doesn't read as momentum.
+        ret = _f(r.get("perf_52w_vs_spy"))
         mom.append(None if ret is None else max(MOM_FLOOR, min(MOM_CAP, ret)))
 
     p_r40 = _percentiles([_f(r.get("rule_of_40")) for r in subset])

--- a/test_screen.py
+++ b/test_screen.py
@@ -20,7 +20,8 @@ def facts(*rows: dict) -> list[dict]:
         "price": 10, "price_asof": "2026-06-03", "rev_growth_ttm": None,
         "gross_margin": None, "fcf_margin": None, "net_margin": None,
         "operating_margin": None, "rule_of_40": None, "ps": None,
-        "ps_median_12m": None, "ret_52w": None, "bull": None, "bear": None,
+        "ps_median_12m": None, "ret_52w": None, "perf_52w_vs_spy": None,
+        "bull": None, "bear": None,
     }
     return [{**base, **r} for r in rows]
 
@@ -82,9 +83,10 @@ class TestScoring(unittest.TestCase):
 
     def test_momentum_collar(self):
         # A huge winner is capped, a crash floored — both still rank by collar.
+        # Momentum scores on alpha vs SPY (perf_52w_vs_spy), not the raw return.
         rows = facts(
-            {"ticker": "MOON", "ret_52w": 500, "rule_of_40": 1, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
-            {"ticker": "KNIFE", "ret_52w": -90, "rule_of_40": 1, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+            {"ticker": "MOON", "perf_52w_vs_spy": 500, "rule_of_40": 1, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+            {"ticker": "KNIFE", "perf_52w_vs_spy": -90, "rule_of_40": 1, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
         )
         cfg = {"weights": {"quality": 0, "value": 0, "momentum": 100}, "aiMultiplier": False}
         out = screen.score_screen(rows, cfg)

--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -59,7 +59,26 @@ function fmt(v: number | null, opts?: { pct?: boolean; mult?: boolean; dp?: numb
   if (opts?.mult) return `${s}×`;
   return s;
 }
+// Percent with an explicit sign — for signed metrics (returns, alpha) where the
+// direction is the point.
+function fmtSigned(v: number | null, dp = 1): string {
+  if (v == null || !Number.isFinite(v)) return "—";
+  return `${v >= 0 ? "+" : ""}${v.toFixed(dp)}%`;
+}
 const PAGE_SIZE = 250;
+
+// Hover explanations for the result columns (header mouseover).
+const COL_HELP: Record<string, string> = {
+  ps: "Price-to-sales — market cap ÷ trailing-12-month revenue. Lower is cheaper on sales.",
+  rev_growth_ttm: "Revenue growth — trailing twelve months, year over year.",
+  gross_margin: "Gross margin — gross profit ÷ revenue.",
+  rule_of_40:
+    "Rule of 40 — revenue growth % + free-cash-flow margin %. ≥ 40 is the bar for a healthy growth-vs-profitability balance.",
+  fcf_margin: "Free-cash-flow margin — free cash flow ÷ revenue.",
+  ret_52w: "Trailing 52-week price return — the raw move, not measured against the market.",
+  perf_52w_vs_spy:
+    "Alpha vs SPY — the stock's trailing 52-week return minus SPY's over the same window. Positive = beat the market. This is what the Momentum score ranks on.",
+};
 
 // Hover explanations for the (jargon-y) ranking controls.
 const WEIGHT_HELP: Record<"quality" | "value" | "momentum", string> = {
@@ -68,7 +87,7 @@ const WEIGHT_HELP: Record<"quality" | "value" | "momentum", string> = {
   value:
     "Value — how cheap it is on sales versus the stock's own 12-month median P/S (not an absolute P/S). Raise it to favour names trading below their usual valuation.",
   momentum:
-    "Momentum — trailing 52-week price return, collared so falling knives and blow-off tops don't dominate. Raise it to favour recent leaders.",
+    "Momentum — trailing 52-week return vs SPY (alpha), collared so falling knives and blow-off tops don't dominate. Raise it to favour names beating the market.",
 };
 const RANKING_HELP =
   "Each name's Score is a percentile blend of Quality, Value and Momentum, weighted by these sliders, relative to the names matching your filters — so it's this screen's own ranking, not a fixed house score.";
@@ -86,19 +105,23 @@ function topWeight(w: { quality: number; value: number; momentum: number }): str
 interface Col {
   key: string;
   label: string;
-  green?: boolean;
+  green?: boolean; // force green text (a "more = better" metric)
+  signed?: (r: Row) => number | null; // colour the cell green/red by this value's sign
+  help?: string; // header mouseover explaining the column
   render: (r: Row) => string;
 }
+// "vs SPY" (alpha) is a base column: it's the Momentum driver, so showing it by
+// default makes the ranking legible without opening the column picker.
 const BASE_COLS: Col[] = [
-  { key: "ps", label: "P/S", render: (r) => fmt(r.ps, { mult: true }) },
-  { key: "rev_growth_ttm", label: "Rev gr%", green: true, render: (r) => fmt(r.rev_growth_ttm, { pct: true }) },
-  { key: "gross_margin", label: "GM%", green: true, render: (r) => fmt(r.gross_margin, { pct: true }) },
-  { key: "rule_of_40", label: "R40", green: true, render: (r) => fmt(r.rule_of_40, { dp: 0 }) },
+  { key: "ps", label: "P/S", help: COL_HELP.ps, render: (r) => fmt(r.ps, { mult: true }) },
+  { key: "rev_growth_ttm", label: "Rev gr%", green: true, help: COL_HELP.rev_growth_ttm, render: (r) => fmt(r.rev_growth_ttm, { pct: true }) },
+  { key: "gross_margin", label: "GM%", green: true, help: COL_HELP.gross_margin, render: (r) => fmt(r.gross_margin, { pct: true }) },
+  { key: "rule_of_40", label: "R40", green: true, help: COL_HELP.rule_of_40, render: (r) => fmt(r.rule_of_40, { dp: 0 }) },
+  { key: "perf_52w_vs_spy", label: "vs SPY", help: COL_HELP.perf_52w_vs_spy, signed: (r) => r.perf_52w_vs_spy, render: (r) => fmtSigned(r.perf_52w_vs_spy) },
 ];
 const EXTRA_COLS: Col[] = [
-  { key: "fcf_margin", label: "FCF M%", green: true, render: (r) => fmt(r.fcf_margin, { pct: true }) },
-  { key: "ret_52w", label: "52w%", render: (r) => fmt(r.ret_52w, { pct: true, dp: 0 }) },
-  { key: "perf_52w_vs_spy", label: "vs SPY", green: true, render: (r) => fmt(r.perf_52w_vs_spy, { pct: true, dp: 0 }) },
+  { key: "fcf_margin", label: "FCF M%", green: true, help: COL_HELP.fcf_margin, render: (r) => fmt(r.fcf_margin, { pct: true }) },
+  { key: "ret_52w", label: "52w%", help: COL_HELP.ret_52w, signed: (r) => r.ret_52w, render: (r) => fmtSigned(r.ret_52w, 0) },
   { key: "net_margin", label: "Net M%", green: true, render: (r) => fmt(r.net_margin, { pct: true }) },
   { key: "operating_margin", label: "Op M%", green: true, render: (r) => fmt(r.operating_margin, { pct: true }) },
   { key: "price", label: "Price", render: (r) => (r.price == null ? "—" : `$${r.price.toFixed(2)}`) },
@@ -542,9 +565,9 @@ export default function ScreenerClient({
             <tr className="bg-white/[0.02]">
               <Th className="text-left w-7">#</Th>
               <Th className="text-left">Ticker</Th>
-              <Th>Score</Th>
+              <Th help={RANKING_HELP}>Score</Th>
               {cols.map((c) => (
-                <Th key={c.key}>{c.label}</Th>
+                <Th key={c.key} help={c.help}>{c.label}</Th>
               ))}
               <th className="relative font-mono text-[10px] text-text-muted font-normal px-2 py-2.5 text-right">
                 <button
@@ -812,10 +835,27 @@ function AdvancedAdd({ onAdd }: { onAdd: (f: Filter) => void }) {
   );
 }
 
-function Th({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+function Th({
+  children,
+  className = "",
+  help,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  help?: string;
+}) {
   return (
     <th className={`font-mono text-[10px] tracking-[0.04em] text-text-muted font-normal px-2 py-2.5 text-right ${className}`}>
-      {children}
+      {help ? (
+        <span
+          title={help}
+          className="cursor-help underline decoration-dotted decoration-white/25 underline-offset-2"
+        >
+          {children}
+        </span>
+      ) : (
+        children
+      )}
     </th>
   );
 }
@@ -866,14 +906,26 @@ function RowView({
         <td className="px-2 py-2.5 text-right text-[12.5px] font-mono border-t border-white/10 text-[var(--color-cyan)]">
           {fmt(r.score, { dp: 1 })}
         </td>
-        {cols.map((c) => (
-          <td
-            key={c.key}
-            className={`px-2 py-2.5 text-right text-[12.5px] font-mono border-t border-white/10 ${c.green ? "text-green" : "text-text"}`}
-          >
-            {c.render(r)}
-          </td>
-        ))}
+        {cols.map((c) => {
+          const sv = c.signed ? c.signed(r) : null;
+          const tone = c.signed
+            ? sv == null
+              ? "text-text-muted"
+              : sv >= 0
+                ? "text-green"
+                : "text-[var(--color-red,#FF3333)]"
+            : c.green
+              ? "text-green"
+              : "text-text";
+          return (
+            <td
+              key={c.key}
+              className={`px-2 py-2.5 text-right text-[12.5px] font-mono border-t border-white/10 ${tone}`}
+            >
+              {c.render(r)}
+            </td>
+          );
+        })}
         <td className="border-t border-white/10" />
       </tr>
     </>

--- a/web/lib/screen/score.ts
+++ b/web/lib/screen/score.ts
@@ -50,7 +50,9 @@ export interface ScoredRow extends ScreenFacts {
 }
 
 // Momentum collar (brief / CLAUDE.md): a falling knife scores 0, a blow-off
-// top is capped — applied before percentile-ranking the 52w return.
+// top is capped — applied before percentile-ranking the return. Momentum is
+// alpha vs SPY (perf_52w_vs_spy), so a name that merely tracked the market up
+// doesn't read as momentum.
 const MOM_FLOOR = -50;
 const MOM_CAP = 40;
 
@@ -147,7 +149,9 @@ export function scoreScreen(
     return denom ? r.ps / denom : null;
   });
   const mom = subset.map((r) =>
-    r.ret_52w == null ? null : Math.max(MOM_FLOOR, Math.min(MOM_CAP, r.ret_52w)),
+    r.perf_52w_vs_spy == null
+      ? null
+      : Math.max(MOM_FLOOR, Math.min(MOM_CAP, r.perf_52w_vs_spy)),
   );
 
   const pR40 = percentiles(subset.map((r) => r.rule_of_40));


### PR DESCRIPTION
## What & why

At Tier 1, Momentum was scoring on the **raw 52-week return**, so a name that merely rode a rising market read as "momentum" when it had no alpha. The vs-SPY figure (`perf_52w_vs_spy` = the stock's 52w return − SPY's over the same window) was already derived in the loaders from `benchmark_prices` and exposed as a filter/display field — but the composite never used it, and on the page it sat hidden in the column picker rendered as plain green.

This points Momentum at the alpha figure and surfaces it.

## Changes

**Scoring — Momentum = alpha vs SPY**
- `web/lib/screen/score.ts` and `screen.py` now rank Momentum on `perf_52w_vs_spy` (same `[-50, +40]` pp collar). The website and the Python buyer stay identical.
- `test_screen.py` momentum-collar test updated; all 14 Python tests pass.
- `CLAUDE.md` momentum description corrected.

**Screener page — surface the alpha**
- Promoted **"vs SPY"** from a hidden toggle to an **always-visible base column** (it's the Momentum driver, so the ranking is now legible without opening the picker).
- Rendered as **signed alpha** — `+12.3%` / `−5.0%`, green when beating SPY / red when lagging (new `Col.signed`); the raw "52w%" column is signed too.
- Added **header mouseover tooltips** across the result columns (Score, P/S, Rev gr%, GM%, R40, FCF M%, 52w%, vs SPY) via a reusable `Col.help` (dotted-underline cursor-help), and fixed the Momentum slider help text to "vs SPY (alpha)".

## Notes

- **No schema migration.** I initially drafted one to materialize `ret_52w_vs_spy` into `screen_facts_mv`, but discarded it — that would duplicate the already-derived `perf_52w_vs_spy` under a second name. (If you'd prefer it materialized as a true Tier 1 fact column for non-screener consumers like `/api/v1/universe`, that's a clean follow-up.)
- Couldn't run `tsc` in the sandbox (no `node_modules`); CI will typecheck the TS.

https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY)_