### PR TITLE
Add per-portfolio rebalance cadence toggle (daily | weekly)

### DIFF
--- a/.github/workflows/agent-heartbeat.yml
+++ b/.github/workflows/agent-heartbeat.yml
@@ -1,13 +1,14 @@
 name: Agent Heartbeat
 
-# Weekly rebalance loop. Every agent row with a non-null `strategy` and a
+# Daily rebalance loop. Every agent row with a non-null `strategy` and a
 # due `last_heartbeat_at` gets its portfolio re-evaluated against its
-# strategy (see agent_strategies.STRATEGIES).
+# strategy (see agent_strategies.STRATEGIES). Each agent / portfolio member
+# only rebalances when its own `heartbeat_interval_hours` cadence is due, so
+# most daily runs are cheap no-op skips — a daily curator and a weekly buyer
+# coexist in one portfolio (migration 029).
 #
-# Sunday 07:00 UTC — runs at the end of the Sunday morning data block,
-# after every input the picker depends on has refreshed:
-#   04:00 bear-evaluation   (refreshes companies.bear_eval)
-#   04:30 bull-evaluation   (refreshes companies.bull_eval)
+# 07:00 UTC daily — runs at the end of the morning data block, after every
+# input the picker depends on has refreshed:
 #   05:00 score-ai-analysis (composite scores + sort_order)
 #   05:30 portfolio-valuation
 #   06:00 universe-snapshot (the JSON the picker reads)
@@ -15,7 +16,7 @@ name: Agent Heartbeat
 
 on:
   schedule:
-    - cron: "0 7 * * 0"
+    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       handle:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -739,8 +739,15 @@ One row per signed-in human (migration 023). Auto-provisioned by a trigger on
 ```
 id (UUID PK), slug (UNIQUE), display_name, description,
 owner_agent_id (FK → agents, nullable), owner_user_id (FK → profiles, nullable),
-is_public, mode ('paper' | 'live'), launched_at, last_heartbeat_at, created_at, updated_at
+is_public, mode ('paper' | 'live'), rebalance_cadence ('daily' | 'weekly'),
+launched_at, last_heartbeat_at, created_at, updated_at
 ```
+`rebalance_cadence` (migration 051, default `'weekly'`) is the owner-set
+rebalance frequency — the heartbeat re-evaluates the portfolio at most every
+24h (`daily`) or 168h (`weekly`) via `agent_heartbeat._portfolio_is_due`. The
+heartbeat workflow runs daily (`0 7 * * *`); this column decides how often each
+portfolio actually acts on a tick. Owner toggle on the portfolio page
+(`rebalance-cadence-toggle.tsx` → `setPortfolioRebalanceCadence`).
 Introduced by migration 021; ownership + visibility added by 024, launch +
 heartbeat columns by 025 (the launch concept was removed in 031). Exactly
 one owner kind per row (`CHECK`): legacy agent portfolios have

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -282,15 +282,28 @@ def _run_one(
     return status
 
 
-# Human portfolios rebalance weekly, matching the default agent cadence.
+# Human portfolios rebalance weekly by default, matching the default agent
+# cadence. Owners can opt a portfolio into a daily cadence via the
+# portfolios.rebalance_cadence toggle (migration 051).
 PORTFOLIO_HEARTBEAT_INTERVAL_HOURS = 168
+PORTFOLIO_CADENCE_HOURS = {"daily": 24, "weekly": 168}
+
+
+def _portfolio_interval_hours(portfolio: dict) -> int:
+    """The min hours between rebalances for this portfolio (migration 051).
+
+    Reads portfolios.rebalance_cadence ('daily' | 'weekly'); anything else
+    (including NULL on a pre-migration row) falls back to the weekly default.
+    """
+    cadence = (portfolio.get("rebalance_cadence") or "weekly").strip().lower()
+    return PORTFOLIO_CADENCE_HOURS.get(cadence, PORTFOLIO_HEARTBEAT_INTERVAL_HOURS)
 
 
 def _portfolio_is_due(portfolio: dict, now: datetime) -> bool:
     last = _parse_ts(portfolio.get("last_heartbeat_at"))
     if last is None:
         return True
-    return now >= last + timedelta(hours=PORTFOLIO_HEARTBEAT_INTERVAL_HOURS)
+    return now >= last + timedelta(hours=_portfolio_interval_hours(portfolio))
 
 
 def _resolve_member_mandate(member_row: dict, portfolio_mandate: str | None) -> str | None:

--- a/migrations/051_portfolio_rebalance_cadence.sql
+++ b/migrations/051_portfolio_rebalance_cadence.sql
@@ -1,0 +1,33 @@
+-- Migration 051: per-portfolio rebalance cadence toggle (daily | weekly).
+--
+-- The agent heartbeat gates a whole portfolio on portfolios.last_heartbeat_at
+-- via a hardcoded interval (agent_heartbeat._portfolio_is_due,
+-- PORTFOLIO_HEARTBEAT_INTERVAL_HOURS = 168). That fixed weekly cadence is now
+-- owner-configurable: a portfolio can opt into a DAILY rebalance instead.
+--
+--   weekly (default) → the portfolio is re-evaluated at most every 168h
+--   daily            → the portfolio is re-evaluated at most every 24h
+--
+-- The heartbeat workflow itself runs daily (.github/workflows/agent-heartbeat.yml,
+-- "0 7 * * *"); this column decides how often each portfolio actually acts on a
+-- tick. Default is 'weekly' so existing portfolios keep their current behaviour.
+--
+-- Additive & idempotent. Paste-and-run in the Supabase SQL editor.
+
+ALTER TABLE portfolios
+    ADD COLUMN IF NOT EXISTS rebalance_cadence TEXT NOT NULL DEFAULT 'weekly';
+
+-- Constrain to the two supported values. Guarded so re-running is a no-op.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'portfolios_rebalance_cadence_check'
+    ) THEN
+        ALTER TABLE portfolios
+            ADD CONSTRAINT portfolios_rebalance_cadence_check
+            CHECK (rebalance_cadence IN ('daily', 'weekly'));
+    END IF;
+END $$;
+
+COMMENT ON COLUMN portfolios.rebalance_cadence IS
+    'How often the heartbeat re-evaluates this portfolio: daily (24h) or weekly (168h, default). See agent_heartbeat._portfolio_is_due.';

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Nav from "@/components/nav";
 import HoldingsList from "@/components/holdings-list";
 import { TradeTape, type Trade } from "@/components/trade-tape";
 import VisibilityToggle from "@/components/portfolio/visibility-toggle";
+import RebalanceCadenceToggle from "@/components/portfolio/rebalance-cadence-toggle";
 import TeamBuilder from "@/components/portfolio/team-builder";
 import TeamScheduleNote from "@/components/portfolio/team-schedule-note";
 import BetaDisclaimer from "@/components/beta-disclaimer";
@@ -258,6 +259,12 @@ export default async function PortfolioPage({ params }: PageParams) {
                   holdingsCount={holdingsCount}
                 />
               )}
+              {isOwner && mode !== "live" && (
+                <RebalanceCadenceToggle
+                  portfolioId={portfolio.id}
+                  cadence={portfolio.rebalance_cadence}
+                />
+              )}
               {/* Owner-only real-money marker (migration 036). */}
               {isOwner && mode === "live" && (
                 <>
@@ -310,7 +317,7 @@ export default async function PortfolioPage({ params }: PageParams) {
                       "none yet"
                     ) : (
                       <span className="text-[var(--color-green)]">
-                        <TeamScheduleNote />
+                        <TeamScheduleNote cadence={portfolio.rebalance_cadence} />
                       </span>
                     )
                   }

--- a/web/components/portfolio/rebalance-cadence-toggle.tsx
+++ b/web/components/portfolio/rebalance-cadence-toggle.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { setPortfolioRebalanceCadence } from "@/lib/portfolios-mutations";
+
+/**
+ * Owner control for how often the heartbeat re-evaluates the portfolio
+ * (migration 051). A compact two-segment switch — Weekly (default) | Daily —
+ * sitting next to the visibility pill in the page-header row.
+ *
+ * The heartbeat workflow runs every day, but each portfolio only acts on a
+ * tick once its cadence has elapsed (agent_heartbeat._portfolio_is_due), so
+ * Weekly rebalances ~once a week and Daily reconsiders every day.
+ */
+export default function RebalanceCadenceToggle({
+  portfolioId,
+  cadence,
+}: {
+  portfolioId: string;
+  cadence: "daily" | "weekly";
+}) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function setCadence(next: "daily" | "weekly") {
+    if (next === cadence || pending) return;
+    setError(null);
+    startTransition(async () => {
+      const result = await setPortfolioRebalanceCadence({
+        portfolioId,
+        cadence: next,
+      });
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  const options: { value: "weekly" | "daily"; label: string }[] = [
+    { value: "weekly", label: "Weekly" },
+    { value: "daily", label: "Daily" },
+  ];
+
+  return (
+    <div className="inline-flex flex-col gap-1">
+      <span
+        className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.02] px-3 py-1 text-[11px] font-mono uppercase tracking-[0.14em]"
+        title="How often your team re-evaluates this portfolio. Weekly rebalances about once a week; Daily reconsiders every day."
+      >
+        <span className="text-text-muted">Rebalance</span>
+        <span aria-hidden className="text-text-muted/60">
+          ·
+        </span>
+        <span
+          role="group"
+          aria-label="Rebalance cadence"
+          className="inline-flex items-center gap-0.5"
+        >
+          {options.map((opt) => {
+            const active = cadence === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setCadence(opt.value)}
+                disabled={pending}
+                aria-pressed={active}
+                className={`rounded px-1.5 py-0.5 transition-colors disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-text/40 ${
+                  active
+                    ? "text-[var(--color-green)]"
+                    : "text-text-muted hover:text-text disabled:opacity-50"
+                }`}
+              >
+                {pending && !active ? "…" : opt.label}
+              </button>
+            );
+          })}
+        </span>
+      </span>
+      {error && (
+        <span className="text-xs text-[var(--color-red)] font-mono">{error}</span>
+      )}
+    </div>
+  );
+}

--- a/web/components/portfolio/team-schedule-note.tsx
+++ b/web/components/portfolio/team-schedule-note.tsx
@@ -1,18 +1,28 @@
 "use client";
 
 /**
- * The summary "Team" card's status line: "scheduled · next run Sun 08:00".
- * The next run is the next weekly heartbeat tick, shown in the viewer's local
+ * The summary "Team" card's status line: "scheduled · next run Tue 08:00".
+ * The next run is the next heartbeat tick for the portfolio's rebalance
+ * cadence (migration 051) — daily or weekly — shown in the viewer's local
  * time. Computed after mount (Date.now()) so server and first client render
  * agree — avoiding a hydration mismatch on a time value.
  */
 
 import { useEffect, useState } from "react";
-import { nextHeartbeatTick, shortRunLabel } from "@/lib/agents/schedule";
+import { nextRunForCadence, shortRunLabel } from "@/lib/agents/schedule";
 
-export default function TeamScheduleNote() {
+export default function TeamScheduleNote({
+  cadence = "weekly",
+}: {
+  cadence?: "daily" | "weekly";
+}) {
   const [now, setNow] = useState<number | null>(null);
   useEffect(() => setNow(Date.now()), []);
   if (now == null) return <>scheduled</>;
-  return <>scheduled · next run {shortRunLabel(nextHeartbeatTick(now))}</>;
+  return (
+    <>
+      {cadence === "daily" ? "daily" : "weekly"} · next run{" "}
+      {shortRunLabel(nextRunForCadence(now, cadence))}
+    </>
+  );
 }

--- a/web/lib/agents/schedule.ts
+++ b/web/lib/agents/schedule.ts
@@ -1,15 +1,16 @@
 /**
  * Heartbeat-schedule helpers — client-safe, no server imports.
  *
- * The rebalance automation runs on a fixed weekly cron: Sunday 07:00 UTC
- * (.github/workflows/agent-heartbeat.yml: "0 7 * * 0"). Each agent acts on that
- * tick once its own cadence (heartbeat_interval_hours) has elapsed, so the next
- * run is deterministic — the next Sunday-07:00-UTC at/after the agent's due
- * time. Keep this the single source of the cron constant; if the workflow
- * schedule changes, change it here.
+ * The rebalance automation runs on a daily cron: 07:00 UTC every day
+ * (.github/workflows/agent-heartbeat.yml: "0 7 * * *"). Each agent / portfolio
+ * acts on that tick once its own cadence has elapsed (an agent's
+ * heartbeat_interval_hours; a portfolio's rebalance_cadence, migration 051), so
+ * the next run is deterministic — the next 07:00-UTC at/after the due time.
+ * Keep this the single source of the cron constant; if the workflow schedule
+ * changes, change it here.
  */
 
-export const HEARTBEAT_UTC_DAY = 0; // Sunday
+export const HEARTBEAT_WEEKLY_UTC_DAY = 0; // Sunday — the weekly-cadence anchor
 export const HEARTBEAT_UTC_HOUR = 7; // 07:00 UTC
 
 /** Coarse relative duration: "just now" / "5m" / "3h" / "5d". */
@@ -43,10 +44,11 @@ export function shortRunLabel(ts: number): string {
   });
 }
 
-/** The smallest Sunday-07:00-UTC instant at or after `after`. */
+/** The smallest 07:00-UTC instant (any day) at or after `after` — the daily
+ *  cron tick the heartbeat fires on. */
 export function nextHeartbeatTick(after: number): number {
   const d = new Date(after);
-  let cand = Date.UTC(
+  const todayTick = Date.UTC(
     d.getUTCFullYear(),
     d.getUTCMonth(),
     d.getUTCDate(),
@@ -55,13 +57,30 @@ export function nextHeartbeatTick(after: number): number {
     0,
     0,
   );
-  for (let i = 0; i < 8; i++) {
-    if (new Date(cand).getUTCDay() === HEARTBEAT_UTC_DAY && cand >= after) {
-      return cand;
-    }
+  return todayTick >= after ? todayTick : todayTick + 86_400_000;
+}
+
+/** The smallest Sunday-07:00-UTC instant at or after `after` — the tick a
+ *  weekly-cadence portfolio next acts on. */
+export function nextWeeklyHeartbeatTick(after: number): number {
+  let cand = nextHeartbeatTick(after);
+  for (let i = 0; i < 7; i++) {
+    if (new Date(cand).getUTCDay() === HEARTBEAT_WEEKLY_UTC_DAY) return cand;
     cand += 86_400_000;
   }
   return cand;
+}
+
+/** Next run tick for a portfolio's rebalance cadence (migration 051): the next
+ *  daily 07:00-UTC tick for 'daily', the next Sunday 07:00-UTC tick for
+ *  'weekly'. A coarse "when does this portfolio next act" hint. */
+export function nextRunForCadence(
+  after: number,
+  cadence: "daily" | "weekly",
+): number {
+  return cadence === "daily"
+    ? nextHeartbeatTick(after)
+    : nextWeeklyHeartbeatTick(after);
 }
 
 /**

--- a/web/lib/home-roster-query.ts
+++ b/web/lib/home-roster-query.ts
@@ -138,7 +138,7 @@ function nonEmpty(s: string | null | undefined): string | null {
   return t.length > 0 ? t : null;
 }
 
-// UTC label for the next weekly heartbeat tick, e.g. "Sun 07:00 UTC".
+// UTC label for the next daily heartbeat tick, e.g. "Mon 07:00 UTC".
 function nextRunLabel(now: number): string {
   const d = new Date(nextHeartbeatTick(now));
   const day = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][d.getUTCDay()];

--- a/web/lib/portfolios-mutations.ts
+++ b/web/lib/portfolios-mutations.ts
@@ -368,6 +368,41 @@ export async function setPortfolioVisibility(input: {
   return { ok: true };
 }
 
+/**
+ * Owner control for how often the heartbeat re-evaluates the portfolio
+ * (migration 051): 'daily' (24h) or 'weekly' (168h, default). Mirrors
+ * setPortfolioVisibility — single update with the ownership check in the
+ * WHERE clause, no pre-write lookup.
+ */
+export async function setPortfolioRebalanceCadence(input: {
+  portfolioId: string;
+  cadence: "daily" | "weekly";
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+
+  if (input.cadence !== "daily" && input.cadence !== "weekly") {
+    return { ok: false, error: "Cadence must be daily or weekly." };
+  }
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("portfolios")
+    .update({ rebalance_cadence: input.cadence })
+    .eq("id", input.portfolioId)
+    .eq("owner_user_id", user.id)
+    .select("slug")
+    .maybeSingle();
+
+  if (error) {
+    console.error("setPortfolioRebalanceCadence failed:", error);
+    return { ok: false, error: "Could not update rebalance cadence. Try again." };
+  }
+  if (!data) return { ok: false, error: NOT_FOUND_ERROR };
+
+  revalidate(data.slug);
+  return { ok: true };
+}
+
 interface ResolvedAgent {
   id: string;
   available_for_hire: boolean;

--- a/web/lib/portfolios-query.ts
+++ b/web/lib/portfolios-query.ts
@@ -29,6 +29,8 @@ export interface Portfolio {
   screen_config: Record<string, unknown> | null;
   /** Swarm draft settings (migration 041); presence opts into the swarm. */
   draft_config: Record<string, unknown> | null;
+  /** How often the heartbeat re-evaluates this portfolio (migration 051). */
+  rebalance_cadence: "daily" | "weekly";
 }
 
 /**
@@ -38,7 +40,7 @@ export interface Portfolio {
  * server serializes to the browser. Read `mode` only via `getPortfolioMode`.
  */
 const PORTFOLIO_COLUMNS =
-  "id, slug, display_name, description, owner_agent_id, owner_user_id, is_public, created_at, updated_at, screen_config, draft_config";
+  "id, slug, display_name, description, owner_agent_id, owner_user_id, is_public, created_at, updated_at, screen_config, draft_config, rebalance_cadence";
 
 /**
  * The owner-only paper/live mode of a portfolio (migration 036). Gated on a


### PR DESCRIPTION
## Summary
Implements migration 051: owner-configurable rebalance cadence for human portfolios. Portfolios can now opt into a **daily** (24h) rebalance cycle instead of the default **weekly** (168h), while the heartbeat workflow itself runs daily.

## Key Changes

**Database & Backend**
- Migration 051: adds `rebalance_cadence` column to `portfolios` table (default `'weekly'`, constrained to `'daily'` | `'weekly'`)
- `setPortfolioRebalanceCadence()` server action mirrors `setPortfolioVisibility()` pattern — single update with ownership check in WHERE clause
- `agent_heartbeat.py`: refactored `_portfolio_is_due()` to read per-portfolio cadence via `_portfolio_interval_hours()` helper; falls back to weekly default for pre-migration rows

**Heartbeat Schedule**
- `.github/workflows/agent-heartbeat.yml`: changed cron from `"0 7 * * 0"` (Sunday) to `"0 7 * * *"` (daily at 07:00 UTC)
- `web/lib/agents/schedule.ts`: 
  - `nextHeartbeatTick()` now returns the next daily 07:00-UTC tick (any day)
  - New `nextWeeklyHeartbeatTick()` for Sunday 07:00-UTC anchor
  - New `nextRunForCadence()` helper that dispatches to daily or weekly based on portfolio cadence
  - Renamed `HEARTBEAT_UTC_DAY` → `HEARTBEAT_WEEKLY_UTC_DAY` for clarity

**UI Components**
- New `RebalanceCadenceToggle` component: compact two-segment switch (Weekly | Daily) in the portfolio page header, owner-only, paper-mode only
- `TeamScheduleNote`: updated to accept `cadence` prop and display "daily" or "weekly" prefix + compute next run via `nextRunForCadence()`
- Portfolio page: conditionally renders `RebalanceCadenceToggle` for owners in paper mode; passes cadence to `TeamScheduleNote`

**Type & Query Updates**
- `Portfolio` interface: added `rebalance_cadence: "daily" | "weekly"` field
- `PORTFOLIO_COLUMNS` query: includes `rebalance_cadence` in SELECT
- `CLAUDE.md`: documented the new column and its behavior

## Implementation Details
- The heartbeat workflow now runs **every day**, but each portfolio only acts when its cadence is due (checked in `_portfolio_is_due()`)
- Cadence is read from the database row; pre-migration rows (NULL) safely default to weekly
- UI toggle is owner-only and hidden in live mode (matching visibility toggle pattern)
- Next-run calculations are deterministic and timezone-aware (computed client-side post-mount to avoid hydration mismatches)

https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8