### PR TITLE
Screener: manual 1-year exclusions (blocklist) for screener + agents

### DIFF
--- a/migrations/048_screener_exclusions.sql
+++ b/migrations/048_screener_exclusions.sql
@@ -1,0 +1,37 @@
+-- Migration 048: screener exclusions (manual 1-year blocklist).
+--
+-- A manually-removed company stays out of BOTH the screener results and the
+-- buyer's candidate pool (top-N of the screen) for a year — so the agents won't
+-- buy it either. Operator-curated and global (the screener is the house research
+-- surface; the buyer is the house pipeline), expiring automatically.
+--
+-- Applied at read time:
+--   * web/lib/screen/query.ts runScreen()  -> filters the screener
+--   * screen.py load_facts()               -> filters the Python buyer
+-- both drop tickers whose exclusion hasn't expired.
+--
+-- Public-read so those read paths (and a logged-out screener) can filter;
+-- writes are service-role only (the owner UI calls a server action that checks
+-- auth first, then writes service-role) — there's no anon/auth write policy.
+--
+-- Additive & idempotent.
+
+CREATE TABLE IF NOT EXISTS screener_exclusions (
+    ticker      TEXT PRIMARY KEY,
+    excluded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at  TIMESTAMPTZ NOT NULL,
+    note        TEXT,
+    created_by  UUID REFERENCES auth.users(id),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Active-exclusion lookups filter on expires_at > now().
+CREATE INDEX IF NOT EXISTS idx_screener_exclusions_expires
+    ON screener_exclusions (expires_at);
+
+ALTER TABLE screener_exclusions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "public read screener_exclusions" ON screener_exclusions;
+CREATE POLICY "public read screener_exclusions"
+    ON screener_exclusions FOR SELECT USING (true);
+-- No INSERT/UPDATE/DELETE policy → writes are service-role only.

--- a/screen.py
+++ b/screen.py
@@ -219,10 +219,30 @@ def _spy_ret_52w(db) -> float | None:
     return (lv / av - 1) * 100
 
 
+def _active_exclusions(db) -> set[str]:
+    """Tickers on the manual 1-year blocklist (migration 048) — dropped from the
+    screen, so the buyer never considers them. Mirrors query.ts. Fail-open: a
+    read error returns no exclusions rather than blocking the whole screen."""
+    from datetime import datetime, timezone
+    try:
+        resp = (
+            db.client.table("screener_exclusions")
+            .select("ticker")
+            .gt("expires_at", datetime.now(timezone.utc).isoformat())
+            .execute()
+        )
+    except Exception:  # noqa: BLE001
+        return set()
+    return {(r.get("ticker") or "").upper() for r in (resp.data or [])}
+
+
 def load_facts(db) -> list[dict]:
     """Load Level 0 facts for the whole Tier 1 universe + the AI overlay."""
     facts = _rpc_all(db, "screen_facts")
     overlay = {r["ticker"]: r for r in _rpc_all(db, "screen_ai_overlay")}
+    excluded = _active_exclusions(db)
+    if excluded:
+        facts = [r for r in facts if (r.get("ticker") or "").upper() not in excluded]
     spy = _spy_ret_52w(db)
     for r in facts:
         v = overlay.get(r["ticker"])

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -8,6 +8,7 @@ import {
   isHousePreset,
 } from "@/lib/screen/config";
 import { runScreen } from "@/lib/screen/query";
+import { listActiveExclusions } from "@/lib/screen/exclusions-query";
 import { getSupabase } from "@/lib/supabase";
 import { screenConfigSchema, type ScreenConfig } from "@/lib/screen/config";
 import ScreenerClient from "@/app/screener/screener-client";
@@ -125,9 +126,10 @@ export default async function ScreenerPage({
 }) {
   const sp = await resolveParams(searchParams);
   const config = (sp.screen ? await savedConfig(sp.screen) : null) ?? configFromParams(sp);
-  const [initial, companyTickers] = await Promise.all([
+  const [initial, companyTickers, exclusions] = await Promise.all([
     runScreen(config),
     getCompanyTickers(),
+    listActiveExclusions(),
   ]);
 
   return (
@@ -185,6 +187,7 @@ export default async function ScreenerPage({
             }}
             sectors={initial.sectors}
             companyTickers={companyTickers}
+            exclusions={exclusions.map((e) => e.ticker)}
             defaultEncoded={encodeConfig(configFromParams({ preset: DEFAULT_PRESET }))}
           />
         </div>

--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -5,6 +5,10 @@ import Link from "next/link";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { saveScreen } from "@/lib/screen/saved-mutations";
 import {
+  excludeFromScreener,
+  unexcludeFromScreener,
+} from "@/lib/screen/exclusions-mutations";
+import {
   FILTER_FIELDS,
   FILTER_OPS,
   METRIC_META,
@@ -139,6 +143,7 @@ export default function ScreenerClient({
   initialData,
   sectors = [],
   companyTickers = [],
+  exclusions = [],
 }: {
   initialConfig: ScreenConfig;
   initialData: ScreenData;
@@ -146,6 +151,8 @@ export default function ScreenerClient({
   sectors?: string[];
   /** Tickers that have a /company/<ticker> page (others render unlinked). */
   companyTickers?: string[];
+  /** Tickers on the manual 1-year blocklist (owner-managed). */
+  exclusions?: string[];
   defaultEncoded?: string;
 }) {
   const linkable = useMemo(
@@ -155,6 +162,8 @@ export default function ScreenerClient({
   const [config, setConfig] = useState<ScreenConfig>(initialConfig);
   const [data, setData] = useState<ScreenData>(initialData);
   const [loading, setLoading] = useState(false);
+  const [excluded, setExcluded] = useState<string[]>(exclusions);
+  const [exclBusy, setExclBusy] = useState(false);
   const [showIntro, setShowIntro] = useState(false);
   const [signedIn, setSignedIn] = useState(false);
   const [saveLink, setSaveLink] = useState<string | null>(null);
@@ -290,6 +299,46 @@ export default function ScreenerClient({
     setConfig((c) => ({ ...c, preset: "custom", ...p }));
     setSaveLink(null);
   }, []);
+
+  // Re-fetch the current screen — used after an exclusion changes the universe.
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/screen?config=${encodeConfig(config)}`, {
+        cache: "no-store",
+      });
+      if (res.ok) setData((await res.json()) as ScreenData);
+    } finally {
+      setLoading(false);
+    }
+  }, [config]);
+
+  const excludedSet = useMemo(
+    () => new Set(excluded.map((t) => t.toUpperCase())),
+    [excluded],
+  );
+
+  async function onExclude(ticker: string) {
+    const t = ticker.toUpperCase();
+    setExclBusy(true);
+    const res = await excludeFromScreener(t);
+    setExclBusy(false);
+    if (res.ok) {
+      setExcluded((prev) => Array.from(new Set([...prev, t])));
+      await refetch();
+    }
+  }
+
+  async function onRestore(ticker: string) {
+    const t = ticker.toUpperCase();
+    setExclBusy(true);
+    const res = await unexcludeFromScreener(t);
+    setExclBusy(false);
+    if (res.ok) {
+      setExcluded((prev) => prev.filter((x) => x.toUpperCase() !== t));
+      await refetch();
+    }
+  }
 
   function selectPreset(id: string) {
     setConfig(presetConfig(id));
@@ -532,6 +581,41 @@ export default function ScreenerClient({
         </div>
       </details>
 
+      {/* Hidden names — the owner's manual 1-year blocklist. Removed names
+          drop from the screener AND the agents' candidate pool until they
+          expire (or are restored here). */}
+      {signedIn && excluded.length > 0 && (
+        <details className={`mb-2 ${card}`}>
+          <summary className="list-none cursor-pointer font-mono text-[11px] text-text-muted px-3 py-2 marker:hidden [&::-webkit-details-marker]:hidden flex items-center justify-between">
+            <span>
+              🚫 Hidden ({excluded.length}) — removed from screener &amp; agents
+              for 1 year
+            </span>
+            <span className="text-text-muted/60">manage ▾</span>
+          </summary>
+          <div className="px-3 pb-3 flex flex-wrap gap-1.5">
+            {[...excludedSet].sort().map((t) => (
+              <span
+                key={t}
+                className="inline-flex items-center gap-1.5 font-mono text-[11px] text-text border border-white/10 bg-white/[0.03] rounded-md px-2 py-1"
+              >
+                {t}
+                <button
+                  type="button"
+                  disabled={exclBusy}
+                  onClick={() => onRestore(t)}
+                  title={`Restore ${t} to the screener now`}
+                  aria-label={`Restore ${t}`}
+                  className="text-[var(--color-cyan)] hover:underline disabled:opacity-40"
+                >
+                  restore
+                </button>
+              </span>
+            ))}
+          </div>
+        </details>
+      )}
+
       {/* Results */}
       <div className={`${card} overflow-hidden`}>
         <table className="w-full border-collapse" aria-label="Screened equities ranked by your composite">
@@ -592,6 +676,9 @@ export default function ScreenerClient({
                 topN={config.topN}
                 runHref={runHref}
                 hasPage={linkable.has(r.ticker.toUpperCase())}
+                canExclude={signedIn}
+                exclBusy={exclBusy}
+                onExclude={onExclude}
               />
             ))}
             {data.rows.length === 0 && (
@@ -960,6 +1047,9 @@ function RowView({
   topN,
   runHref,
   hasPage,
+  canExclude,
+  exclBusy,
+  onExclude,
 }: {
   r: Row;
   cols: Col[];
@@ -969,6 +1059,10 @@ function RowView({
   topN: number;
   runHref: string;
   hasPage: boolean;
+  /** Owner-only: show the ✕ "remove from screener for a year" control. */
+  canExclude: boolean;
+  exclBusy: boolean;
+  onExclude: (ticker: string) => void;
 }) {
   return (
     <>
@@ -1026,7 +1120,20 @@ function RowView({
             </td>
           );
         })}
-        <td className="border-t border-white/10" />
+        <td className="border-t border-white/10 text-right pr-2">
+          {canExclude && (
+            <button
+              type="button"
+              disabled={exclBusy}
+              onClick={() => onExclude(r.ticker)}
+              title={`Remove ${r.ticker} from the screener for 1 year — also blocks the agents from buying it`}
+              aria-label={`Remove ${r.ticker} for a year`}
+              className="font-mono text-[12px] text-text-muted/50 hover:text-[var(--color-red,#FF3333)] disabled:opacity-40"
+            >
+              ✕
+            </button>
+          )}
+        </td>
       </tr>
     </>
   );

--- a/web/lib/screen/exclusions-mutations.ts
+++ b/web/lib/screen/exclusions-mutations.ts
@@ -1,0 +1,59 @@
+"use server";
+
+/**
+ * Server actions for the screener's manual 1-year blocklist (migration 048).
+ * Auth-gated (a signed-in user), then service-role write — same verify-then-
+ * service-role pattern as portfolios-mutations. The exclusion is global: it
+ * drops the name from the screener AND the buyer's candidate pool (screen.py),
+ * so the agents won't buy it either, until it expires.
+ */
+
+import { revalidatePath } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+import { requireUser } from "@/lib/auth/require-user";
+
+export type ExclusionResult = { ok: true } | { ok: false; error: string };
+
+const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+export async function excludeFromScreener(
+  ticker: string,
+): Promise<ExclusionResult> {
+  const { user } = await requireUser();
+  const t = ticker.trim().toUpperCase();
+  if (!t) return { ok: false, error: "Ticker required." };
+
+  const now = new Date();
+  const { error } = await getSupabase().from("screener_exclusions").upsert(
+    {
+      ticker: t,
+      excluded_at: now.toISOString(),
+      expires_at: new Date(now.getTime() + YEAR_MS).toISOString(),
+      created_by: user.id,
+    },
+    { onConflict: "ticker" },
+  );
+  if (error) {
+    console.error("excludeFromScreener failed:", error);
+    return { ok: false, error: "Could not remove it. Try again." };
+  }
+  revalidatePath("/screener");
+  return { ok: true };
+}
+
+export async function unexcludeFromScreener(
+  ticker: string,
+): Promise<ExclusionResult> {
+  await requireUser();
+  const t = ticker.trim().toUpperCase();
+  const { error } = await getSupabase()
+    .from("screener_exclusions")
+    .delete()
+    .eq("ticker", t);
+  if (error) {
+    console.error("unexcludeFromScreener failed:", error);
+    return { ok: false, error: "Could not restore it. Try again." };
+  }
+  revalidatePath("/screener");
+  return { ok: true };
+}

--- a/web/lib/screen/exclusions-query.ts
+++ b/web/lib/screen/exclusions-query.ts
@@ -1,0 +1,21 @@
+import { getSupabase } from "@/lib/supabase";
+
+export interface ScreenerExclusion {
+  ticker: string;
+  expires_at: string;
+}
+
+/** Active (non-expired) screener exclusions — the manual 1-year blocklist
+ *  (migration 048). Drives the owner's "hidden names" manage panel. */
+export async function listActiveExclusions(): Promise<ScreenerExclusion[]> {
+  const { data, error } = await getSupabase()
+    .from("screener_exclusions")
+    .select("ticker, expires_at")
+    .gt("expires_at", new Date().toISOString())
+    .order("excluded_at", { ascending: false });
+  if (error) {
+    console.error("listActiveExclusions failed:", error);
+    return [];
+  }
+  return (data ?? []) as ScreenerExclusion[];
+}

--- a/web/lib/screen/query.ts
+++ b/web/lib/screen/query.ts
@@ -144,9 +144,39 @@ export interface ScreenResponse extends ScreenResult {
   sectors: string[];
 }
 
+/**
+ * Tickers on the manual 1-year blocklist (migration 048). Dropped from the
+ * screener results; mirrored in screen.py so the buyer never considers them.
+ * Fetched fresh (not in the facts cache) so an exclusion takes effect on the
+ * next request. Fail-open on error.
+ */
+async function activeExclusions(): Promise<Set<string>> {
+  try {
+    const { data, error } = await getSupabase()
+      .from("screener_exclusions")
+      .select("ticker")
+      .gt("expires_at", new Date().toISOString());
+    if (error) {
+      console.error("activeExclusions failed:", error.message);
+      return new Set();
+    }
+    return new Set(
+      ((data ?? []) as { ticker: string }[]).map((r) => r.ticker.toUpperCase()),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
 /** Full contract response for a config: scored rows + counts + as-of. */
 export async function runScreen(config: ScreenConfig): Promise<ScreenResponse> {
-  const facts = await loadFacts();
+  const [allFacts, excluded] = await Promise.all([
+    loadFacts(),
+    activeExclusions(),
+  ]);
+  const facts = excluded.size
+    ? allFacts.filter((f) => !excluded.has(f.ticker.toUpperCase()))
+    : allFacts;
   const result = scoreScreen(facts, config, facts.length);
   const data_asof = facts.reduce<string | null>((acc, f) => {
     if (f.price_asof && (!acc || f.price_asof > acc)) return f.price_asof;


### PR DESCRIPTION
## What

A simple owner-managed **blocklist** so you can manually remove a company from the Screener for **1 year**. The exclusion is **global**: the name also drops out of the buyer's candidate pool, so the agents won't buy it either, until it expires.

This implements the request: *"I want to be able to manually remove certain companies from the Watchlist. When I remove them, they should stay removed for 1 yr. Needs to be a simple interface."* — clarified scope: remove from the **Screener results** + **block agents too**.

## How

- **migration 048** — `screener_exclusions` (`ticker` PK, `expires_at`, `created_by`), public-read RLS, service-role writes. *Must be applied to the DB.*
- **screen.py** — `_active_exclusions()` filters the Tier 1 facts in `load_facts` (fail-open on read error), so `portfolio_screen_candidates → run_screen` honours the blocklist → the agents skip excluded names.
- **web/lib/screen/query.ts** — `activeExclusions()` filters `runScreen` results, fetched fresh outside the facts cache so a removal takes effect on the next request.
- **exclusions-mutations.ts / exclusions-query.ts** — auth-gated server actions (`excludeFromScreener` / `unexcludeFromScreener`, verify-then-service-role) + the active-list read for the manage panel.
- **screener-client.tsx** — owner-only per-row ✕ remove control + a "Hidden (N) — manage" panel with restore.

## Simple interface

- Signed-in viewer gets a muted ✕ on each result row → one click removes it for a year (screener + agents).
- A collapsible **🚫 Hidden (N)** panel above the table lists removed names with a **restore** link each.
- Logged-out viewers see neither — pure research view unchanged.

## Verification

- `npx tsc --noEmit` clean.
- `npx next build` TypeScript compile passes (only pre-existing prerender failures from missing Supabase env at build time).
- `screen.py` parses; `_active_exclusions` uses the same `db.client` table access as the rest of the module.

## Follow-up

Apply migration 048 before this takes effect.

https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU)_