### PR TITLE
Add 200-week average sniper agent (ma_sniper)

### DIFF
--- a/.github/workflows/prices-daily.yml
+++ b/.github/workflows/prices-daily.yml
@@ -1,9 +1,10 @@
 name: Level 0 Prices Daily
 
 # Daily EOD price layer for the Tier 1 set (spec §3 — the "prices" clock).
-# Writes the latest trading day for every Tier 1 ticker and backfills 2y of
-# history for any newly-promoted name. Runs 04:15 UTC, after the weekly gate
-# has settled and alongside the other daily fundamentals jobs.
+# Writes the latest trading day for every Tier 1 ticker and backfills 5y of
+# history for any newly-promoted name (enough for the 200-week MA the
+# ma_sniper strategy reads). Runs 04:15 UTC, after the weekly gate has
+# settled and alongside the other daily fundamentals jobs.
 
 on:
   schedule:
@@ -11,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       backfill:
-        description: "Force full 2y backfill for ALL Tier 1 (not just new names)"
+        description: "Force full 5y backfill for ALL Tier 1 (not just new names)"
         type: boolean
         default: false
       dry_run:

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -372,17 +372,45 @@ def _run_portfolio_swarm(
 
     sw_buyers: list = []
     convictions: dict[str, dict[str, int]] = {}
+    sniper_details: dict[str, dict] = {}
     for m in buyers_m:
         aid = m["agent"]["id"]
         cfg = m.get("config") or {}
+        strat = m["agent"].get("strategy")
+        if strat == "ma_sniper":
+            # The 200-week sniper sources conviction from each candidate's
+            # proximity to its long-run trend instead of the screen-rank
+            # baseline: it expresses conviction ONLY for names at/below their
+            # 200-week MA (within `band_pct`), and is silent — accumulating
+            # cash — for everything else. Sizing honours the `target_position_pct`
+            # slider on this path (translated to the draft's max-per-name).
+            import ma_sniper as _ma_sniper
+
+            band = float(cfg.get("band_pct", _ma_sniper.DEFAULT_BAND * 100.0)) / 100.0
+            size_pct = cfg.get("target_position_pct")
+            max_per = (
+                float(size_pct) / 100.0
+                if size_pct is not None
+                else float(cfg.get("maxPerName", 0.05) or 0.05)
+            )
+            convictions[aid] = _ma_sniper.sniper_convictions(
+                db, draftable, prices, band=band, details=sniper_details,
+            )
+        else:
+            max_per = float(cfg.get("maxPerName", 0.08) or 0.08)
+            convictions[aid] = dict(rank_conv)
         sw_buyers.append(
             _swarm.Buyer(
                 aid,
                 gate=int(cfg.get("convictionGate", 1) or 1),
-                max_per_name=float(cfg.get("maxPerName", 0.08) or 0.08),
+                max_per_name=max_per,
             )
         )
-        convictions[aid] = dict(rank_conv)
+    if sniper_details:
+        logger.info(
+            "  portfolio %-22s sniper: %d name(s) at/below 200w MA (%s)",
+            slug, len(sniper_details), ", ".join(sorted(sniper_details)),
+        )
 
     plan = _swarm.snake_draft_plan(
         sw_buyers, draftable, prices, total_value, cash, convictions=convictions
@@ -408,6 +436,15 @@ def _run_portfolio_swarm(
             mode=mode, executor=executor,
         )
         rationale = cand_map.get(pick.ticker)
+        snipe = sniper_details.get(pick.ticker)
+        if snipe:
+            # A sniper strike — record the discount to the 200-week average so
+            # the thesis captures the fat pitch, not just the screen rank.
+            disc = snipe["discount_pct"]
+            where = f"{abs(disc):.1f}% below" if disc < 0 else f"{disc:.1f}% above"
+            rationale = (
+                f"At 200-week average ({where} trend); {rationale or 'quality screen pick'}"
+            )
         note = f"swarm draft (conviction {pick.conviction}/5): {rationale or ''}".strip()
         thesis = {"thesis_text": rationale} if rationale else None
         try:

--- a/agent_strategies.py
+++ b/agent_strategies.py
@@ -1323,6 +1323,181 @@ def rebalance_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
 
 
 # ---------------------------------------------------------------------------
+# Strategy: ma_sniper (the "200-week average sniper")
+# ---------------------------------------------------------------------------
+#
+# Charlie Munger's patience discipline: wait, fully prepared, for a QUALITY
+# business to trade down to its long-run trend, then strike. Quality is the
+# portfolio's screen top-N (quality-weighted — same candidate set every buyer
+# uses); the trend is the 200-week (~3.85y) moving average. The conviction core
+# lives in ma_sniper.py and is the primary path on the swarm (the heartbeat
+# sources per-name conviction from it). This standalone rebalance is the
+# non-swarm fallback so the strategy also works on a 1:1 / non-buyer portfolio
+# and so get_strategy('ma_sniper') resolves.
+#
+# Patient accumulator: it only ever BUYS — deploying available cash into names
+# at/below their 200-week average, deepest discount first — and never force-
+# sells to fund a buy. Most runs buy nothing (no quality name is on sale);
+# selling is the reviewer's job.
+
+
+MA_SNIPER_DEFAULTS = {
+    "band_pct": 5.0,            # proximity band to the 200w MA (percent)
+    "target_position_pct": 5.0,  # size per strike (percent of total value)
+    "cash_reserve_pct": 0.02,   # keep 2% cash for rounding / drift
+    "min_trade_usd": 500.0,     # ignore sub-noise notionals
+    "max_positions": 25,        # stop accumulating past this many holdings
+}
+
+
+def _format_ma_sniper_buy_note(ticker: str, detail: dict, rationale: str | None) -> str:
+    disc = detail.get("discount_pct", 0.0)
+    where = f"{abs(disc):.1f}% below" if disc < 0 else f"{disc:.1f}% above"
+    base = f"Bought {ticker} — at 200-week average ({where} long-run trend)"
+    return f"{base}; {rationale}." if rationale else f"{base}."
+
+
+def rebalance_ma_sniper(ctx: RebalanceContext) -> RebalanceResult:
+    """Patient accumulator: buy quality screen names at/below their 200w MA.
+
+    Algorithm:
+        1. Candidate set = the portfolio's screen top-N (quality-weighted).
+        2. Drop names already held or on the 90-day re-buy cooldown; price the
+           rest.
+        3. Compute each candidate's 200-week MA (ma_sniper) and keep only those
+           trading within ``band_pct`` of / below it — deepest discount first.
+        4. Deploy available cash into them at ``target_position_pct`` each,
+           keeping a cash reserve and capping total holdings at ``max_positions``.
+           Never sells. Records a thesis (with the discount) per buy.
+
+    Idempotent modulo price drift: a second run buys nothing when no quality
+    name is on sale (the common case) or everything is already at target.
+    """
+    result = RebalanceResult()
+    params = {**MA_SNIPER_DEFAULTS, **(ctx.params or {})}
+    handle = ctx.agent.get("handle", ctx.agent["id"][:8])
+
+    if not ctx.portfolio_id:
+        result.notes["reason"] = "ma_sniper only runs on a human portfolio"
+        return result
+
+    import ma_sniper as _ma_sniper
+
+    cand_map = _portfolio_screen_candidates(ctx)
+    candidates = list(cand_map.keys())
+    if not candidates:
+        result.notes["reason"] = "portfolio has no screen configured or screen is empty"
+        return result
+
+    book = ctx.get_book()
+    total_value = float(book["total_value_usd"])
+    if total_value <= 0:
+        result.errors.append(f"total_value_usd <= 0 for {handle}")
+        return result
+    cash = float(book["cash_usd"])
+    held = {h["ticker"] for h in book["holdings"]}
+
+    recently_sold = ctx.db.get_recently_sold_tickers(ctx.portfolio_id, days=90)
+
+    # Price only the names we could actually buy (not held, off cooldown).
+    prices: dict[str, float] = {}
+    unpriced: list[str] = []
+    for t in candidates:
+        if t in held or t in recently_sold:
+            continue
+        try:
+            prices[t] = ctx.pm.get_price(t)
+        except PortfolioError:
+            unpriced.append(t)
+    if unpriced:
+        result.notes["unpriced"] = unpriced
+
+    band = float(params["band_pct"]) / 100.0
+    details: dict[str, dict] = {}
+    convs = _ma_sniper.sniper_convictions(
+        ctx.db, list(prices.keys()), prices, band=band, details=details,
+    )
+    if not convs:
+        result.notes["reason"] = "no quality screen name at/below its 200-week average"
+        return result
+
+    # Deepest discount (highest conviction) first; screen rank breaks ties.
+    qualifying = sorted(convs, key=lambda t: (-convs[t], candidates.index(t)))
+
+    max_positions = int(params["max_positions"])
+    slots = max(0, max_positions - len(held))
+    target_usd = total_value * float(params["target_position_pct"]) / 100.0
+    reserve = total_value * float(params["cash_reserve_pct"])
+    min_trade = float(params["min_trade_usd"])
+
+    buys: list[tuple[str, int]] = []
+    spendable = cash - reserve
+    for t in qualifying:
+        if len(buys) >= slots:
+            break
+        price = prices[t]
+        budget = min(target_usd, spendable)
+        qty = int(math.floor(budget / price)) if price > 0 else 0
+        if qty < 1 or qty * price < min_trade:
+            continue
+        buys.append((t, qty))
+        spendable -= qty * price
+
+    if ctx.dry_run:
+        result.notes["dry_run_plan"] = {
+            "buys": [
+                {
+                    "ticker": t,
+                    "qty": q,
+                    "conviction": convs[t],
+                    **details.get(t, {}),
+                }
+                for (t, q) in buys
+            ],
+            "qualifying": [
+                {"ticker": t, "conviction": convs[t], **details.get(t, {})}
+                for t in qualifying
+            ],
+            "slots": slots,
+            "target_usd": round(target_usd, 2),
+            "total_value_usd": total_value,
+        }
+        logger.info(
+            "[dry-run] %s: %d sniper buy(s), %d name(s) at/below 200w MA, total=$%.2f",
+            handle, len(buys), len(qualifying), total_value,
+        )
+        return result
+
+    for t, qty in buys:
+        rationale = cand_map.get(t)
+        note = _format_ma_sniper_buy_note(t, details.get(t, {}), rationale)
+        # Thesis records the discount-to-trend so the audit trail captures the
+        # fat pitch, not just the screen rank.
+        d = details.get(t, {})
+        thesis = {
+            "thesis_text": note,
+            "extend_signals": [],
+            # If price recovers well above the 200w MA the entry logic no longer
+            # holds — a natural break signal for the reviewer to weigh.
+            "break_signals": (
+                [{"metric": "price", "op": ">", "value": round(d["ma_200w"] * 1.5, 4)}]
+                if d.get("ma_200w")
+                else []
+            ),
+        }
+        try:
+            ctx.buy(t, qty, note=note, thesis=thesis)
+            result.buys += 1
+        except PortfolioError as exc:
+            result.errors.append(f"buy {t} x{qty}: {exc}")
+
+    result.notes["targets"] = len(buys)
+    result.notes["qualifying"] = len(qualifying)
+    result.notes["total_value_usd"] = total_value
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 
@@ -1370,6 +1545,7 @@ STRATEGIES: dict[str, Strategy] = {
     "trading_agents": _trading_agents_lazy,
     "watchlist_buyer": rebalance_watchlist_buyer,
     "llm_watchlist_buyer": _llm_watchlist_buyer_lazy,
+    "ma_sniper": rebalance_ma_sniper,
     "portfolio_reviewer": _portfolio_reviewer_lazy,
 }
 

--- a/ma_sniper.py
+++ b/ma_sniper.py
@@ -1,0 +1,185 @@
+"""
+ma_sniper.py — the "200-week average sniper" conviction engine.
+
+A version of Charlie Munger's patience discipline: wait, fully prepared, for a
+*quality* business to trade down to its long-run trend, then strike. Here the
+long-run trend is the **200-week moving average** (~3.85 years of weekly
+closes) and "quality" is already supplied upstream — the candidate set is the
+top N of the portfolio's screen (quality-weighted; see screen.py), so this
+module only has to answer one question per candidate: *is it on sale relative
+to its own 200-week average right now?*
+
+It is a **conviction provider**, not a rebalance strategy. The portfolio swarm
+(agent_heartbeat._run_portfolio_swarm) drafts names by per-buyer conviction;
+a normal buyer's conviction is the deterministic screen-rank baseline
+(swarm.rank_to_conviction). A sniper replaces that baseline: it expresses
+conviction ONLY for names trading at/below their 200-week MA (within a small
+band), and stays silent — passes its draft turn, accumulating cash — for
+everything else. Most heartbeats it buys nothing; it strikes only on the dip.
+
+The core (weekly resampling, the MA, the price→conviction mapping) is pure and
+unit-tested in test_ma_sniper.py — no DB, no LLM. `sniper_convictions` is the
+thin DB-facing wrapper the heartbeat calls.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as _date
+from typing import Any
+
+logger = logging.getLogger("ma_sniper")
+
+# A 200-week MA needs 200 weekly closes (~3.85y). We allow a name to be sniped
+# with somewhat less than a full window so a name with ~3y of history still
+# gets a (slightly shorter) trend rather than being silently un-tradeable —
+# but below MIN_WEEKS there isn't enough of a long-run trend to call it one.
+WINDOW_WEEKS = 200
+MIN_WEEKS = 150
+
+# Default proximity band: a name counts as "at its 200-week average" when its
+# price is no more than this fraction above the MA. Above the band → the sniper
+# waits (no conviction). Tunable per instance via the agent's `band_pct` param.
+DEFAULT_BAND = 0.05
+
+
+# ---------------------------------------------------------------------------
+# Pure core
+# ---------------------------------------------------------------------------
+
+
+def _adj(row: dict) -> float | None:
+    """Preferred close for a prices_daily row: adj_close, falling back to close."""
+    for key in ("adj_close", "close"):
+        v = row.get(key)
+        if v is None:
+            continue
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            continue
+        if f == f and f > 0:  # finite, positive
+            return f
+    return None
+
+
+def weekly_closes(prices: list[dict]) -> list[float]:
+    """Resample ascending daily prices_daily rows to one close per ISO week.
+
+    Takes the LAST available close within each ISO (year, week) bucket — the
+    week's settling price — preserving chronological order. Rows must be sorted
+    ascending by date (``db.get_prices_daily`` returns them that way). Rows with
+    no usable close or unparseable date are skipped.
+    """
+    by_week: dict[tuple[int, int], float] = {}
+    order: list[tuple[int, int]] = []
+    for row in prices:
+        d = row.get("date")
+        close = _adj(row)
+        if not d or close is None:
+            continue
+        try:
+            y, w, _ = _date.fromisoformat(str(d)[:10]).isocalendar()
+        except ValueError:
+            continue
+        key = (y, w)
+        if key not in by_week:
+            order.append(key)
+        by_week[key] = close  # last write wins → the week's final close
+    return [by_week[k] for k in order]
+
+
+def two_hundred_week_ma(
+    prices: list[dict],
+    *,
+    window: int = WINDOW_WEEKS,
+    min_weeks: int = MIN_WEEKS,
+) -> float | None:
+    """The mean of the last ``window`` weekly closes, or None if too short.
+
+    Returns None when fewer than ``min_weeks`` weekly closes are available — a
+    name without a long-run trend can't be sniped against one.
+    """
+    closes = weekly_closes(prices)
+    if len(closes) < min_weeks:
+        return None
+    tail = closes[-window:]
+    return sum(tail) / len(tail)
+
+
+def sniper_conviction(price: float, ma: float, band: float = DEFAULT_BAND) -> int:
+    """Map a price's discount-to-200wMA to a 0..5 conviction.
+
+    0  → above the band: the sniper waits (won't draft this name).
+    1  → within the band but above the MA (a marginal pitch).
+    3  → at or below the MA (on trend / on sale).
+    4  → ~5%+ below the MA.
+    5  → ~10%+ below the MA (a deep, fat-pitch discount).
+
+    Graduated so the swarm's snake draft strikes the deepest discount first.
+    """
+    if ma <= 0 or price <= 0:
+        return 0
+    if price > ma * (1.0 + band):
+        return 0
+    if price <= ma * 0.90:
+        return 5
+    if price <= ma * 0.95:
+        return 4
+    if price <= ma:
+        return 3
+    if price <= ma * (1.0 + band / 2.0):
+        return 2
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# DB-facing wrapper
+# ---------------------------------------------------------------------------
+
+
+def sniper_convictions(
+    db: Any,
+    candidates: list[str],
+    current_prices: dict[str, float],
+    *,
+    band: float = DEFAULT_BAND,
+    details: dict[str, dict] | None = None,
+) -> dict[str, int]:
+    """Per-candidate sniper conviction for the swarm's convictions map.
+
+    For each candidate with a current price, computes its 200-week MA from
+    ``prices_daily`` and maps the price's proximity to it onto a 0..5
+    conviction (see ``sniper_conviction``). Names above the band — or without
+    enough history for a 200-week MA — are simply absent from the result, so
+    the swarm never drafts them (the sniper waits).
+
+    ``details`` (optional) is populated with ``{ticker: {ma, price, discount_pct,
+    conviction}}`` for the names that cleared, so the heartbeat can journal /
+    note *why* each strike fired.
+    """
+    out: dict[str, int] = {}
+    for ticker in candidates:
+        price = current_prices.get(ticker)
+        if not price or price <= 0:
+            continue
+        try:
+            rows = db.get_prices_daily(ticker)
+        except Exception as exc:  # noqa: BLE001 — a bad read just skips the name
+            logger.warning("ma_sniper: price read failed for %s: %s", ticker, exc)
+            continue
+        ma = two_hundred_week_ma(rows)
+        if ma is None:
+            continue
+        conv = sniper_conviction(price, ma, band)
+        if conv <= 0:
+            continue
+        out[ticker] = conv
+        if details is not None:
+            details[ticker] = {
+                "ma_200w": round(ma, 4),
+                "price": round(price, 4),
+                "discount_pct": round((price / ma - 1.0) * 100, 1),
+                "conviction": conv,
+            }
+    return out

--- a/migrations/049_ma_sniper_agent.sql
+++ b/migrations/049_ma_sniper_agent.sql
@@ -1,0 +1,37 @@
+-- Migration 049: the 200-week average sniper becomes a real mechanical agent.
+--
+-- A version of Charlie Munger's "sit on your hands until the fat pitch" sniper:
+-- wait for a QUALITY business to trade down to its long-run trend (the 200-week
+-- moving average), then strike. The seeded `agent-200w-reversion` (migration
+-- 045/046) only ever described this — it was wired to the generic LLM buyer
+-- (`llm_watchlist_buyer`), an LLM reading a prose brief, with NO actual access
+-- to a 200-week average. This migration points it at the real `ma_sniper`
+-- engine (ma_sniper.py + agent_strategies.rebalance_ma_sniper), which sources
+-- per-name conviction from each candidate's distance to its 200-week MA.
+--
+-- Quality is already supplied upstream: the candidate set is the top N of the
+-- portfolio's screen (quality-weighted), so the agent only has to answer "is it
+-- on sale vs its own 200-week average?". Sizing/gate params map onto the
+-- strategy's config keys the heartbeat reads on the swarm path.
+--
+-- Mechanical (no LLM brain): `powered_by` becomes 'Rules-based' and, per the
+-- migration-046 convention, `default_mandate` is cleared to NULL so the team
+-- builder shows no editable brief field for it (a brief no engine reads).
+--
+-- Idempotent. Paste-and-run in the Supabase SQL editor.
+
+UPDATE agents SET
+    strategy          = 'ma_sniper',
+    display_name      = '200-Week Sniper',
+    action            = 'buy',
+    available_for_hire = TRUE,
+    powered_by        = 'Rules-based',
+    default_mandate   = NULL,
+    param_schema      = '[
+        {"key":"band_pct","label":"Buy within of 200w avg","type":"number","min":0,"max":25,"step":1,"unit":"%","default":5},
+        {"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":5}
+    ]'::jsonb,
+    sentence_template =
+        'Waits for quality names to trade down to their 200-week average, then '
+        'buys within {band_pct}% of it — up to {target_position_pct}% per position.'
+    WHERE handle = 'agent-200w-reversion';

--- a/prices_daily_updater.py
+++ b/prices_daily_updater.py
@@ -6,8 +6,11 @@ Daily clock (spec §3). Maintains `prices_daily` for the Tier 1 set:
   * Daily increment — one `eod-bulk-last-day` call writes the latest trading
     day's OHLCV for every Tier 1 ticker (idempotent upsert on (ticker, date)).
   * Backfill — any Tier 1 ticker with no recent prices_daily row (a fresh
-    promotion from the weekly gate) gets a full 2y per-ticker history pull
-    (spec §11 step 3 / §12 — 2 years of daily history).
+    promotion from the weekly gate) gets a full per-ticker history pull
+    (``HISTORY_YEARS`` of daily history). 5 years is carried so long-horizon
+    lenses work — notably the 200-week (~3.85y) moving average the
+    ``ma_sniper`` strategy gates on; a 200wMA needs ~4y of weekly closes to
+    even compute, so 2y was not enough.
 
 `dollar_volume` (close * volume) is stored alongside so the affordability gate
 and liquidity lenses don't recompute it. `adj_close` carries EODHD's
@@ -15,7 +18,7 @@ split/dividend-adjusted close so valuation-over-time stays consistent.
 
 Usage:
     python prices_daily_updater.py                 # increment + backfill new names
-    python prices_daily_updater.py --backfill      # force full 2y for all Tier 1
+    python prices_daily_updater.py --backfill      # force full 5y for all Tier 1
     python prices_daily_updater.py --tickers NVDA AAPL
     python prices_daily_updater.py --dry-run
 """
@@ -34,7 +37,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger("prices_daily")
 
-HISTORY_YEARS = 2
+HISTORY_YEARS = 5   # 5y of daily history → enough for a 200-week (~3.85y) MA
 RECENT_WINDOW_DAYS = 7   # a Tier 1 ticker with a row newer than this is "current"
 
 
@@ -96,7 +99,7 @@ def daily_increment(db: SupabaseDB, client: EODHDClient, tier1: set[str],
 def main() -> None:
     ap = argparse.ArgumentParser(description="Level 0 prices_daily updater")
     ap.add_argument("--backfill", action="store_true",
-                    help="force full 2y backfill for all Tier 1 (not just new names)")
+                    help="force full backfill for all Tier 1 (not just new names)")
     ap.add_argument("--tickers", nargs="+", help="limit to these tickers")
     ap.add_argument("--years", type=int, default=HISTORY_YEARS)
     ap.add_argument("--dry-run", action="store_true")
@@ -120,7 +123,7 @@ def main() -> None:
         since = (date.today() - timedelta(days=RECENT_WINDOW_DAYS)).isoformat()
         current = db.get_tickers_with_recent_prices(since)
         to_backfill = tier1 - current
-    logger.info("Backfilling %d ticker(s) (2y history)", len(to_backfill))
+    logger.info("Backfilling %d ticker(s) (%dy history)", len(to_backfill), args.years)
 
     backfilled_rows = 0
     errors = 0

--- a/test_ma_sniper.py
+++ b/test_ma_sniper.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Unit tests for the 200-week average sniper core (ma_sniper.py).
+
+Pure-logic tests of weekly resampling, the 200-week MA, and the price→
+conviction mapping — plus the sniper_convictions wrapper against a tiny fake
+db. No real DB, no LLM. Run: python test_ma_sniper.py
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import date, timedelta
+
+import ma_sniper as ms
+
+
+def _daily_series(weeks: int, value: float, *, start: str = "2019-01-07") -> list[dict]:
+    """A flat daily price series spanning `weeks` ISO weeks (Mon+Wed per week)."""
+    d0 = date.fromisoformat(start)
+    rows: list[dict] = []
+    for w in range(weeks):
+        monday = d0 + timedelta(weeks=w)
+        for offset in (0, 2):  # two trading days per week
+            rows.append(
+                {"date": (monday + timedelta(days=offset)).isoformat(),
+                 "adj_close": value, "close": value}
+            )
+    return rows
+
+
+class TestWeeklyResample(unittest.TestCase):
+    def test_one_close_per_iso_week_last_wins(self):
+        rows = [
+            {"date": "2024-01-01", "adj_close": 10.0},  # ISO 2024-W01 Mon
+            {"date": "2024-01-03", "adj_close": 11.0},  # same week, later → wins
+            {"date": "2024-01-08", "adj_close": 20.0},  # ISO 2024-W02
+        ]
+        self.assertEqual(ms.weekly_closes(rows), [11.0, 20.0])
+
+    def test_adj_close_preferred_then_close(self):
+        rows = [
+            {"date": "2024-01-01", "adj_close": None, "close": 9.0},
+            {"date": "2024-01-08", "adj_close": 12.0, "close": 99.0},
+        ]
+        self.assertEqual(ms.weekly_closes(rows), [9.0, 12.0])
+
+    def test_bad_rows_skipped(self):
+        rows = [
+            {"date": "not-a-date", "adj_close": 5.0},
+            {"date": "2024-01-01", "adj_close": 0},      # non-positive → skip
+            {"date": "2024-01-02", "adj_close": -3.0},   # negative → skip
+            {"date": "2024-01-03", "adj_close": 7.0},
+        ]
+        self.assertEqual(ms.weekly_closes(rows), [7.0])
+
+
+class TestMovingAverage(unittest.TestCase):
+    def test_none_when_too_short(self):
+        rows = _daily_series(ms.MIN_WEEKS - 1, 50.0)
+        self.assertIsNone(ms.two_hundred_week_ma(rows))
+
+    def test_computes_when_long_enough(self):
+        rows = _daily_series(ms.MIN_WEEKS, 50.0)
+        self.assertAlmostEqual(ms.two_hundred_week_ma(rows), 50.0)
+
+    def test_only_last_window_weeks_count(self):
+        # 100 weeks at 10, then 200 weeks at 30 → MA over the last 200 is 30.
+        rows = _daily_series(100, 10.0, start="2017-01-02")
+        rows += _daily_series(200, 30.0, start="2019-01-07")
+        ma = ms.two_hundred_week_ma(rows)
+        self.assertAlmostEqual(ma, 30.0)
+
+
+class TestConvictionMapping(unittest.TestCase):
+    def test_above_band_waits(self):
+        # 6% above MA with a 5% band → no conviction (the sniper waits).
+        self.assertEqual(ms.sniper_conviction(106.0, 100.0, band=0.05), 0)
+
+    def test_within_band_above_ma(self):
+        self.assertEqual(ms.sniper_conviction(104.0, 100.0, band=0.05), 1)
+
+    def test_at_or_below_ma_scales(self):
+        self.assertEqual(ms.sniper_conviction(100.0, 100.0), 3)
+        self.assertEqual(ms.sniper_conviction(94.0, 100.0), 4)   # ~6% below
+        self.assertEqual(ms.sniper_conviction(85.0, 100.0), 5)   # deep discount
+
+    def test_degenerate_inputs(self):
+        self.assertEqual(ms.sniper_conviction(0.0, 100.0), 0)
+        self.assertEqual(ms.sniper_conviction(100.0, 0.0), 0)
+
+
+class _FakeDB:
+    def __init__(self, series: dict[str, list[dict]]):
+        self._series = series
+
+    def get_prices_daily(self, ticker, since=None):
+        return self._series.get(ticker, [])
+
+
+class TestSniperConvictions(unittest.TestCase):
+    def test_only_on_sale_quality_names_clear(self):
+        db = _FakeDB({
+            "DIP": _daily_series(ms.WINDOW_WEEKS, 100.0),   # MA = 100
+            "HIGH": _daily_series(ms.WINDOW_WEEKS, 100.0),  # MA = 100
+            "NEW": _daily_series(10, 100.0),                # too short → no MA
+        })
+        prices = {"DIP": 90.0, "HIGH": 130.0, "NEW": 50.0}
+        details: dict[str, dict] = {}
+        convs = ms.sniper_convictions(
+            db, ["DIP", "HIGH", "NEW"], prices, band=0.05, details=details,
+        )
+        # DIP is on sale → clears; HIGH is way above band; NEW lacks history.
+        self.assertEqual(set(convs), {"DIP"})
+        self.assertEqual(convs["DIP"], 5)
+        self.assertIn("DIP", details)
+        self.assertAlmostEqual(details["DIP"]["discount_pct"], -10.0)
+
+    def test_missing_price_skipped(self):
+        db = _FakeDB({"DIP": _daily_series(ms.WINDOW_WEEKS, 100.0)})
+        convs = ms.sniper_convictions(db, ["DIP"], {}, band=0.05)
+        self.assertEqual(convs, {})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
A version of Charlie Munger's "wait for the fat pitch" discipline: a public, hireable agent that snipes quality companies only when they trade down to their 200-week moving average.

- ma_sniper.py: pure conviction core (weekly resample, 200w MA, price->
  conviction mapping) + a DB-facing sniper_convictions wrapper.
- agent_heartbeat: the swarm now sources per-name conviction from the sniper for ma_sniper buyers (the seam the code already anticipated) instead of the screen-rank baseline; it stays silent (accumulates cash) until a quality screen name is at/below its 200w average. Buy notes/theses record the discount to trend.
- agent_strategies: register ma_sniper with a standalone patient-accumulator rebalance for the non-swarm path; quality = the portfolio's screen top-N.
- prices_daily_updater: deepen history 2y -> 5y (a 200w MA needs ~4y); update prices-daily.yml accordingly.
- migration 049: re-point the seeded agent-200w-reversion at the real engine (was the generic LLM buyer with no MA access); now mechanical, function-first.
- test_ma_sniper.py: 12 pure-logic tests.