### PR TITLE
Screener: persist chosen result columns across refresh

### DIFF
--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -66,6 +66,8 @@ function fmtSigned(v: number | null, dp = 1): string {
   return `${v >= 0 ? "+" : ""}${v.toFixed(dp)}%`;
 }
 const PAGE_SIZE = 250;
+// localStorage key for the viewer's chosen extra result columns (survives refresh).
+const COLS_STORAGE_KEY = "alphamolt:screener:cols";
 
 // Hover explanations for the result columns (header mouseover).
 const COL_HELP: Record<string, string> = {
@@ -157,10 +159,39 @@ export default function ScreenerClient({
   const [extraCols, setExtraCols] = useState<Set<string>>(new Set());
   const [visible, setVisible] = useState(PAGE_SIZE);
   const firstRender = useRef(true);
+  const colsHydrated = useRef(false);
 
   // Render only the first chunk; "Load more" reveals more from memory. Reset to
   // the first page whenever the ranking changes.
   useEffect(() => setVisible(PAGE_SIZE), [data]);
+
+  // The chosen extra columns are a per-viewer VIEW preference (not part of the
+  // shareable screen recipe), so they persist in localStorage rather than the
+  // URL — otherwise a refresh silently drops them. Hydrate after mount (so the
+  // server/client first paint match), then mirror every change back.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(COLS_STORAGE_KEY);
+      if (raw) {
+        const keys = (JSON.parse(raw) as string[]).filter((k) =>
+          EXTRA_COLS.some((c) => c.key === k),
+        );
+        if (keys.length) setExtraCols(new Set(keys));
+      }
+    } catch {
+      /* ignore malformed/blocked storage — just start with no extra columns */
+    }
+    colsHydrated.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!colsHydrated.current) return; // don't overwrite storage with the pre-hydration empty set
+    try {
+      localStorage.setItem(COLS_STORAGE_KEY, JSON.stringify([...extraCols]));
+    } catch {
+      /* storage unavailable (private mode / quota) — non-fatal */
+    }
+  }, [extraCols]);
 
   useEffect(() => {
     const supabase = createSupabaseBrowserClient();


### PR DESCRIPTION
## What & why

The screener's "cols ▾" picker (Sector, Country, FCF M%, Net M%, etc.) stored its selection only in component state (`useState(new Set())`), so a page refresh silently reset it to the defaults — added columns appeared to "disappear."

## Change

Column choice is a per-viewer **view preference**, not part of the shareable screen recipe (which lives in the URL), so persist `extraCols` in `localStorage`:
- **Hydrate after mount** (in `useEffect`, not a lazy initializer) so the server/client first paint stay identical — no hydration mismatch.
- Validate stored keys against the current `EXTRA_COLS` so a removed/renamed column key can't break hydration.
- Mirror every change back to storage, guarded by a `colsHydrated` ref so the pre-hydration empty set never clobbers a saved selection.
- Storage being blocked/full (private mode, quota) is caught and non-fatal.

Deliberately **not** the URL: column choice shouldn't pollute the shareable/indexable screen recipe, but it should survive a refresh — which it now does.

## Note

Touches `screener-client.tsx` in a different region than #1460, so the two merge cleanly in either order.

https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY)_