### PR TITLE
Homepage section 4: consensus & divergence (swarms agree / split)

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -21,7 +21,9 @@ import {
 import { getRosterData, ROSTER_FALLBACK } from "@/lib/home-roster-query";
 import {
   getLatestConsensus,
+  getContestedTicker,
   type ConsensusResult,
+  type ContestedTicker,
 } from "@/lib/consensus-query";
 import { absoluteUrl } from "@/lib/site";
 
@@ -142,18 +144,29 @@ export default async function HomePage() {
 
 async function HomeConsensusSection() {
   let consensus: ConsensusResult = { snapshot_date: null, rows: [] };
+  let contested: ContestedTicker | null = null;
   try {
-    consensus = await getLatestConsensus();
+    [consensus, contested] = await Promise.all([
+      getLatestConsensus(),
+      getContestedTicker().catch((err) => {
+        // Divergence is optional — its absence just hides the strip, it
+        // never blocks the consensus table.
+        console.error("homepage contested fetch failed:", err);
+        return null;
+      }),
+    ]);
   } catch (err) {
     console.error("homepage consensus fetch failed:", err);
   }
-  // HomeConsensus already renders its own <section id="consensus">; we
-  // just add the vertical rhythm the page wants between major blocks.
+  // Hide the whole section on data failure / empty — never a skeleton with
+  // fabricated tickers (section 4 brief).
+  if (consensus.rows.length === 0) return null;
   return (
     <div className="mt-20 sm:mt-28">
       <HomeConsensus
         rows={consensus.rows}
         snapshotDate={consensus.snapshot_date}
+        contested={contested}
       />
     </div>
   );

--- a/web/components/home-consensus.tsx
+++ b/web/components/home-consensus.tsx
@@ -1,88 +1,114 @@
 import Link from "next/link";
-import type { ConsensusHolder, ConsensusRow } from "@/lib/consensus-query";
+import type {
+  ConsensusHolder,
+  ConsensusRow,
+  ContestedTicker,
+} from "@/lib/consensus-query";
 
 interface Props {
   rows: ConsensusRow[];
   snapshotDate: string | null;
+  contested: ContestedTicker | null;
   topN?: number;
 }
 
-// Homepage variant of the /consensus table — top N tickers only, fewer
-// columns than the full page. Server component (no state, no
-// interactivity beyond static links) so it lands in the SSR HTML
-// without a hydration cost. Visual treatment mirrors HomeLeaderboard
-// for consistency: same rounded-2xl card, same backdrop blur, same
-// FooterRow link to the canonical page.
-export default function HomeConsensus({ rows, snapshotDate, topN = 5 }: Props) {
+/**
+ * Homepage section 4 — "Where the swarms agree, and where they split"
+ * (section4-redesign-brief.md / alphamolt-section4-v2.html).
+ *
+ * Reframes the most-held equities as *observations about model behaviour*
+ * (consensus + divergence) rather than stock tips. The holder count is a
+ * discrete segmented bar (a count of independent swarms, not a continuous
+ * gauge), losing positions stay visible, and the disclaimer sits inside the
+ * panel next to the data. Portfolio-runners are called "swarms" throughout
+ * (section 2 owns the team-member vocabulary).
+ *
+ * The P&L column is the swarm's share-weighted P&L SINCE ENTRY
+ * ((price − weighted avg entry) / entry), not a 30-day return — header
+ * labelled accordingly so it never overclaims.
+ *
+ * Server component (no client state); the parent hides the whole section on
+ * data failure / empty so a skeleton never shows fabricated tickers.
+ */
+export default function HomeConsensus({
+  rows,
+  snapshotDate,
+  contested,
+  topN = 5,
+}: Props) {
   const top = rows.slice(0, topN);
-  const totalAgents = top[0]?.total_agents ?? 0;
+  if (top.length === 0) return null;
+
+  // Live swarm count drives both the segment total and the lede number.
+  const totalSwarms = rows.reduce((m, r) => Math.max(m, r.total_agents), 0);
 
   return (
     <section id="consensus" className="scroll-mt-16">
-      <header className="flex items-start justify-between gap-4 mb-5 flex-wrap">
+      <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-green)]/25 bg-[var(--color-green)]/[0.10] px-3 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-[var(--color-green)]">
+        Arena data
+      </span>
+
+      <div className="mt-5 mb-6 flex flex-wrap items-end justify-between gap-x-6 gap-y-3">
         <div>
-          <h2 className="text-2xl sm:text-[28px] font-bold tracking-tight text-text leading-tight">
-            AI stock-picker favourites
+          <h2 className="text-[28px] sm:text-[34px] lg:text-[36px] font-bold tracking-[-0.025em] text-text leading-[1.12]">
+            Where the swarms agree &mdash;
+            <br />
+            and where they split.
           </h2>
-          <p className="mt-1.5 text-sm text-text-muted">
-            Most-held equities across the arena&rsquo;s {totalAgents || ""}{" "}
-            {totalAgents === 1 ? "agent" : "agents"}
-            {snapshotDate && (
-              <>
-                {" · "}snapshot{" "}
-                <time
-                  dateTime={snapshotDate}
-                  className="text-text-dim font-mono"
-                >
-                  {formatSnapshotDate(snapshotDate)}
-                </time>
-              </>
-            )}
+          <p className="mt-3 max-w-[58ch] text-[15px] leading-relaxed text-text-muted">
+            {totalSwarms || "Several"} founding swarms research the same market
+            independently. When most of them converge on a name, that&rsquo;s{" "}
+            <strong className="font-semibold text-text">
+              data about how these models think
+            </strong>{" "}
+            &mdash; and when they split, that&rsquo;s where the arena gets
+            interesting.
           </p>
         </div>
-      </header>
+        {snapshotDate && (
+          <span className="whitespace-nowrap pb-1 font-mono text-[11px] text-text-muted">
+            snapshot {formatSnapshotDate(snapshotDate)} &middot; updates weekly
+          </span>
+        )}
+      </div>
 
-      <div
-        className="relative rounded-2xl border border-white/10 overflow-hidden"
-        style={{
-          background:
-            "linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.015))",
-          backdropFilter: "blur(12px)",
-          WebkitBackdropFilter: "blur(12px)",
-          boxShadow:
-            "0 24px 48px -24px rgba(0,0,0,0.8), inset 0 1px 0 rgba(255,255,255,0.06)",
-        }}
-      >
-        {top.length === 0 ? <EmptyState /> : <Table rows={top} />}
-        <FooterRow />
+      <div className="overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02]">
+        <Table rows={top} totalSwarms={totalSwarms} />
+        {contested && <ContestedStrip contested={contested} />}
+        <PanelFoot />
+      </div>
+
+      <div className="mt-3 text-right">
+        <Link
+          href="/consensus"
+          className="font-mono text-[11.5px] text-text-dim hover:text-text"
+        >
+          Full consensus &amp; divergence data &rarr;
+        </Link>
       </div>
     </section>
   );
 }
 
-function Table({ rows }: { rows: ConsensusRow[] }) {
+function Table({ rows, totalSwarms }: { rows: ConsensusRow[]; totalSwarms: number }) {
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-sm">
+      <table className="w-full">
         <thead>
-          <tr className="text-[10px] uppercase tracking-[0.12em] text-text-muted font-semibold border-b border-white/[0.06] bg-white/[0.02]">
-            <th className="text-left py-3 pl-5 pr-2 font-semibold">
-              Ticker
-            </th>
-            <th className="text-left py-3 px-2 min-w-[180px] font-semibold">
-              Conviction
-            </th>
-            <th className="hidden md:table-cell text-left py-3 px-2 font-semibold">
+          <tr className="border-b border-white/10 bg-white/[0.02] font-mono text-[10px] uppercase tracking-[0.12em] text-text-muted">
+            <th className="px-3 py-3.5 text-left font-medium sm:px-5">Ticker</th>
+            <th className="px-3 py-3.5 text-left font-medium sm:px-5">Held by</th>
+            <th className="hidden px-5 py-3.5 text-left font-medium md:table-cell">
               Top holders
             </th>
-            <th className="text-right py-3 pr-5 pl-2 w-24 font-semibold">
-              Swarm P&amp;L
+            <th className="px-3 py-3.5 text-right font-medium sm:px-5">
+              Holders&rsquo; P&amp;L (since entry)
             </th>
           </tr>
         </thead>
         <tbody>
           {rows.map((row) => (
-            <Row key={row.ticker} row={row} />
+            <Row key={row.ticker} row={row} totalSwarms={totalSwarms} />
           ))}
         </tbody>
       </table>
@@ -90,60 +116,64 @@ function Table({ rows }: { rows: ConsensusRow[] }) {
   );
 }
 
-function Row({ row }: { row: ConsensusRow }) {
+function Row({ row, totalSwarms }: { row: ConsensusRow; totalSwarms: number }) {
   return (
-    <tr className="border-t border-white/[0.05] hover:bg-white/[0.025] transition-colors">
-      <td className="py-4 pl-5 pr-2">
-        <Link
-          href={`/company/${encodeURIComponent(row.ticker)}`}
-          className="group flex items-baseline gap-2 min-w-0"
-        >
-          <span className="font-mono text-[15px] font-bold text-green group-hover:underline decoration-1 underline-offset-[3px]">
+    <tr className="border-b border-white/[0.06] transition-colors last:border-b-0 hover:bg-[var(--color-green)]/[0.025]">
+      <td className="px-3 py-3.5 align-middle sm:px-5">
+        <Link href={`/company/${encodeURIComponent(row.ticker)}`} className="group">
+          <span className="font-mono text-[13.5px] font-semibold text-[var(--color-green)] group-hover:underline decoration-1 underline-offset-[3px]">
             {row.ticker}
           </span>
-          <span className="text-xs text-text-muted truncate max-w-[160px] hidden sm:inline">
+          <span className="mt-0.5 block text-[12.5px] text-text-muted">
             {row.company_name}
           </span>
         </Link>
       </td>
-      <td className="py-4 px-2">
-        <ConvictionCell row={row} />
+      <td className="px-3 py-3.5 align-middle sm:px-5">
+        <HeldByBar held={row.num_agents} total={row.total_agents || totalSwarms} />
       </td>
-      <td className="hidden md:table-cell py-4 px-2">
+      <td className="hidden px-5 py-3.5 align-middle md:table-cell">
         <HoldersChips holders={row.top_holders} />
       </td>
-      <td className="py-4 pr-5 pl-2 text-right">
+      <td className="px-3 py-3.5 text-right align-middle sm:px-5">
         <PnLCell value={row.swarm_pnl_pct} />
       </td>
     </tr>
   );
 }
 
-function ConvictionCell({ row }: { row: ConsensusRow }) {
-  const pct = Math.max(0, Math.min(100, row.pct_agents));
+// Discrete segmented bar: one segment per swarm in the arena, `held` lit.
+// Deliberately NOT a continuous gauge — it's a count of independent holders.
+function HeldByBar({ held, total }: { held: number; total: number }) {
+  const segs = Math.max(total, held, 1);
+  const lit = Math.max(0, Math.min(held, segs));
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-2.5">
       <div
-        className="relative h-1.5 flex-1 max-w-[160px] rounded-full overflow-hidden"
-        style={{ background: "rgba(255,255,255,0.06)" }}
-        role="progressbar"
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-valuenow={Math.round(pct)}
-        aria-label={`${row.pct_agents.toFixed(0)} percent of agents hold ${row.ticker}`}
+        className="flex gap-0.5"
+        role="img"
+        aria-label={`${held} of ${segs} swarms hold this`}
       >
-        <div
-          className="absolute inset-y-0 left-0 rounded-full"
-          style={{
-            width: `${pct}%`,
-            background: "var(--color-green)",
-            boxShadow:
-              "0 0 8px rgba(0, 255, 65, 0.55), 0 0 2px rgba(0, 255, 65, 0.35)",
-          }}
-        />
+        {Array.from({ length: segs }, (_, i) => (
+          <span
+            key={i}
+            className="h-3.5 w-[9px] rounded-[2px] border"
+            style={
+              i < lit
+                ? {
+                    background: "var(--color-green)",
+                    borderColor: "var(--color-green)",
+                  }
+                : {
+                    background: "rgba(255,255,255,0.03)",
+                    borderColor: "rgba(255,255,255,0.10)",
+                  }
+            }
+          />
+        ))}
       </div>
-      <span className="text-xs text-text-dim tabular-nums whitespace-nowrap">
-        {row.num_agents} of {row.total_agents}
+      <span className="whitespace-nowrap font-mono text-[11px] text-text-dim">
+        {held} of {segs}
       </span>
     </div>
   );
@@ -153,24 +183,21 @@ function HoldersChips({ holders }: { holders: ConsensusHolder[] }) {
   if (holders.length === 0) {
     return <span className="text-xs text-text-muted">&mdash;</span>;
   }
-  // Homepage variant: just two visible chips + a `+N` count (no
-  // tooltip — the full /consensus page is the place to drill in).
-  // Kept as a server component so SSR HTML is interactivity-free.
   const visible = holders.slice(0, 2);
   const overflow = holders.length - visible.length;
   return (
-    <div className="flex items-center gap-1.5 flex-wrap">
+    <div className="flex flex-wrap items-center gap-1.5">
       {visible.map((h) => (
         <Link
           key={h.handle}
           href={`/portfolios/${h.handle}`}
-          className="inline-flex items-center px-2 py-0.5 rounded-md text-xs text-text-dim hover:text-text border border-white/10 hover:border-white/20 transition-colors"
+          className="inline-flex items-center rounded-full border border-white/10 px-2.5 py-1 font-mono text-[10.5px] text-text-dim transition-colors hover:border-white/20 hover:text-text"
         >
           {h.display_name}
         </Link>
       ))}
       {overflow > 0 && (
-        <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs text-green border border-green/30">
+        <span className="inline-flex items-center rounded-full border border-dashed border-white/15 px-2.5 py-1 font-mono text-[10.5px] text-text-muted">
           +{overflow}
         </span>
       )}
@@ -180,56 +207,100 @@ function HoldersChips({ holders }: { holders: ConsensusHolder[] }) {
 
 function PnLCell({ value }: { value: number | null }) {
   if (value == null) {
-    return <span className="text-text-muted text-sm">&mdash;</span>;
+    return <span className="font-mono text-[13px] text-text-muted">&mdash;</span>;
   }
   const positive = value >= 0;
-  const sign = positive ? "+" : "−";
   return (
     <span
-      className="text-sm font-bold tabular-nums"
-      style={{
-        color: positive ? "var(--color-green)" : "var(--color-red)",
-        textShadow: positive
-          ? "0 0 12px rgba(0, 255, 65, 0.35)"
-          : "0 0 12px rgba(255, 80, 80, 0.30)",
-      }}
+      className="font-mono text-[13px] font-semibold tabular-nums"
+      style={{ color: positive ? "var(--color-green)" : "var(--color-red)" }}
     >
-      {sign}
+      {positive ? "+" : "−"}
       {Math.abs(value).toFixed(1)}%
     </span>
   );
 }
 
-function EmptyState() {
+// "Where they split" — one genuinely contested ticker. Rendered only when the
+// divergence query returns a qualifying name.
+function ContestedStrip({ contested }: { contested: ContestedTicker }) {
+  const total = contested.held + contested.exited;
+  const holdPct = total > 0 ? (contested.held / total) * 100 : 50;
   return (
-    <div className="px-6 py-12 text-center">
-      <p className="text-sm text-text-muted font-mono">
-        No consensus snapshot yet — first run lands Sunday 08:00 UTC.
+    <>
+      <p className="px-5 pt-3 font-mono text-[10px] uppercase tracking-[0.14em] text-[var(--color-orange)]">
+        &#9650; Where they split
       </p>
-    </div>
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-3 px-5 pb-[18px] pt-3">
+        <div className="min-w-[150px]">
+          <Link href={`/company/${encodeURIComponent(contested.ticker)}`}>
+            <span className="font-mono text-[13.5px] font-semibold text-[var(--color-orange)]">
+              {contested.ticker}
+            </span>
+          </Link>
+          <span className="mt-0.5 block text-[12.5px] text-text-muted">
+            {contested.company_name}
+          </span>
+        </div>
+        <div
+          className="flex h-3.5 min-w-[160px] flex-1 overflow-hidden rounded-full border border-white/10"
+          role="img"
+          aria-label={`${contested.held} hold, ${contested.exited} exited`}
+        >
+          <span
+            style={{ width: `${holdPct}%`, background: "var(--color-green)", opacity: 0.85 }}
+          />
+          <span
+            style={{ width: `${100 - holdPct}%`, background: "var(--color-red)", opacity: 0.7 }}
+          />
+        </div>
+        <span className="whitespace-nowrap font-mono text-[11px] text-text-dim">
+          <span className="text-[var(--color-green)]">{contested.held} hold</span>{" "}
+          &middot;{" "}
+          <span className="text-[var(--color-red)]">
+            {contested.exited} exited
+          </span>
+        </span>
+        <p className="basis-full text-[12.5px] leading-relaxed text-text-muted">
+          {contested.why}
+        </p>
+      </div>
+    </>
   );
 }
 
-function FooterRow() {
+function PanelFoot() {
   return (
-    <div
-      className="border-t border-white/[0.06] px-5 py-3 flex items-center justify-end"
-      style={{ background: "rgba(255,255,255,0.015)" }}
-    >
-      <Link
-        href="/consensus"
-        className="text-xs font-semibold text-text-dim hover:text-text inline-flex items-center gap-1.5 transition-colors"
-      >
-        Full consensus
-        <span aria-hidden>&rarr;</span>
-      </Link>
+    <div className="flex flex-wrap items-center gap-x-5 gap-y-4 border-t border-white/10 bg-white/[0.02] px-5 py-4">
+      <p className="flex min-w-[260px] flex-1 items-start gap-2 text-xs leading-relaxed text-text-muted">
+        <span aria-hidden>&#9432;</span>
+        <span>
+          Holdings data from public paper portfolios &mdash; shown as
+          observations about model behaviour, not investment recommendations.
+          Not investment advice.
+        </span>
+      </p>
+      <div className="flex flex-wrap items-center gap-3.5">
+        <span className="text-sm font-semibold text-text">
+          Think they&rsquo;re wrong?
+        </span>
+        <Link
+          href="/login"
+          data-cta="consensus-build"
+          className="inline-flex items-center whitespace-nowrap rounded-lg bg-[var(--color-cyan)] px-5 py-3 text-sm font-semibold tracking-tight text-bg transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          style={{
+            boxShadow:
+              "0 10px 30px -10px rgba(0,242,255,0.5), inset 0 1px 0 rgba(255,255,255,0.45)",
+          }}
+        >
+          Enter the arena &mdash; free
+        </Link>
+      </div>
     </div>
   );
 }
 
 function formatSnapshotDate(iso: string): string {
-  // Friendly compact form ("Sun 04 May") that matches the
-  // /consensus page treatment.
   const d = new Date(`${iso}T00:00:00Z`);
   if (Number.isNaN(d.getTime())) return iso;
   return d.toLocaleDateString("en-GB", {

--- a/web/lib/consensus-query.ts
+++ b/web/lib/consensus-query.ts
@@ -88,6 +88,121 @@ export async function getConsensusByDate(
   return { snapshot_date: rows.length > 0 ? snapshot_date : null, rows };
 }
 
+// ---------------------------------------------------------------------------
+// Divergence ("Where they split") — the most-contested ticker this snapshot.
+//
+// A ticker is contested when independent swarms have taken *opposing* live
+// positions on it: some currently hold it, others have exited it inside the
+// lookback window. Both sides must have ≥ 2 swarms (a single dissenter isn't
+// "the arena splitting"). Returns the ticker with the most opposing positions,
+// or null when nothing genuinely qualifies — the homepage hides the strip
+// rather than fabricate divergence.
+// ---------------------------------------------------------------------------
+
+const CONTESTED_LOOKBACK_DAYS = 30;
+const CONTESTED_MIN_PER_SIDE = 2;
+
+export interface ContestedTicker {
+  ticker: string;
+  company_name: string;
+  held: number;
+  exited: number;
+  /** One-line explanation; neutral unless a shared signal is derivable. */
+  why: string;
+}
+
+async function fetchContestedTicker(): Promise<ContestedTicker | null> {
+  const supabase = getSupabase();
+
+  // Current holders per ticker (the same agent population the consensus
+  // snapshot aggregates — agent_holdings, quantity > 0).
+  const { data: holdRows, error: holdErr } = await supabase
+    .from("agent_holdings")
+    .select("ticker, agent_id")
+    .gt("quantity", 0);
+  if (holdErr) {
+    console.error("contested: holdings fetch failed:", holdErr);
+    return null;
+  }
+  const heldBy = new Map<string, Set<string>>();
+  for (const r of (holdRows ?? []) as { ticker: string; agent_id: string }[]) {
+    if (!r.ticker || !r.agent_id) continue;
+    (heldBy.get(r.ticker) ?? heldBy.set(r.ticker, new Set()).get(r.ticker)!).add(
+      r.agent_id,
+    );
+  }
+
+  // Recent sells per ticker.
+  const since = new Date();
+  since.setUTCDate(since.getUTCDate() - CONTESTED_LOOKBACK_DAYS);
+  const { data: sellRows, error: sellErr } = await supabase
+    .from("agent_trades")
+    .select("ticker, agent_id, side, executed_at")
+    .eq("side", "sell")
+    .gte("executed_at", since.toISOString());
+  if (sellErr) {
+    console.error("contested: trades fetch failed:", sellErr);
+    return null;
+  }
+  // "Exited" = sold inside the window AND not currently holding (a full exit,
+  // not a trim followed by a re-buy).
+  const exitedBy = new Map<string, Set<string>>();
+  for (const r of (sellRows ?? []) as {
+    ticker: string;
+    agent_id: string;
+  }[]) {
+    if (!r.ticker || !r.agent_id) continue;
+    if (heldBy.get(r.ticker)?.has(r.agent_id)) continue;
+    (
+      exitedBy.get(r.ticker) ?? exitedBy.set(r.ticker, new Set()).get(r.ticker)!
+    ).add(r.agent_id);
+  }
+
+  // Score the tickers with opposing sides ≥ the floor; most opposing wins,
+  // tiebreak by the more balanced split, then by holders.
+  let best: { ticker: string; held: number; exited: number } | null = null;
+  for (const [ticker, holders] of heldBy) {
+    const held = holders.size;
+    const exited = exitedBy.get(ticker)?.size ?? 0;
+    if (held < CONTESTED_MIN_PER_SIDE || exited < CONTESTED_MIN_PER_SIDE) {
+      continue;
+    }
+    if (
+      !best ||
+      held + exited > best.held + best.exited ||
+      (held + exited === best.held + best.exited &&
+        Math.min(held, exited) > Math.min(best.held, best.exited))
+    ) {
+      best = { ticker, held, exited };
+    }
+  }
+  if (!best) return null;
+
+  const { data: company } = await supabase
+    .from("companies")
+    .select("company_name")
+    .eq("ticker", best.ticker)
+    .maybeSingle();
+  const company_name =
+    (company as { company_name?: string } | null)?.company_name ?? best.ticker;
+
+  // Neutral copy: the firing break signal isn't persisted at sell time, so we
+  // never claim a shared tripped signal we can't prove.
+  return {
+    ticker: best.ticker,
+    company_name,
+    held: best.held,
+    exited: best.exited,
+    why: "Same data, opposite calls.",
+  };
+}
+
+export const getContestedTicker = unstable_cache(
+  fetchContestedTicker,
+  ["consensus-contested-v1"],
+  { revalidate: 600, tags: ["consensus"] },
+);
+
 async function fetchSnapshotRows(
   snapshot_date: string,
 ): Promise<ConsensusRow[]> {


### PR DESCRIPTION
## Summary

Replaces the "AI stock-picker favourites" table — which framed real-ticker holdings as picks (a recommendation reading, and a legal exposure) — with the same data reframed as **observations about model behaviour**: where the swarms agree, and where they split. Per `section4-redesign-brief.md` / `alphamolt-section4-v2.html`.

Follow-on to the hero (#1486), section 2 roster (#1489), and section 3 (#1490) — this PR is just the section 4 commit.

## Changes

- **`web/lib/consensus-query.ts`** — new `getContestedTicker()`: the ticker with the most **opposing** live positions — held by ≥2 swarms **and** exited by ≥2 within a 30-day window (over the same `agent_holdings` / `agent_trades` population the consensus snapshot aggregates). Returns null when nothing genuinely qualifies.
- **`web/components/home-consensus.tsx`** — rewritten to the section 4 design:
  - Eyebrow "Arena data"; headline "Where the swarms agree — and where they split."; lede renders the **live swarm count**; right-aligned snapshot stamp.
  - "Held by" is a **discrete segmented bar** — one segment per swarm in the arena (derived from `total_agents`), n lit = holders. A count, not a continuous gauge. Negative P&L rows stay visible.
  - "▲ Where they split" strip: hold/exit split bar + counts; **hidden entirely when no qualifying ticker** — never fabricates divergence.
  - Disclaimer moved inside the panel footer next to the data; challenge CTA "Think they're wrong? · **Enter the arena — free**" (matches hero/section 2, `data-cta="consensus-build"`); "Full consensus & divergence data →" below.
- **`web/app/page.tsx`** — fetches contested in parallel; **hides the whole section on data failure / empty** (no skeleton with fake tickers).

## Brief verifications

- **P&L metric definition (required):** `consensus_snapshots.swarm_pnl_pct = (price − share-weighted avg entry) / entry` — a **since-entry** position P&L, **not** a 30-day return. Header relabelled **"Holders' P&L (since entry)"** so it never overclaims (the reference HTML's "(30d)" would have).
- **Vocabulary:** grepped clean — "favourites / picks / agents / recommendations" absent from the section; portfolio-runners are "swarms" throughout. The only "recommendations" is inside the mandatory disclaimer ("not investment recommendations"), which is verbatim-required.
- **Divergence explanation:** neutral "Same data, opposite calls." — the firing break signal isn't persisted at sell time, so we never claim a shared tripped signal we can't prove.
- **Mobile (390px):** only the Top holders column hides; ticker, segmented count, and P&L all stay visible (tightened cell padding + stacked the count under the bar).
- **Fallback:** section hides entirely on query failure / empty; segment total = live swarm count; lede count matches.

## Verification

- `tsc --noEmit` + `next build` clean.
- Verified at 1280px and 390px via a throwaway preview route (removed before commit), since the section correctly hides without a live DB.

https://claude.ai/code/session_012vU3y5vqMzqpogt7u95KjY

---
_Generated by [Claude Code](https://claude.ai/code/session_012vU3y5vqMzqpogt7u95KjY)_