### PR TITLE
Screener: give the house presets meaningful filter sets

### DIFF
--- a/web/lib/screen/config.ts
+++ b/web/lib/screen/config.ts
@@ -90,48 +90,68 @@ export const PRESETS: Record<string, Preset> = {
     id: "quality-growth",
     label: "Quality Growth",
     description:
-      "Durable compounders — Rule of 40, fat FCF and gross margins, valuation kept sane.",
+      "Durable compounders — Rule of 40 ≥ 40, double-digit growth, fat gross margins, valuation kept sane.",
     config: {
       ...base,
       brief:
-        "Durable quality compounders: high Rule of 40, fat free cash flow and gross margins, with the valuation kept sane — P/S under 15.",
-      filters: [{ field: "ps", op: "<=", value: 15 }],
+        "Durable quality compounders: Rule of 40 at or above 40, still growing revenue 10%+, with fat gross margins (40%+) and the valuation kept sane — P/S under 15.",
+      filters: [
+        { field: "rule_of_40", op: ">=", value: 40 },
+        { field: "rev_growth_ttm", op: ">=", value: 10 },
+        { field: "gross_margin", op: ">=", value: 40 },
+        { field: "ps", op: "<=", value: 15 },
+      ],
       weights: { quality: 60, value: 25, momentum: 15 },
     },
   },
   "deep-value": {
     id: "deep-value",
     label: "Deep Value",
-    description: "Cheap on sales relative to their own history; quality is secondary.",
+    description:
+      "Cheap on sales vs their own history — but still profitable and not shrinking, to dodge value traps.",
     config: {
       ...base,
       brief:
-        "Cheap on sales relative to their own 12-month history. I'll tolerate weaker quality for the discount — P/S under 8.",
-      filters: [{ field: "ps", op: "<=", value: 8 }],
+        "Cheap on sales relative to their own 12-month history — P/S under 8 — but still profitable (operating margin ≥ 0) and not shrinking (revenue growth ≥ 0), so the discount isn't a value trap.",
+      filters: [
+        { field: "ps", op: "<=", value: 8 },
+        { field: "operating_margin", op: ">=", value: 0 },
+        { field: "rev_growth_ttm", op: ">=", value: 0 },
+      ],
       weights: { quality: 20, value: 60, momentum: 20 },
     },
   },
   momentum: {
     id: "momentum",
     label: "Momentum",
-    description: "Leaders by trailing 52-week price strength, quality as a sanity check.",
+    description:
+      "Price leaders beating SPY, filtered for real growth and decent margins so it's not junk.",
     config: {
       ...base,
       brief:
-        "Market leaders by trailing 52-week price strength, with quality as a sanity check so I'm not just chasing junk.",
-      filters: [],
+        "Market leaders by trailing 52-week price strength — beating SPY by 5%+ — with real revenue growth (10%+) and decent gross margins (25%+) as a quality sanity check so I'm not just chasing junk.",
+      filters: [
+        { field: "perf_52w_vs_spy", op: ">=", value: 5 },
+        { field: "rev_growth_ttm", op: ">=", value: 10 },
+        { field: "gross_margin", op: ">=", value: 25 },
+      ],
       weights: { quality: 25, value: 15, momentum: 60 },
     },
   },
   "high-fcf": {
     id: "high-fcf",
     label: "High FCF",
-    description: "Cash machines — free-cash-flow margin and Rule of 40 lead the score.",
+    description:
+      "Cash machines — high free-cash-flow margin, Rule of 40, and genuine operating profitability.",
     config: {
       ...base,
       brief:
-        "Cash machines: strong free-cash-flow margin (10%+) and Rule of 40 lead the ranking; valuation is secondary.",
-      filters: [{ field: "fcf_margin", op: ">=", value: 10 }],
+        "Cash machines: free-cash-flow margin of 15%+, Rule of 40 at or above 40, and genuine operating profitability (operating margin 10%+). Valuation is secondary.",
+      filters: [
+        { field: "fcf_margin", op: ">=", value: 15 },
+        { field: "rule_of_40", op: ">=", value: 40 },
+        { field: "operating_margin", op: ">=", value: 10 },
+      ],
       weights: { quality: 65, value: 20, momentum: 15 },
     },
   },


### PR DESCRIPTION
Makes the house presets actually *mean* something. (Follow-up to #1499, which merged the read-only filter display — this is the matching substance: real filter sets.)

## The problem

The presets differed almost entirely in their scoring **weights**; their filters barely defined a universe (Quality Growth was just `P/S ≤ 15`). Over the Level 0 **all-equities** universe (not a pre-screened growth set), that still surfaced unprofitable, no-growth names ranked by weight.

## Design constraint

A numeric filter **excludes any name missing that field** (`score.ts:94`), so each fundamental gate also drops names with no fundamentals (most financials/utilities). To avoid compounding that null-exclusion, each preset gates on **3–4 fundamental-derived fields** (present/absent together).

## New filter sets

| Preset | Filters (new) | Weights (unchanged) |
|---|---|---|
| **Quality Growth** | `R40 ≥ 40`, `Rev growth ≥ 10%`, `Gross margin ≥ 40%`, `P/S ≤ 15` | Q60 · V25 · M15 |
| **Deep Value** | `P/S ≤ 8`, `Operating margin ≥ 0`, `Rev growth ≥ 0` | Q20 · V60 · M20 |
| **Momentum** | `vs SPY ≥ +5%`, `Rev growth ≥ 10%`, `Gross margin ≥ 25%` | Q25 · V15 · M60 |
| **High FCF** | `FCF margin ≥ 15%`, `R40 ≥ 40`, `Operating margin ≥ 10%` | Q65 · V20 · M15 |

Each set encodes the preset's *definition* as hard gates (so the candidate universe is right); the weights rank *within* it. Deep Value gains "profitable + not shrinking" so the discount isn't a value trap; Momentum gains a growth/margin sanity check so it isn't chasing junk; Quality Growth and High FCF require the Rule-of-40 / margin floors their names imply. Descriptions + briefs updated to match.

**Thresholds are easily tunable** — I couldn't run the screen here to eyeball counts, so the values are deliberately moderate to avoid an empty default screen. Say the word and I'll loosen/tighten any.

## Verification

- `npx tsc --noEmit` clean.

https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcLaGiXQuMHf8P8BGL2TCU)_