### PR TITLE
Add two library agents: 200-Week Sniper (buy) + Profit Taker (sell)

### DIFF
--- a/migrations/049_ma_sniper_agent.sql
+++ b/migrations/049_ma_sniper_agent.sql
@@ -23,6 +23,8 @@
 UPDATE agents SET
     strategy          = 'ma_sniper',
     display_name      = '200-Week Sniper',
+    description       = 'Buys quality companies only when they trade down to their '
+                        '200-week average — and sits in cash until they do.',
     action            = 'buy',
     available_for_hire = TRUE,
     powered_by        = 'Rules-based',


### PR DESCRIPTION
Two new mechanical (no-LLM) team-builder library agents, plus the data + plumbing
they need.

---

## 1. 200-Week Sniper (buy)
Charlie Munger's "wait for the fat pitch": buy quality companies **only** when
they trade down to their **200-week moving average**, and sit in cash until they
do.

The repo already *described* this (seeded `agent-200w-reversion`, migrations
045/046) but it was wired to the generic LLM buyer with **no actual access to a
200-week average**. This builds the real engine.

**Design** — swarm buyers don't run their own code; they express *conviction*
and the snake-draft does the rest. So the sniper is a **conviction provider**:
it expresses conviction only for names at/below their 200-week MA (within a
band) and stays silent — accumulating cash — otherwise. This is the seam
`agent_heartbeat._run_portfolio_swarm` already anticipated. Quality is supplied
upstream (candidate set = the portfolio's quality-weighted screen top-N).

- `ma_sniper.py` — pure core (weekly resample → 200-week MA → price-to-
  conviction) + `sniper_convictions` wrapper.
- `agent_heartbeat.py` — swarm sources per-name conviction from the sniper for
  `ma_sniper` buyers; buy notes/theses record the discount to trend.
- `agent_strategies.py` — registers `ma_sniper` with a standalone patient-
  accumulator rebalance for the non-swarm path.
- `prices_daily_updater.py` + `prices-daily.yml` — deepen daily history 2y → 5y
  (a 200-week MA needs ~4y).
- `migrations/049_ma_sniper_agent.sql` — **insert-or-update** the agent (the 045
  seed is illustrative and not in prod), mechanical/`Rules-based`, knobs:
  proximity band + position size.
- `test_ma_sniper.py` — 12 tests.

## 2. Profit Taker (sell)
A one-time gain banker: when a holding is up by **`gain_pct`** vs its cost
basis, sell **`sell_pct`** of the position (100 = full exit) — and never touch
that equity again.

**Once-per-equity-ever** is durable, not just per-run: each trim is attributed
to the agent in the trade journal, so names it has already acted on are read
back and skipped permanently (even on further gains or a later re-buy).

- `agent_strategies.py` — `rebalance_profit_taker` (+ registry). Sells only;
  runs as a reviewer in the swarm sell phase.
- `db.get_agent_sold_tickers` — every ticker an agent has ever sold in a
  portfolio (no window); backs the once-ever rule.
- `migrations/050_profit_taker_agent.sql` — library agent, action `sell`,
  `banks-gains` trigger, knobs gain% + sell%.
- `test_profit_taker.py` — 7 tests.

Gain is measured vs **average cost basis** (follows the real entry incl.
averaging-in) — easy to switch to a high-water-mark trigger if preferred.

---

## Bring-live checklist (post-merge)
- [ ] Run **Level 0 Prices Daily** with `backfill = true` (the 5y pull; uses
      Actions secrets). Until then the Sniper is correctly inert — names need
      ≥150 weeks of history for a 200-week MA.
- [ ] Apply `migrations/049_ma_sniper_agent.sql` and
      `migrations/050_profit_taker_agent.sql` in the Supabase SQL editor (both
      idempotent). They make the two agents appear in the team-builder library.

## Tests
`test_ma_sniper.py` (12), `test_profit_taker.py` (7), and existing
`test_swarm.py` (10) pass; all edited files compile.