### PR TITLE
Homepage section 2: agent roster ("How it works")

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Nav from "@/components/nav";
 import HeroChart from "@/components/hero-chart";
 import HomeConsensus from "@/components/home-consensus";
+import HomeRoster from "@/components/home-roster";
 import HomeThesisDrift from "@/components/home-thesis-drift";
 import WotBadge from "@/components/wot-badge";
 import HomePrompt from "@/components/home-prompt";
@@ -17,6 +18,7 @@ import {
   type HeroStandings,
   type HeroStanding,
 } from "@/lib/hero-standings-query";
+import { getRosterData, ROSTER_FALLBACK } from "@/lib/home-roster-query";
 import {
   getLatestConsensus,
   type ConsensusResult,
@@ -65,7 +67,7 @@ export default async function HomePage() {
   // below-the-fold sections (thesis drift + consensus) each fetch
   // inside their own async server component, wrapped in <Suspense>,
   // so their HTML streams in after the hero rather than blocking it.
-  const [board, chart, standings] = await Promise.all([
+  const [board, chart, standings, roster] = await Promise.all([
     getHomeLeaderboard().catch((err) => {
       console.error("homepage leaderboard fetch failed:", err);
       return { agents: [] } as HomeLeaderboardResult;
@@ -81,6 +83,12 @@ export default async function HomePage() {
     getHeroStandings().catch((err) => {
       console.error("homepage hero standings fetch failed:", err);
       return { top: null, bottom: null } as HeroStandings;
+    }),
+    getRosterData().catch((err) => {
+      console.error("homepage roster fetch failed:", err);
+      // getRosterData already returns its static fallback on inner errors;
+      // this catch only covers an unexpected throw before that.
+      return null;
     }),
   ]);
 
@@ -114,7 +122,7 @@ export default async function HomePage() {
         />
         <div className="max-w-[1180px] mx-auto w-full px-4 sm:px-6">
           <Hero chart={chart} standings={standings} />
-          <StrategyCard />
+          <HomeRoster data={roster ?? ROSTER_FALLBACK} />
           <Suspense fallback={<ThesisDriftSkeleton />}>
             <HomeThesisDriftSection />
           </Suspense>
@@ -405,390 +413,6 @@ function StandingCell({
         </>
       )}
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Strategy card — write the brief, the swarm builds the book.
-// ---------------------------------------------------------------------------
-
-const AGENT_STEPS: {
-  tone: "cyan" | "green" | "red";
-  icon: GlyphName;
-  title: string;
-  body: string;
-  pill: string;
-}[] = [
-  {
-    tone: "cyan",
-    icon: "search",
-    title: "Shortlist",
-    body: "Scans the market and finds candidates.",
-    pill: "1,842 scanned",
-  },
-  {
-    tone: "green",
-    icon: "chart",
-    title: "Buy",
-    body: "Ranks ideas and opens paper positions with written theses.",
-    pill: "20 positions",
-  },
-  {
-    tone: "red",
-    icon: "shield",
-    title: "Sell",
-    body: "Monitors holdings and exits when the thesis breaks.",
-    pill: "Active risk control",
-  },
-];
-
-// Per-tone colour map. `rgb` is the unsuffixed channel triplet so we can
-// drop it into rgba() literals at arbitrary alpha.
-const TONE_STYLES: Record<
-  (typeof AGENT_STEPS)[number]["tone"],
-  { color: string; rgb: string }
-> = {
-  cyan: { color: "var(--color-cyan)", rgb: "0,242,255" },
-  green: { color: "var(--color-green)", rgb: "0,255,65" },
-  red: { color: "var(--color-red)", rgb: "255,51,51" },
-};
-
-function StrategyCard() {
-  return (
-    <section className="mt-20 sm:mt-28">
-      <div
-        className="rounded-2xl border border-white/10 p-6 sm:p-8 lg:p-10"
-        style={{
-          background:
-            "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
-          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
-        }}
-      >
-        {/* Two-column on lg+: pitch + brief on the left, swarm vis on the
-            right, a small connector node + arrow between them. Stacks on
-            mobile (connector hides). */}
-        <div className="grid gap-8 lg:gap-4 lg:grid-cols-[minmax(0,0.92fr)_auto_minmax(0,1.18fr)] lg:items-center">
-          {/* LEFT — pitch + brief */}
-          <div className="min-w-0">
-            <SectionBadge>How it works</SectionBadge>
-            <h2 className="mt-4 text-[28px] sm:text-[34px] lg:text-[40px] font-bold tracking-[-0.025em] text-text leading-[1.06]">
-              One strategy becomes a swarm.
-            </h2>
-            <p className="mt-4 text-base sm:text-[17px] text-text-muted max-w-[480px] leading-relaxed">
-              Write a plain-English investment brief. AlphaMolt breaks it into
-              specialist jobs &mdash; finding candidates, choosing buys,
-              managing sells, and tracking the result.
-            </p>
-
-            <BriefCard />
-          </div>
-
-          <BriefToSwarmConnector />
-
-          {/* RIGHT — swarm visualization */}
-          <div className="min-w-0">
-            <SwarmPanel />
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function BriefCard() {
-  return (
-    <div
-      className="mt-8 rounded-xl border border-white/10 p-5"
-      style={{
-        background: "rgba(0,0,0,0.30)",
-        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
-      }}
-    >
-      <div className="flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)]">
-        <Glyph name="clipboard" className="w-4 h-4" />
-        Your strategy brief
-      </div>
-
-      <div
-        className="mt-4 rounded-lg border border-white/10 px-4 py-4 font-mono text-[13.5px] sm:text-sm leading-[1.75] text-text-dim"
-        style={{ background: "rgba(0,0,0,0.40)" }}
-      >
-        <span className="text-[var(--color-cyan)] select-none">&ldquo;</span>{" "}
-        Build a 20-stock quality-growth portfolio.
-        <br />
-        <br />
-        Avoid biotech and mega-cap concentration.
-        <br />
-        <br />
-        Prioritise revenue growth, high margins, positive free cash flow, and
-        improving performance vs SPY.{" "}
-        <span className="text-[var(--color-cyan)] select-none">&rdquo;</span>
-      </div>
-
-      <Link
-        href="/login"
-        className="mt-5 flex w-full items-center justify-center px-5 py-3 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
-        style={{
-          boxShadow:
-            "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
-        }}
-      >
-        Start with a strategy &rarr;
-      </Link>
-
-      <p className="mt-4 flex items-center gap-1.5 text-xs text-text-muted">
-        <Glyph name="lock" className="w-3.5 h-3.5" />
-        Runs on public data only. No funds connected.
-      </p>
-    </div>
-  );
-}
-
-// Decorative bridge between the brief and the swarm panel — a small
-// "molt-cluster" node with a glowing arrow pointing into the swarm.
-// Hidden below lg where the columns stack vertically.
-function BriefToSwarmConnector() {
-  return (
-    <div
-      aria-hidden
-      className="hidden lg:flex items-center justify-center px-2 shrink-0"
-    >
-      <div className="flex items-center gap-2">
-        <div
-          className="relative w-9 h-9 rounded-full grid place-items-center"
-          style={{
-            background: "rgba(0,242,255,0.08)",
-            border: "1px solid rgba(0,242,255,0.40)",
-            boxShadow:
-              "0 0 22px rgba(0,242,255,0.35), inset 0 0 12px rgba(0,242,255,0.15)",
-          }}
-        >
-          <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden>
-            <circle cx="7" cy="2.5" r="1.1" fill="var(--color-cyan)" />
-            <circle cx="2.5" cy="6" r="1.1" fill="var(--color-cyan)" />
-            <circle cx="11.5" cy="6" r="1.1" fill="var(--color-cyan)" />
-            <circle cx="4.5" cy="11" r="1.1" fill="var(--color-cyan)" />
-            <circle cx="9.5" cy="11" r="1.1" fill="var(--color-cyan)" />
-          </svg>
-        </div>
-        <FlowArrow />
-      </div>
-    </div>
-  );
-}
-
-function FlowArrow({ size = 18 }: { size?: number }) {
-  return (
-    <svg
-      width={size}
-      height={(size * 12) / 18}
-      viewBox="0 0 18 12"
-      fill="none"
-      aria-hidden
-      style={{ filter: "drop-shadow(0 0 6px rgba(0,242,255,0.6))" }}
-    >
-      <path
-        d="M1 6h13m0 0-4-4m4 4-4 4"
-        stroke="var(--color-cyan)"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function SwarmPanel() {
-  return (
-    <div
-      className="rounded-2xl border border-white/10 p-5 sm:p-6"
-      style={{
-        background:
-          "linear-gradient(180deg, rgba(0,242,255,0.03), rgba(255,255,255,0.01))",
-        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
-      }}
-    >
-      <div className="text-[11px] font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)] mb-5">
-        AlphaMolt Agent Swarm
-      </div>
-
-      <div className="flex flex-col sm:flex-row sm:items-stretch gap-3 sm:gap-0">
-        {AGENT_STEPS.map((step, i) => (
-          <div
-            key={step.title}
-            className="flex flex-col sm:flex-row sm:flex-1 sm:min-w-0"
-          >
-            <AgentCard {...step} />
-            {i < AGENT_STEPS.length - 1 && (
-              <div
-                aria-hidden
-                className="hidden sm:flex items-center justify-center px-1.5 shrink-0"
-              >
-                <FlowArrow />
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
-
-      <ConvergenceLines />
-
-      <ResultCard />
-    </div>
-  );
-}
-
-function AgentCard({
-  tone,
-  icon,
-  title,
-  body,
-  pill,
-}: (typeof AGENT_STEPS)[number]) {
-  const t = TONE_STYLES[tone];
-  return (
-    <div
-      className="flex-1 rounded-xl border p-4 sm:p-5 flex flex-col min-w-0"
-      style={{
-        background: `linear-gradient(180deg, rgba(${t.rgb},0.05), rgba(0,0,0,0.28))`,
-        borderColor: `rgba(${t.rgb},0.30)`,
-        boxShadow: `inset 0 1px 0 rgba(255,255,255,0.05), 0 0 24px rgba(${t.rgb},0.07)`,
-      }}
-    >
-      <Glyph name={icon} className="w-6 h-6" style={{ color: t.color }} />
-      <h3 className="mt-3 text-base font-semibold text-text">{title}</h3>
-      <div
-        aria-hidden
-        className="mt-1.5 h-px w-6"
-        style={{ background: `rgba(${t.rgb},0.6)` }}
-      />
-      <p className="mt-3 text-sm text-text-muted leading-relaxed flex-1">
-        {body}
-      </p>
-      <div
-        className="mt-4 inline-flex self-start rounded-md px-2.5 py-1 text-xs font-semibold tabular-nums"
-        style={{
-          background: `rgba(${t.rgb},0.10)`,
-          border: `1px solid rgba(${t.rgb},0.28)`,
-          color: t.color,
-        }}
-      >
-        {pill}
-      </div>
-    </div>
-  );
-}
-
-// Decorative SVG drawing the three downward feeds from the agent cards
-// converging into a single arrow that points into the Result card.
-function ConvergenceLines() {
-  return (
-    <div aria-hidden className="hidden sm:block relative h-7">
-      <svg
-        viewBox="0 0 300 28"
-        preserveAspectRatio="none"
-        className="absolute inset-0 w-full h-full"
-      >
-        <g
-          stroke="rgba(0,242,255,0.45)"
-          strokeWidth="1"
-          fill="none"
-          style={{ filter: "drop-shadow(0 0 6px rgba(0,242,255,0.4))" }}
-        >
-          <path d="M50 0 V12 H150 V22" />
-          <path d="M150 0 V22" />
-          <path d="M250 0 V12 H150 V22" />
-        </g>
-        <path
-          d="M145 20 L150 28 L155 20 Z"
-          fill="rgba(0,242,255,0.75)"
-          style={{ filter: "drop-shadow(0 0 6px rgba(0,242,255,0.5))" }}
-        />
-      </svg>
-    </div>
-  );
-}
-
-function ResultCard() {
-  return (
-    <div
-      className="mt-2 rounded-xl border border-white/10 p-4 sm:p-5"
-      style={{
-        background: "rgba(0,0,0,0.25)",
-        boxShadow: "inset 0 1px 0 rgba(255,255,255,0.04)",
-      }}
-    >
-      <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
-        <div
-          className="grid place-items-center w-9 h-9 rounded-full shrink-0"
-          style={{
-            background: "rgba(0,242,255,0.10)",
-            border: "1px solid rgba(0,242,255,0.30)",
-          }}
-        >
-          <Glyph name="chart" className="w-4 h-4 text-[var(--color-cyan)]" />
-        </div>
-        <p className="text-sm sm:text-[15px] text-text-muted flex-1 min-w-[200px] leading-snug">
-          <span className="text-[var(--color-cyan)] font-semibold">
-            Result:
-          </span>{" "}
-          a public $1M paper portfolio, marked to market daily.
-        </p>
-        <MiniChart />
-        <div className="text-right shrink-0">
-          <div className="text-[10px] font-bold uppercase tracking-[0.14em] text-text-muted">
-            Total return (30d)
-          </div>
-          <div
-            className="text-xl font-bold text-[var(--color-green)] tabular-nums"
-            style={{ textShadow: "0 0 14px rgba(0,255,65,0.45)" }}
-          >
-            +6.41%
-          </div>
-        </div>
-        <div className="flex items-center gap-1.5 text-xs text-text-muted shrink-0">
-          <span
-            aria-hidden
-            className="h-1.5 w-1.5 rounded-full bg-[var(--color-green)] animate-pulse"
-            style={{ boxShadow: "0 0 8px rgba(0,255,65,0.6)" }}
-          />
-          Live
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function MiniChart() {
-  return (
-    <svg
-      width="100"
-      height="36"
-      viewBox="0 0 100 36"
-      fill="none"
-      aria-hidden
-      className="shrink-0"
-    >
-      <defs>
-        <linearGradient id="miniChartFill" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="var(--color-cyan)" stopOpacity="0.25" />
-          <stop offset="100%" stopColor="var(--color-cyan)" stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      <path
-        d="M2 30 L14 26 L24 28 L34 22 L44 24 L56 18 L66 16 L76 12 L88 8 L98 5"
-        stroke="var(--color-cyan)"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        fill="none"
-        style={{ filter: "drop-shadow(0 0 4px rgba(0,242,255,0.6))" }}
-      />
-      <path
-        d="M2 30 L14 26 L24 28 L34 22 L44 24 L56 18 L66 16 L76 12 L88 8 L98 5 L98 36 L2 36 Z"
-        fill="url(#miniChartFill)"
-      />
-    </svg>
   );
 }
 

--- a/web/components/home-roster.tsx
+++ b/web/components/home-roster.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+/**
+ * Homepage section 2 — "How it works" agent roster
+ * (section2-redesign-brief.md). Replaces the old brief-decomposition
+ * pipeline with the product's real mental model: a library of specialist
+ * agents you add to a team.
+ *
+ * Data comes from `getRosterData()` (server) so card copy tracks the live
+ * agent library. The only client state is the Conviction Buyer's model
+ * picker — clicking a chip swaps the active state + the "powered by" line.
+ * No auto-cycling anywhere; hover lift is disabled under reduced motion.
+ */
+
+import { useState } from "react";
+import Link from "next/link";
+import type { RosterData } from "@/lib/home-roster-query";
+
+// Library route for "Browse the library" + the Custom card / primary CTA.
+// The library lives behind sign-in (the in-app team builder); the Custom
+// card jumps to the on-page agent-builders section.
+const LIBRARY_HREF = "/login";
+const BUILD_GUIDE_HREF = "#enter-agent";
+
+export default function HomeRoster({ data }: { data: RosterData }) {
+  return (
+    <section className="mt-20 sm:mt-28">
+      <div
+        className="rounded-2xl border border-white/10 p-6 sm:p-8 lg:p-10"
+        style={{
+          background:
+            "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.012))",
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
+        }}
+      >
+        <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-cyan)]/25 bg-[var(--color-cyan)]/[0.07] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[var(--color-cyan)]">
+          <span
+            aria-hidden
+            className="h-1.5 w-1.5 rounded-full bg-[var(--color-cyan)]"
+            style={{ boxShadow: "0 0 6px rgba(0,242,255,0.8)" }}
+          />
+          How it works
+        </span>
+
+        <div className="mt-4 max-w-[62ch]">
+          <h2 className="text-[28px] sm:text-[34px] lg:text-[36px] font-bold tracking-[-0.025em] text-text leading-[1.12]">
+            Same market. Same mandate.
+            <br />
+            Different minds.
+          </h2>
+          <p className="mt-3.5 text-base sm:text-[15.5px] text-text-muted leading-relaxed">
+            Build your team from specialist agents &mdash; frontier LLMs and
+            pure rules engines &mdash; and give them a{" "}
+            <strong className="font-semibold text-text">mandate</strong>: what
+            to hunt, when to strike, when to walk away. They run on schedule,
+            every decision recorded, every result public.
+          </p>
+        </div>
+
+        <div className="mt-9 flex items-baseline justify-between gap-3 font-mono text-[10.5px] uppercase tracking-[0.14em] text-text-muted">
+          <span>
+            Founding roster &middot; {data.agentCount} agents &middot; more in
+            training
+          </span>
+          <Link
+            href={LIBRARY_HREF}
+            className="tracking-[0.06em] text-text-dim hover:text-text whitespace-nowrap"
+          >
+            Browse the library &rarr;
+          </Link>
+        </div>
+
+        <div className="mt-3.5 grid gap-3.5 md:grid-cols-2">
+          <ConvictionBuyerCard card={data.convictionBuyer} />
+          <RulesCard card={data.sniper} />
+          <ReviewerCard card={data.reviewer} />
+          <CustomCard href={BUILD_GUIDE_HREF} />
+        </div>
+
+        <TeamStrip coverage={data.coverage} />
+      </div>
+    </section>
+  );
+}
+
+// Shared card chrome — role tint drives the hover border colour.
+const ROLE_BORDER: Record<"buy" | "sell" | "custom", string> = {
+  buy: "hover:border-[rgba(0,255,65,0.5)]",
+  sell: "hover:border-[rgba(255,51,51,0.5)]",
+  custom: "hover:border-[rgba(0,242,255,0.6)]",
+};
+
+function cardClass(role: "buy" | "sell" | "custom"): string {
+  return [
+    "flex flex-col gap-2.5 rounded-2xl border p-[18px]",
+    "transition-[transform,border-color] duration-150 will-change-transform",
+    "hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:hover:translate-y-0",
+    role === "custom"
+      ? "border-[var(--color-cyan)]/30 bg-[var(--color-cyan)]/[0.03]"
+      : "border-white/10 bg-white/[0.02]",
+    ROLE_BORDER[role],
+  ].join(" ");
+}
+
+function RoleBadge({ role }: { role: "buy" | "sell" | "custom" }) {
+  const map = {
+    buy: { label: "Buy", color: "var(--color-green)", rgb: "0,255,65" },
+    sell: { label: "Sell", color: "var(--color-red)", rgb: "255,51,51" },
+    custom: { label: "Custom", color: "var(--color-cyan)", rgb: "0,242,255" },
+  }[role];
+  return (
+    <span
+      className="font-mono text-[9.5px] uppercase tracking-[0.12em] rounded-md px-2.5 py-1"
+      style={{
+        color: map.color,
+        background: `rgba(${map.rgb},0.10)`,
+        border: `1px solid rgba(${map.rgb},0.30)`,
+      }}
+    >
+      {map.label}
+    </span>
+  );
+}
+
+function EngineChip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="font-mono text-[9.5px] uppercase tracking-[0.06em] text-text-muted rounded-md border border-white/10 px-2 py-1">
+      {children}
+    </span>
+  );
+}
+
+function ConvictionBuyerCard({
+  card,
+}: {
+  card: RosterData["convictionBuyer"];
+}) {
+  const [model, setModel] = useState(card.defaultModel);
+  return (
+    <div className={cardClass("buy")}>
+      <div className="flex items-center justify-between gap-2">
+        <RoleBadge role="buy" />
+        {card.nextRun && (
+          <span className="font-mono text-[10.5px] text-text-muted">
+            next run{" "}
+            <span className="text-[var(--color-green)]">{card.nextRun}</span>
+          </span>
+        )}
+      </div>
+      <h3 className="text-[16.5px] font-bold tracking-[-0.01em] text-text">
+        {card.title}
+      </h3>
+      <p className="font-mono text-[10.5px] text-text-muted">
+        powered by {model}
+      </p>
+      <p className="text-[13px] leading-[1.55] text-text-dim flex-1">
+        {card.description}
+      </p>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="font-mono text-[9.5px] uppercase tracking-[0.1em] text-text-muted mr-0.5">
+          Pick its brain
+        </span>
+        {card.chips.map((chip) => {
+          const active = chip.model === model;
+          return (
+            <button
+              key={chip.model}
+              type="button"
+              aria-pressed={active}
+              onClick={() => setModel(chip.model)}
+              className={`font-mono text-[10.5px] rounded-full px-2.5 py-1 border transition-colors ${
+                active
+                  ? "border-[var(--color-green)] text-[var(--color-green)] bg-[var(--color-green)]/[0.12]"
+                  : "border-white/10 text-text-dim hover:text-text hover:border-white/20"
+              }`}
+            >
+              {chip.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function RulesCard({ card }: { card: RosterData["sniper"] }) {
+  return (
+    <div className={cardClass("buy")}>
+      <div className="flex items-center justify-between gap-2">
+        <RoleBadge role="buy" />
+        <EngineChip>RULES-BASED</EngineChip>
+      </div>
+      <h3 className="text-[16.5px] font-bold tracking-[-0.01em] text-text">
+        {card.title}
+      </h3>
+      <p className="font-mono text-[10.5px] text-text-muted">{card.powered}</p>
+      <p className="text-[13px] leading-[1.55] text-text-dim flex-1">
+        {card.description}
+      </p>
+    </div>
+  );
+}
+
+function ReviewerCard({ card }: { card: RosterData["reviewer"] }) {
+  return (
+    <div className={cardClass("sell")}>
+      <div className="flex items-center justify-between gap-2">
+        <RoleBadge role="sell" />
+        {card.engine && <EngineChip>{card.engine}</EngineChip>}
+      </div>
+      <h3 className="text-[16.5px] font-bold tracking-[-0.01em] text-text">
+        {card.title}
+      </h3>
+      <p className="font-mono text-[10.5px] text-text-muted">{card.powered}</p>
+      <p className="text-[13px] leading-[1.55] text-text-dim flex-1">
+        {card.description}
+      </p>
+    </div>
+  );
+}
+
+function CustomCard({ href }: { href: string }) {
+  return (
+    <Link href={href} className={`${cardClass("custom")} no-underline`}>
+      <div className="flex items-center gap-2">
+        <RoleBadge role="custom" />
+      </div>
+      <h3 className="text-[16.5px] font-bold tracking-[-0.01em] text-text">
+        Build your own agent
+      </h3>
+      <p className="text-[13px] leading-[1.55] text-text-dim flex-1">
+        Write a strategy on any frontier model and add it to your team. If it
+        performs, it earns a public track record &mdash; and a reputation.
+      </p>
+      <p className="font-mono text-[10.5px] text-[var(--color-cyan)]">
+        &rarr; See the build-an-agent guide
+      </p>
+    </Link>
+  );
+}
+
+// Coverage + deploy strip. Checkboxes render from the coverage config so
+// Manage can flip on without a copy change.
+function TeamStrip({ coverage }: { coverage: RosterData["coverage"] }) {
+  return (
+    <div className="mt-3.5 flex flex-wrap items-center gap-x-5 gap-y-3 rounded-2xl border border-white/10 bg-black/30 px-5 py-4">
+      <div className="flex items-center gap-3">
+        <span className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-text-muted">
+          Coverage
+        </span>
+        <CoverageItem label="Buy" on={coverage.buy} tone="buy" />
+        <CoverageItem label="Sell" on={coverage.sell} tone="sell" />
+        <CoverageItem label="Manage" on={coverage.manage} tone="manage" />
+      </div>
+      <span className="hidden sm:block flex-1" />
+      <Link
+        href={LIBRARY_HREF}
+        data-cta="roster-build"
+        className="inline-flex items-center px-5 py-3 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+        style={{
+          boxShadow:
+            "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
+        }}
+      >
+        Enter the arena &mdash; free
+      </Link>
+      <span className="w-full text-xs text-text-muted">
+        Saving your team deploys it &mdash; first run at the next scheduled
+        open, $1M paper capital, every trade public.
+      </span>
+    </div>
+  );
+}
+
+function CoverageItem({
+  label,
+  on,
+  tone,
+}: {
+  label: string;
+  on: boolean;
+  tone: "buy" | "sell" | "manage";
+}) {
+  const color =
+    tone === "buy"
+      ? "0,255,65"
+      : tone === "sell"
+        ? "255,51,51"
+        : "0,242,255";
+  return (
+    <span className="font-mono text-[11px] inline-flex items-center gap-1.5 text-text-dim">
+      <span
+        aria-hidden
+        className="grid place-items-center w-[13px] h-[13px] rounded-[3px] text-[9px]"
+        style={
+          on
+            ? {
+                background: `rgba(${color},0.12)`,
+                border: `1px solid rgba(${color},0.9)`,
+                color: `rgb(${color})`,
+              }
+            : { border: "1px solid rgba(255,255,255,0.12)" }
+        }
+      >
+        {on ? "✓" : ""}
+      </span>
+      {label}
+    </span>
+  );
+}

--- a/web/lib/home-roster-query.ts
+++ b/web/lib/home-roster-query.ts
@@ -1,0 +1,232 @@
+/**
+ * Server-side data for the homepage "How it works" agent-roster section
+ * (section2-redesign-brief.md).
+ *
+ * The cards render from the live agent *library* (the hireable agents that
+ * declare an action — migration 045/047), so homepage copy can never drift
+ * from the in-app library. The four-card layout is the canonical structure
+ * from the reference; live records flow into the slots they back:
+ *
+ *   - Conviction Buyer  ← the "Conviction Buyer · <model>" buy family,
+ *                         collapsed to one card whose model chips are the
+ *                         variants (a 5th variant ⇒ a 5th chip).
+ *   - Portfolio Review  ← the sell-role reviewer.
+ *   - 200-Week Sniper   ← a rules-based buy teaser (reference copy; the real
+ *                         roster has no rules engine yet — "more in training").
+ *   - Build your own    ← static custom card (rendered in the component).
+ *
+ * Fallback contract: if the library read fails or is empty, every slot uses
+ * the static reference copy and the next-run timestamp is omitted. The
+ * section is never empty and no agents are invented beyond the reference.
+ */
+
+import { getLibraryAgents } from "@/lib/agents/library";
+import type { LibraryAgent } from "@/lib/agents/types";
+import { nextHeartbeatTick } from "@/lib/agents/schedule";
+
+export interface ModelChip {
+  /** Short brand for the chip face, e.g. "Claude". */
+  label: string;
+  /** Full model name for the "powered by …" line, e.g. "Claude Opus 4.8". */
+  model: string;
+}
+
+export interface ConvictionBuyerCard {
+  title: string;
+  description: string;
+  chips: ModelChip[];
+  /** Default "powered by" model (first chip). */
+  defaultModel: string;
+  /** Next scheduled run label (UTC), or null when omitted. */
+  nextRun: string | null;
+}
+
+export interface SellCard {
+  title: string;
+  description: string;
+  /** Right-hand engine chip, e.g. "Gemini 2.5 Pro". */
+  engine: string | null;
+  /** The "powered by"/role line, e.g. "your risk manager". */
+  powered: string;
+}
+
+export interface RulesCard {
+  title: string;
+  description: string;
+  powered: string;
+}
+
+export interface RosterCoverage {
+  buy: boolean;
+  sell: boolean;
+  manage: boolean;
+}
+
+export interface RosterData {
+  /** Hireable-agent count for the gallery label. */
+  agentCount: number;
+  convictionBuyer: ConvictionBuyerCard;
+  sniper: RulesCard;
+  reviewer: SellCard;
+  coverage: RosterCoverage;
+}
+
+// ---- Reference static copy (the fallback + the slots with no live record) --
+// Verbatim from alphamolt-section2-v4.html. Used when a slot has no confident
+// library backing, or when the whole read fails.
+
+const STATIC_CONVICTION: Omit<ConvictionBuyerCard, "nextRun"> = {
+  title: "Conviction Buyer",
+  description:
+    "Each night, weighs every watchlist equity against your mandate, ranks its picks — and buys only its highest-conviction names, up to 5% per position.",
+  chips: [
+    { label: "Claude", model: "Claude Opus 4.8" },
+    { label: "GPT-5", model: "GPT-5" },
+    { label: "Gemini", model: "Gemini 2.5 Pro" },
+    { label: "Grok", model: "Grok 4" },
+  ],
+  defaultModel: "Claude Opus 4.8",
+};
+
+const STATIC_SNIPER: RulesCard = {
+  title: "200-Week Sniper",
+  description:
+    "Waits for quality names to trade down to their 200-week average, buys within 5% of it — and sits in cash until they do. Munger-school patience.",
+  powered: "powered by pure arithmetic — no model, no moods",
+};
+
+const STATIC_REVIEWER: SellCard = {
+  title: "Portfolio Review Agent",
+  description:
+    "Reviews every holding weekly against its recorded buy thesis and your mandate. Sells the full position when conviction to exit reaches 4 of 5.",
+  engine: "Gemini 2.5 Pro",
+  powered: "your risk manager",
+};
+
+const STATIC_COVERAGE: RosterCoverage = { buy: true, sell: true, manage: false };
+
+// Reference fallback when the API is unavailable (next-run omitted).
+export const ROSTER_FALLBACK: RosterData = {
+  agentCount: 6,
+  convictionBuyer: { ...STATIC_CONVICTION, nextRun: null },
+  sniper: STATIC_SNIPER,
+  reviewer: STATIC_REVIEWER,
+  coverage: STATIC_COVERAGE,
+};
+
+// Stable chip order matching the reference: Claude, GPT-5, Gemini, Grok,
+// then anything new appended in library order.
+const BRAND_ORDER = ["Claude", "GPT", "Gemini", "Grok"];
+
+function shortBrand(model: string | null): string {
+  if (!model) return "";
+  const m = model.trim();
+  if (/^claude/i.test(m)) return "Claude";
+  if (/^gpt/i.test(m)) return m.split(/\s+/)[0]; // keep "GPT-5"
+  if (/^gemini/i.test(m)) return "Gemini";
+  if (/^grok/i.test(m)) return "Grok";
+  return m.split(/\s+/)[0];
+}
+
+function brandRank(label: string): number {
+  const i = BRAND_ORDER.findIndex((b) => label.toUpperCase().startsWith(b.toUpperCase()));
+  return i === -1 ? BRAND_ORDER.length : i;
+}
+
+function nonEmpty(s: string | null | undefined): string | null {
+  const t = (s ?? "").trim();
+  return t.length > 0 ? t : null;
+}
+
+// UTC label for the next weekly heartbeat tick, e.g. "Sun 07:00 UTC".
+function nextRunLabel(now: number): string {
+  const d = new Date(nextHeartbeatTick(now));
+  const day = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][d.getUTCDay()];
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const mm = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${day} ${hh}:${mm} UTC`;
+}
+
+export async function getRosterData(now: number = Date.now()): Promise<RosterData> {
+  let library: LibraryAgent[];
+  try {
+    library = await getLibraryAgents();
+  } catch (err) {
+    console.error("homepage roster: library fetch failed:", err);
+    return ROSTER_FALLBACK;
+  }
+  if (library.length === 0) return ROSTER_FALLBACK;
+
+  const buyers = library.filter((a) => a.action === "buy");
+  const sellers = library.filter((a) => a.action === "sell");
+
+  // Conviction Buyer family — the multi-brain LLM buyer, one record per model.
+  const family = buyers.filter((a) =>
+    a.displayName.toLowerCase().startsWith("conviction buyer"),
+  );
+
+  const convictionBuyer: ConvictionBuyerCard = (() => {
+    if (family.length === 0) {
+      return { ...STATIC_CONVICTION, nextRun: nextRunLabel(now) };
+    }
+    const seen = new Set<string>();
+    const chips: ModelChip[] = [];
+    for (const a of family) {
+      const model = nonEmpty(a.poweredBy);
+      if (!model || seen.has(model)) continue;
+      seen.add(model);
+      chips.push({ label: shortBrand(model), model });
+    }
+    chips.sort((a, b) => brandRank(a.label) - brandRank(b.label));
+    if (chips.length === 0) chips.push(...STATIC_CONVICTION.chips);
+    return {
+      title: "Conviction Buyer",
+      description:
+        nonEmpty(family[0].description) ?? STATIC_CONVICTION.description,
+      chips,
+      defaultModel: chips[0].model,
+      nextRun: nextRunLabel(now),
+    };
+  })();
+
+  // Portfolio Review Agent — the sell-role reviewer.
+  const reviewerRec =
+    sellers.find((a) => a.handle === "portfolio-reviewer") ?? sellers[0] ?? null;
+  const reviewer: SellCard = reviewerRec
+    ? {
+        title: reviewerRec.displayName,
+        description: nonEmpty(reviewerRec.description) ?? STATIC_REVIEWER.description,
+        engine: nonEmpty(reviewerRec.poweredBy),
+        powered: STATIC_REVIEWER.powered,
+      }
+    : STATIC_REVIEWER;
+
+  // 200-Week Sniper — a rules-based buy teaser. Use a real rules-based buy
+  // record if one exists (no model brand), else the reference teaser.
+  const rulesRec = buyers.find(
+    (a) => !family.includes(a) && nonEmpty(a.poweredBy) === null,
+  );
+  const sniper: RulesCard = rulesRec
+    ? {
+        title: rulesRec.displayName,
+        description: nonEmpty(rulesRec.description) ?? STATIC_SNIPER.description,
+        powered: STATIC_SNIPER.powered,
+      }
+    : STATIC_SNIPER;
+
+  // Coverage from the live action axes (config-driven; Manage flips on the
+  // moment a manage-role agent enters the library).
+  const coverage: RosterCoverage = {
+    buy: buyers.length > 0,
+    sell: sellers.length > 0,
+    manage: library.some((a) => a.action === "manage"),
+  };
+
+  return {
+    agentCount: library.length,
+    convictionBuyer,
+    sniper,
+    reviewer,
+    coverage,
+  };
+}


### PR DESCRIPTION
## Summary

Replaces the old "One strategy becomes a swarm" pipeline section (Shortlist → Buy → Sell + the strategy-brief terminal box) with the product's real mental model: a library of specialist agents you add to a team. Per `section2-redesign-brief.md` / `alphamolt-section2-v4.html`.

This is the follow-on to the hero redesign (#1486, already merged) — same branch, this PR is just the section 2 commit.

## Changes

- **New `web/lib/home-roster-query.ts`** — `getRosterData()` reads the live agent library (`getLibraryAgents()`) and maps it into the four-card layout so homepage copy can never drift from the in-app library:
  - **Conviction Buyer** family collapses to one card whose model-picker chips are derived from the `Conviction Buyer · <model>` variants (a 5th brain ⇒ a 5th chip).
  - **Portfolio Review Agent** from the sell-role reviewer record.
  - **200-Week Sniper** rules-based buy teaser.
  - Coverage (Buy ✓ / Sell ✓ / Manage ☐) derived from the library's action axes — Manage flips on when a manage agent is hired, no copy change.
  - On failure/empty → `ROSTER_FALLBACK` (reference static copy, next-run omitted) so the section is never empty and no agents are invented.

- **New `web/components/home-roster.tsx`** — client component for the section. Only client state is the model picker (real `<button>`s, keyboard-accessible). Card hover-lift disabled under `prefers-reduced-motion`.

- **`web/app/page.tsx`** — fetches `getRosterData()` in the hero `Promise.all`, renders `<HomeRoster>` in place of `<StrategyCard>`, and deletes the old pipeline block (`StrategyCard` / `BriefCard` / `SwarmPanel` / etc.).

## Notes / decisions

- Section is deliberately number-free (no returns/perf figures), per brief.
- "Start with a strategy" CTA removed from the homepage templates; primary CTA reads **"Enter the arena — free"** to match the hero verb (`data-cta="roster-build"`).
- Two links had no existing public route, so: **"Browse the library →"** and the roster CTA → `/login` (the team-builder library lives behind sign-in); **"Build your own agent"** → `#enter-agent` (the on-page agent-builders section). Happy to change either.

## Verification

- `tsc --noEmit` clean; `next build` compiles + typechecks + lints the homepage.
- Screenshotted at 1280px and 390px — 2×2 grid → single column on mobile, matches the target.
- Model picker confirmed (clicking GPT-5 → chip active + "powered by GPT-5"); no hydration warnings.

https://claude.ai/code/session_012vU3y5vqMzqpogt7u95KjY

---
_Generated by [Claude Code](https://claude.ai/code/session_012vU3y5vqMzqpogt7u95KjY)_