### PR TITLE
Fix "Create a portfolio" CTAs: link to /login, not /signup (agent registration)

### DIFF
--- a/user_report.py
+++ b/user_report.py
@@ -697,7 +697,18 @@ def _deliver_resend(report: str, subject: str, recipient: str) -> bool:
     try:
         with urllib.request.urlopen(req, timeout=20) as resp:
             ok = 200 <= resp.status < 300
-        logger.info("Resend email %s to %s", "ok" if ok else "failed", recipient)
+            raw = resp.read().decode(errors="replace")
+        msg_id = None
+        try:
+            msg_id = json.loads(raw).get("id")
+        except (ValueError, AttributeError):
+            pass
+        # Accepted by Resend ≠ delivered. Trace this id in the Resend
+        # dashboard (Emails) to see delivered / bounced / dropped + reason.
+        logger.info(
+            "Resend email %s to %s (id=%s) — check Resend dashboard for delivery status",
+            "accepted" if ok else "rejected", recipient, msg_id,
+        )
         return ok
     except urllib.error.HTTPError as exc:  # surface Resend's error body
         body = exc.read().decode(errors="replace")[:300]

--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -772,7 +772,7 @@ function CtaBand({
       <p className="mt-2.5 mb-5 text-[14px] text-text-muted max-w-[520px]">{supporting}</p>
       <div className="flex flex-wrap items-center gap-3">
         <Link
-          href="/signup"
+          href="/login"
           data-cta="company-create"
           className="inline-flex items-center px-5 py-2.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60"
         >
@@ -890,7 +890,7 @@ function PositionLedger({
           entry price, sizing, and the reason it bought.
         </p>
         <Link
-          href="/signup"
+          href="/login"
           data-cta="ledger-create"
           className="inline-block mt-3.5 font-mono text-[13.5px] text-cyan hover:underline"
         >

--- a/web/components/nav.tsx
+++ b/web/components/nav.tsx
@@ -118,7 +118,7 @@ export default function Nav() {
           <NavAuth email={email} ready={ready} />
           {ready && !email && (
             <Link
-              href="/signup"
+              href="/login"
               data-cta="nav-create"
               className="ml-1 inline-flex items-center px-3 py-1.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight transition-[filter] hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-cyan)]/60"
             >
@@ -186,7 +186,7 @@ export default function Nav() {
                     Sign in
                   </Link>
                   <Link
-                    href="/signup"
+                    href="/login"
                     data-cta="nav-create"
                     onClick={() => setMenuOpen(false)}
                     className="mt-1 inline-flex items-center px-3 py-1.5 rounded-lg bg-[var(--color-cyan)] text-bg text-sm font-semibold tracking-tight"


### PR DESCRIPTION
## Summary

Fixes a wrong-destination bug: the **"Create a portfolio"** CTAs pointed to `/signup`, which is the **agent-handle registration** page ("Reserve your agent handle"), not the portfolio-creation flow — so clicking "Create a portfolio" sent people to *build an agent* instead.

The create-a-portfolio path is the passwordless **`/login`** (the signup page's own "Sign in and run a portfolio →" link goes there, and the homepage hero/section CTAs already use it).

## Changes

Repoints all four CTAs from `/signup` → `/login`:
- `components/nav.tsx` — the global "Create a portfolio" button (desktop + mobile).
- `app/company/[ticker]/page.tsx` — the CTA band ("Create your portfolio") and the position-ledger invitation ("Create a portfolio with a [sector] brief").

(If this PR also carries the prior small commit logging the Resend message id in `user_report.py`, that's incidental to the same branch — the headline change is the link fix.)

## Verification

`tsc --noEmit` clean.

## Open question for the reviewer

The nav "Create a portfolio" button is **global** (from the company-page brief P4.1), so it also shows on the homepage where the hero already has "Enter the arena — free". Happy to remove the nav button if you'd prefer the homepage not doubled-up — say the word.

https://claude.ai/code/session_012vU3y5vqMzqpogt7u95KjY

---
_Generated by [Claude Code](https://claude.ai/code/session_012vU3y5vqMzqpogt7u95KjY)_