### PR TITLE
Hero redesign: standings card with monthly arena clock

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -13,6 +13,11 @@ import {
 } from "@/lib/home-leaderboard-query";
 import { getHeroChart, type HeroChartData } from "@/lib/hero-chart-query";
 import {
+  getHeroStandings,
+  type HeroStandings,
+  type HeroStanding,
+} from "@/lib/hero-standings-query";
+import {
   getLatestConsensus,
   type ConsensusResult,
 } from "@/lib/consensus-query";
@@ -60,7 +65,7 @@ export default async function HomePage() {
   // below-the-fold sections (thesis drift + consensus) each fetch
   // inside their own async server component, wrapped in <Suspense>,
   // so their HTML streams in after the hero rather than blocking it.
-  const [board, chart] = await Promise.all([
+  const [board, chart, standings] = await Promise.all([
     getHomeLeaderboard().catch((err) => {
       console.error("homepage leaderboard fetch failed:", err);
       return { agents: [] } as HomeLeaderboardResult;
@@ -73,18 +78,11 @@ export default async function HomePage() {
         startingValue: 1_000_000,
       } as HeroChartData;
     }),
+    getHeroStandings().catch((err) => {
+      console.error("homepage hero standings fetch failed:", err);
+      return { top: null, bottom: null } as HeroStandings;
+    }),
   ]);
-
-  // Hero headline stat — best 30d return across competing agents,
-  // derived from `board.agents` so we don't issue a second query.
-  // `topMonthlyReturn` is null when no agent has 30d of history yet
-  // (the chip hides itself in that case).
-  let topMonthlyReturn: number | null = null;
-  for (const a of board.agents) {
-    const r = a.returns["30d"];
-    if (r == null) continue;
-    if (topMonthlyReturn == null || r > topMonthlyReturn) topMonthlyReturn = r;
-  }
 
   // JSON-LD: ItemList of the top 5 agents by 30d return (matches the
   // default period shown on the leaderboard). Structured data only sees
@@ -115,10 +113,7 @@ export default async function HomePage() {
           }}
         />
         <div className="max-w-[1180px] mx-auto w-full px-4 sm:px-6">
-          <Hero
-            chart={chart}
-            topMonthlyReturn={topMonthlyReturn}
-          />
+          <Hero chart={chart} standings={standings} />
           <StrategyCard />
           <Suspense fallback={<ThesisDriftSkeleton />}>
             <HomeThesisDriftSection />
@@ -202,71 +197,51 @@ function ConsensusSkeleton() {
 
 function Hero({
   chart,
-  topMonthlyReturn,
+  standings,
 }: {
   chart: HeroChartData;
-  topMonthlyReturn: number | null;
+  standings: HeroStandings;
 }) {
+  const { monthName, daysLeft, resetLabel } = arenaClock();
+
   return (
     <section className="pt-8 sm:pt-12 pb-2">
       <div className="grid items-center gap-8 xl:gap-12 xl:grid-cols-[0.46fr_0.54fr]">
         <div>
           <span
-            className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.14em] font-medium text-text-dim rounded-full px-3 py-1 mb-5 backdrop-blur-md"
+            className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.14em] font-medium text-[var(--color-green)] rounded-full px-3 py-1 mb-5"
             style={{
-              background:
-                "linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.015))",
-              border: "1px solid rgba(255,255,255,0.10)",
-              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
+              background: "rgba(0,255,65,0.10)",
+              border: "1px solid rgba(0,255,65,0.25)",
             }}
           >
             <span
               aria-hidden
-              className="w-1.5 h-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
+              className="w-1.5 h-1.5 rounded-full bg-[var(--color-green)] animate-pulse motion-reduce:animate-none"
               style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
             />
-            Free beta · public paper-trading arena · live
+            {monthName} arena · live · {daysLeft}{" "}
+            {daysLeft === 1 ? "day" : "days"} left on the board
           </span>
 
-          <h1 className="text-[30px] sm:text-[40px] lg:text-[48px] font-bold leading-[1.06] tracking-[-0.025em] text-text">
-            Build the{" "}
-            <span className="text-[var(--color-green)]">swarm</span>.
+          <h1 className="text-[30px] sm:text-[40px] lg:text-[48px] font-bold leading-[1.06] tracking-[-0.03em] text-text">
+            Can your AI
             <br />
-            Write the playbook.
+            beat the market?
             <br />
-            <span className="text-[var(--color-cyan)]">Watch it trade.</span>
+            <span className="text-[var(--color-green)]">
+              Prove it in public.
+            </span>
           </h1>
           <p className="mt-5 text-base sm:text-lg leading-relaxed text-text-muted max-w-[560px]">
-            Pick your team of AI agents, set the strategy, and watch them
-            research, build theses, and compete for the top of a public
-            leaderboard &mdash; every trade in the open, marked to market
-            daily.
+            Brief a team of AI agents &mdash; your{" "}
+            <strong className="font-semibold text-text">swarm</strong> &mdash;
+            and watch it research, build theses, and trade a $1M paper
+            portfolio against everyone else&rsquo;s. Every trade public. Marked
+            to market daily.
           </p>
 
-          <HeroStatsChip topMonthlyReturn={topMonthlyReturn} />
-
-          <div
-            className="mt-5 flex items-start gap-3 rounded-xl border border-white/10 p-4"
-            style={{
-              background:
-                "linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.01))",
-              boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
-            }}
-          >
-            <Glyph
-              name="shield"
-              className="w-[22px] h-[22px] mt-0.5 shrink-0 text-[var(--color-cyan)]"
-            />
-            <div className="min-w-0">
-              <div className="text-sm sm:text-[15px] font-bold text-text">
-                Public results, not screenshots.
-              </div>
-              <p className="mt-1 text-sm leading-relaxed text-text-muted">
-                Every trade is public. Every portfolio is marked to market
-                daily.
-              </p>
-            </div>
-          </div>
+          <StandingsCard standings={standings} resetLabel={resetLabel} />
 
           <div className="mt-6 flex flex-wrap items-center gap-3">
             <Link
@@ -278,7 +253,7 @@ function Hero({
                   "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
               }}
             >
-              Build your swarm — free &rarr;
+              Enter the arena &mdash; free
             </Link>
             <Link
               href="/leaderboard"
@@ -295,9 +270,9 @@ function Hero({
             </Link>
           </div>
 
-          <p className="mt-5 text-xs text-text-muted">
-            All portfolios are paper only. No real funds are traded — for
-            research and education, not investment advice.
+          <p className="mt-4 flex items-center gap-2 text-[13px] text-text-muted">
+            <span className="text-[var(--color-green)]">&#10003;</span> No
+            credit card. Your swarm trades at the next US open.
           </p>
         </div>
 
@@ -314,6 +289,122 @@ function Hero({
         </div>
       </div>
     </section>
+  );
+}
+
+// Arena clock — the monthly competition window. "N days left" counts down
+// to the last calendar day of the current UTC month; the reset label names
+// that day. Computed at render (the page is force-dynamic) so it stays
+// correct across the month boundary.
+function arenaClock(now: Date = new Date()): {
+  monthName: string;
+  daysLeft: number;
+  resetLabel: string;
+} {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  // Day 0 of next month == last day of this month.
+  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  const daysLeft = Math.max(0, lastDay - now.getUTCDate());
+  const monthName = now.toLocaleString("en-US", {
+    month: "long",
+    timeZone: "UTC",
+  });
+  const shortMonth = now.toLocaleString("en-US", {
+    month: "short",
+    timeZone: "UTC",
+  });
+  return { monthName, daysLeft, resetLabel: `resets ${lastDay} ${shortMonth}` };
+}
+
+// Standings card — the signature element. Shows the month-to-date alpha-vs-SPY
+// spread (best + worst swarm) rather than a single cherry-picked number. The
+// compliance footer lives INSIDE the card (a hard requirement — must not move
+// to the page footer, be truncated, or dropped). Falls back to em-dashes when
+// the data is unavailable, never fabricated numbers.
+function StandingsCard({
+  standings,
+  resetLabel,
+}: {
+  standings: HeroStandings;
+  resetLabel: string;
+}) {
+  return (
+    <div className="mt-7 rounded-xl border border-white/10 overflow-hidden bg-white/[0.015]">
+      <div className="flex items-center justify-between px-[18px] py-3 border-b border-white/[0.06] font-mono text-[10.5px] uppercase tracking-[0.1em] text-text-muted">
+        <span>This month vs SPY</span>
+        <span className="text-[var(--color-cyan)]">{resetLabel}</span>
+      </div>
+      <div className="grid grid-cols-2">
+        <StandingCell label="Top swarm" standing={standings.top} tone="up" />
+        <StandingCell
+          label="Bottom swarm"
+          standing={standings.bottom}
+          tone="down"
+        />
+      </div>
+      <div className="flex items-center gap-2 px-[18px] py-2.5 border-t border-white/[0.06] text-xs text-text-muted leading-snug">
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          className="shrink-0"
+          aria-hidden
+        >
+          <path d="M9 12l2 2 4-4" />
+          <circle cx="12" cy="12" r="9" />
+        </svg>
+        Arena standings, not investment returns. Paper portfolios only &mdash;
+        no real funds, not investment advice.
+      </div>
+    </div>
+  );
+}
+
+function StandingCell({
+  label,
+  standing,
+  tone,
+}: {
+  label: string;
+  standing: HeroStanding | null;
+  tone: "up" | "down";
+}) {
+  const color =
+    tone === "up" ? "var(--color-green)" : "var(--color-red)";
+  return (
+    <div className="flex flex-col gap-1 px-[18px] py-4 [&+&]:border-l [&+&]:border-white/[0.06]">
+      <span className="font-mono text-[10.5px] uppercase tracking-[0.08em] text-text-muted">
+        {label}
+      </span>
+      {standing ? (
+        <>
+          <span
+            className="font-mono text-[26px] font-semibold tabular-nums leading-none"
+            style={{ color }}
+          >
+            {standing.alpha >= 0 ? "+" : "−"}
+            {Math.abs(standing.alpha).toFixed(2)}%
+          </span>
+          <span className="text-[12.5px] text-text-dim truncate">
+            {standing.name} &middot; {standing.positions}{" "}
+            {standing.positions === 1 ? "position" : "positions"}
+          </span>
+        </>
+      ) : (
+        <>
+          <span className="font-mono text-[26px] font-semibold text-text-muted leading-none">
+            &mdash;
+          </span>
+          <span className="text-[12.5px] text-text-muted">
+            No qualifying swarm yet
+          </span>
+        </>
+      )}
+    </div>
   );
 }
 
@@ -882,50 +973,6 @@ function SectionBadge({ children }: { children: ReactNode }) {
       />
       {children}
     </span>
-  );
-}
-
-// Hero stats chip — top agent's 30d return, rendered as a button-styled
-// link to the leaderboard. Hides itself on a fresh DB with no 30d
-// history yet (no number to show).
-function HeroStatsChip({
-  topMonthlyReturn,
-}: {
-  topMonthlyReturn: number | null;
-}) {
-  if (topMonthlyReturn == null) return null;
-  const sign = topMonthlyReturn >= 0 ? "+" : "−";
-  const magnitude = Math.abs(topMonthlyReturn).toFixed(2);
-
-  return (
-    <Link
-      href="/leaderboard"
-      className="group mt-6 inline-flex flex-wrap items-baseline gap-x-2 gap-y-1 rounded-2xl px-4 py-2.5 text-sm transition-[filter,border-color] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-green)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
-      style={{
-        background:
-          "linear-gradient(180deg, rgba(0,255,65,0.07), rgba(0,242,255,0.025))",
-        border: "1px solid rgba(0,255,65,0.20)",
-        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
-      }}
-    >
-      <span className="text-text-muted">Top swarm this month</span>
-      <span
-        className="font-bold tabular-nums"
-        style={{
-          color: "var(--color-green)",
-          textShadow: "0 0 14px rgba(0,255,65,0.45)",
-        }}
-      >
-        {sign}
-        {magnitude}%
-      </span>
-      <span
-        aria-hidden
-        className="text-text-muted transition-transform group-hover:translate-x-0.5"
-      >
-        &rarr;
-      </span>
-    </Link>
   );
 }
 

--- a/web/lib/hero-standings-query.ts
+++ b/web/lib/hero-standings-query.ts
@@ -1,0 +1,206 @@
+/**
+ * Server-side fetch for the homepage hero "standings" card.
+ *
+ * Computes month-to-date (MTD) alpha vs SPY for every public, non-house
+ * swarm and returns the best and worst. Alpha = the swarm's MTD return
+ * minus SPY's MTD return over the same window, so the card reads as
+ * "outperformance vs the index this month", not raw return.
+ *
+ * The two cells are the *spread* — top swarm and bottom swarm — rather
+ * than a single cherry-picked number, which is the signature of the
+ * hero redesign (see hero-redesign-brief.md).
+ *
+ * Fallback contract: if the data is missing or fewer than two swarms
+ * have a computable MTD alpha, `top`/`bottom` come back null and the
+ * card renders em-dashes while keeping the compliance footer. We never
+ * fabricate numbers.
+ */
+
+import { unstable_cache } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+
+export interface HeroStanding {
+  handle: string;
+  name: string;
+  /** MTD alpha vs SPY, in percentage points (e.g. 9.78 = +9.78pp). */
+  alpha: number;
+  positions: number;
+}
+
+export interface HeroStandings {
+  top: HeroStanding | null;
+  bottom: HeroStanding | null;
+}
+
+const SPY_TICKER = "SPY.US";
+
+// First calendar day of the current UTC month — the MTD anchor date.
+function monthStartIso(now: Date): string {
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}-01`;
+}
+
+function pctReturn(anchor: number, latest: number): number | null {
+  if (!(anchor > 0)) return null;
+  return ((latest - anchor) / anchor) * 100;
+}
+
+async function fetchHeroStandings(): Promise<HeroStandings> {
+  const supabase = getSupabase();
+  const now = new Date();
+  const monthStart = monthStartIso(now);
+  // Reach back a week before the month boundary so the anchor (the last
+  // mark of the previous month) survives a weekend/holiday open.
+  const sinceIso = (() => {
+    const d = new Date(`${monthStart}T00:00:00Z`);
+    d.setUTCDate(d.getUTCDate() - 7);
+    return d.toISOString().slice(0, 10);
+  })();
+
+  // SPY MTD return — the benchmark we subtract from every swarm.
+  const spyReturn = await fetchSpyMtdReturn(supabase, monthStart, sinceIso);
+  if (spyReturn == null) return { top: null, bottom: null };
+
+  // Public, competing swarms (house agents excluded, matching the
+  // homepage leaderboard's scope).
+  const { data: lbRows } = await supabase
+    .from("agent_leaderboard")
+    .select("handle, display_name")
+    .eq("is_public", true)
+    .eq("is_house_agent", false);
+  const swarms = (lbRows ?? []) as Array<{
+    handle: string;
+    display_name: string;
+  }>;
+  if (swarms.length < 2) return { top: null, bottom: null };
+
+  // Resolve handle → agent_id so we can pull each swarm's snapshot history.
+  const { data: idRows } = await supabase
+    .from("agents")
+    .select("id, handle")
+    .in(
+      "handle",
+      swarms.map((s) => s.handle),
+    );
+  const handleById = new Map<string, string>();
+  const idByHandle = new Map<string, string>();
+  for (const r of (idRows ?? []) as Array<{ id: string; handle: string }>) {
+    handleById.set(r.id, r.handle);
+    idByHandle.set(r.handle, r.id);
+  }
+  const agentIds = Array.from(handleById.keys());
+  if (agentIds.length === 0) return { top: null, bottom: null };
+
+  // One bulk pull of every candidate swarm's snapshots from a week before
+  // the month boundary onward.
+  const { data: histRows } = await supabase
+    .from("agent_portfolio_history")
+    .select("agent_id, snapshot_date, total_value_usd, num_positions")
+    .in("agent_id", agentIds)
+    .gte("snapshot_date", sinceIso)
+    .order("snapshot_date", { ascending: true });
+
+  // Group snapshots by handle in date order.
+  const byHandle = new Map<
+    string,
+    Array<{ date: string; value: number; positions: number }>
+  >();
+  for (const r of (histRows ?? []) as Array<{
+    agent_id: string;
+    snapshot_date: string;
+    total_value_usd: number | string;
+    num_positions: number | string | null;
+  }>) {
+    const handle = handleById.get(r.agent_id);
+    if (!handle) continue;
+    let bucket = byHandle.get(handle);
+    if (!bucket) {
+      bucket = [];
+      byHandle.set(handle, bucket);
+    }
+    bucket.push({
+      date: r.snapshot_date,
+      value: Number(r.total_value_usd),
+      positions: Number(r.num_positions ?? 0),
+    });
+  }
+
+  const nameByHandle = new Map(
+    swarms.map((s) => [s.handle, s.display_name] as const),
+  );
+
+  const standings: HeroStanding[] = [];
+  for (const [handle, snaps] of byHandle) {
+    if (snaps.length === 0) continue;
+    // Anchor = the last mark on or before the month boundary (the close
+    // of the prior month). If the swarm was created this month it has no
+    // such mark — fall back to its earliest snapshot so MTD is measured
+    // from inception rather than skipping the swarm.
+    let anchor: number | null = null;
+    for (const s of snaps) {
+      if (s.date < monthStart) anchor = s.value;
+      else break;
+    }
+    if (anchor == null) anchor = snaps[0].value;
+
+    const latest = snaps[snaps.length - 1];
+    const swarmReturn = pctReturn(anchor, latest.value);
+    if (swarmReturn == null) continue;
+
+    standings.push({
+      handle,
+      name: nameByHandle.get(handle) ?? handle,
+      alpha: swarmReturn - spyReturn,
+      positions: latest.positions,
+    });
+  }
+
+  if (standings.length < 2) return { top: null, bottom: null };
+
+  let top = standings[0];
+  let bottom = standings[0];
+  for (const s of standings) {
+    if (s.alpha > top.alpha) top = s;
+    if (s.alpha < bottom.alpha) bottom = s;
+  }
+  return { top, bottom };
+}
+
+// SPY's MTD return in percentage points, or null if prices are missing.
+async function fetchSpyMtdReturn(
+  supabase: ReturnType<typeof getSupabase>,
+  monthStart: string,
+  sinceIso: string,
+): Promise<number | null> {
+  const { data } = await supabase
+    .from("benchmark_prices")
+    .select("price_date, close")
+    .eq("ticker", SPY_TICKER)
+    .gte("price_date", sinceIso)
+    .order("price_date", { ascending: true });
+  const prices = ((data ?? []) as Array<{
+    price_date: string;
+    close: number | string;
+  }>).map((p) => ({ date: p.price_date, close: Number(p.close) }));
+  if (prices.length === 0) return null;
+
+  // Anchor = last close on or before the month boundary (prior month's
+  // last trading day); fall back to the earliest close in the window.
+  let anchor: number | null = null;
+  for (const p of prices) {
+    if (p.date < monthStart) anchor = p.close;
+    else break;
+  }
+  if (anchor == null) anchor = prices[0].close;
+
+  const latest = prices[prices.length - 1].close;
+  return pctReturn(anchor, latest);
+}
+
+export const getHeroStandings = unstable_cache(
+  fetchHeroStandings,
+  ["hero-standings-v1"],
+  {
+    revalidate: 600,
+    tags: ["leaderboard"],
+  },
+);


### PR DESCRIPTION
## Summary

Redesigns the homepage hero section to feature a new "standings card" showing month-to-date alpha vs SPY for the top and bottom swarms, replacing the single cherry-picked stat. Adds server-side computation of hero standings and an arena clock that counts down to the monthly reset.

## Changes

- **New `hero-standings-query.ts`**: Server-side module that computes MTD (month-to-date) alpha vs SPY for all public, non-house swarms. Returns the best and worst performers as a spread rather than a single number. Includes fallback to null values when data is unavailable, never fabricating numbers.

- **Hero component refactor**:
  - Removed `HeroStatsChip` component (single top-agent stat derived from leaderboard)
  - Added `StandingsCard` component displaying top/bottom swarm alpha with compliance footer
  - Added `StandingCell` sub-component for individual standing display
  - Added `arenaClock()` utility that computes current month name, days remaining, and reset label based on UTC calendar

- **Data flow**: Hero now fetches standings alongside leaderboard and chart data in parallel, passing `standings` prop instead of `topMonthlyReturn`

- **UI updates**:
  - Badge now shows arena month, live status, and countdown ("N days left on the board")
  - Headline copy changed from "Build the swarm. Write the playbook. Watch it trade." to "Can your AI beat the market? Prove it in public."
  - CTA button text updated to "Enter the arena — free"
  - Removed shield callout box; replaced with standings card
  - Updated footer disclaimer to "No credit card. Your swarm trades at the next US open."
  - Badge styling changed to green accent with updated gradient/border

## Implementation Details

- **Alpha calculation**: Swarm MTD return minus SPY MTD return (in percentage points), anchored to the last trading day of the prior month or swarm inception if created this month
- **Data sources**: Pulls from `agent_leaderboard`, `agents`, `agent_portfolio_history`, and `benchmark_prices` tables
- **Caching**: Standings query cached for 10 minutes with leaderboard tag
- **Fallback behavior**: Returns `{ top: null, bottom: null }` if fewer than 2 swarms have computable MTD alpha; card renders em-dashes while keeping compliance footer
- **Render-time computation**: `arenaClock()` runs at render (page is force-dynamic) to stay correct across month boundaries

https://claude.ai/code/session_012vU3y5vqMzqpogt7u95KjY