### PR TITLE
Backfill securities sectors from EODHD (screener Sector column was ~71% empty)

### DIFF
--- a/.github/workflows/backfill-sectors.yml
+++ b/.github/workflows/backfill-sectors.yml
@@ -1,0 +1,71 @@
+name: Backfill sectors (Level 0)
+
+# Populates securities.gics_sector / gics_industry from EODHD fundamentals.
+# universe_sync builds `securities` from the exchange-symbol-list (no sector),
+# so sectors start NULL. Run this manually with only_missing OFF once to seed
+# the whole Tier 1 column in one taxonomy; the weekly cron then runs
+# --only-missing to fill names universe_sync has since added.
+
+on:
+  workflow_dispatch:
+    inputs:
+      only_missing:
+        description: "Only rows with a NULL sector (leave ON for a top-up; turn OFF for a full re-fetch)"
+        type: boolean
+        default: true
+      all_securities:
+        description: "Every active security (Tier 0), not just Tier 1"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Fetch but write nothing"
+        type: boolean
+        default: false
+      limit:
+        description: "Cap rows (smoke test). Blank = all."
+        required: false
+        default: ""
+  schedule:
+    - cron: "45 2 * * 0" # Sunday 02:45 UTC, just after universe_sync (02:00)
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Backfill sectors from EODHD
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          EODHD_API_KEY: ${{ secrets.EODHD_API_KEY }}
+          EVENT: ${{ github.event_name }}
+          ONLY_MISSING: ${{ inputs.only_missing }}
+          ALL_SECURITIES: ${{ inputs.all_securities }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          LIMIT: ${{ inputs.limit }}
+        run: |
+          # Scheduled runs are always a cheap top-up of the NULLs.
+          if [ "$EVENT" = "schedule" ]; then
+            args="--only-missing"
+          else
+            args=""
+            if [ "$ONLY_MISSING" = "true" ]; then args="$args --only-missing"; fi
+            if [ "$ALL_SECURITIES" = "true" ]; then args="$args --all-securities"; fi
+            if [ "$DRY_RUN" = "true" ]; then args="$args --dry-run"; fi
+            if [ -n "$LIMIT" ]; then args="$args --limit $LIMIT"; fi
+          fi
+          echo "Running: python backfill_sectors.py $args"
+          python backfill_sectors.py $args

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,17 @@ name with no recent row (a fresh gate promotion) gets a full 2y per-ticker
 backfill. Stores `dollar_volume` + `adj_close`. Flags: `--backfill` (force 2y
 for all Tier 1), `--tickers`, `--years`, `--dry-run`.
 
+### backfill_sectors.py (Sundays 02:45 UTC — weekly, + one-off full run)
+Populates `securities.gics_sector` / `gics_industry` from EODHD `fundamentals`
+(`General.Sector` / `General.Industry`). `universe_sync.py` builds `securities`
+from the exchange-symbol-list, which carries **no sector**, so sectors start
+NULL (the screener's Sector column/filter was ~71% empty). Run once with
+`--only-missing` OFF to seed the whole Tier 1 column in one consistent EODHD
+taxonomy; the weekly cron runs `--only-missing` to fill names universe_sync has
+since added. Never blanks an existing sector when EODHD has no classification;
+refreshes `screen_facts` at the end. Flags: `--only-missing`, `--all-securities`
+(Tier 0), `--tickers`, `--limit`, `--dry-run`, `--no-refresh`.
+
 ### migrate_companies_to_level0.py (one-off)
 Seeds Level 0 enrichment from the existing pipeline (spec §11 step 4 — reuse
 the ~1k already-enriched rows): copies scalar fundamentals from `companies`

--- a/backfill_sectors.py
+++ b/backfill_sectors.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+backfill_sectors.py — populate securities.gics_sector / gics_industry from EODHD.
+
+universe_sync.py builds the Tier 0 `securities` table from EODHD's
+exchange-symbol-list, which carries no sector — so gics_sector starts NULL for
+every name (~71% of Tier 1 had no sector, leaving the screener's Sector column
+and filter mostly empty). This fetches each security's General.Sector /
+General.Industry from the EODHD `fundamentals` endpoint and writes them onto
+`securities`, in ONE consistent EODHD taxonomy.
+
+By default it re-fetches EVERY active Tier 1 name (uniform taxonomy across the
+whole column); `--only-missing` fills just the NULLs (cheap — the weekly cron
+mode, to pick up names universe_sync added). After writing it refreshes the
+screen_facts materialized view so the screener shows the sectors immediately.
+
+It never overwrites an existing sector with a blank: a name EODHD has no sector
+for keeps whatever it already had.
+
+    python backfill_sectors.py                  # all active Tier 1 (full re-fetch)
+    python backfill_sectors.py --only-missing    # only rows with a NULL sector
+    python backfill_sectors.py --tickers IAG GFI DRD
+    python backfill_sectors.py --all-securities  # Tier 0 (every active security)
+    python backfill_sectors.py --dry-run --limit 20
+
+Env: EODHD_API_KEY, SUPABASE_URL, SUPABASE_SERVICE_KEY.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+
+from db import SupabaseDB
+from eodhd import EODHDClient, EODHDError
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger("backfill_sectors")
+
+WRITE_BATCH = 200
+
+
+def _clean(v: object) -> str | None:
+    """EODHD sometimes returns '', 'NA' or None for an unclassified field."""
+    if not isinstance(v, str):
+        return None
+    s = v.strip()
+    if not s or s.upper() in {"NA", "N/A", "NONE", "NULL"}:
+        return None
+    return s
+
+
+def select_targets(db: SupabaseDB, args: argparse.Namespace) -> list[dict]:
+    """The securities to (re)fetch, honouring the scope flags."""
+    rows = db.get_all_securities(
+        columns="ticker,is_tier1,gics_sector", status="active"
+    )
+    if args.tickers:
+        want = {t.upper() for t in args.tickers}
+        rows = [r for r in rows if (r.get("ticker") or "").upper() in want]
+    elif not args.all_securities:
+        rows = [r for r in rows if r.get("is_tier1")]
+    if args.only_missing:
+        rows = [r for r in rows if not _clean(r.get("gics_sector"))]
+    rows.sort(key=lambda r: r.get("ticker") or "")
+    if args.limit:
+        rows = rows[: args.limit]
+    return rows
+
+
+def main() -> int:
+    load_dotenv()
+    ap = argparse.ArgumentParser(description="Backfill securities sectors from EODHD")
+    ap.add_argument("--only-missing", action="store_true",
+                    help="only rows whose gics_sector is NULL (cron mode)")
+    ap.add_argument("--all-securities", action="store_true",
+                    help="every active security (Tier 0), not just Tier 1")
+    ap.add_argument("--tickers", nargs="+", default=None,
+                    help="restrict to these bare tickers (e.g. IAG GFI)")
+    ap.add_argument("--limit", type=int, default=None, help="cap rows (smoke test)")
+    ap.add_argument("--dry-run", action="store_true", help="fetch but write nothing")
+    ap.add_argument("--no-refresh", action="store_true",
+                    help="skip the screen_facts matview refresh at the end")
+    args = ap.parse_args()
+
+    db = SupabaseDB()
+    client = EODHDClient()
+
+    targets = select_targets(db, args)
+    logger.info("Backfilling sectors for %d securities%s%s",
+                len(targets),
+                " (only missing)" if args.only_missing else "",
+                " [dry-run]" if args.dry_run else "")
+
+    pending: list[dict] = []
+    written = updated = missing = errors = 0
+    now = datetime.now(timezone.utc).isoformat()
+
+    def flush() -> None:
+        nonlocal written
+        if pending and not args.dry_run:
+            db.upsert_securities_batch(pending)
+            written += len(pending)
+        pending.clear()
+
+    for i, r in enumerate(targets, 1):
+        ticker = r.get("ticker")
+        if not ticker:
+            continue
+        try:
+            fund = client.fundamentals(f"{ticker}.US")
+        except EODHDError as e:
+            errors += 1
+            logger.warning("%s: fundamentals failed (%s)", ticker, e)
+            continue
+
+        general = (fund or {}).get("General") or {}
+        sector = _clean(general.get("Sector"))
+        industry = _clean(general.get("Industry"))
+        if not sector and not industry:
+            missing += 1
+        else:
+            # Only write the fields we actually got — never blank out an
+            # existing sector when EODHD has no classification for the name.
+            row: dict = {"ticker": ticker, "updated_at": now}
+            if sector:
+                row["gics_sector"] = sector
+            if industry:
+                row["gics_industry"] = industry
+            pending.append(row)
+            updated += 1
+
+        if len(pending) >= WRITE_BATCH:
+            flush()
+        if i % 200 == 0:
+            logger.info("  %d/%d  (updated=%d missing=%d errors=%d)",
+                        i, len(targets), updated, missing, errors)
+
+    flush()
+
+    logger.info("Done. fetched=%d updated=%d written=%d missing=%d errors=%d",
+                len(targets), updated, written, missing, errors)
+
+    if not args.dry_run and not args.no_refresh and written:
+        logger.info("Refreshing screen_facts matview so the screener picks up sectors…")
+        try:
+            db.refresh_screen_facts()
+        except Exception as e:  # noqa: BLE001 — a refresh hiccup shouldn't fail the run
+            logger.warning("matview refresh failed (%s) — daily price job will refresh", e)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What & why

The screener's **Sector** column/filter is mostly "—": 2307 of 3241 Tier 1 securities (**71%**) have a NULL `gics_sector`. Root cause: `universe_sync.py` builds `securities` from EODHD's `exchange-symbol-list`, which carries **no sector**, so it never sets one. The 934 that *do* have a sector are the slice overlapping the legacy `companies` pipeline — and a `companies`-based backfill would cover only **2** of the 2307 gaps (the rest are foreign ADRs / miners / financials the old growth screen never tracked). So **EODHD fundamentals (`General.Sector` / `General.Industry`) is the only viable source.**

## Changes

- **`backfill_sectors.py`** — fetches `General.Sector`/`Industry` per ticker from the EODHD `fundamentals` endpoint and writes them onto `securities`, in **one consistent EODHD taxonomy**. Full re-fetch by default (uniform column); `--only-missing` for a cheap top-up. Never blanks an existing sector when EODHD has no classification; refreshes `screen_facts` at the end so the screener shows sectors immediately. Flags: `--only-missing`, `--all-securities`, `--tickers`, `--limit`, `--dry-run`, `--no-refresh`.
- **`.github/workflows/backfill-sectors.yml`** — `workflow_dispatch` (turn **only_missing OFF** for the one-time full seed) + a **Sunday 02:45 UTC cron** (`--only-missing`) right after `universe_sync`, so names added weekly get a sector going forward.
- **`CLAUDE.md`** — documents the new script.

## To actually populate the data

This needs `EODHD_API_KEY` + a ~55-min run, so it can't run from the dev sandbox. After merge, run the **Backfill sectors** Action once with **only_missing unchecked** (full re-fetch). The weekly cron keeps it current after that. A `--dry-run --limit 20` is a safe first smoke test.

https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fb13VkYEseSfBNvvyePEKY)_