### PR TITLE
Land no-portfolio users on the Portfolio page in its unconfigured state

### DIFF
--- a/web/app/account/page.tsx
+++ b/web/app/account/page.tsx
@@ -4,15 +4,13 @@ import { redirect } from "next/navigation";
 import Nav from "@/components/nav";
 import Sparkline from "@/components/sparkline";
 import BetaDisclaimer from "@/components/beta-disclaimer";
-import BriefTeamForm from "@/components/portfolio/brief-team-form";
+import Onboarding from "@/components/account/onboarding";
 import PulseSection from "@/components/dashboard/pulse-section";
 import NeedsAttention, {
   type AttentionItem,
 } from "@/components/dashboard/needs-attention";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { getDashboardData, type DashPortfolio, type DashTrade } from "@/lib/dashboard-query";
-import { getHouseTicker, type HouseTick } from "@/lib/house-activity-query";
-import { PRESETS, DEFAULT_PRESET } from "@/lib/screen/config";
 
 export const metadata: Metadata = {
   // Private surface — never indexed, never in the sitemap (dashboard brief §6).
@@ -29,7 +27,8 @@ const PUBLIC_THRESHOLD = 15;
  * every element reports state or links to the page that owns an action. NOTHING
  * here edits config — mandate / screen / agents / knobs all live on the
  * portfolio + screener pages. Onboarding (no portfolio) falls back to the
- * brief-first first-run screen (EmptyState).
+ * brief-first first-run screen (the shared `Onboarding` component, also
+ * rendered on /account/portfolio).
  */
 export default async function AccountPage() {
   const supabase = await createSupabaseServerClient();
@@ -59,7 +58,7 @@ export default async function AccountPage() {
       <main className="flex-1 w-full">
         <div className="max-w-[1100px] mx-auto w-full px-4 sm:px-6 py-8 sm:py-10">
           {portfolios.length === 0 && !livePortfolio ? (
-            <EmptyState displayName={displayName} />
+            <Onboarding displayName={displayName} />
           ) : (
             <Dashboard
               displayName={displayName}
@@ -406,108 +405,4 @@ function buildAttention(
   // Sparse: high first, capped.
   const order = { high: 0, med: 1, low: 2 } as const;
   return items.sort((a, b) => order[a.urgency] - order[b.urgency]).slice(0, 5);
-}
-
-/**
- * First-run screen (onboarding brief): brief a team that's standing by, don't
- * build a portfolio. One model statement, one ~80%-pre-filled "Brief your team"
- * card whose only required field is the mandate, and a live ticker of real
- * house activity beside it so a newcomer sees the product working. The ticker
- * is hidden entirely when the house board is quiet (never a fake board).
- */
-async function EmptyState({ displayName }: { displayName: string }) {
-  const ticks = await getHouseTicker(12);
-  const presets = Object.values(PRESETS).map((p) => ({
-    id: p.id,
-    label: p.label,
-    description: p.description,
-  }));
-  const defaultName = `${displayName}'s Portfolio`;
-
-  return (
-    <div>
-      <header className="max-w-[58ch]">
-        <h1 className="text-[26px] sm:text-[32px] font-bold tracking-[-0.02em] text-text leading-[1.15]">
-          Welcome, {displayName}
-        </h1>
-        <p className="mt-3 text-[15px] text-text border-l-2 border-[var(--color-green,#00FF41)] pl-3 leading-relaxed">
-          Brief a team of AI agents. They trade your strategy on paper. The
-          leaderboard ranks everyone by alpha vs SPY.
-        </p>
-      </header>
-
-      <div className="mt-8 grid gap-6 lg:grid-cols-[1fr_300px] items-start">
-        <BriefTeamForm
-          presets={presets}
-          defaultPreset={DEFAULT_PRESET}
-          defaultName={defaultName}
-        />
-        {ticks.length > 0 && <LiveTicker ticks={ticks} />}
-      </div>
-    </div>
-  );
-}
-
-// Real recent house-agent trades — teaches the product in a line (brief §3).
-// Only rendered when there's genuine activity to show.
-function LiveTicker({ ticks }: { ticks: HouseTick[] }) {
-  return (
-    <aside className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <span
-          aria-hidden
-          className="h-1.5 w-1.5 rounded-full bg-[var(--color-green,#00FF41)] animate-pulse"
-          style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
-        />
-        <h2 className="text-[10px] font-mono font-bold uppercase tracking-[0.14em] text-text-dim">
-          Live · house agents
-        </h2>
-      </div>
-      <ul className="space-y-2.5">
-        {ticks.map((t) => {
-          const sell = t.side.toLowerCase() === "sell";
-          return (
-            <li key={String(t.id)} className="text-[13px] leading-snug">
-              <span className="text-text">{t.agentName}</span>{" "}
-              <span
-                className={
-                  sell
-                    ? "text-[var(--color-red,#FF3333)]"
-                    : "text-[var(--color-green,#00FF41)]"
-                }
-              >
-                {sell ? "sold" : "bought"}
-              </span>{" "}
-              <Link
-                href={`/company/${t.ticker}`}
-                className="font-mono text-text hover:text-[var(--color-green,#00FF41)]"
-              >
-                {t.ticker}
-              </Link>
-              <span className="text-text-muted"> · {ago(t.executedAt)}</span>
-            </li>
-          );
-        })}
-      </ul>
-      <Link
-        href="/leaderboard"
-        className="mt-3 inline-block text-[11px] font-mono text-text-muted hover:text-text"
-      >
-        See the board →
-      </Link>
-    </aside>
-  );
-}
-
-// Compact relative time ("2m", "3h", "5d") for the live ticker.
-function ago(iso: string): string {
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return "";
-  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
-  if (secs < 60) return `${secs}s`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h`;
-  return `${Math.floor(hrs / 24)}d`;
 }

--- a/web/app/account/portfolio/page.tsx
+++ b/web/app/account/portfolio/page.tsx
@@ -1,17 +1,22 @@
 import { redirect } from "next/navigation";
+import Nav from "@/components/nav";
+import Onboarding from "@/components/account/onboarding";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { getPortfolioForUser } from "@/lib/portfolios-query";
 
 export const dynamic = "force-dynamic";
 
 /**
- * Server-side redirect to the signed-in user's own portfolio detail page
- * (`/portfolios/<slug>`). The nav links here so visitors have a stable
- * "Portfolio" entry that always resolves to whichever slug they own — no
- * need for the nav to fetch the slug client-side.
+ * The signed-in user's "Portfolio" surface. The nav links here so visitors
+ * have a stable entry that always resolves to whichever portfolio they own —
+ * no need for the nav to fetch the slug client-side. It is also the default
+ * landing for a magic-link sign-in (the auth callback's `next`).
  *
- *   * Not signed in → /login?next=/account/portfolio
- *   * Signed in, no portfolio yet → /account (where they'd create one)
+ *   * Not signed in            → /login?next=/account/portfolio
+ *   * Signed in, no portfolio  → render the unconfigured onboarding in place
+ *                                (the "Brief your team" first-run screen), so a
+ *                                first-time user lands on the Portfolio page in
+ *                                its unconfigured state rather than the dashboard
  *   * Signed in with portfolio → /portfolios/<slug>
  */
 export default async function PortfolioRedirect() {
@@ -25,9 +30,33 @@ export default async function PortfolioRedirect() {
   }
 
   const portfolio = await getPortfolioForUser(user.id);
-  if (!portfolio) {
-    redirect("/account");
+  if (portfolio) {
+    redirect(`/portfolios/${portfolio.slug}`);
   }
 
-  redirect(`/portfolios/${portfolio.slug}`);
+  // No portfolio yet — show the Portfolio page in its unconfigured state
+  // (the same first-run onboarding the dashboard uses) instead of bouncing
+  // to /account.
+  let displayName = user.email?.split("@")[0] ?? "there";
+  try {
+    const { data } = await supabase
+      .from("profiles")
+      .select("display_name")
+      .eq("id", user.id)
+      .maybeSingle();
+    if (data?.display_name) displayName = data.display_name;
+  } catch {
+    /* ignore — greeting falls back to the email local-part */
+  }
+
+  return (
+    <>
+      <Nav />
+      <main className="flex-1 w-full">
+        <div className="max-w-[1100px] mx-auto w-full px-4 sm:px-6 py-8 sm:py-10">
+          <Onboarding displayName={displayName} />
+        </div>
+      </main>
+    </>
+  );
 }

--- a/web/components/account/onboarding.tsx
+++ b/web/components/account/onboarding.tsx
@@ -1,0 +1,118 @@
+import Link from "next/link";
+import BriefTeamForm from "@/components/portfolio/brief-team-form";
+import { getHouseTicker, type HouseTick } from "@/lib/house-activity-query";
+import { PRESETS, DEFAULT_PRESET } from "@/lib/screen/config";
+
+/**
+ * First-run / unconfigured portfolio screen (onboarding brief): brief a team
+ * that's standing by, don't build a portfolio. One model statement, one
+ * ~80%-pre-filled "Brief your team" card whose only required field is the
+ * mandate, and a live ticker of real house activity beside it so a newcomer
+ * sees the product working. The ticker is hidden entirely when the house
+ * board is quiet (never a fake board).
+ *
+ * Shared by the Dashboard (/account) and the Portfolio route
+ * (/account/portfolio): a signed-in user who owns no portfolio yet sees this
+ * unconfigured state on EITHER surface, so a magic-link sign-in lands them on
+ * the Portfolio page in its unconfigured state rather than bouncing away.
+ */
+export default async function Onboarding({
+  displayName,
+}: {
+  displayName: string;
+}) {
+  const ticks = await getHouseTicker(12);
+  const presets = Object.values(PRESETS).map((p) => ({
+    id: p.id,
+    label: p.label,
+    description: p.description,
+  }));
+  const defaultName = `${displayName}'s Portfolio`;
+
+  return (
+    <div>
+      <header className="max-w-[58ch]">
+        <h1 className="text-[26px] sm:text-[32px] font-bold tracking-[-0.02em] text-text leading-[1.15]">
+          Welcome, {displayName}
+        </h1>
+        <p className="mt-3 text-[15px] text-text border-l-2 border-[var(--color-green,#00FF41)] pl-3 leading-relaxed">
+          Brief a team of AI agents. They trade your strategy on paper. The
+          leaderboard ranks everyone by alpha vs SPY.
+        </p>
+      </header>
+
+      <div className="mt-8 grid gap-6 lg:grid-cols-[1fr_300px] items-start">
+        <BriefTeamForm
+          presets={presets}
+          defaultPreset={DEFAULT_PRESET}
+          defaultName={defaultName}
+        />
+        {ticks.length > 0 && <LiveTicker ticks={ticks} />}
+      </div>
+    </div>
+  );
+}
+
+// Real recent house-agent trades — teaches the product in a line (brief §3).
+// Only rendered when there's genuine activity to show.
+function LiveTicker({ ticks }: { ticks: HouseTick[] }) {
+  return (
+    <aside className="rounded-2xl border border-white/10 bg-white/[0.02] p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <span
+          aria-hidden
+          className="h-1.5 w-1.5 rounded-full bg-[var(--color-green,#00FF41)] animate-pulse"
+          style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
+        />
+        <h2 className="text-[10px] font-mono font-bold uppercase tracking-[0.14em] text-text-dim">
+          Live · house agents
+        </h2>
+      </div>
+      <ul className="space-y-2.5">
+        {ticks.map((t) => {
+          const sell = t.side.toLowerCase() === "sell";
+          return (
+            <li key={String(t.id)} className="text-[13px] leading-snug">
+              <span className="text-text">{t.agentName}</span>{" "}
+              <span
+                className={
+                  sell
+                    ? "text-[var(--color-red,#FF3333)]"
+                    : "text-[var(--color-green,#00FF41)]"
+                }
+              >
+                {sell ? "sold" : "bought"}
+              </span>{" "}
+              <Link
+                href={`/company/${t.ticker}`}
+                className="font-mono text-text hover:text-[var(--color-green,#00FF41)]"
+              >
+                {t.ticker}
+              </Link>
+              <span className="text-text-muted"> · {ago(t.executedAt)}</span>
+            </li>
+          );
+        })}
+      </ul>
+      <Link
+        href="/leaderboard"
+        className="mt-3 inline-block text-[11px] font-mono text-text-muted hover:text-text"
+      >
+        See the board →
+      </Link>
+    </aside>
+  );
+}
+
+// Compact relative time ("2m", "3h", "5d") for the live ticker.
+function ago(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  return `${Math.floor(hrs / 24)}d`;
+}


### PR DESCRIPTION
## What & why

A first-time / no-portfolio user's magic link defaults to `/account/portfolio`, which previously **redirected to `/account`** (the dashboard) when no portfolio existed. So the Portfolio and Dashboard routes looked identical, and the "Brief your team" onboarding only ever appeared on the dashboard.

## Change

- Extract the first-run "Brief your team" onboarding (`EmptyState` + its `LiveTicker`) out of the dashboard route into a shared `web/components/account/onboarding.tsx`.
- Render it **in place** on `/account/portfolio` for users with no portfolio yet — so a first-time user lands on the **Portfolio page in its unconfigured state** rather than being bounced to the dashboard.
- Users who own a portfolio still redirect straight to `/portfolios/<slug>`; the dashboard renders the same shared onboarding, so there's no duplication.

## Net effect on the magic-link flow

- First-time / no-portfolio user → lands on the Portfolio page, unconfigured ("Brief your team").
- Returning user with a portfolio → lands on their portfolio detail page.

https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY)_