### PR TITLE
Stop broken Screener → company links (404 for Level 0-only names)

### DIFF
--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -103,6 +103,21 @@ function formatAsOf(s: string): string {
   });
 }
 
+/**
+ * Tickers that have a /company/<ticker> page (the legacy `companies` table).
+ * The screener ranks the full Level 0 Tier 1 universe, which is broader than
+ * `companies`, so names outside this set would 404 — we render them as plain
+ * text instead of a broken link.
+ */
+async function getCompanyTickers(): Promise<string[]> {
+  const { data, error } = await getSupabase().from("companies").select("ticker");
+  if (error) {
+    console.error("getCompanyTickers failed:", error);
+    return [];
+  }
+  return ((data ?? []) as { ticker: string }[]).map((r) => r.ticker);
+}
+
 export default async function ScreenerPage({
   searchParams,
 }: {
@@ -110,7 +125,10 @@ export default async function ScreenerPage({
 }) {
   const sp = await resolveParams(searchParams);
   const config = (sp.screen ? await savedConfig(sp.screen) : null) ?? configFromParams(sp);
-  const initial = await runScreen(config);
+  const [initial, companyTickers] = await Promise.all([
+    runScreen(config),
+    getCompanyTickers(),
+  ]);
 
   return (
     <>
@@ -166,6 +184,7 @@ export default async function ScreenerPage({
               data_asof: initial.data_asof,
             }}
             sectors={initial.sectors}
+            companyTickers={companyTickers}
             defaultEncoded={encodeConfig(configFromParams({ preset: DEFAULT_PRESET }))}
           />
         </div>

--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -134,13 +134,20 @@ export default function ScreenerClient({
   initialConfig,
   initialData,
   sectors = [],
+  companyTickers = [],
 }: {
   initialConfig: ScreenConfig;
   initialData: ScreenData;
   /** Distinct sectors for the sector filter dropdown. */
   sectors?: string[];
+  /** Tickers that have a /company/<ticker> page (others render unlinked). */
+  companyTickers?: string[];
   defaultEncoded?: string;
 }) {
+  const linkable = useMemo(
+    () => new Set(companyTickers.map((t) => t.toUpperCase())),
+    [companyTickers],
+  );
   const [config, setConfig] = useState<ScreenConfig>(initialConfig);
   const [data, setData] = useState<ScreenData>(initialData);
   const [loading, setLoading] = useState(false);
@@ -546,6 +553,7 @@ export default function ScreenerClient({
                 spanCols={metricColCount + 3}
                 topN={config.topN}
                 runHref={runHref}
+                hasPage={linkable.has(r.ticker.toUpperCase())}
               />
             ))}
             {data.rows.length === 0 && (
@@ -913,6 +921,7 @@ function RowView({
   spanCols,
   topN,
   runHref,
+  hasPage,
 }: {
   r: Row;
   cols: Col[];
@@ -921,6 +930,7 @@ function RowView({
   spanCols: number;
   topN: number;
   runHref: string;
+  hasPage: boolean;
 }) {
   return (
     <>
@@ -943,10 +953,17 @@ function RowView({
           {r.rank}
         </td>
         <td className="px-2 py-2.5 text-left border-t border-white/10">
-          <Link href={`/company/${r.ticker}`} className="hover:text-[var(--color-cyan)]">
-            <span className="font-mono text-text text-[12.5px]">{r.ticker}</span>{" "}
-            <span className="text-[11px] text-text-muted">{r.name}</span>
-          </Link>
+          {hasPage ? (
+            <Link href={`/company/${r.ticker}`} className="hover:text-[var(--color-cyan)]">
+              <span className="font-mono text-text text-[12.5px]">{r.ticker}</span>{" "}
+              <span className="text-[11px] text-text-muted">{r.name}</span>
+            </Link>
+          ) : (
+            <span title="No analysis page for this name yet">
+              <span className="font-mono text-text text-[12.5px]">{r.ticker}</span>{" "}
+              <span className="text-[11px] text-text-muted">{r.name}</span>
+            </span>
+          )}
         </td>
         <td className="px-2 py-2.5 text-right text-[12.5px] font-mono border-t border-white/10 text-[var(--color-cyan)]">
           {fmt(r.score, { dp: 1 })}


### PR DESCRIPTION
## The bug
Clicking an equity in the Screener goes to a broken **"No Alpha Here"** 404 page.

The Screener ranks the full Level 0 Tier 1 universe (~3127 names), but `/company/<ticker>` reads from the legacy `companies` table (~1k TradingView-screened names) and `notFound()`s for anything outside it. So tech/health names work, but the gold miners / financials / ADRs (CDE, IAG, GFI, …) 404.

## The fix
Pass the set of company-backed tickers from the server to the screener client, and render a `/company/<ticker>` **Link only for tickers that have a page**. Names without one show as plain (non-linked) ticker + name with a "No analysis page for this name yet" tooltip — so there are no more dead clicks.

Small + safe: one extra cheap `select ticker from companies` query (run in parallel with the screen), no change to the company page.

## Follow-up (bigger)
The real long-term fix is **company pages for the whole Level 0 universe** (fall back to securities / screen_facts / prices_daily when a name isn't in `companies`), so every screened name is clickable. Flagging it separately — happy to build it if you want it.

## Verification
`tsc` clean, `next build` compiles.

https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU)_