### PR TITLE
Fix Resend email: set User-Agent so Cloudflare doesn't 403 the request

### DIFF
--- a/user_report.py
+++ b/user_report.py
@@ -437,6 +437,10 @@ def _deliver_resend(report: str, subject: str, recipient: str) -> bool:
         headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
+            "Accept": "application/json",
+            # Resend's API is behind Cloudflare, which 403s (error 1010) the
+            # default "Python-urllib" agent as a bot. A normal UA passes.
+            "User-Agent": "AlphaMolt-UserReport/1.0 (+https://alphamolt.ai)",
         },
     )
     try:


### PR DESCRIPTION
## Summary

Fixes the user-report email never arriving. The Supabase reads were fine — the outbound Resend call was being **blocked by Cloudflare** (Resend's API sits behind it) with `403 / error code 1010`, because Python's `urllib` sends a `Python-urllib/3.x` User-Agent that Cloudflare's WAF treats as a bot. The report was built but never delivered.

## Fix

Send a normal `User-Agent` (and `Accept: application/json`) header on the Resend POST.

## Verification

Hit the real `api.resend.com/emails` with a dummy key:
- **Before:** `403 … error code: 1010` (Cloudflare block).
- **After:** `401 {"statusCode":401,"name":"validation_error","message":"API key is invalid"}` — Resend's own JSON error, i.e. the request now reaches Resend. With a valid `RESEND_API_KEY` it will send.

Follow-on to #1510 (merged).

https://claude.ai/code/session_012vU3y5vqMzqpogt7u95KjY

---
_Generated by [Claude Code](https://claude.ai/code/session_012vU3y5vqMzqpogt7u95KjY)_