### PR TITLE
Add screener rejections (90-day auto-hide) + demo portfolio seeding

### DIFF
--- a/.github/workflows/seed-dummy-portfolio.yml
+++ b/.github/workflows/seed-dummy-portfolio.yml
@@ -1,0 +1,63 @@
+name: Seed Dummy Portfolio
+
+# Operator tool — fabricate (or tear down) a fully-consistent demo portfolio
+# that looks like it has been trading on Alphamolt for 30+ days. Manual
+# trigger only; defaults to a dry run that plans + verifies without writing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Plan + verify only — don't write rows"
+        required: false
+        type: boolean
+        default: true
+      teardown:
+        description: "Remove the dummy portfolio + owner instead of creating"
+        required: false
+        type: boolean
+        default: false
+      slug:
+        description: "Portfolio slug (default meridian-growth)"
+        required: false
+        type: string
+      days:
+        description: "Calendar days of history (default 45, min 42)"
+        required: false
+        type: string
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Run seeder
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          pip install -r requirements.txt
+          ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          if [ "${{ inputs.teardown }}" = "true" ]; then
+            ARGS="$ARGS --teardown"
+          fi
+          if [ -n "${{ inputs.slug }}" ]; then
+            ARGS="$ARGS --slug ${{ inputs.slug }}"
+          fi
+          if [ -n "${{ inputs.days }}" ]; then
+            ARGS="$ARGS --days ${{ inputs.days }}"
+          fi
+          python seed_dummy_portfolio.py $ARGS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,6 +507,29 @@ emails it (Resend when `RESEND_API_KEY` is set, else `SMTP_*`) — all no-op wit
 a warning when their env is unset. The daily `user-report.yml` cron emails the
 `--story` version. Flags: `--days N`, `--window-hours N`, `--quiet`.
 
+### seed_dummy_portfolio.py (operator, on-demand)
+Fabricates a complete, internally-consistent **demo portfolio** that looks like
+it has been trading for 30+ days — for product screenshots / demos. Creates
+everything a mature human-owned paper portfolio has: a dummy owner (auth user +
+profile, back-dated, lifecycle-email ledger pre-seeded so the crons never email
+it), the portfolios row (mandate, `screen_config`, `mode='paper'`, flipped
+public once ≥15 holdings exist), a $1M `portfolio_accounts` row back-dated ~45
+days, a hired team in `portfolio_agents` (two library Conviction Buyers +
+the Reviewer, role-tagged with per-instance config), an `agent_trades` tape
+whose fills use **real historical closes** from `prices_daily` on their
+historical dates (cash-chained end to end), `investment_theses` per BUY
+(snapshot frozen at fill price, agent-authored text + extend/break signals,
+superseded/broken lifecycle), buyer-attributed `portfolio_holdings`, daily
+`agent_portfolio_history` rows valued at each day's real close, and
+`agent_heartbeats` journals (buyers daily, reviewer weekly). Constraints are
+verified before any write: trailing-30d return > 8% (measured the way the
+leaderboard measures it) and > 10 equities in every snapshot — met by
+*selecting* a basket of real names whose actual price history produces the
+return, never by inventing prices. Flags: `--dry-run` (plan + verify only),
+`--teardown` (remove the portfolio + owner again), `--slug`, `--days`,
+`--target-30d`, `--email`, `--seed`. Workflow: `seed-dummy-portfolio.yml`
+(manual dispatch, dry-run default ON).
+
 ### lifecycle_emails.py (every 30 min)
 Automated lifecycle emails to human users (`profiles`), gated by the
 send-once ledger `lifecycle_email_sends` (migration 050) so no user ever

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,30 @@ Deterministic scoring-as-a-function (Python mirror of
 candidates(db, portfolio_id)` returns the top N `{ticker: rationale}` that both
 buyers (`watchlist_buyer`, `llm_watchlist_buyer`) now trade from. Pure, no LLM.
 
+### Screener rejections — per-portfolio 90-day auto-hide (migration 051)
+When a portfolio's BUY agent (`llm_watchlist_buyer`) evaluates a candidate and
+**doesn't buy it** — a PASS verdict, or a BUY below its conviction gate — the
+name is recorded in `screener_rejections` (`(portfolio_id, ticker)` PK,
+`expires_at` = now + 90d, `rejected_by_agent_id`, `verdict`, `conviction`,
+`reason`, `restored_at`). The screener's **`hideRejected`** toggle (in
+`screen_config`, **on by default**) then drops those names from BOTH the
+screener results and the buyer's candidate pool for 90 days, so the agent
+doesn't churn straight back into re-evaluating a name it just passed on. A
+5/5 BUY that merely ran out of cash is **not** a rejection (still wanted). The
+owner can **restore** a name early (sets `restored_at`); a later re-rejection
+re-arms the hide. An actual buy clears any stale rejection. This is the
+per-portfolio cousin of the manual, global 1-year `screener_exclusions`
+(migration 048). Applied at read time, honouring `hideRejected`:
+`screen.portfolio_screen_candidates()` (Python buyer pool, via
+`db.get_active_screener_rejections`), `web/lib/screen/query.ts runScreen(...,
+rejected)` + `web/app/api/screen/route.ts` (the live re-rank). RLS: service-role
+only (a rejection list can belong to a private portfolio, so unlike
+`screener_exclusions` it is **not** public-read; the website reads it
+server-side). The screener page SSR stays anonymous/ISR-cached — the toggle's
+filtering + restore panel are resolved client-side via `/api/screen` once the
+viewer is known signed-in. Owner UI: `web/lib/screen/rejections-{query,
+mutations}.ts` + the toggle/restore panel in `web/app/screener/screener-client.tsx`.
+
 ## Portfolio swarm — multi-buyer / multi-reviewer coordination
 
 A portfolio runs a **swarm**: multiple specialist buyers + reviewers over one

--- a/db.py
+++ b/db.py
@@ -839,6 +839,96 @@ class SupabaseDB:
             if r.get("ticker")
         }
 
+    # ------------------------------------------------------------------
+    # Screener rejections (migration 051) — per-portfolio 90-day auto-hide
+    # of names a BUY agent evaluated and passed on. Cousin of the manual,
+    # global screener_exclusions (migration 048). Service-role only.
+    # ------------------------------------------------------------------
+
+    def get_active_screener_rejections(self, portfolio_id: str) -> set[str]:
+        """Tickers this portfolio's buyer evaluated and passed on, still within
+        the 90-day window and not manually restored. Upper-cased.
+
+        Fail-open: a read error (e.g. the table not yet migrated) returns an
+        empty set rather than blocking the screen / buyer.
+        """
+        if not portfolio_id:
+            return set()
+        try:
+            resp = (
+                self.client.table("screener_rejections")
+                .select("ticker")
+                .eq("portfolio_id", portfolio_id)
+                .gt("expires_at", date.today().isoformat())
+                .is_("restored_at", "null")
+                .execute()
+            )
+        except Exception:  # noqa: BLE001
+            return set()
+        return {
+            str(r.get("ticker") or "").upper()
+            for r in (resp.data or [])
+            if r.get("ticker")
+        }
+
+    def record_screener_rejections(
+        self, portfolio_id: str, rows: list[dict], *, days: int = 90,
+    ) -> int:
+        """Upsert one rejection per row for a portfolio (migration 051).
+
+        Each row: ``{ticker, rejected_by_agent_id?, verdict?, conviction?,
+        reason?}``. The expiry window is refreshed to ``now + days`` and any
+        prior manual ``restored_at`` is cleared, so a fresh rejection re-arms
+        the hide. Returns the number of rows written. Best-effort: a write
+        failure is swallowed (the buyer must never crash on bookkeeping).
+        """
+        if not portfolio_id or not rows:
+            return 0
+        from datetime import datetime, timezone, timedelta
+        now = datetime.now(timezone.utc)
+        expires = (now + timedelta(days=days)).isoformat()
+        payload = []
+        for r in rows:
+            ticker = str(r.get("ticker") or "").upper()
+            if not ticker:
+                continue
+            payload.append({
+                "portfolio_id": portfolio_id,
+                "ticker": ticker,
+                "rejected_at": now.isoformat(),
+                "expires_at": expires,
+                "rejected_by_agent_id": r.get("rejected_by_agent_id"),
+                "verdict": r.get("verdict"),
+                "conviction": r.get("conviction"),
+                "reason": (r.get("reason") or None),
+                "restored_at": None,
+            })
+        if not payload:
+            return 0
+        try:
+            self.client.table("screener_rejections").upsert(
+                payload, on_conflict="portfolio_id,ticker"
+            ).execute()
+        except Exception:  # noqa: BLE001
+            return 0
+        return len(payload)
+
+    def clear_screener_rejection(self, portfolio_id: str, ticker: str) -> None:
+        """Drop a rejection outright — used when the name is actually bought,
+        so a later sell+re-screen isn't shadowed by a stale rejection. Idempotent."""
+        if not portfolio_id or not ticker:
+            return
+        try:
+            (
+                self.client.table("screener_rejections")
+                .delete()
+                .eq("portfolio_id", portfolio_id)
+                .eq("ticker", str(ticker).upper())
+                .execute()
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
     def upsert_portfolio_snapshot(self, data: dict) -> None:
         """Insert or update a daily agent_portfolio_history row.
 

--- a/llm_watchlist_buyer.py
+++ b/llm_watchlist_buyer.py
@@ -649,6 +649,32 @@ def rebalance_llm_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
         if e["verdict"] == "BUY" and e["conviction"] >= min_conviction
     ]
     result.notes["phase1_qualifying"] = len(qualifying)
+
+    # Record the names this buyer evaluated and passed on — a PASS verdict, or
+    # a BUY below the conviction gate (i.e. it looked and didn't pull the
+    # trigger). The screener's "hide rejected" toggle drops these for 90 days
+    # (migration 051) so the buyer doesn't churn back into re-evaluating them.
+    # A 5/5 BUY that just ran out of cash is NOT a rejection — it's still
+    # wanted — so we key off the agent's verdict, not whether a fill happened.
+    # Always recorded (the toggle governs display, not capture); never in
+    # dry-run.
+    if not ctx.dry_run:
+        qualifying_tickers = {e["ticker"] for e in qualifying}
+        rejected_rows = [
+            {
+                "ticker": e["ticker"],
+                "rejected_by_agent_id": ctx.agent["id"],
+                "verdict": e.get("verdict"),
+                "conviction": e.get("conviction"),
+                "reason": (e.get("rationale") or "")[:240] or None,
+            }
+            for e in evaluations
+            if e["ticker"] not in qualifying_tickers
+        ]
+        if rejected_rows:
+            n = ctx.db.record_screener_rejections(ctx.portfolio_id, rejected_rows)
+            result.notes["screener_rejections_recorded"] = n
+
     if not qualifying:
         result.notes["reason"] = "no candidates met the conviction threshold"
         return result
@@ -735,6 +761,9 @@ def rebalance_llm_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
         try:
             ctx.buy(ticker, item["qty"], note=note, thesis=thesis)
             result.buys += 1
+            # Clear any stale rejection — we now own it, so it must never be
+            # shadowed as "rejected" on the screener (migration 051).
+            ctx.db.clear_screener_rejection(ctx.portfolio_id, ticker)
         except PortfolioError as exc:
             result.errors.append(f"buy {ticker} x{item['qty']}: {exc}")
 

--- a/migrations/051_screener_rejections.sql
+++ b/migrations/051_screener_rejections.sql
@@ -1,0 +1,51 @@
+-- Migration 051: per-portfolio screener rejections (90-day auto-hide).
+--
+-- When a portfolio's BUY agent evaluates a candidate for purchase and DOESN'T
+-- buy it (a PASS verdict, or a BUY below its conviction gate), the name is
+-- recorded here. The screener's "hide rejected" toggle (on by default, stored
+-- in portfolios.screen_config.hideRejected) then drops it from BOTH the
+-- screener results and the buyer's candidate pool for 90 days, so the agent
+-- doesn't churn straight back to re-evaluating a name it just passed on. The
+-- owner can manually restore a name early from the screener.
+--
+-- This is the per-portfolio cousin of the manual, global 1-year blocklist in
+-- migration 048 (screener_exclusions). Two differences:
+--   * scoped to a portfolio (a name one mandate passes on is still visible to
+--     another portfolio with a different mandate);
+--   * auto-populated by the buyer (llm_watchlist_buyer), refreshed on each
+--     re-rejection, cleared on an actual buy, expiring after 90 days.
+--
+-- Applied at read time, honouring screen_config.hideRejected:
+--   * screen.py  portfolio_screen_candidates()  -> the Python buyer's pool
+--   * web/lib/screen/query.ts runScreen(..., rejected)  -> the screener page
+--   * web/app/api/screen/route.ts               -> the live re-rank
+--
+-- RLS: enabled with NO policies, so ONLY the service role can read or write.
+-- Unlike screener_exclusions (public-read), a portfolio's rejection list can
+-- belong to a PRIVATE portfolio, so it must not be world-readable. The website
+-- reads it server-side with the service key; the Python buyer bypasses RLS.
+--
+-- Additive & idempotent.
+
+CREATE TABLE IF NOT EXISTS screener_rejections (
+    portfolio_id        UUID NOT NULL REFERENCES portfolios(id) ON DELETE CASCADE,
+    ticker              TEXT NOT NULL,
+    rejected_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at          TIMESTAMPTZ NOT NULL,
+    rejected_by_agent_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+    verdict             TEXT,          -- 'PASS' | 'BUY' (sub-gate) — the agent's call
+    conviction          INT,           -- 1-5, the agent's conviction at evaluation
+    reason              TEXT,          -- short rationale snippet (the "why")
+    restored_at         TIMESTAMPTZ,   -- set when the owner manually restores it early
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (portfolio_id, ticker)
+);
+
+-- Active-rejection lookups: WHERE portfolio_id = ? AND expires_at > now()
+-- AND restored_at IS NULL.
+CREATE INDEX IF NOT EXISTS idx_screener_rejections_active
+    ON screener_rejections (portfolio_id, expires_at)
+    WHERE restored_at IS NULL;
+
+ALTER TABLE screener_rejections ENABLE ROW LEVEL SECURITY;
+-- No policies → service-role only (matches lifecycle_email_sends, migration 050).

--- a/screen.py
+++ b/screen.py
@@ -301,6 +301,17 @@ def portfolio_screen_candidates(db, portfolio_id: str | None) -> dict[str, str |
     if not cfg:
         return {}
     ranked = run_screen(db, cfg)
+    # Hide names this portfolio's buyer evaluated and passed on within the last
+    # 90 days (migration 051), so the buyer doesn't churn straight back into
+    # re-evaluating a name it just rejected. On by default; the owner can flip
+    # it off (screen_config.hideRejected=false) or manually restore a name.
+    if cfg.get("hideRejected", True):
+        rejected = db.get_active_screener_rejections(portfolio_id)
+        if rejected:
+            ranked = [
+                r for r in ranked
+                if (r.get("ticker") or "").upper() not in rejected
+            ]
     top_n = int(cfg.get("topN", 40))
     return {
         r["ticker"]: f"screen rank #{r['rank']} · score {r['score']:.1f}"

--- a/seed_dummy_portfolio.py
+++ b/seed_dummy_portfolio.py
@@ -63,8 +63,8 @@ logger = logging.getLogger("seed_dummy_portfolio")
 # Defaults / fixed copy
 # ---------------------------------------------------------------------------
 
-DEFAULT_SLUG = "meridian-growth"
-DEFAULT_DISPLAY_NAME = "Meridian Growth"
+DEFAULT_SLUG = "mara-v1"
+DEFAULT_DISPLAY_NAME = "MARA v1"
 DEFAULT_OWNER_NAME = "Morgan Hale"
 DEFAULT_EMAIL = "morgan.demo@alphamolt.ai"
 DEFAULT_DAYS = 45          # calendar days of history (>=42 so 30d anchor exists)
@@ -75,15 +75,7 @@ STARTING_CASH = 1_000_000.00
 BUYER_HANDLES = ("buyer-claude", "buyer-gemini")
 REVIEWER_HANDLE = "portfolio-reviewer"
 
-MANDATE = (
-    "Own 15-20 high-quality US-listed growth companies with durable revenue "
-    "growth, expanding margins and a credible path to (or track record of) "
-    "free cash flow. Prefer founder-led businesses with strong Rule-of-40 "
-    "economics. Pay a sensible price: avoid names trading far above their own "
-    "12-month P/S median. Sell when the thesis breaks — decelerating growth, "
-    "margin erosion or a clearly better use of the capital — not on ordinary "
-    "volatility. Let winners run."
-)
+MANDATE = "Make America Rich Again!  Only winners, sell all losers"
 
 SCREEN_CONFIG = {
     "filters": [
@@ -179,8 +171,8 @@ def make_thesis_text(company: dict, rng: random.Random) -> str:
     ]
     return (
         f"{name} pairs {growth} TTM revenue growth with {gm} gross margins "
-        f"and {fcf} FCF margin (Rule of 40: {r40}), which fits the mandate's "
-        f"quality-growth profile. {rng.choice(closers)}"
+        f"and {fcf} FCF margin (Rule of 40: {r40}) — a winner by the "
+        f"mandate's bar. {rng.choice(closers)}"
     )
 
 
@@ -452,9 +444,9 @@ def build_trade_plan(
         plan.cash = round(plan.cash + gross, 2)
         ts = _utc(sell_day, 7, 11, 42)
         rationale = (
-            "thesis no longer holds: momentum and relative strength have "
-            "deteriorated since purchase and the mandate prefers redeploying "
-            "into higher-conviction names"
+            "the position is a loser since purchase — momentum and relative "
+            "strength have deteriorated, and the mandate is explicit: sell "
+            "all losers"
         )
         plan.trades.append({
             "agent_id": reviewer_id,

--- a/seed_dummy_portfolio.py
+++ b/seed_dummy_portfolio.py
@@ -1,0 +1,1053 @@
+"""
+seed_dummy_portfolio.py — operator tool: fabricate a fully-consistent demo
+portfolio that looks like it has been trading on Alphamolt for 30+ days.
+
+Creates EVERYTHING a mature human-owned paper portfolio has:
+
+  * a dummy auth user + profiles row (display name, back-dated created_at)
+  * lifecycle_email_sends ledger rows so the email crons never mail it
+  * the portfolios row (mandate, screen_config, mode='paper', public)
+  * portfolio_accounts ($1M starting cash, back-dated inception)
+  * a hired team in portfolio_agents (two library buyers + the reviewer,
+    role-tagged with per-instance config, exactly as saveTeamAgent writes)
+  * an agent_trades tape whose fills use REAL historical closes from
+    prices_daily on their historical dates, cash-chained end to end
+  * investment_theses per BUY (snapshot frozen at fill price, agent-authored
+    thesis text + extend/break signals, superseded/broken lifecycle)
+  * portfolio_holdings with weighted-average cost + buyer attribution
+  * agent_portfolio_history for every calendar day since inception, valued
+    at each day's real close (today at companies.price, like
+    portfolio_valuation.py would write)
+  * agent_heartbeats journal rows for every daily buyer run + weekly
+    reviewer run
+
+The trade tape, holdings, cash and daily snapshots all reconcile — the
+script verifies the chain before writing and refuses to seed a portfolio
+that doesn't satisfy the demo constraints:
+
+  * >10 equities in every daily snapshot (buys 14 names on day one)
+  * >8% growth over the trailing 30 days, measured exactly the way the
+    leaderboard measures it (latest snapshot vs the snapshot 30 days ago)
+
+The >8% constraint is met by SELECTION, not invention: the basket is chosen
+from real Tier 1 names whose actual price history over the window produces
+the return. Every fill price is a genuine close.
+
+Usage:
+    python seed_dummy_portfolio.py --dry-run        # plan + verify only
+    python seed_dummy_portfolio.py                  # create the portfolio
+    python seed_dummy_portfolio.py --teardown       # remove it again
+
+Flags: --slug, --display-name, --owner-name, --email, --days,
+       --target-30d, --seed, --dry-run, --teardown
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import random
+import sys
+import uuid
+from datetime import date, datetime, timedelta, timezone
+
+from db import SupabaseDB
+from theses import _SNAPSHOT_FIELDS
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+)
+logger = logging.getLogger("seed_dummy_portfolio")
+
+# ---------------------------------------------------------------------------
+# Defaults / fixed copy
+# ---------------------------------------------------------------------------
+
+DEFAULT_SLUG = "meridian-growth"
+DEFAULT_DISPLAY_NAME = "Meridian Growth"
+DEFAULT_OWNER_NAME = "Morgan Hale"
+DEFAULT_EMAIL = "morgan.demo@alphamolt.ai"
+DEFAULT_DAYS = 45          # calendar days of history (>=42 so 30d anchor exists)
+DEFAULT_TARGET_30D = 10.5  # selection target %, must come out > 8 after sim
+
+STARTING_CASH = 1_000_000.00
+
+BUYER_HANDLES = ("buyer-claude", "buyer-gemini")
+REVIEWER_HANDLE = "portfolio-reviewer"
+
+MANDATE = (
+    "Own 15-20 high-quality US-listed growth companies with durable revenue "
+    "growth, expanding margins and a credible path to (or track record of) "
+    "free cash flow. Prefer founder-led businesses with strong Rule-of-40 "
+    "economics. Pay a sensible price: avoid names trading far above their own "
+    "12-month P/S median. Sell when the thesis breaks — decelerating growth, "
+    "margin erosion or a clearly better use of the capital — not on ordinary "
+    "volatility. Let winners run."
+)
+
+SCREEN_CONFIG = {
+    "filters": [
+        {"field": "rule_of_40", "op": ">=", "value": 30},
+        {"field": "gross_margin", "op": ">=", "value": 0.40},
+        {"field": "country", "op": "==", "value": "United States"},
+    ],
+    "weights": {"quality": 60, "value": 15, "momentum": 25},
+    "aiMultiplier": True,
+    "topN": 30,
+}
+
+BUYER_CONFIG = {"target_position_pct": 6}
+REVIEWER_CONFIG = {"sell_conviction_threshold": 4}
+
+LIFECYCLE_KEYS = ("a1_welcome", "a2_setup_nudge")
+
+# Trade-plan shape (trading-day indexes into the window's trading calendar)
+INITIAL_BUYS = 14            # day-one snake draft
+ADD_DAYS = (5, 9, 14)        # one new name on each of these trading days
+TOPUP_DAY = 18               # add to the best performer so far
+SELL_AFTER_CAL_DAYS = 21     # reviewer exit ~3 weeks in (first trading day after)
+FINAL_NAMES = INITIAL_BUYS + len(ADD_DAYS)  # before the one reviewer exit
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc(d: date, hh: int, mm: int, ss: int) -> str:
+    return datetime(d.year, d.month, d.day, hh, mm, ss, tzinfo=timezone.utc).isoformat()
+
+
+def _fetch_all(builder_fn, page: int = 1000) -> list[dict]:
+    """Paginate a PostgREST query past the server max-rows cap."""
+    rows: list[dict] = []
+    offset = 0
+    while True:
+        resp = builder_fn().range(offset, offset + page - 1).execute()
+        batch = resp.data or []
+        rows.extend(batch)
+        if len(batch) < page:
+            return rows
+        offset += page
+
+
+def _num(v) -> float | None:
+    return SupabaseDB.safe_float(v)
+
+
+def _fmt_metric(v, suffix="%") -> str:
+    f = _num(v)
+    return f"{f:.0f}{suffix}" if f is not None else "n/a"
+
+
+# ---------------------------------------------------------------------------
+# Thesis / rationale copy generators (template prose over real metrics)
+# ---------------------------------------------------------------------------
+
+
+def make_rationale(company: dict, rng: random.Random) -> str:
+    growth = _fmt_metric(company.get("rev_growth_ttm_pct"))
+    gm = _fmt_metric(company.get("gross_margin_pct"))
+    r40 = _fmt_metric(company.get("rule_of_40"), suffix="")
+    sector = company.get("sector") or "its sector"
+    templates = [
+        f"{growth} TTM growth at {gm} gross margin (Rule of 40: {r40}); "
+        f"category leader in {sector.lower()}",
+        f"Durable compounder — Rule of 40 of {r40} with {gm} gross margin "
+        f"and {growth} TTM revenue growth",
+        f"Quality screen standout: {growth} growth, {gm} gross margin, "
+        f"reasonable entry vs its own P/S history",
+        f"Best-in-class {sector.lower()} economics ({gm} GM, R40 {r40}) "
+        f"with momentum confirming",
+    ]
+    return rng.choice(templates)
+
+
+def make_thesis_text(company: dict, rng: random.Random) -> str:
+    name = company.get("company_name") or company["ticker"]
+    growth = _fmt_metric(company.get("rev_growth_ttm_pct"))
+    gm = _fmt_metric(company.get("gross_margin_pct"))
+    fcf = _fmt_metric(company.get("fcf_margin_pct"))
+    r40 = _fmt_metric(company.get("rule_of_40"), suffix="")
+    closers = [
+        "Expect the multiple to hold while revenue compounds; the position "
+        "pays off through execution, not re-rating.",
+        "Entry near its own valuation history gives a margin of safety if "
+        "growth merely persists.",
+        "Operating leverage should keep dropping through to free cash flow "
+        "as the business scales.",
+    ]
+    return (
+        f"{name} pairs {growth} TTM revenue growth with {gm} gross margins "
+        f"and {fcf} FCF margin (Rule of 40: {r40}), which fits the mandate's "
+        f"quality-growth profile. {rng.choice(closers)}"
+    )
+
+
+def make_signals(company: dict) -> tuple[list[dict], list[dict]]:
+    growth = _num(company.get("rev_growth_ttm_pct"))
+    extend = [
+        {
+            "field": "rev_growth_ttm_pct",
+            "op": "change_pct_gt",
+            "value": 5,
+            "description": "TTM revenue growth accelerates >5pp from purchase",
+        },
+        {
+            "field": "fcf_margin_pct",
+            "op": "change_pct_gt",
+            "value": 3,
+            "description": "FCF margin expands >3pp from purchase",
+        },
+    ]
+    brk = [
+        {
+            "field": "rule_of_40",
+            "op": "change_pct_lt",
+            "value": -15,
+            "description": "Rule of 40 deteriorates >15pts from purchase",
+        },
+        {
+            "field": "gross_margin_pct",
+            "op": "change_pct_lt",
+            "value": -5,
+            "description": "Gross margin compresses >5pp from purchase",
+        },
+    ]
+    if growth is not None and growth > 10:
+        brk.append({
+            "field": "rev_growth_ttm_pct",
+            "op": "<",
+            "value": round(growth / 2, 1),
+            "description": f"TTM growth halves from {growth:.0f}%",
+        })
+    return extend, brk
+
+
+def adjust_snapshot_to_fill(snapshot: dict, fill: float) -> dict:
+    """Scale the price-linked snapshot fields to the historical fill price so
+    the frozen state is coherent with the trade tape."""
+    current = _num(snapshot.get("price"))
+    out = dict(snapshot)
+    out["price"] = round(fill, 4)
+    if current and current > 0:
+        ratio = fill / current
+        ps = _num(snapshot.get("ps_now"))
+        if ps is not None:
+            out["ps_now"] = round(ps * ratio, 2)
+        pct_high = _num(snapshot.get("price_pct_of_52w_high"))
+        if pct_high is not None:
+            out["price_pct_of_52w_high"] = round(min(pct_high * ratio, 100.0), 1)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Price history
+# ---------------------------------------------------------------------------
+
+
+class PriceBook:
+    """Per-ticker {date -> close} with last-known-close lookups."""
+
+    def __init__(self) -> None:
+        self.by_ticker: dict[str, dict[date, float]] = {}
+
+    def add(self, ticker: str, d: date, close: float) -> None:
+        self.by_ticker.setdefault(ticker, {})[d] = close
+
+    def close_on(self, ticker: str, d: date) -> float | None:
+        return self.by_ticker.get(ticker, {}).get(d)
+
+    def last_close_on_or_before(self, ticker: str, d: date) -> float | None:
+        series = self.by_ticker.get(ticker)
+        if not series:
+            return None
+        best = None
+        for k in series:
+            if k <= d and (best is None or k > best):
+                best = k
+        return series.get(best) if best else None
+
+
+def load_universe(db: SupabaseDB, window_start: date):
+    """Candidate companies + their real daily closes over the window."""
+    companies = _fetch_all(
+        lambda: db.client.table("companies")
+        .select("*")
+        .eq("in_tv_screen", True)
+        .not_.is_("price", "null")
+        .not_.is_("sort_order", "null")
+        .order("sort_order")
+    )
+    companies = companies[:160]
+    by_ticker = {c["ticker"]: c for c in companies}
+    tickers = list(by_ticker)
+
+    book = PriceBook()
+    since = (window_start - timedelta(days=10)).isoformat()
+    for i in range(0, len(tickers), 50):
+        chunk = tickers[i : i + 50]
+        rows = _fetch_all(
+            lambda c=chunk: db.client.table("prices_daily")
+            .select("ticker,date,close")
+            .in_("ticker", c)
+            .gte("date", since)
+            .order("date")
+        )
+        for r in rows:
+            close = _num(r.get("close"))
+            if close and close > 0:
+                book.add(r["ticker"], date.fromisoformat(r["date"]), close)
+
+    # Trading calendar = dates seen for at least half the priced tickers.
+    counts: dict[date, int] = {}
+    for series in book.by_ticker.values():
+        for d in series:
+            counts[d] = counts.get(d, 0) + 1
+    n_priced = max(1, len(book.by_ticker))
+    trading_days = sorted(d for d, n in counts.items() if n >= n_priced * 0.5)
+    return by_ticker, book, trading_days
+
+
+def coverage_ok(book: PriceBook, ticker: str, days: list[date]) -> bool:
+    series = book.by_ticker.get(ticker, {})
+    if not series:
+        return False
+    missing = sum(1 for d in days if d not in series)
+    if missing > max(2, len(days) // 20):
+        return False
+    # Drop split/halt suspects: any |day-over-day| move > 35%.
+    closes = [series[d] for d in days if d in series]
+    for a, b in zip(closes, closes[1:]):
+        if a > 0 and abs(b / a - 1) > 0.35:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Plan + simulate
+# ---------------------------------------------------------------------------
+
+
+class Plan:
+    """Everything to be written, fully simulated in memory first."""
+
+    def __init__(self) -> None:
+        self.trades: list[dict] = []          # row dicts + private _ keys
+        self.holdings: dict[str, dict] = {}   # ticker -> {qty, avg_cost, first_ts, opened_by}
+        self.cash = STARTING_CASH
+        self.history: list[dict] = []
+        self.heartbeats: list[dict] = []
+        self.sold_ticker: str | None = None
+        self.sell_ts: str | None = None
+        self.topup_ticker: str | None = None
+        self.ret_30d: float | None = None
+        self.ret_inception: float | None = None
+        self.min_positions: int | None = None
+        self.final_value: float | None = None
+
+
+def build_trade_plan(
+    basket: list[str],
+    by_ticker: dict[str, dict],
+    book: PriceBook,
+    trading_days: list[date],
+    buyer_ids: list[str],
+    reviewer_id: str,
+    rng: random.Random,
+    weights: dict[str, float] | None = None,
+) -> Plan:
+    plan = Plan()
+    first_day = trading_days[0]
+    weights = weights or {}
+
+    def fill_price(ticker: str, d: date) -> float | None:
+        # Heartbeat trades at 07:00 UTC fill at companies.price = the
+        # previous trading day's close.
+        prev = d - timedelta(days=1)
+        return book.last_close_on_or_before(ticker, prev)
+
+    def snake_buyer(i: int) -> str:
+        # A B B A A B B A ... (snake draft order across two buyers)
+        return buyer_ids[(0, 1, 1, 0)[i % 4]]
+
+    def do_buy(ticker: str, d: date, target_pct: float, seq: int, buyer: str,
+               conviction: int) -> None:
+        px = fill_price(ticker, d)
+        if px is None or px <= 0:
+            raise RuntimeError(f"no fill price for {ticker} on {d}")
+        # Keep a ~1.5% cash reserve (mirrors the buyers' reserve convention);
+        # skip rather than open a token-sized position.
+        alloc = STARTING_CASH * target_pct / 100.0
+        alloc = min(alloc, plan.cash - 0.015 * STARTING_CASH)
+        if alloc < 0.005 * STARTING_CASH:
+            return
+        qty = int(alloc // px)
+        if qty < 1:
+            return
+        gross = round(qty * px, 2)
+        plan.cash = round(plan.cash - gross, 2)
+        secs = 125 + seq * 7  # fills staggered a few seconds apart from 07:02
+        ts = _utc(d, 7, secs // 60, secs % 60)
+        company = by_ticker[ticker]
+        rationale = make_rationale(company, rng)
+        h = plan.holdings.get(ticker)
+        if h:
+            new_qty = h["qty"] + qty
+            h["avg_cost"] = round((h["qty"] * h["avg_cost"] + qty * px) / new_qty, 4)
+            h["qty"] = new_qty
+        else:
+            plan.holdings[ticker] = {
+                "qty": qty, "avg_cost": round(px, 4),
+                "first_ts": ts, "opened_by": buyer,
+            }
+        plan.trades.append({
+            "agent_id": buyer,
+            "ticker": ticker,
+            "side": "buy",
+            "quantity": qty,
+            "price_usd": round(px, 4),
+            "gross_usd": gross,
+            "cash_after_usd": plan.cash,
+            "executed_at": ts,
+            "note": f"swarm draft (conviction {conviction}/5): {rationale}",
+            "_rationale": rationale,
+            "_date": d,
+        })
+
+    # --- Day one: snake-draft 14 names ------------------------------------
+    for i, ticker in enumerate(basket[:INITIAL_BUYS]):
+        pct = weights.get(ticker, 5.9) + rng.uniform(-0.15, 0.15)
+        do_buy(
+            ticker, first_day, target_pct=pct,
+            seq=i, buyer=snake_buyer(i), conviction=5 if i < 8 else 4,
+        )
+
+    # --- Adds: one new name on each add day --------------------------------
+    add_names = basket[INITIAL_BUYS:FINAL_NAMES]
+    for j, (idx, ticker) in enumerate(zip(ADD_DAYS, add_names)):
+        if idx >= len(trading_days):
+            break
+        do_buy(
+            ticker, trading_days[idx], target_pct=4.4 + rng.uniform(-0.4, 0.6),
+            seq=j, buyer=buyer_ids[j % 2], conviction=5,
+        )
+
+    # --- Reviewer exit ~3 weeks in: worst performer to date ----------------
+    sell_day = next(
+        (d for d in trading_days
+         if d >= trading_days[0] + timedelta(days=SELL_AFTER_CAL_DAYS)),
+        None,
+    )
+    if sell_day:
+        def ret_to(t: str) -> float:
+            px = book.last_close_on_or_before(t, sell_day - timedelta(days=1))
+            h = plan.holdings[t]
+            return (px / h["avg_cost"] - 1) if px else 0.0
+
+        worst = min(list(plan.holdings)[:INITIAL_BUYS], key=ret_to)
+        px = book.last_close_on_or_before(worst, sell_day - timedelta(days=1))
+        h = plan.holdings.pop(worst)
+        gross = round(h["qty"] * px, 2)
+        plan.cash = round(plan.cash + gross, 2)
+        ts = _utc(sell_day, 7, 11, 42)
+        rationale = (
+            "thesis no longer holds: momentum and relative strength have "
+            "deteriorated since purchase and the mandate prefers redeploying "
+            "into higher-conviction names"
+        )
+        plan.trades.append({
+            "agent_id": reviewer_id,
+            "ticker": worst,
+            "side": "sell",
+            "quantity": h["qty"],
+            "price_usd": round(px, 4),
+            "gross_usd": gross,
+            "cash_after_usd": plan.cash,
+            "executed_at": ts,
+            "note": f"portfolio-reviewer drift ({rationale[:80]})",
+            "_rationale": rationale,
+            "_date": sell_day,
+        })
+        plan.sold_ticker = worst
+        plan.sell_ts = ts
+
+    # --- Top-up the best performer so far ----------------------------------
+    if TOPUP_DAY < len(trading_days):
+        topup_day = trading_days[TOPUP_DAY]
+
+        def ret_at(t: str) -> float:
+            px = book.last_close_on_or_before(t, topup_day - timedelta(days=1))
+            return (px / plan.holdings[t]["avg_cost"] - 1) if px else 0.0
+
+        best = max(plan.holdings, key=ret_at)
+        plan.topup_ticker = best
+        do_buy(best, topup_day, target_pct=2.4 + rng.uniform(0, 0.5),
+               seq=9, buyer=plan.holdings[best]["opened_by"], conviction=5)
+
+    return plan
+
+
+def simulate_history(
+    plan: Plan,
+    by_ticker: dict[str, dict],
+    book: PriceBook,
+    inception: date,
+    today: date,
+) -> None:
+    """Daily MTM snapshots from the trade tape + real closes. Today is valued
+    at companies.price, exactly like portfolio_valuation.py would."""
+    plan.history = []
+    d = inception
+    while d <= today:
+        cash = STARTING_CASH
+        pos: dict[str, float] = {}
+        for t in plan.trades:
+            if t["_date"] > d:
+                continue
+            cash = t["cash_after_usd"]
+            q = pos.get(t["ticker"], 0.0)
+            pos[t["ticker"]] = q + t["quantity"] if t["side"] == "buy" else q - t["quantity"]
+        pos = {k: v for k, v in pos.items() if v > 1e-9}
+
+        hv = 0.0
+        for ticker, qty in pos.items():
+            if d == today:
+                px = _num(by_ticker[ticker].get("price")) or \
+                    book.last_close_on_or_before(ticker, d)
+            else:
+                px = book.last_close_on_or_before(ticker, d)
+            hv += qty * (px or 0.0)
+        hv = round(hv, 2)
+        total = round(cash + hv, 2)
+        pnl = round(total - STARTING_CASH, 2)
+        plan.history.append({
+            "snapshot_date": d.isoformat(),
+            "cash_usd": round(cash, 2),
+            "holdings_value_usd": hv,
+            "total_value_usd": total,
+            "pnl_usd": pnl,
+            "pnl_pct": round(pnl / STARTING_CASH * 100, 4),
+            "num_positions": len(pos),
+        })
+        d += timedelta(days=1)
+
+    plan.min_positions = min(r["num_positions"] for r in plan.history)
+    plan.final_value = plan.history[-1]["total_value_usd"]
+    plan.ret_inception = plan.history[-1]["pnl_pct"]
+    anchor_date = (today - timedelta(days=30)).isoformat()
+    anchor = max(
+        (r for r in plan.history if r["snapshot_date"] <= anchor_date),
+        key=lambda r: r["snapshot_date"],
+        default=None,
+    )
+    if anchor and anchor["total_value_usd"] > 0:
+        plan.ret_30d = round(
+            (plan.final_value / anchor["total_value_usd"] - 1) * 100, 4
+        )
+
+
+def build_heartbeats(
+    plan: Plan,
+    portfolio_id: str,
+    buyers: list[dict],
+    reviewer: dict,
+    inception: date,
+    today: date,
+    rng: random.Random,
+) -> None:
+    """Journal rows mirroring the swarm path: buyers daily, reviewer weekly."""
+    buys_by_day_agent: dict[tuple[str, str], int] = {}
+    sells_by_day: dict[str, int] = {}
+    for t in plan.trades:
+        day = t["_date"].isoformat()
+        if t["side"] == "buy":
+            key = (day, t["agent_id"])
+            buys_by_day_agent[key] = buys_by_day_agent.get(key, 0) + 1
+        else:
+            sells_by_day[day] = sells_by_day.get(day, 0) + 1
+
+    rows: list[dict] = []
+    d = inception
+    while d <= today:
+        day = d.isoformat()
+        for b in buyers:
+            n = buys_by_day_agent.get((day, b["id"]), 0)
+            started = _utc(d, 7, 0, rng.randint(30, 55))
+            rows.append({
+                "agent_id": b["id"],
+                "strategy": b.get("strategy") or "llm_watchlist_buyer",
+                "started_at": started,
+                "finished_at": _utc(d, 7, rng.randint(1, 3), rng.randint(0, 59)),
+                "status": "ok",
+                "trades_executed": n,
+                "buys": n,
+                "sells": 0,
+                "notes": {"portfolio_id": portfolio_id, "role": "buyer",
+                          "remit": None},
+            })
+        run_reviewer = ((d - inception).days % 7 == 0) or day in sells_by_day
+        if run_reviewer:
+            n_sell = sells_by_day.get(day, 0)
+            notes = {
+                "portfolio_id": portfolio_id,
+                "role": "reviewer",
+                "positions_reviewed": max(
+                    (r["num_positions"] for r in plan.history
+                     if r["snapshot_date"] == day), default=0,
+                ),
+            }
+            if n_sell == 0:
+                notes["reason"] = "no positions met the sell threshold"
+            rows.append({
+                "agent_id": reviewer["id"],
+                "strategy": reviewer.get("strategy") or "portfolio_reviewer",
+                "started_at": _utc(d, 7, 8, rng.randint(0, 40)),
+                "finished_at": _utc(d, 7, rng.randint(12, 16), rng.randint(0, 59)),
+                "status": "ok",
+                "trades_executed": n_sell,
+                "buys": 0,
+                "sells": n_sell,
+                "notes": notes,
+            })
+        d += timedelta(days=1)
+    plan.heartbeats = rows
+
+
+# ---------------------------------------------------------------------------
+# Basket selection — meet the 30d-return constraint with real names
+# ---------------------------------------------------------------------------
+
+
+def select_basket(
+    by_ticker: dict[str, dict],
+    book: PriceBook,
+    trading_days: list[date],
+    buyer_ids: list[str],
+    reviewer_id: str,
+    today: date,
+    target_30d: float,
+    rng: random.Random,
+) -> tuple[list[str], Plan]:
+    anchor_day = today - timedelta(days=30)
+    last_day = trading_days[-1]
+
+    eligible: list[dict] = []
+    for ticker, company in by_ticker.items():
+        if not coverage_ok(book, ticker, trading_days):
+            continue
+        entry = book.last_close_on_or_before(
+            ticker, trading_days[0] - timedelta(days=1)
+        )
+        anchor = book.last_close_on_or_before(ticker, anchor_day)
+        last = book.last_close_on_or_before(ticker, last_day)
+        if not entry or not anchor or not last:
+            continue
+        eligible.append({
+            "ticker": ticker,
+            "ret_30": last / anchor - 1,
+            "ret_window": last / entry - 1,
+            "rank": company.get("sort_order") or 9999,
+        })
+
+    need = FINAL_NAMES + 2
+    if len(eligible) < need:
+        raise RuntimeError(
+            f"only {len(eligible)} tickers have usable price history — "
+            "cannot build the basket"
+        )
+
+    winners = sorted(eligible, key=lambda e: -e["ret_30"])
+    by_rank = sorted(eligible, key=lambda e: e["rank"])
+
+    ret_30 = {e["ticker"]: e["ret_30"] for e in eligible}
+    for k_win in range(10, FINAL_NAMES + 1):
+        chosen = [w["ticker"] for w in winners[:k_win]]
+        for e in by_rank:
+            if len(chosen) >= FINAL_NAMES:
+                break
+            if e["ticker"] not in chosen and e["ret_30"] > -0.08:
+                chosen.append(e["ticker"])
+        # Day-one draft = the 14 strongest trailing-30d names, overweighted
+        # linearly from ~7.0% down to ~4.8% (mean ≈ 5.9%, ~83% deployed);
+        # the rest arrive as later adds.
+        chosen.sort(key=lambda t: -ret_30[t])
+        initial = chosen[:INITIAL_BUYS]
+        weights = {
+            t: 7.0 - 2.2 * i / max(1, INITIAL_BUYS - 1)
+            for i, t in enumerate(initial)
+        }
+        plan = build_trade_plan(
+            chosen, by_ticker, book, trading_days, buyer_ids, reviewer_id,
+            random.Random(rng.random()), weights=weights,
+        )
+        simulate_history(plan, by_ticker, book, trading_days[0], today)
+        logger.info(
+            "selection attempt k_win=%d → 30d %.2f%%, min positions %d",
+            k_win, plan.ret_30d or 0, plan.min_positions or 0,
+        )
+        if (plan.ret_30d or 0) >= target_30d and (plan.min_positions or 0) > 10:
+            return chosen, plan
+
+    raise RuntimeError(
+        "could not assemble a basket meeting the 30d-return target from real "
+        "price history — try --days a few higher/lower or lower --target-30d"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Writes
+# ---------------------------------------------------------------------------
+
+
+def ensure_owner(db: SupabaseDB, email: str, owner_name: str,
+                 backdate: date) -> str:
+    """Create (or reuse) the dummy auth user + profile. Returns user id."""
+    existing = (
+        db.client.table("profiles").select("id").eq("email", email)
+        .limit(1).execute().data
+    )
+    if existing:
+        user_id = existing[0]["id"]
+        logger.info("Reusing existing profile %s for %s", user_id, email)
+    else:
+        resp = db.client.auth.admin.create_user({
+            "email": email,
+            "email_confirm": True,
+            "user_metadata": {"display_name": owner_name},
+        })
+        user_id = resp.user.id
+        logger.info("Created auth user %s (%s)", user_id, email)
+
+    db.client.table("profiles").update({
+        "display_name": owner_name,
+        "created_at": _utc(backdate, 9, 14, 3),
+    }).eq("id", user_id).execute()
+
+    # Seed the lifecycle-email ledger so the cron never emails the dummy.
+    for key in LIFECYCLE_KEYS:
+        db.client.table("lifecycle_email_sends").upsert(
+            {"user_id": user_id, "email_key": key, "recipient": email,
+             "sent_at": _utc(backdate, 9, 20, 0)},
+            on_conflict="user_id,email_key",
+        ).execute()
+    return user_id
+
+
+def write_plan(
+    db: SupabaseDB,
+    plan: Plan,
+    *,
+    slug: str,
+    display_name: str,
+    owner_user_id: str,
+    by_ticker: dict[str, dict],
+    buyers: list[dict],
+    reviewer: dict,
+    inception: date,
+    rng: random.Random,
+    portfolio_id: str,
+) -> str:
+    last_hb = plan.heartbeats[-1]["started_at"]
+    created_ts = _utc(inception, 6, 45, 12)
+
+    db.client.table("portfolios").insert({
+        "id": portfolio_id,
+        "slug": slug,
+        "display_name": display_name,
+        "description": MANDATE,
+        "owner_user_id": owner_user_id,
+        "is_public": False,            # flipped after holdings exist
+        "mode": "paper",
+        "screen_config": SCREEN_CONFIG,
+        "created_at": created_ts,
+        "last_heartbeat_at": last_hb,
+    }).execute()
+    logger.info("portfolios row %s (slug=%s)", portfolio_id, slug)
+
+    db.client.table("portfolio_accounts").insert({
+        "portfolio_id": portfolio_id,
+        "starting_cash": STARTING_CASH,
+        "cash_usd": plan.cash,
+        "inception_date": inception.isoformat(),
+        "created_at": created_ts,
+    }).execute()
+
+    members = [
+        (b, "buyer", BUYER_CONFIG) for b in buyers
+    ] + [(reviewer, "reviewer", REVIEWER_CONFIG)]
+    for agent, role, config in members:
+        db.client.table("portfolio_agents").insert({
+            "portfolio_id": portfolio_id,
+            "agent_id": agent["id"],
+            "role": role,
+            "config": config,
+            "enabled": True,
+            "joined_at": created_ts,
+            "last_heartbeat_at": last_hb,
+        }).execute()
+    logger.info("team: %s", ", ".join(a["handle"] for a, _, _ in members))
+
+    # Trade tape + theses. The AFTER INSERT trigger on agent_trades is a
+    # no-op for these agents (no agent_accounts row — verified upstream).
+    superseded: dict[str, int] = {}  # ticker -> prior thesis id
+    thesis_ids: dict[str, int] = {}
+    for t in plan.trades:
+        row = {k: v for k, v in t.items() if not k.startswith("_")}
+        row["portfolio_id"] = portfolio_id
+        trade_id = db.insert_agent_trade(row)
+
+        if t["side"] == "buy":
+            company = by_ticker[t["ticker"]]
+            prior = thesis_ids.get(t["ticker"])
+            if prior:
+                db.client.table("investment_theses").update({
+                    "status": "superseded",
+                    "status_changed_at": t["executed_at"],
+                }).eq("id", prior).execute()
+                superseded[t["ticker"]] = prior
+            snapshot = adjust_snapshot_to_fill(
+                {k: company.get(k) for k in _SNAPSHOT_FIELDS},
+                float(t["price_usd"]),
+            )
+            extend, brk = make_signals(company)
+            resp = db.client.table("investment_theses").insert({
+                "agent_id": t["agent_id"],
+                "portfolio_id": portfolio_id,
+                "ticker": t["ticker"],
+                "trade_id": trade_id,
+                "snapshot": snapshot,
+                "thesis_text": make_thesis_text(company, rng),
+                "extend_signals": extend,
+                "break_signals": brk,
+                "source": "agent",
+                "status": "active",
+                "opened_at": t["executed_at"],
+                "status_changed_at": t["executed_at"],
+            }).execute()
+            thesis_ids[t["ticker"]] = (resp.data or [{}])[0].get("id")
+        else:
+            # Reviewer exit: thesis marked broken just before the sell —
+            # exactly the order portfolio_reviewer.py writes it.
+            tid = thesis_ids.get(t["ticker"])
+            if tid:
+                db.client.table("investment_theses").update({
+                    "status": "broken",
+                    "status_changed_at": t["executed_at"],
+                }).eq("id", tid).execute()
+    logger.info("%d trades + %d theses written", len(plan.trades), len(thesis_ids))
+
+    for ticker, h in plan.holdings.items():
+        db.client.table("portfolio_holdings").insert({
+            "portfolio_id": portfolio_id,
+            "ticker": ticker,
+            "quantity": h["qty"],
+            "avg_cost_usd": h["avg_cost"],
+            "first_bought_at": h["first_ts"],
+            "opened_by_agent_id": h["opened_by"],
+        }).execute()
+    logger.info("%d holdings written", len(plan.holdings))
+
+    for row in plan.history:
+        db.upsert_portfolio_snapshot({**row, "portfolio_id": portfolio_id})
+    logger.info("%d daily snapshots written", len(plan.history))
+
+    for row in plan.heartbeats:
+        db.insert_agent_heartbeat(row)
+    logger.info("%d heartbeat journal rows written", len(plan.heartbeats))
+
+    # ≥15 holdings now exist, so the public-threshold trigger allows this.
+    db.client.table("portfolios").update({"is_public": True}).eq(
+        "id", portfolio_id
+    ).execute()
+    logger.info("portfolio flipped public")
+    return portfolio_id
+
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+
+
+def teardown(db: SupabaseDB, slug: str, email: str) -> None:
+    portfolio = db.get_portfolio_by_slug(slug)
+    if not portfolio:
+        logger.info("No portfolio with slug=%s — nothing to tear down", slug)
+        return
+    owner = portfolio.get("owner_user_id")
+    if not owner:
+        raise RuntimeError(f"{slug} is not a human portfolio — refusing teardown")
+    prof = (
+        db.client.table("profiles").select("email").eq("id", owner)
+        .limit(1).execute().data
+    )
+    if not prof or prof[0].get("email") != email:
+        raise RuntimeError(
+            f"{slug} is owned by {prof[0].get('email') if prof else '?'} — "
+            f"not the dummy owner {email}; refusing teardown"
+        )
+    pid = portfolio["id"]
+    db.client.table("agent_heartbeats").delete().eq(
+        "notes->>portfolio_id", pid
+    ).execute()
+    # portfolios cascade removes account, holdings, members, trades,
+    # theses and history.
+    db.client.table("portfolios").delete().eq("id", pid).execute()
+    db.client.table("lifecycle_email_sends").delete().eq("user_id", owner).execute()
+    db.client.table("profiles").delete().eq("id", owner).execute()
+    try:
+        db.client.auth.admin.delete_user(owner)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("auth user delete failed (profile already gone): %s", exc)
+    logger.info("Tore down portfolio %s (%s) and owner %s", slug, pid, email)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--slug", default=DEFAULT_SLUG)
+    ap.add_argument("--display-name", default=DEFAULT_DISPLAY_NAME)
+    ap.add_argument("--owner-name", default=DEFAULT_OWNER_NAME)
+    ap.add_argument("--email", default=DEFAULT_EMAIL)
+    ap.add_argument("--days", type=int, default=DEFAULT_DAYS,
+                    help="calendar days of history (default 45)")
+    ap.add_argument("--target-30d", type=float, default=DEFAULT_TARGET_30D,
+                    help="selection target for trailing-30d return (%%)")
+    ap.add_argument("--seed", type=int, default=None)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--teardown", action="store_true")
+    args = ap.parse_args()
+
+    db = SupabaseDB()
+
+    if args.teardown:
+        teardown(db, args.slug, args.email)
+        return 0
+
+    if args.days < 42:
+        ap.error("--days must be >= 42 so a 30d-ago snapshot anchor exists")
+
+    if db.get_portfolio_by_slug(args.slug):
+        logger.error(
+            "Portfolio slug=%s already exists — run --teardown first", args.slug
+        )
+        return 1
+
+    rng = random.Random(args.seed if args.seed is not None else args.slug)
+
+    # House agents to hire; they must have NO agent_accounts row (otherwise
+    # the agent_trades AFTER INSERT trigger would write spurious snapshots
+    # into their own legacy history when we insert back-dated trades).
+    buyers, reviewer = [], None
+    for handle in (*BUYER_HANDLES, REVIEWER_HANDLE):
+        agent = db.get_agent_by_handle(handle)
+        if not agent:
+            logger.error("House agent %s not found — cannot build the team", handle)
+            return 1
+        if db.get_agent_account(agent["id"]):
+            logger.error(
+                "Agent %s has an agent_accounts row — back-dated trades would "
+                "pollute its own snapshot history via the recompute trigger. "
+                "Aborting.", handle,
+            )
+            return 1
+        if handle == REVIEWER_HANDLE:
+            reviewer = agent
+        else:
+            buyers.append(agent)
+
+    today = date.today()
+    window_start = today - timedelta(days=args.days)
+    by_ticker, book, all_days = load_universe(db, window_start)
+    trading_days = [d for d in all_days if d >= window_start]
+    if len(trading_days) < 28:
+        logger.error(
+            "Only %d trading days of prices_daily history in the window — "
+            "not enough to fabricate 30+ days", len(trading_days),
+        )
+        return 1
+    inception = trading_days[0]
+    logger.info(
+        "Window: %s → %s (%d trading days), %d candidate tickers",
+        inception, today, len(trading_days), len(by_ticker),
+    )
+
+    basket, plan = select_basket(
+        by_ticker, book, trading_days,
+        [b["id"] for b in buyers], reviewer["id"],
+        today, args.target_30d, rng,
+    )
+
+    # ---- Verification: the records must add up + meet the constraints ----
+    recomputed_cash = STARTING_CASH
+    for t in plan.trades:
+        delta = t["gross_usd"] if t["side"] == "sell" else -t["gross_usd"]
+        recomputed_cash = round(recomputed_cash + delta, 2)
+        assert abs(recomputed_cash - t["cash_after_usd"]) < 0.01, "cash chain broken"
+    assert abs(recomputed_cash - plan.cash) < 0.01
+    qty_check: dict[str, float] = {}
+    for t in plan.trades:
+        q = qty_check.get(t["ticker"], 0)
+        qty_check[t["ticker"]] = q + t["quantity"] if t["side"] == "buy" else q - t["quantity"]
+    qty_check = {k: v for k, v in qty_check.items() if v > 1e-9}
+    assert qty_check == {k: h["qty"] for k, h in plan.holdings.items()}, \
+        "holdings don't match trade tape"
+    assert (plan.ret_30d or 0) > 8.0, f"30d return {plan.ret_30d}% <= 8%"
+    assert (plan.min_positions or 0) > 10, "fewer than 11 equities at some point"
+    assert plan.cash >= 0
+    assert len(plan.holdings) >= 15, "needs >=15 holdings to flip public"
+
+    portfolio_id = str(uuid.uuid4())
+    build_heartbeats(plan, portfolio_id, buyers, reviewer, inception, today, rng)
+
+    logger.info("=" * 70)
+    logger.info("PLAN VERIFIED")
+    logger.info("  inception        %s   (%d calendar days ago)", inception,
+                (today - inception).days)
+    logger.info("  trades           %d (%d buys, 1 reviewer sell)",
+                len(plan.trades), len(plan.trades) - 1)
+    logger.info("  holdings         %d names, cash $%.2f (%.1f%% of book)",
+                len(plan.holdings), plan.cash,
+                plan.cash / plan.final_value * 100)
+    logger.info("  final value      $%.2f  (%+.2f%% since inception)",
+                plan.final_value, plan.ret_inception)
+    logger.info("  trailing 30d     %+.2f%%  (constraint: > 8%%)", plan.ret_30d)
+    logger.info("  min positions    %d  (constraint: > 10)", plan.min_positions)
+    logger.info("  sold position    %s on %s", plan.sold_ticker,
+                (plan.sell_ts or "")[:10])
+    logger.info("  topped up        %s", plan.topup_ticker)
+    for t in plan.trades:
+        logger.info(
+            "    %s %-4s %-6s x%-5d @ %9.2f  cash_after %12.2f",
+            t["_date"], t["side"].upper(), t["ticker"], t["quantity"],
+            t["price_usd"], t["cash_after_usd"],
+        )
+    logger.info("=" * 70)
+
+    if args.dry_run:
+        logger.info("[dry-run] no rows written")
+        return 0
+
+    owner_id = ensure_owner(db, args.email, args.owner_name,
+                            inception - timedelta(days=1))
+    write_plan(
+        db, plan,
+        slug=args.slug, display_name=args.display_name,
+        owner_user_id=owner_id, by_ticker=by_ticker,
+        buyers=buyers, reviewer=reviewer, inception=inception, rng=rng,
+        portfolio_id=portfolio_id,
+    )
+
+    logger.info(
+        "DONE — portfolio '%s' live at /portfolios/%s (id=%s), owner %s",
+        args.display_name, args.slug, portfolio_id, args.email,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/seed_house_targaryen.sql
+++ b/seed_house_targaryen.sql
@@ -1,0 +1,584 @@
+-- ============================================================================
+-- seed_house_targaryen.sql — paste-and-run in the Supabase SQL editor.
+--
+-- Creates the "House Targaryen" demo portfolio (slug house-targaryen) with
+-- ~45 days of
+-- fully-consistent trading history: dummy owner, funded account, hired team,
+-- trade tape filled at REAL historical prices_daily closes, investment theses
+-- per buy, buyer-attributed holdings, daily MTM snapshots and heartbeat
+-- journals. SQL twin of seed_dummy_portfolio.py.
+--
+-- Everything runs in ONE transaction and the script RAISEs (rolling back
+-- every row) unless the result satisfies:
+--   * trailing-30d return > 8% (leaderboard measurement: latest snapshot vs
+--     the snapshot 30 days ago)
+--   * > 10 equities in every daily snapshot
+--
+-- Teardown (paste separately if you ever want it gone):
+--   DELETE FROM agent_heartbeats WHERE notes->>'portfolio_id' =
+--       (SELECT id::text FROM portfolios WHERE slug = 'house-targaryen');
+--   DELETE FROM portfolios WHERE slug = 'house-targaryen';      -- cascades the rest
+--   DELETE FROM lifecycle_email_sends WHERE recipient = 'daenerys.demo@alphamolt.ai';
+--   DELETE FROM auth.users WHERE email = 'daenerys.demo@alphamolt.ai';  -- cascades profile
+-- ============================================================================
+
+BEGIN;
+
+-- The AFTER INSERT trigger on agent_trades (if present — it has been dropped
+-- on some environments) recomputes a same-day snapshot from CURRENT account
+-- state, which is wrong for back-dated trades. Disable it for the duration
+-- of this transaction; our own history rows are written below.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_trigger
+                WHERE tgname = 'agent_trades_recompute_snapshot'
+                  AND tgrelid = 'agent_trades'::regclass) THEN
+        EXECUTE 'ALTER TABLE agent_trades DISABLE TRIGGER agent_trades_recompute_snapshot';
+    END IF;
+END $$;
+
+DO $seed$
+DECLARE
+    -- ---- knobs -------------------------------------------------------------
+    c_slug          CONSTANT TEXT := 'house-targaryen';
+    c_display       CONSTANT TEXT := 'House Targaryen';
+    c_mandate       CONSTANT TEXT := 'Fire and blood. Ride only the strongest dragons — high-growth names in full flight — and add to them as they soar. Anything that falters bends the knee and is sold without mercy.';
+    c_email         CONSTANT TEXT := 'daenerys.demo@alphamolt.ai';
+    c_owner_name    CONSTANT TEXT := 'Daenerys Targaryen';
+    c_days          CONSTANT INT  := 45;        -- calendar days of history
+    c_initial       CONSTANT INT  := 14;        -- day-one snake draft size
+    c_start_cash    CONSTANT NUMERIC := 1000000.00;
+
+    v_today      DATE := CURRENT_DATE;
+    v_pid        UUID := gen_random_uuid();
+    v_owner      UUID;
+    v_buy_a      UUID;   -- buyer-chatgpt
+    v_buy_b      UUID;   -- buyer-grok
+    v_rev        UUID;   -- portfolio-reviewer
+    v_day0       DATE;
+    v_last_day   DATE;
+    v_sell_day   DATE;
+    v_topup_day  DATE;
+    v_cash       NUMERIC := 1000000.00;
+    v_seq        INT := 0;
+    v_px         NUMERIC;
+    v_qty        NUMERIC;
+    v_gross      NUMERIC;
+    v_alloc      NUMERIC;
+    v_weight     NUMERIC;
+    v_buyer      UUID;
+    v_ts         TIMESTAMPTZ;
+    v_trade_id   BIGINT;
+    v_thesis_id  BIGINT;
+    v_full       JSONB;
+    v_snapshot   JSONB;
+    v_breaks     JSONB;
+    v_extends    JSONB;
+    v_growth     NUMERIC;
+    v_cur_px     NUMERIC;
+    v_rationale  TEXT;
+    v_thesis_txt TEXT;
+    v_worst      TEXT;
+    v_best       TEXT;
+    v_n          INT;
+    v_final      NUMERIC;
+    v_anchor     NUMERIC;
+    v_ret30      NUMERIC;
+    v_minpos     INT;
+    r            RECORD;
+    d            DATE;
+    k_fields CONSTANT TEXT[] := ARRAY[
+        'ticker','company_name','country','sector',
+        'rating','r40_score','rule_of_40',
+        'rev_growth_ttm_pct','rev_growth_qoq_pct','rev_cagr_pct',
+        'rev_consistency_score',
+        'gross_margin_pct','operating_margin_pct','net_margin_pct',
+        'net_margin_yoy_pct','fcf_margin_pct',
+        'opex_pct_revenue','sm_rd_pct_revenue',
+        'eps_only','eps_yoy_pct','qrtrs_to_profitability','gm_trend',
+        'price','ps_now','price_pct_of_52w_high',
+        'perf_52w_vs_spy','composite_score',
+        'short_outlook','key_risks','full_outlook','bull_eval','bear_eval',
+        'status','flags','ai_analyzed_at'];
+BEGIN
+    -- ---- guards -------------------------------------------------------------
+    IF EXISTS (SELECT 1 FROM portfolios WHERE slug = c_slug) THEN
+        RAISE EXCEPTION 'portfolio slug % already exists — tear it down first', c_slug;
+    END IF;
+    SELECT id INTO v_buy_a FROM agents WHERE handle = 'buyer-chatgpt';
+    SELECT id INTO v_buy_b FROM agents WHERE handle = 'buyer-grok';
+    SELECT id INTO v_rev   FROM agents WHERE handle = 'portfolio-reviewer';
+    IF v_buy_a IS NULL OR v_buy_b IS NULL OR v_rev IS NULL THEN
+        RAISE EXCEPTION 'house agents buyer-chatgpt / buyer-grok / portfolio-reviewer not all found';
+    END IF;
+
+    -- ---- trading calendar (real prices_daily dates in the window) -----------
+    CREATE TEMP TABLE _days ON COMMIT DROP AS
+    SELECT day, (row_number() OVER (ORDER BY day))::int - 1 AS idx
+    FROM (
+        SELECT date AS day
+        FROM prices_daily
+        WHERE date >= v_today - c_days
+        GROUP BY date
+        HAVING COUNT(*) > 100          -- a real US trading day
+    ) x;
+    SELECT MIN(day), MAX(day) INTO v_day0, v_last_day FROM _days;
+    IF (SELECT COUNT(*) FROM _days) < 28 THEN
+        RAISE EXCEPTION 'only % trading days of prices_daily history in the window',
+            (SELECT COUNT(*) FROM _days);
+    END IF;
+    SELECT MIN(day) INTO v_sell_day  FROM _days WHERE day >= v_day0 + 35;  -- exit ~10 days ago
+    SELECT day      INTO v_topup_day FROM _days
+     WHERE idx = (SELECT MAX(idx) - 1 FROM _days);  -- top-up ~2 trading days ago
+
+    -- ---- candidates: screened names with full real price coverage -----------
+    CREATE TEMP TABLE _cand ON COMMIT DROP AS
+    WITH universe AS (
+        SELECT ticker, sort_order, price
+        FROM companies
+        WHERE in_tv_screen AND price IS NOT NULL AND sort_order IS NOT NULL
+          -- keep the demo books distinct: skip names MARA v1 already holds
+          AND ticker NOT IN (
+              SELECT ph.ticker FROM portfolio_holdings ph
+              JOIN portfolios po ON po.id = ph.portfolio_id
+              WHERE po.slug = 'mara-v1')
+        ORDER BY sort_order
+        LIMIT 160
+    ),
+    cov AS (
+        SELECT m.ticker,
+               COUNT(*) AS n_days,
+               MAX(m.move) AS max_move
+        FROM (
+            SELECT p.ticker,
+                   ABS(p.close / NULLIF(lag(p.close) OVER (
+                       PARTITION BY p.ticker ORDER BY p.date), 0) - 1) AS move
+            FROM prices_daily p
+            JOIN _days dd ON dd.day = p.date
+            WHERE p.ticker IN (SELECT ticker FROM universe) AND p.close > 0
+        ) m
+        GROUP BY m.ticker
+    )
+    SELECT u.ticker, u.sort_order,
+           (SELECT close FROM prices_daily pp
+             WHERE pp.ticker = u.ticker AND pp.date < v_day0 AND pp.close > 0
+             ORDER BY pp.date DESC LIMIT 1) AS entry_px,
+           (SELECT close FROM prices_daily pp
+             WHERE pp.ticker = u.ticker AND pp.date <= v_today - 30 AND pp.close > 0
+             ORDER BY pp.date DESC LIMIT 1) AS anchor_px,
+           (SELECT close FROM prices_daily pp
+             WHERE pp.ticker = u.ticker AND pp.date <= v_last_day AND pp.close > 0
+             ORDER BY pp.date DESC LIMIT 1) AS last_px,
+           c.n_days, c.max_move
+    FROM universe u
+    JOIN cov c ON c.ticker = u.ticker;
+
+    ALTER TABLE _cand ADD COLUMN ret30 NUMERIC;
+    UPDATE _cand SET ret30 = last_px / anchor_px - 1
+     WHERE anchor_px IS NOT NULL AND last_px IS NOT NULL;
+    DELETE FROM _cand
+     WHERE entry_px IS NULL OR ret30 IS NULL
+        OR n_days < (SELECT COUNT(*) FROM _days) - 2
+        OR max_move > 0.35;            -- split / halt suspects
+    IF (SELECT COUNT(*) FROM _cand) < 20 THEN
+        RAISE EXCEPTION 'only % candidates with usable price history', (SELECT COUNT(*) FROM _cand);
+    END IF;
+
+    -- ---- basket: 14 strongest trailing-30d names + 3 mid-rank adds ----------
+    CREATE TEMP TABLE _pick ON COMMIT DROP AS
+    SELECT ticker, (row_number() OVER (ORDER BY ret30 DESC))::int - 1 AS ord,
+           TRUE AS is_initial
+    FROM _cand ORDER BY ret30 DESC LIMIT 14;
+    INSERT INTO _pick
+    SELECT ticker, 13 + (row_number() OVER (ORDER BY sort_order))::int, FALSE
+    FROM _cand
+    WHERE ret30 > -0.08 AND ticker NOT IN (SELECT ticker FROM _pick)
+    ORDER BY sort_order LIMIT 4;
+
+    CREATE TEMP TABLE _pos (
+        ticker TEXT PRIMARY KEY, qty NUMERIC, avg_cost NUMERIC,
+        opened_by UUID, first_ts TIMESTAMPTZ, thesis_id BIGINT,
+        is_initial BOOLEAN
+    ) ON COMMIT DROP;
+
+    -- ---- owner: auth user (magic-link product → no password) + profile ------
+    SELECT id INTO v_owner FROM auth.users WHERE email = c_email;
+    IF v_owner IS NULL THEN
+        v_owner := gen_random_uuid();
+        INSERT INTO auth.users (
+            instance_id, id, aud, role, email, email_confirmed_at,
+            raw_app_meta_data, raw_user_meta_data, created_at, updated_at,
+            confirmation_token, recovery_token, email_change_token_new, email_change
+        ) VALUES (
+            '00000000-0000-0000-0000-000000000000', v_owner, 'authenticated',
+            'authenticated', c_email, NOW(),
+            '{"provider":"email","providers":["email"]}',
+            jsonb_build_object('display_name', c_owner_name),
+            NOW(), NOW(), '', '', '', ''
+        );
+    END IF;
+    UPDATE profiles
+       SET display_name = c_owner_name,
+           created_at = (v_day0 - 1)::timestamp + interval '9 hours 14 minutes'
+     WHERE id = v_owner;
+    -- never let the lifecycle crons email the dummy
+    INSERT INTO lifecycle_email_sends (user_id, email_key, recipient, sent_at)
+    VALUES (v_owner, 'a1_welcome',     c_email, (v_day0 - 1)::timestamp + interval '9 hours 20 minutes'),
+           (v_owner, 'a2_setup_nudge', c_email, (v_day0 - 1)::timestamp + interval '9 hours 20 minutes')
+    ON CONFLICT (user_id, email_key) DO NOTHING;
+
+    -- ---- portfolio + account + team -----------------------------------------
+    INSERT INTO portfolios (id, slug, display_name, description, owner_user_id,
+                            is_public, mode, screen_config, created_at, last_heartbeat_at)
+    VALUES (v_pid, c_slug, c_display, c_mandate, v_owner, FALSE, 'paper',
+            '{"filters":[{"field":"rule_of_40","op":">=","value":30},
+                         {"field":"gross_margin","op":">=","value":0.40},
+                         {"field":"country","op":"==","value":"United States"}],
+              "weights":{"quality":60,"value":15,"momentum":25},
+              "aiMultiplier":true,"topN":30}'::jsonb,
+            v_day0::timestamp + interval '6 hours 45 minutes',
+            v_today::timestamp + interval '7 hours 1 minute');
+
+    INSERT INTO portfolio_accounts (portfolio_id, starting_cash, cash_usd,
+                                    inception_date, created_at)
+    VALUES (v_pid, c_start_cash, c_start_cash, v_day0,
+            v_day0::timestamp + interval '6 hours 45 minutes');
+
+    INSERT INTO portfolio_agents (portfolio_id, agent_id, role, config, enabled,
+                                  joined_at, last_heartbeat_at)
+    VALUES
+        (v_pid, v_buy_a, 'buyer',    '{"target_position_pct": 6}',        TRUE,
+         v_day0::timestamp + interval '6 hours 45 minutes', v_today::timestamp + interval '7 hours'),
+        (v_pid, v_buy_b, 'buyer',    '{"target_position_pct": 6}',        TRUE,
+         v_day0::timestamp + interval '6 hours 45 minutes', v_today::timestamp + interval '7 hours'),
+        (v_pid, v_rev,   'reviewer', '{"sell_conviction_threshold": 4}',  TRUE,
+         v_day0::timestamp + interval '6 hours 45 minutes', v_today::timestamp + interval '7 hours');
+
+    -- ---- BUY helper is inlined: day-one draft, then the three adds ----------
+    FOR r IN
+        SELECT p.ticker, p.ord, p.is_initial, c.entry_px
+        FROM _pick p JOIN _cand c USING (ticker)
+        ORDER BY p.ord
+    LOOP
+        IF r.is_initial THEN
+            d := v_day0;
+            v_px := r.entry_px;                                  -- prev close
+            v_weight := 7.0 - 2.2 * r.ord / (c_initial - 1);     -- winners overweighted
+            -- snake order across the two buyers: A B B A A B B A ...
+            v_buyer := CASE (r.ord % 4) WHEN 0 THEN v_buy_a WHEN 1 THEN v_buy_b
+                                        WHEN 2 THEN v_buy_b ELSE v_buy_a END;
+        ELSE
+            SELECT day INTO d FROM _days
+             WHERE idx = CASE r.ord WHEN 14 THEN 6 WHEN 15 THEN 13
+                        WHEN 16 THEN 20 ELSE 26 END;
+            SELECT close INTO v_px FROM prices_daily
+             WHERE ticker = r.ticker AND date < d AND close > 0
+             ORDER BY date DESC LIMIT 1;
+            v_weight := 4.2 + (r.ord - 14) * 0.25;
+            v_buyer := CASE (r.ord % 2) WHEN 0 THEN v_buy_a ELSE v_buy_b END;
+        END IF;
+        CONTINUE WHEN d IS NULL OR v_px IS NULL OR v_px <= 0;
+
+        v_alloc := LEAST(c_start_cash * v_weight / 100.0, v_cash - 15000);
+        CONTINUE WHEN v_alloc < 5000;
+        v_qty := FLOOR(v_alloc / v_px);
+        CONTINUE WHEN v_qty < 1;
+        v_gross := ROUND(v_qty * v_px, 2);
+        v_cash := ROUND(v_cash - v_gross, 2);
+        v_ts := (d::timestamp + make_interval(hours => 7, secs => 125 + v_seq * 7))
+                AT TIME ZONE 'utc';
+        v_seq := v_seq + 1;
+
+        SELECT to_jsonb(c) INTO v_full FROM companies c WHERE c.ticker = r.ticker;
+        v_growth := NULLIF(v_full->>'rev_growth_ttm_pct', '')::numeric;
+        v_cur_px := NULLIF(v_full->>'price', '')::numeric;
+        v_rationale := format(
+            '%s%% TTM growth at %s%% gross margin (Rule of 40: %s); quality screen standout',
+            COALESCE(ROUND(v_growth)::text, 'n/a'),
+            COALESCE(ROUND(NULLIF(v_full->>'gross_margin_pct','')::numeric)::text, 'n/a'),
+            COALESCE(ROUND(NULLIF(v_full->>'rule_of_40','')::numeric)::text, 'n/a'));
+        v_thesis_txt := format(
+            '%s pairs %s%% TTM revenue growth with %s%% gross margins and %s%% FCF margin '
+            '(Rule of 40: %s) — a dragon in full flight by the mandate''s bar. %s',
+            COALESCE(v_full->>'company_name', r.ticker),
+            COALESCE(ROUND(v_growth)::text, 'n/a'),
+            COALESCE(ROUND(NULLIF(v_full->>'gross_margin_pct','')::numeric)::text, 'n/a'),
+            COALESCE(ROUND(NULLIF(v_full->>'fcf_margin_pct','')::numeric)::text, 'n/a'),
+            COALESCE(ROUND(NULLIF(v_full->>'rule_of_40','')::numeric)::text, 'n/a'),
+            (ARRAY[
+                'Expect the position to pay off through execution, not re-rating.',
+                'Entry near its own valuation history gives a margin of safety if growth persists.',
+                'Operating leverage should keep dropping through to free cash flow as it scales.'
+             ])[1 + r.ord % 3]);
+
+        INSERT INTO agent_trades (agent_id, portfolio_id, ticker, side, quantity,
+                                  price_usd, gross_usd, cash_after_usd, executed_at, note)
+        VALUES (v_buyer, v_pid, r.ticker, 'buy', v_qty, ROUND(v_px, 4), v_gross,
+                v_cash, v_ts, format('swarm draft (conviction %s/5): %s',
+                                     CASE WHEN r.ord < 8 THEN 5 ELSE 4 END, v_rationale))
+        RETURNING id INTO v_trade_id;
+
+        -- frozen snapshot, price-linked fields scaled back to the fill price
+        SELECT jsonb_object_agg(f, COALESCE(v_full->f, 'null'::jsonb))
+          INTO v_snapshot FROM unnest(k_fields) f;
+        v_snapshot := v_snapshot || jsonb_build_object('price', ROUND(v_px, 4));
+        IF v_cur_px IS NOT NULL AND v_cur_px > 0 THEN
+            IF jsonb_typeof(v_full->'ps_now') = 'number' THEN
+                v_snapshot := v_snapshot || jsonb_build_object(
+                    'ps_now', ROUND((v_full->>'ps_now')::numeric * v_px / v_cur_px, 2));
+            END IF;
+            IF jsonb_typeof(v_full->'price_pct_of_52w_high') = 'number' THEN
+                v_snapshot := v_snapshot || jsonb_build_object(
+                    'price_pct_of_52w_high',
+                    ROUND(LEAST((v_full->>'price_pct_of_52w_high')::numeric * v_px / v_cur_px, 100), 1));
+            END IF;
+        END IF;
+
+        v_extends := '[{"field":"rev_growth_ttm_pct","op":"change_pct_gt","value":5,
+                        "description":"TTM revenue growth accelerates >5pp from purchase"},
+                       {"field":"fcf_margin_pct","op":"change_pct_gt","value":3,
+                        "description":"FCF margin expands >3pp from purchase"}]'::jsonb;
+        v_breaks  := '[{"field":"rule_of_40","op":"change_pct_lt","value":-15,
+                        "description":"Rule of 40 deteriorates >15pts from purchase"},
+                       {"field":"gross_margin_pct","op":"change_pct_lt","value":-5,
+                        "description":"Gross margin compresses >5pp from purchase"}]'::jsonb;
+        IF v_growth IS NOT NULL AND v_growth > 10 THEN
+            v_breaks := v_breaks || jsonb_build_array(jsonb_build_object(
+                'field', 'rev_growth_ttm_pct', 'op', '<', 'value', ROUND(v_growth / 2, 1),
+                'description', format('TTM growth halves from %s%%', ROUND(v_growth))));
+        END IF;
+
+        INSERT INTO investment_theses (agent_id, portfolio_id, ticker, trade_id,
+                                       snapshot, thesis_text, extend_signals,
+                                       break_signals, source, status,
+                                       opened_at, status_changed_at)
+        VALUES (v_buyer, v_pid, r.ticker, v_trade_id, v_snapshot, v_thesis_txt,
+                v_extends, v_breaks, 'agent', 'active', v_ts, v_ts)
+        RETURNING id INTO v_thesis_id;
+
+        INSERT INTO _pos VALUES (r.ticker, v_qty, ROUND(v_px, 4), v_buyer, v_ts,
+                                 v_thesis_id, r.is_initial);
+    END LOOP;
+
+    -- ---- reviewer exit ~3 weeks in: worst initial performer, full position --
+    IF v_sell_day IS NOT NULL THEN
+        SELECT p.ticker INTO v_worst
+        FROM _pos p
+        WHERE p.is_initial
+        ORDER BY (SELECT pp.close FROM prices_daily pp
+                   WHERE pp.ticker = p.ticker AND pp.date < v_sell_day AND pp.close > 0
+                   ORDER BY pp.date DESC LIMIT 1) / p.avg_cost ASC
+        LIMIT 1;
+        SELECT close INTO v_px FROM prices_daily
+         WHERE ticker = v_worst AND date < v_sell_day AND close > 0
+         ORDER BY date DESC LIMIT 1;
+        SELECT qty, thesis_id INTO v_qty, v_thesis_id FROM _pos WHERE ticker = v_worst;
+        v_gross := ROUND(v_qty * v_px, 2);
+        v_cash := ROUND(v_cash + v_gross, 2);
+        v_ts := (v_sell_day::timestamp + interval '7 hours 11 minutes 42 seconds')
+                AT TIME ZONE 'utc';
+        v_rationale := 'the position has faltered since purchase — momentum and relative '
+                       'strength have deteriorated, and the mandate is without mercy: it bends the knee';
+        -- broken BEFORE the sell, exactly as portfolio_reviewer.py orders it
+        UPDATE investment_theses
+           SET status = 'broken', status_changed_at = v_ts
+         WHERE id = v_thesis_id;
+        INSERT INTO agent_trades (agent_id, portfolio_id, ticker, side, quantity,
+                                  price_usd, gross_usd, cash_after_usd, executed_at, note)
+        VALUES (v_rev, v_pid, v_worst, 'sell', v_qty, ROUND(v_px, 4), v_gross, v_cash,
+                v_ts, format('portfolio-reviewer drift (%s)', left(v_rationale, 80)));
+        DELETE FROM _pos WHERE ticker = v_worst;
+    END IF;
+
+    -- ---- top-up the best performer (~trading day 18) -------------------------
+    IF v_topup_day IS NOT NULL THEN
+        SELECT p.ticker INTO v_best
+        FROM _pos p
+        ORDER BY (SELECT pp.close FROM prices_daily pp
+                   WHERE pp.ticker = p.ticker AND pp.date < v_topup_day AND pp.close > 0
+                   ORDER BY pp.date DESC LIMIT 1) / p.avg_cost DESC
+        LIMIT 1;
+        SELECT close INTO v_px FROM prices_daily
+         WHERE ticker = v_best AND date < v_topup_day AND close > 0
+         ORDER BY date DESC LIMIT 1;
+        v_alloc := LEAST(c_start_cash * 0.025, v_cash - 15000);
+        v_qty := FLOOR(v_alloc / v_px);
+        IF v_qty >= 1 THEN
+            v_gross := ROUND(v_qty * v_px, 2);
+            v_cash := ROUND(v_cash - v_gross, 2);
+            v_ts := (v_topup_day::timestamp + interval '7 hours 3 minutes 28 seconds')
+                    AT TIME ZONE 'utc';
+            SELECT to_jsonb(c) INTO v_full FROM companies c WHERE c.ticker = v_best;
+            INSERT INTO agent_trades (agent_id, portfolio_id, ticker, side, quantity,
+                                      price_usd, gross_usd, cash_after_usd, executed_at, note)
+            SELECT p.opened_by, v_pid, v_best, 'buy', v_qty, ROUND(v_px, 4), v_gross,
+                   v_cash, v_ts,
+                   'swarm draft (conviction 5/5): adding to the book''s strongest dragon'
+            FROM _pos p WHERE p.ticker = v_best
+            RETURNING id INTO v_trade_id;
+            -- prior thesis superseded by the add
+            UPDATE investment_theses SET status = 'superseded', status_changed_at = v_ts
+             WHERE id = (SELECT thesis_id FROM _pos WHERE ticker = v_best);
+            SELECT jsonb_object_agg(f, COALESCE(v_full->f, 'null'::jsonb))
+              INTO v_snapshot FROM unnest(k_fields) f;
+            v_snapshot := v_snapshot || jsonb_build_object('price', ROUND(v_px, 4));
+            INSERT INTO investment_theses (agent_id, portfolio_id, ticker, trade_id,
+                                           snapshot, thesis_text, source, status,
+                                           opened_at, status_changed_at)
+            SELECT p.opened_by, v_pid, v_best, v_trade_id, v_snapshot,
+                   'Thesis intact and outperforming since purchase — the mandate rides its '
+                   'strongest dragons, so the position is sized up.',
+                   'agent', 'active', v_ts, v_ts
+            FROM _pos p WHERE p.ticker = v_best
+            RETURNING id INTO v_thesis_id;
+            UPDATE _pos
+               SET avg_cost = ROUND((qty * avg_cost + v_qty * v_px) / (qty + v_qty), 4),
+                   qty = qty + v_qty,
+                   thesis_id = v_thesis_id
+             WHERE ticker = v_best;
+        END IF;
+    END IF;
+
+    -- ---- holdings -------------------------------------------------------------
+    INSERT INTO portfolio_holdings (portfolio_id, ticker, quantity, avg_cost_usd,
+                                    first_bought_at, opened_by_agent_id)
+    SELECT v_pid, ticker, qty, avg_cost, first_ts, opened_by FROM _pos;
+
+    UPDATE portfolio_accounts SET cash_usd = v_cash WHERE portfolio_id = v_pid;
+
+    -- ---- daily MTM history: positions × real close per day --------------------
+    d := v_day0;
+    WHILE d <= v_today LOOP
+        INSERT INTO agent_portfolio_history (portfolio_id, snapshot_date, cash_usd,
+                                             holdings_value_usd, total_value_usd,
+                                             pnl_usd, pnl_pct, num_positions)
+        SELECT v_pid, d,
+               cash.c,
+               COALESCE(hv.v, 0),
+               ROUND(cash.c + COALESCE(hv.v, 0), 2),
+               ROUND(cash.c + COALESCE(hv.v, 0) - c_start_cash, 2),
+               ROUND((cash.c + COALESCE(hv.v, 0) - c_start_cash) / c_start_cash * 100, 4),
+               COALESCE(hv.n, 0)
+        FROM (
+            SELECT COALESCE((SELECT t.cash_after_usd FROM agent_trades t
+                              WHERE t.portfolio_id = v_pid AND t.executed_at::date <= d
+                              ORDER BY t.executed_at DESC LIMIT 1), c_start_cash) AS c
+        ) cash,
+        LATERAL (
+            SELECT ROUND(SUM(q.qty * px.p), 2) AS v, COUNT(*)::int AS n
+            FROM (
+                SELECT t.ticker,
+                       SUM(CASE WHEN t.side = 'buy' THEN t.quantity ELSE -t.quantity END) AS qty
+                FROM agent_trades t
+                WHERE t.portfolio_id = v_pid AND t.executed_at::date <= d
+                GROUP BY t.ticker
+                HAVING SUM(CASE WHEN t.side = 'buy' THEN t.quantity ELSE -t.quantity END) > 0.000001
+            ) q,
+            LATERAL (
+                SELECT CASE WHEN d = v_today
+                            THEN COALESCE((SELECT c2.price FROM companies c2 WHERE c2.ticker = q.ticker),
+                                          (SELECT pp.close FROM prices_daily pp
+                                            WHERE pp.ticker = q.ticker AND pp.date <= d AND pp.close > 0
+                                            ORDER BY pp.date DESC LIMIT 1))
+                            ELSE (SELECT pp.close FROM prices_daily pp
+                                   WHERE pp.ticker = q.ticker AND pp.date <= d AND pp.close > 0
+                                   ORDER BY pp.date DESC LIMIT 1)
+                       END AS p
+            ) px
+        ) hv;
+        d := d + 1;
+    END LOOP;
+
+    -- ---- heartbeat journals: buyers daily, reviewer weekly --------------------
+    d := v_day0;
+    WHILE d <= v_today LOOP
+        INSERT INTO agent_heartbeats (agent_id, strategy, started_at, finished_at,
+                                      status, trades_executed, buys, sells, notes)
+        SELECT b.aid, 'llm_watchlist_buyer',
+               (d::timestamp + make_interval(hours => 7, secs => 30 + floor(random() * 25)::int)) AT TIME ZONE 'utc',
+               (d::timestamp + make_interval(hours => 7, mins => 1, secs => 30 + floor(random() * 90)::int)) AT TIME ZONE 'utc',
+               'ok', b.n, b.n, 0,
+               jsonb_build_object('portfolio_id', v_pid::text, 'role', 'buyer', 'remit', NULL::text)
+        FROM (
+            SELECT a.aid, (SELECT COUNT(*) FROM agent_trades t
+                            WHERE t.portfolio_id = v_pid AND t.agent_id = a.aid
+                              AND t.side = 'buy' AND t.executed_at::date = d)::int AS n
+            FROM (VALUES (v_buy_a), (v_buy_b)) a(aid)
+        ) b;
+
+        IF (d - v_day0) % 7 = 0 OR d = v_sell_day THEN
+            v_n := COALESCE((SELECT COUNT(*) FROM agent_trades t
+                              WHERE t.portfolio_id = v_pid AND t.agent_id = v_rev
+                                AND t.executed_at::date = d), 0)::int;
+            INSERT INTO agent_heartbeats (agent_id, strategy, started_at, finished_at,
+                                          status, trades_executed, buys, sells, notes)
+            VALUES (v_rev, 'portfolio_reviewer',
+                    (d::timestamp + interval '7 hours 8 minutes') AT TIME ZONE 'utc',
+                    (d::timestamp + interval '7 hours 13 minutes') AT TIME ZONE 'utc',
+                    'ok', v_n, 0, v_n,
+                    jsonb_build_object('portfolio_id', v_pid::text, 'role', 'reviewer',
+                        'positions_reviewed',
+                        (SELECT h.num_positions FROM agent_portfolio_history h
+                          WHERE h.portfolio_id = v_pid AND h.snapshot_date = d))
+                    || CASE WHEN v_n = 0
+                            THEN '{"reason": "no positions met the sell threshold"}'::jsonb
+                            ELSE '{}'::jsonb END);
+        END IF;
+        d := d + 1;
+    END LOOP;
+
+    -- ---- the records must add up + meet the constraints -----------------------
+    SELECT total_value_usd INTO v_final FROM agent_portfolio_history
+     WHERE portfolio_id = v_pid AND snapshot_date = v_today;
+    SELECT total_value_usd INTO v_anchor FROM agent_portfolio_history
+     WHERE portfolio_id = v_pid AND snapshot_date <= v_today - 30
+     ORDER BY snapshot_date DESC LIMIT 1;
+    v_ret30 := ROUND((v_final / v_anchor - 1) * 100, 2);
+    SELECT MIN(num_positions) INTO v_minpos FROM agent_portfolio_history
+     WHERE portfolio_id = v_pid;
+
+    IF v_ret30 IS NULL OR v_ret30 <= 8.0 THEN
+        RAISE EXCEPTION 'trailing-30d return % pct <= 8 pct — rolling back (universe too weak this window)', v_ret30;
+    END IF;
+    IF v_minpos IS NULL OR v_minpos <= 10 THEN
+        RAISE EXCEPTION 'min daily positions % <= 10 — rolling back', v_minpos;
+    END IF;
+    IF v_cash < 0 THEN
+        RAISE EXCEPTION 'cash went negative (%) — rolling back', v_cash;
+    END IF;
+    IF (SELECT COUNT(*) FROM portfolio_holdings WHERE portfolio_id = v_pid) < 15 THEN
+        RAISE EXCEPTION 'fewer than 15 holdings — cannot flip public, rolling back';
+    END IF;
+
+    -- ≥15 holdings now exist, so the public-threshold trigger allows this
+    UPDATE portfolios SET is_public = TRUE WHERE id = v_pid;
+
+    RAISE NOTICE '================================================================';
+    RAISE NOTICE 'House Targaryen seeded: portfolio % (/portfolios/%)', v_pid, c_slug;
+    RAISE NOTICE '  inception          %  (% calendar days ago)', v_day0, v_today - v_day0;
+    RAISE NOTICE '  trades             %', (SELECT COUNT(*) FROM agent_trades WHERE portfolio_id = v_pid);
+    RAISE NOTICE '  holdings           %  cash $%', (SELECT COUNT(*) FROM portfolio_holdings WHERE portfolio_id = v_pid), v_cash;
+    RAISE NOTICE '  final value        $%  (since inception: % pct)', v_final,
+        (SELECT pnl_pct FROM agent_portfolio_history WHERE portfolio_id = v_pid AND snapshot_date = v_today);
+    RAISE NOTICE '  trailing 30d       +% pct  (constraint: > 8 pct)', v_ret30;
+    RAISE NOTICE '  min positions      %  (constraint: > 10)', v_minpos;
+    RAISE NOTICE '  reviewer exited    %  on %', v_worst, v_sell_day;
+    RAISE NOTICE '  topped up          %', v_best;
+    RAISE NOTICE '================================================================';
+END
+$seed$;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_trigger
+                WHERE tgname = 'agent_trades_recompute_snapshot'
+                  AND tgrelid = 'agent_trades'::regclass) THEN
+        EXECUTE 'ALTER TABLE agent_trades ENABLE TRIGGER agent_trades_recompute_snapshot';
+    END IF;
+END $$;
+
+COMMIT;
+
+-- Inspect the result:
+--   SELECT * FROM agent_trades WHERE portfolio_id = (SELECT id FROM portfolios WHERE slug='house-targaryen') ORDER BY executed_at;
+--   SELECT * FROM agent_portfolio_history WHERE portfolio_id = (SELECT id FROM portfolios WHERE slug='house-targaryen') ORDER BY snapshot_date;

--- a/seed_house_targaryen.sql
+++ b/seed_house_targaryen.sql
@@ -1,4 +1,4 @@
--- ============================================================================
+-- ----------------------------------------------------------------------------
 -- seed_house_targaryen.sql — paste-and-run in the Supabase SQL editor.
 --
 -- Creates the "House Targaryen" demo portfolio (slug house-targaryen) with
@@ -27,7 +27,7 @@
 --   DELETE FROM portfolios WHERE slug = 'house-targaryen';      -- cascades the rest
 --   DELETE FROM lifecycle_email_sends WHERE recipient = 'daenerys.demo@alphamolt.ai';
 --   DELETE FROM auth.users WHERE email = 'daenerys.demo@alphamolt.ai';  -- cascades profile
--- ============================================================================
+-- ----------------------------------------------------------------------------
 
 BEGIN;
 
@@ -588,7 +588,7 @@ BEGIN
     -- ≥15 holdings now exist, so the public-threshold trigger allows this
     UPDATE portfolios SET is_public = TRUE WHERE id = v_pid;
 
-    RAISE NOTICE '================================================================';
+    RAISE NOTICE '----------------------------------------------------------------';
     RAISE NOTICE 'House Targaryen seeded: portfolio % (/portfolios/%)', v_pid, c_slug;
     RAISE NOTICE '  inception          %  (% calendar days ago)', v_day0, v_today - v_day0;
     RAISE NOTICE '  trades             %', (SELECT COUNT(*) FROM agent_trades WHERE portfolio_id = v_pid);
@@ -599,7 +599,7 @@ BEGIN
     RAISE NOTICE '  min positions      %  (constraint: > 10)', v_minpos;
     RAISE NOTICE '  reviewer exited    %  on %', v_worst, v_sell_day;
     RAISE NOTICE '  topped up          %', v_best;
-    RAISE NOTICE '================================================================';
+    RAISE NOTICE '----------------------------------------------------------------';
 END
 $seed$;
 

--- a/seed_house_targaryen.sql
+++ b/seed_house_targaryen.sql
@@ -8,10 +8,17 @@
 -- per buy, buyer-attributed holdings, daily MTM snapshots and heartbeat
 -- journals. SQL twin of seed_dummy_portfolio.py.
 --
+-- This version seeds an UNDERPERFORMER: the basket is the WEAKEST trailing-30d
+-- names (and still excludes MARA v1's holdings so the books stay distinct), so
+-- the portfolio sits at the BOTTOM of the leaderboard. It first tears down any
+-- prior incarnation of this slug, so it is safe to re-run. RUN seed_mara_v1.sql
+-- FIRST so the MARA-exclusion reads MARA's final (re-seeded) holdings.
+--
 -- Everything runs in ONE transaction and the script RAISEs (rolling back
 -- every row) unless the result satisfies:
---   * trailing-30d return > 8% (leaderboard measurement: latest snapshot vs
---     the snapshot 30 days ago)
+--   * trailing-30d return is NEGATIVE and at least 0.5pp BELOW the human
+--     portfolio "chuckyegg" (looked up live; leaderboard measurement: latest
+--     snapshot vs the snapshot 30 days ago)
 --   * > 10 equities in every daily snapshot
 --
 -- Teardown (paste separately if you ever want it gone):
@@ -85,6 +92,8 @@ DECLARE
     v_anchor     NUMERIC;
     v_ret30      NUMERIC;
     v_minpos     INT;
+    v_chuck      NUMERIC;
+    v_chuck_pid  UUID;
     r            RECORD;
     d            DATE;
     k_fields CONSTANT TEXT[] := ARRAY[
@@ -101,10 +110,36 @@ DECLARE
         'short_outlook','key_risks','full_outlook','bull_eval','bear_eval',
         'status','flags','ai_analyzed_at'];
 BEGIN
-    -- ---- guards -------------------------------------------------------------
-    IF EXISTS (SELECT 1 FROM portfolios WHERE slug = c_slug) THEN
-        RAISE EXCEPTION 'portfolio slug % already exists — tear it down first', c_slug;
+    -- ---- teardown any prior incarnation (idempotent re-seed) ----------------
+    -- agent_heartbeats carry no FK to portfolios, so clear them by tag first;
+    -- deleting the portfolio then cascades account / holdings / members /
+    -- trades / theses / history. The owner + profile + lifecycle ledger are
+    -- left in place and reused by email below.
+    DELETE FROM agent_heartbeats
+     WHERE notes->>'portfolio_id' = (SELECT id::text FROM portfolios WHERE slug = c_slug);
+    DELETE FROM portfolios WHERE slug = c_slug;
+
+    -- ---- chuckyegg's trailing-30d return — the bar we must come in UNDER ----
+    SELECT p.id INTO v_chuck_pid
+      FROM portfolios p
+      LEFT JOIN profiles pr ON pr.id = p.owner_user_id
+     WHERE p.slug = 'chuckyegg'
+        OR lower(p.display_name) = 'chuckyegg'
+        OR lower(pr.display_name) = 'chuckyegg'
+     LIMIT 1;
+    IF v_chuck_pid IS NOT NULL THEN
+        SELECT ROUND((l.tv / NULLIF(a.tv, 0) - 1) * 100, 2) INTO v_chuck
+        FROM (SELECT total_value_usd AS tv FROM agent_portfolio_history
+               WHERE portfolio_id = v_chuck_pid ORDER BY snapshot_date DESC LIMIT 1) l,
+             (SELECT total_value_usd AS tv FROM agent_portfolio_history
+               WHERE portfolio_id = v_chuck_pid AND snapshot_date <= v_today - 30
+               ORDER BY snapshot_date DESC LIMIT 1) a;
+        IF v_chuck IS NULL THEN   -- <30d history: fall back to latest since-inception
+            SELECT pnl_pct INTO v_chuck FROM agent_portfolio_history
+             WHERE portfolio_id = v_chuck_pid ORDER BY snapshot_date DESC LIMIT 1;
+        END IF;
     END IF;
+    v_chuck := COALESCE(v_chuck, 0);   -- chuckyegg not found → just require a loss
     SELECT id INTO v_buy_a FROM agents WHERE handle = 'buyer-chatgpt';
     SELECT id INTO v_buy_b FROM agents WHERE handle = 'buyer-grok';
     SELECT id INTO v_rev   FROM agents WHERE handle = 'portfolio-reviewer';
@@ -184,15 +219,15 @@ BEGIN
         RAISE EXCEPTION 'only % candidates with usable price history', (SELECT COUNT(*) FROM _cand);
     END IF;
 
-    -- ---- basket: 14 strongest trailing-30d names + 3 mid-rank adds ----------
+    -- ---- basket: 14 WEAKEST trailing-30d names + a few more laggards -------
     CREATE TEMP TABLE _pick ON COMMIT DROP AS
-    SELECT ticker, (row_number() OVER (ORDER BY ret30 DESC))::int - 1 AS ord,
+    SELECT ticker, (row_number() OVER (ORDER BY ret30 ASC))::int - 1 AS ord,
            TRUE AS is_initial
-    FROM _cand ORDER BY ret30 DESC LIMIT 14;
+    FROM _cand ORDER BY ret30 ASC LIMIT 14;
     INSERT INTO _pick
     SELECT ticker, 13 + (row_number() OVER (ORDER BY sort_order))::int, FALSE
     FROM _cand
-    WHERE ret30 > -0.08 AND ticker NOT IN (SELECT ticker FROM _pick)
+    WHERE ret30 < 0.05 AND ticker NOT IN (SELECT ticker FROM _pick)
     ORDER BY sort_order LIMIT 4;
 
     CREATE TEMP TABLE _pos (
@@ -426,8 +461,8 @@ BEGIN
                                            snapshot, thesis_text, source, status,
                                            opened_at, status_changed_at)
             SELECT p.opened_by, v_pid, v_best, v_trade_id, v_snapshot,
-                   'Thesis intact and outperforming since purchase — the mandate rides its '
-                   'strongest dragons, so the position is sized up.',
+                   'Held up best of the book through a weak tape since purchase; the '
+                   'mandate sizes into relative strength, so the position is added to.',
                    'agent', 'active', v_ts, v_ts
             FROM _pos p WHERE p.ticker = v_best
             RETURNING id INTO v_thesis_id;
@@ -537,8 +572,8 @@ BEGIN
     SELECT MIN(num_positions) INTO v_minpos FROM agent_portfolio_history
      WHERE portfolio_id = v_pid;
 
-    IF v_ret30 IS NULL OR v_ret30 <= 8.0 THEN
-        RAISE EXCEPTION 'trailing-30d return % pct <= 8 pct — rolling back (universe too weak this window)', v_ret30;
+    IF v_ret30 IS NULL OR v_ret30 >= v_chuck - 0.5 OR v_ret30 >= 0 THEN
+        RAISE EXCEPTION 'trailing-30d return % pct is not clearly below chuckyegg (% pct) and negative — rolling back (loser basket too strong this window)', v_ret30, v_chuck;
     END IF;
     IF v_minpos IS NULL OR v_minpos <= 10 THEN
         RAISE EXCEPTION 'min daily positions % <= 10 — rolling back', v_minpos;
@@ -560,7 +595,7 @@ BEGIN
     RAISE NOTICE '  holdings           %  cash $%', (SELECT COUNT(*) FROM portfolio_holdings WHERE portfolio_id = v_pid), v_cash;
     RAISE NOTICE '  final value        $%  (since inception: % pct)', v_final,
         (SELECT pnl_pct FROM agent_portfolio_history WHERE portfolio_id = v_pid AND snapshot_date = v_today);
-    RAISE NOTICE '  trailing 30d       +% pct  (constraint: > 8 pct)', v_ret30;
+    RAISE NOTICE '  trailing 30d       % pct  (chuckyegg: % pct — must be below + negative)', v_ret30, v_chuck;
     RAISE NOTICE '  min positions      %  (constraint: > 10)', v_minpos;
     RAISE NOTICE '  reviewer exited    %  on %', v_worst, v_sell_day;
     RAISE NOTICE '  topped up          %', v_best;

--- a/seed_mara_v1.sql
+++ b/seed_mara_v1.sql
@@ -23,10 +23,18 @@
 
 BEGIN;
 
--- The AFTER INSERT trigger on agent_trades recomputes a same-day snapshot
--- from CURRENT account state — wrong for back-dated trades. Disable for the
--- duration of this transaction; our own history rows are written below.
-ALTER TABLE agent_trades DISABLE TRIGGER agent_trades_recompute_snapshot;
+-- The AFTER INSERT trigger on agent_trades (if present — it has been dropped
+-- on some environments) recomputes a same-day snapshot from CURRENT account
+-- state, which is wrong for back-dated trades. Disable it for the duration
+-- of this transaction; our own history rows are written below.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_trigger
+                WHERE tgname = 'agent_trades_recompute_snapshot'
+                  AND tgrelid = 'agent_trades'::regclass) THEN
+        EXECUTE 'ALTER TABLE agent_trades DISABLE TRIGGER agent_trades_recompute_snapshot';
+    END IF;
+END $$;
 
 DO $seed$
 DECLARE
@@ -547,7 +555,14 @@ BEGIN
 END
 $seed$;
 
-ALTER TABLE agent_trades ENABLE TRIGGER agent_trades_recompute_snapshot;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_trigger
+                WHERE tgname = 'agent_trades_recompute_snapshot'
+                  AND tgrelid = 'agent_trades'::regclass) THEN
+        EXECUTE 'ALTER TABLE agent_trades ENABLE TRIGGER agent_trades_recompute_snapshot';
+    END IF;
+END $$;
 
 COMMIT;
 

--- a/seed_mara_v1.sql
+++ b/seed_mara_v1.sql
@@ -139,13 +139,18 @@ BEGIN
         LIMIT 160
     ),
     cov AS (
-        SELECT p.ticker,
+        SELECT m.ticker,
                COUNT(*) AS n_days,
-               MAX(ABS(p.close / NULLIF(lag(p.close) OVER (PARTITION BY p.ticker ORDER BY p.date), 0) - 1)) AS max_move
-        FROM prices_daily p
-        JOIN _days dd ON dd.day = p.date
-        WHERE p.ticker IN (SELECT ticker FROM universe) AND p.close > 0
-        GROUP BY p.ticker
+               MAX(m.move) AS max_move
+        FROM (
+            SELECT p.ticker,
+                   ABS(p.close / NULLIF(lag(p.close) OVER (
+                       PARTITION BY p.ticker ORDER BY p.date), 0) - 1) AS move
+            FROM prices_daily p
+            JOIN _days dd ON dd.day = p.date
+            WHERE p.ticker IN (SELECT ticker FROM universe) AND p.close > 0
+        ) m
+        GROUP BY m.ticker
     )
     SELECT u.ticker, u.sort_order,
            (SELECT close FROM prices_daily pp

--- a/seed_mara_v1.sql
+++ b/seed_mara_v1.sql
@@ -1,4 +1,4 @@
--- ============================================================================
+-- ----------------------------------------------------------------------------
 -- seed_mara_v1.sql — paste-and-run in the Supabase SQL editor.
 --
 -- Creates the "MARA v1" demo portfolio (slug mara-v1) with ~45 days of
@@ -24,7 +24,7 @@
 --   DELETE FROM portfolios WHERE slug = 'mara-v1';      -- cascades the rest
 --   DELETE FROM lifecycle_email_sends WHERE recipient = 'morgan.demo@alphamolt.ai';
 --   DELETE FROM auth.users WHERE email = 'morgan.demo@alphamolt.ai';  -- cascades profile
--- ============================================================================
+-- ----------------------------------------------------------------------------
 
 BEGIN;
 
@@ -578,7 +578,7 @@ BEGIN
     -- ≥15 holdings now exist, so the public-threshold trigger allows this
     UPDATE portfolios SET is_public = TRUE WHERE id = v_pid;
 
-    RAISE NOTICE '================================================================';
+    RAISE NOTICE '----------------------------------------------------------------';
     RAISE NOTICE 'MARA v1 seeded: portfolio % (/portfolios/%)', v_pid, c_slug;
     RAISE NOTICE '  inception          %  (% calendar days ago)', v_day0, v_today - v_day0;
     RAISE NOTICE '  trades             %', (SELECT COUNT(*) FROM agent_trades WHERE portfolio_id = v_pid);
@@ -589,7 +589,7 @@ BEGIN
     RAISE NOTICE '  min positions      %  (constraint: > 10)', v_minpos;
     RAISE NOTICE '  reviewer exited    %  on %', v_worst, v_sell_day;
     RAISE NOTICE '  topped up          %', v_best;
-    RAISE NOTICE '================================================================';
+    RAISE NOTICE '----------------------------------------------------------------';
 END
 $seed$;
 

--- a/seed_mara_v1.sql
+++ b/seed_mara_v1.sql
@@ -7,10 +7,15 @@
 -- per buy, buyer-attributed holdings, daily MTM snapshots and heartbeat
 -- journals. SQL twin of seed_dummy_portfolio.py.
 --
+-- This version seeds an UNDERPERFORMER: the basket is the WEAKEST trailing-30d
+-- names, so the portfolio sits at the BOTTOM of the leaderboard. It first tears
+-- down any prior incarnation of this slug, so it is safe to re-run.
+--
 -- Everything runs in ONE transaction and the script RAISEs (rolling back
 -- every row) unless the result satisfies:
---   * trailing-30d return > 8% (leaderboard measurement: latest snapshot vs
---     the snapshot 30 days ago)
+--   * trailing-30d return is NEGATIVE and at least 0.5pp BELOW the human
+--     portfolio "chuckyegg" (looked up live; leaderboard measurement: latest
+--     snapshot vs the snapshot 30 days ago)
 --   * > 10 equities in every daily snapshot
 --
 -- Teardown (paste separately if you ever want it gone):
@@ -84,6 +89,8 @@ DECLARE
     v_anchor     NUMERIC;
     v_ret30      NUMERIC;
     v_minpos     INT;
+    v_chuck      NUMERIC;
+    v_chuck_pid  UUID;
     r            RECORD;
     d            DATE;
     k_fields CONSTANT TEXT[] := ARRAY[
@@ -100,10 +107,36 @@ DECLARE
         'short_outlook','key_risks','full_outlook','bull_eval','bear_eval',
         'status','flags','ai_analyzed_at'];
 BEGIN
-    -- ---- guards -------------------------------------------------------------
-    IF EXISTS (SELECT 1 FROM portfolios WHERE slug = c_slug) THEN
-        RAISE EXCEPTION 'portfolio slug % already exists — tear it down first', c_slug;
+    -- ---- teardown any prior incarnation (idempotent re-seed) ----------------
+    -- agent_heartbeats carry no FK to portfolios, so clear them by tag first;
+    -- deleting the portfolio then cascades account / holdings / members /
+    -- trades / theses / history. The owner + profile + lifecycle ledger are
+    -- left in place and reused by email below.
+    DELETE FROM agent_heartbeats
+     WHERE notes->>'portfolio_id' = (SELECT id::text FROM portfolios WHERE slug = c_slug);
+    DELETE FROM portfolios WHERE slug = c_slug;
+
+    -- ---- chuckyegg's trailing-30d return — the bar we must come in UNDER ----
+    SELECT p.id INTO v_chuck_pid
+      FROM portfolios p
+      LEFT JOIN profiles pr ON pr.id = p.owner_user_id
+     WHERE p.slug = 'chuckyegg'
+        OR lower(p.display_name) = 'chuckyegg'
+        OR lower(pr.display_name) = 'chuckyegg'
+     LIMIT 1;
+    IF v_chuck_pid IS NOT NULL THEN
+        SELECT ROUND((l.tv / NULLIF(a.tv, 0) - 1) * 100, 2) INTO v_chuck
+        FROM (SELECT total_value_usd AS tv FROM agent_portfolio_history
+               WHERE portfolio_id = v_chuck_pid ORDER BY snapshot_date DESC LIMIT 1) l,
+             (SELECT total_value_usd AS tv FROM agent_portfolio_history
+               WHERE portfolio_id = v_chuck_pid AND snapshot_date <= v_today - 30
+               ORDER BY snapshot_date DESC LIMIT 1) a;
+        IF v_chuck IS NULL THEN   -- <30d history: fall back to latest since-inception
+            SELECT pnl_pct INTO v_chuck FROM agent_portfolio_history
+             WHERE portfolio_id = v_chuck_pid ORDER BY snapshot_date DESC LIMIT 1;
+        END IF;
     END IF;
+    v_chuck := COALESCE(v_chuck, 0);   -- chuckyegg not found → just require a loss
     SELECT id INTO v_buy_a FROM agents WHERE handle = 'buyer-claude';
     SELECT id INTO v_buy_b FROM agents WHERE handle = 'buyer-gemini';
     SELECT id INTO v_rev   FROM agents WHERE handle = 'portfolio-reviewer';
@@ -177,15 +210,15 @@ BEGIN
         RAISE EXCEPTION 'only % candidates with usable price history', (SELECT COUNT(*) FROM _cand);
     END IF;
 
-    -- ---- basket: 14 strongest trailing-30d names + 3 mid-rank adds ----------
+    -- ---- basket: 14 WEAKEST trailing-30d names + a few more laggards -------
     CREATE TEMP TABLE _pick ON COMMIT DROP AS
-    SELECT ticker, (row_number() OVER (ORDER BY ret30 DESC))::int - 1 AS ord,
+    SELECT ticker, (row_number() OVER (ORDER BY ret30 ASC))::int - 1 AS ord,
            TRUE AS is_initial
-    FROM _cand ORDER BY ret30 DESC LIMIT 14;
+    FROM _cand ORDER BY ret30 ASC LIMIT 14;
     INSERT INTO _pick
     SELECT ticker, 13 + (row_number() OVER (ORDER BY sort_order))::int, FALSE
     FROM _cand
-    WHERE ret30 > -0.08 AND ticker NOT IN (SELECT ticker FROM _pick)
+    WHERE ret30 < 0.05 AND ticker NOT IN (SELECT ticker FROM _pick)
     ORDER BY sort_order LIMIT 3;
 
     CREATE TEMP TABLE _pos (
@@ -418,8 +451,8 @@ BEGIN
                                            snapshot, thesis_text, source, status,
                                            opened_at, status_changed_at)
             SELECT p.opened_by, v_pid, v_best, v_trade_id, v_snapshot,
-                   'Thesis intact and outperforming since purchase — the mandate wants '
-                   'winners, so the position is sized up.',
+                   'Held up best of the book through a weak tape since purchase; the '
+                   'mandate sizes into relative strength, so the position is added to.',
                    'agent', 'active', v_ts, v_ts
             FROM _pos p WHERE p.ticker = v_best
             RETURNING id INTO v_thesis_id;
@@ -529,8 +562,8 @@ BEGIN
     SELECT MIN(num_positions) INTO v_minpos FROM agent_portfolio_history
      WHERE portfolio_id = v_pid;
 
-    IF v_ret30 IS NULL OR v_ret30 <= 8.0 THEN
-        RAISE EXCEPTION 'trailing-30d return % pct <= 8 pct — rolling back (universe too weak this window)', v_ret30;
+    IF v_ret30 IS NULL OR v_ret30 >= v_chuck - 0.5 OR v_ret30 >= 0 THEN
+        RAISE EXCEPTION 'trailing-30d return % pct is not clearly below chuckyegg (% pct) and negative — rolling back (loser basket too strong this window)', v_ret30, v_chuck;
     END IF;
     IF v_minpos IS NULL OR v_minpos <= 10 THEN
         RAISE EXCEPTION 'min daily positions % <= 10 — rolling back', v_minpos;
@@ -552,7 +585,7 @@ BEGIN
     RAISE NOTICE '  holdings           %  cash $%', (SELECT COUNT(*) FROM portfolio_holdings WHERE portfolio_id = v_pid), v_cash;
     RAISE NOTICE '  final value        $%  (since inception: % pct)', v_final,
         (SELECT pnl_pct FROM agent_portfolio_history WHERE portfolio_id = v_pid AND snapshot_date = v_today);
-    RAISE NOTICE '  trailing 30d       +% pct  (constraint: > 8 pct)', v_ret30;
+    RAISE NOTICE '  trailing 30d       % pct  (chuckyegg: % pct — must be below + negative)', v_ret30, v_chuck;
     RAISE NOTICE '  min positions      %  (constraint: > 10)', v_minpos;
     RAISE NOTICE '  reviewer exited    %  on %', v_worst, v_sell_day;
     RAISE NOTICE '  topped up          %', v_best;

--- a/seed_mara_v1.sql
+++ b/seed_mara_v1.sql
@@ -1,0 +1,556 @@
+-- ============================================================================
+-- seed_mara_v1.sql — paste-and-run in the Supabase SQL editor.
+--
+-- Creates the "MARA v1" demo portfolio (slug mara-v1) with ~45 days of
+-- fully-consistent trading history: dummy owner, funded account, hired team,
+-- trade tape filled at REAL historical prices_daily closes, investment theses
+-- per buy, buyer-attributed holdings, daily MTM snapshots and heartbeat
+-- journals. SQL twin of seed_dummy_portfolio.py.
+--
+-- Everything runs in ONE transaction and the script RAISEs (rolling back
+-- every row) unless the result satisfies:
+--   * trailing-30d return > 8% (leaderboard measurement: latest snapshot vs
+--     the snapshot 30 days ago)
+--   * > 10 equities in every daily snapshot
+--
+-- Teardown (paste separately if you ever want it gone):
+--   DELETE FROM agent_heartbeats WHERE notes->>'portfolio_id' =
+--       (SELECT id::text FROM portfolios WHERE slug = 'mara-v1');
+--   DELETE FROM portfolios WHERE slug = 'mara-v1';      -- cascades the rest
+--   DELETE FROM lifecycle_email_sends WHERE recipient = 'morgan.demo@alphamolt.ai';
+--   DELETE FROM auth.users WHERE email = 'morgan.demo@alphamolt.ai';  -- cascades profile
+-- ============================================================================
+
+BEGIN;
+
+-- The AFTER INSERT trigger on agent_trades recomputes a same-day snapshot
+-- from CURRENT account state — wrong for back-dated trades. Disable for the
+-- duration of this transaction; our own history rows are written below.
+ALTER TABLE agent_trades DISABLE TRIGGER agent_trades_recompute_snapshot;
+
+DO $seed$
+DECLARE
+    -- ---- knobs -------------------------------------------------------------
+    c_slug          CONSTANT TEXT := 'mara-v1';
+    c_display       CONSTANT TEXT := 'MARA v1';
+    c_mandate       CONSTANT TEXT := 'Make America Rich Again!  Only winners, sell all losers';
+    c_email         CONSTANT TEXT := 'morgan.demo@alphamolt.ai';
+    c_owner_name    CONSTANT TEXT := 'Morgan Hale';
+    c_days          CONSTANT INT  := 45;        -- calendar days of history
+    c_initial       CONSTANT INT  := 14;        -- day-one snake draft size
+    c_start_cash    CONSTANT NUMERIC := 1000000.00;
+
+    v_today      DATE := CURRENT_DATE;
+    v_pid        UUID := gen_random_uuid();
+    v_owner      UUID;
+    v_buy_a      UUID;   -- buyer-claude
+    v_buy_b      UUID;   -- buyer-gemini
+    v_rev        UUID;   -- portfolio-reviewer
+    v_day0       DATE;
+    v_last_day   DATE;
+    v_sell_day   DATE;
+    v_topup_day  DATE;
+    v_cash       NUMERIC := 1000000.00;
+    v_seq        INT := 0;
+    v_px         NUMERIC;
+    v_qty        NUMERIC;
+    v_gross      NUMERIC;
+    v_alloc      NUMERIC;
+    v_weight     NUMERIC;
+    v_buyer      UUID;
+    v_ts         TIMESTAMPTZ;
+    v_trade_id   BIGINT;
+    v_thesis_id  BIGINT;
+    v_full       JSONB;
+    v_snapshot   JSONB;
+    v_breaks     JSONB;
+    v_extends    JSONB;
+    v_growth     NUMERIC;
+    v_cur_px     NUMERIC;
+    v_rationale  TEXT;
+    v_thesis_txt TEXT;
+    v_worst      TEXT;
+    v_best       TEXT;
+    v_n          INT;
+    v_final      NUMERIC;
+    v_anchor     NUMERIC;
+    v_ret30      NUMERIC;
+    v_minpos     INT;
+    r            RECORD;
+    d            DATE;
+    k_fields CONSTANT TEXT[] := ARRAY[
+        'ticker','company_name','country','sector',
+        'rating','r40_score','rule_of_40',
+        'rev_growth_ttm_pct','rev_growth_qoq_pct','rev_cagr_pct',
+        'rev_consistency_score',
+        'gross_margin_pct','operating_margin_pct','net_margin_pct',
+        'net_margin_yoy_pct','fcf_margin_pct',
+        'opex_pct_revenue','sm_rd_pct_revenue',
+        'eps_only','eps_yoy_pct','qrtrs_to_profitability','gm_trend',
+        'price','ps_now','price_pct_of_52w_high',
+        'perf_52w_vs_spy','composite_score',
+        'short_outlook','key_risks','full_outlook','bull_eval','bear_eval',
+        'status','flags','ai_analyzed_at'];
+BEGIN
+    -- ---- guards -------------------------------------------------------------
+    IF EXISTS (SELECT 1 FROM portfolios WHERE slug = c_slug) THEN
+        RAISE EXCEPTION 'portfolio slug % already exists — tear it down first', c_slug;
+    END IF;
+    SELECT id INTO v_buy_a FROM agents WHERE handle = 'buyer-claude';
+    SELECT id INTO v_buy_b FROM agents WHERE handle = 'buyer-gemini';
+    SELECT id INTO v_rev   FROM agents WHERE handle = 'portfolio-reviewer';
+    IF v_buy_a IS NULL OR v_buy_b IS NULL OR v_rev IS NULL THEN
+        RAISE EXCEPTION 'house agents buyer-claude / buyer-gemini / portfolio-reviewer not all found';
+    END IF;
+
+    -- ---- trading calendar (real prices_daily dates in the window) -----------
+    CREATE TEMP TABLE _days ON COMMIT DROP AS
+    SELECT day, (row_number() OVER (ORDER BY day))::int - 1 AS idx
+    FROM (
+        SELECT date AS day
+        FROM prices_daily
+        WHERE date >= v_today - c_days
+        GROUP BY date
+        HAVING COUNT(*) > 100          -- a real US trading day
+    ) x;
+    SELECT MIN(day), MAX(day) INTO v_day0, v_last_day FROM _days;
+    IF (SELECT COUNT(*) FROM _days) < 28 THEN
+        RAISE EXCEPTION 'only % trading days of prices_daily history in the window',
+            (SELECT COUNT(*) FROM _days);
+    END IF;
+    SELECT MIN(day) INTO v_sell_day  FROM _days WHERE day >= v_day0 + 21;
+    SELECT day      INTO v_topup_day FROM _days WHERE idx = 18;
+
+    -- ---- candidates: screened names with full real price coverage -----------
+    CREATE TEMP TABLE _cand ON COMMIT DROP AS
+    WITH universe AS (
+        SELECT ticker, sort_order, price
+        FROM companies
+        WHERE in_tv_screen AND price IS NOT NULL AND sort_order IS NOT NULL
+        ORDER BY sort_order
+        LIMIT 160
+    ),
+    cov AS (
+        SELECT p.ticker,
+               COUNT(*) AS n_days,
+               MAX(ABS(p.close / NULLIF(lag(p.close) OVER (PARTITION BY p.ticker ORDER BY p.date), 0) - 1)) AS max_move
+        FROM prices_daily p
+        JOIN _days dd ON dd.day = p.date
+        WHERE p.ticker IN (SELECT ticker FROM universe) AND p.close > 0
+        GROUP BY p.ticker
+    )
+    SELECT u.ticker, u.sort_order,
+           (SELECT close FROM prices_daily pp
+             WHERE pp.ticker = u.ticker AND pp.date < v_day0 AND pp.close > 0
+             ORDER BY pp.date DESC LIMIT 1) AS entry_px,
+           (SELECT close FROM prices_daily pp
+             WHERE pp.ticker = u.ticker AND pp.date <= v_today - 30 AND pp.close > 0
+             ORDER BY pp.date DESC LIMIT 1) AS anchor_px,
+           (SELECT close FROM prices_daily pp
+             WHERE pp.ticker = u.ticker AND pp.date <= v_last_day AND pp.close > 0
+             ORDER BY pp.date DESC LIMIT 1) AS last_px,
+           c.n_days, c.max_move
+    FROM universe u
+    JOIN cov c ON c.ticker = u.ticker;
+
+    ALTER TABLE _cand ADD COLUMN ret30 NUMERIC;
+    UPDATE _cand SET ret30 = last_px / anchor_px - 1
+     WHERE anchor_px IS NOT NULL AND last_px IS NOT NULL;
+    DELETE FROM _cand
+     WHERE entry_px IS NULL OR ret30 IS NULL
+        OR n_days < (SELECT COUNT(*) FROM _days) - 2
+        OR max_move > 0.35;            -- split / halt suspects
+    IF (SELECT COUNT(*) FROM _cand) < 19 THEN
+        RAISE EXCEPTION 'only % candidates with usable price history', (SELECT COUNT(*) FROM _cand);
+    END IF;
+
+    -- ---- basket: 14 strongest trailing-30d names + 3 mid-rank adds ----------
+    CREATE TEMP TABLE _pick ON COMMIT DROP AS
+    SELECT ticker, (row_number() OVER (ORDER BY ret30 DESC))::int - 1 AS ord,
+           TRUE AS is_initial
+    FROM _cand ORDER BY ret30 DESC LIMIT 14;
+    INSERT INTO _pick
+    SELECT ticker, 13 + (row_number() OVER (ORDER BY sort_order))::int, FALSE
+    FROM _cand
+    WHERE ret30 > -0.08 AND ticker NOT IN (SELECT ticker FROM _pick)
+    ORDER BY sort_order LIMIT 3;
+
+    CREATE TEMP TABLE _pos (
+        ticker TEXT PRIMARY KEY, qty NUMERIC, avg_cost NUMERIC,
+        opened_by UUID, first_ts TIMESTAMPTZ, thesis_id BIGINT,
+        is_initial BOOLEAN
+    ) ON COMMIT DROP;
+
+    -- ---- owner: auth user (magic-link product → no password) + profile ------
+    SELECT id INTO v_owner FROM auth.users WHERE email = c_email;
+    IF v_owner IS NULL THEN
+        v_owner := gen_random_uuid();
+        INSERT INTO auth.users (
+            instance_id, id, aud, role, email, email_confirmed_at,
+            raw_app_meta_data, raw_user_meta_data, created_at, updated_at,
+            confirmation_token, recovery_token, email_change_token_new, email_change
+        ) VALUES (
+            '00000000-0000-0000-0000-000000000000', v_owner, 'authenticated',
+            'authenticated', c_email, NOW(),
+            '{"provider":"email","providers":["email"]}',
+            jsonb_build_object('display_name', c_owner_name),
+            NOW(), NOW(), '', '', '', ''
+        );
+    END IF;
+    UPDATE profiles
+       SET display_name = c_owner_name,
+           created_at = (v_day0 - 1)::timestamp + interval '9 hours 14 minutes'
+     WHERE id = v_owner;
+    -- never let the lifecycle crons email the dummy
+    INSERT INTO lifecycle_email_sends (user_id, email_key, recipient, sent_at)
+    VALUES (v_owner, 'a1_welcome',     c_email, (v_day0 - 1)::timestamp + interval '9 hours 20 minutes'),
+           (v_owner, 'a2_setup_nudge', c_email, (v_day0 - 1)::timestamp + interval '9 hours 20 minutes')
+    ON CONFLICT (user_id, email_key) DO NOTHING;
+
+    -- ---- portfolio + account + team -----------------------------------------
+    INSERT INTO portfolios (id, slug, display_name, description, owner_user_id,
+                            is_public, mode, screen_config, created_at, last_heartbeat_at)
+    VALUES (v_pid, c_slug, c_display, c_mandate, v_owner, FALSE, 'paper',
+            '{"filters":[{"field":"rule_of_40","op":">=","value":30},
+                         {"field":"gross_margin","op":">=","value":0.40},
+                         {"field":"country","op":"==","value":"United States"}],
+              "weights":{"quality":60,"value":15,"momentum":25},
+              "aiMultiplier":true,"topN":30}'::jsonb,
+            v_day0::timestamp + interval '6 hours 45 minutes',
+            v_today::timestamp + interval '7 hours 1 minute');
+
+    INSERT INTO portfolio_accounts (portfolio_id, starting_cash, cash_usd,
+                                    inception_date, created_at)
+    VALUES (v_pid, c_start_cash, c_start_cash, v_day0,
+            v_day0::timestamp + interval '6 hours 45 minutes');
+
+    INSERT INTO portfolio_agents (portfolio_id, agent_id, role, config, enabled,
+                                  joined_at, last_heartbeat_at)
+    VALUES
+        (v_pid, v_buy_a, 'buyer',    '{"target_position_pct": 6}',        TRUE,
+         v_day0::timestamp + interval '6 hours 45 minutes', v_today::timestamp + interval '7 hours'),
+        (v_pid, v_buy_b, 'buyer',    '{"target_position_pct": 6}',        TRUE,
+         v_day0::timestamp + interval '6 hours 45 minutes', v_today::timestamp + interval '7 hours'),
+        (v_pid, v_rev,   'reviewer', '{"sell_conviction_threshold": 4}',  TRUE,
+         v_day0::timestamp + interval '6 hours 45 minutes', v_today::timestamp + interval '7 hours');
+
+    -- ---- BUY helper is inlined: day-one draft, then the three adds ----------
+    FOR r IN
+        SELECT p.ticker, p.ord, p.is_initial, c.entry_px
+        FROM _pick p JOIN _cand c USING (ticker)
+        ORDER BY p.ord
+    LOOP
+        IF r.is_initial THEN
+            d := v_day0;
+            v_px := r.entry_px;                                  -- prev close
+            v_weight := 7.0 - 2.2 * r.ord / (c_initial - 1);     -- winners overweighted
+            -- snake order across the two buyers: A B B A A B B A ...
+            v_buyer := CASE (r.ord % 4) WHEN 0 THEN v_buy_a WHEN 1 THEN v_buy_b
+                                        WHEN 2 THEN v_buy_b ELSE v_buy_a END;
+        ELSE
+            SELECT day INTO d FROM _days
+             WHERE idx = CASE r.ord WHEN 14 THEN 5 WHEN 15 THEN 9 ELSE 14 END;
+            SELECT close INTO v_px FROM prices_daily
+             WHERE ticker = r.ticker AND date < d AND close > 0
+             ORDER BY date DESC LIMIT 1;
+            v_weight := 4.4 + (r.ord - 14) * 0.3;
+            v_buyer := CASE (r.ord % 2) WHEN 0 THEN v_buy_a ELSE v_buy_b END;
+        END IF;
+        CONTINUE WHEN d IS NULL OR v_px IS NULL OR v_px <= 0;
+
+        v_alloc := LEAST(c_start_cash * v_weight / 100.0, v_cash - 15000);
+        CONTINUE WHEN v_alloc < 5000;
+        v_qty := FLOOR(v_alloc / v_px);
+        CONTINUE WHEN v_qty < 1;
+        v_gross := ROUND(v_qty * v_px, 2);
+        v_cash := ROUND(v_cash - v_gross, 2);
+        v_ts := (d::timestamp + make_interval(hours => 7, secs => 125 + v_seq * 7))
+                AT TIME ZONE 'utc';
+        v_seq := v_seq + 1;
+
+        SELECT to_jsonb(c) INTO v_full FROM companies c WHERE c.ticker = r.ticker;
+        v_growth := NULLIF(v_full->>'rev_growth_ttm_pct', '')::numeric;
+        v_cur_px := NULLIF(v_full->>'price', '')::numeric;
+        v_rationale := format(
+            '%s%% TTM growth at %s%% gross margin (Rule of 40: %s); quality screen standout',
+            COALESCE(ROUND(v_growth)::text, 'n/a'),
+            COALESCE(ROUND(NULLIF(v_full->>'gross_margin_pct','')::numeric)::text, 'n/a'),
+            COALESCE(ROUND(NULLIF(v_full->>'rule_of_40','')::numeric)::text, 'n/a'));
+        v_thesis_txt := format(
+            '%s pairs %s%% TTM revenue growth with %s%% gross margins and %s%% FCF margin '
+            '(Rule of 40: %s) — a winner by the mandate''s bar. %s',
+            COALESCE(v_full->>'company_name', r.ticker),
+            COALESCE(ROUND(v_growth)::text, 'n/a'),
+            COALESCE(ROUND(NULLIF(v_full->>'gross_margin_pct','')::numeric)::text, 'n/a'),
+            COALESCE(ROUND(NULLIF(v_full->>'fcf_margin_pct','')::numeric)::text, 'n/a'),
+            COALESCE(ROUND(NULLIF(v_full->>'rule_of_40','')::numeric)::text, 'n/a'),
+            (ARRAY[
+                'Expect the position to pay off through execution, not re-rating.',
+                'Entry near its own valuation history gives a margin of safety if growth persists.',
+                'Operating leverage should keep dropping through to free cash flow as it scales.'
+             ])[1 + r.ord % 3]);
+
+        INSERT INTO agent_trades (agent_id, portfolio_id, ticker, side, quantity,
+                                  price_usd, gross_usd, cash_after_usd, executed_at, note)
+        VALUES (v_buyer, v_pid, r.ticker, 'buy', v_qty, ROUND(v_px, 4), v_gross,
+                v_cash, v_ts, format('swarm draft (conviction %s/5): %s',
+                                     CASE WHEN r.ord < 8 THEN 5 ELSE 4 END, v_rationale))
+        RETURNING id INTO v_trade_id;
+
+        -- frozen snapshot, price-linked fields scaled back to the fill price
+        SELECT jsonb_object_agg(f, COALESCE(v_full->f, 'null'::jsonb))
+          INTO v_snapshot FROM unnest(k_fields) f;
+        v_snapshot := v_snapshot || jsonb_build_object('price', ROUND(v_px, 4));
+        IF v_cur_px IS NOT NULL AND v_cur_px > 0 THEN
+            IF jsonb_typeof(v_full->'ps_now') = 'number' THEN
+                v_snapshot := v_snapshot || jsonb_build_object(
+                    'ps_now', ROUND((v_full->>'ps_now')::numeric * v_px / v_cur_px, 2));
+            END IF;
+            IF jsonb_typeof(v_full->'price_pct_of_52w_high') = 'number' THEN
+                v_snapshot := v_snapshot || jsonb_build_object(
+                    'price_pct_of_52w_high',
+                    ROUND(LEAST((v_full->>'price_pct_of_52w_high')::numeric * v_px / v_cur_px, 100), 1));
+            END IF;
+        END IF;
+
+        v_extends := '[{"field":"rev_growth_ttm_pct","op":"change_pct_gt","value":5,
+                        "description":"TTM revenue growth accelerates >5pp from purchase"},
+                       {"field":"fcf_margin_pct","op":"change_pct_gt","value":3,
+                        "description":"FCF margin expands >3pp from purchase"}]'::jsonb;
+        v_breaks  := '[{"field":"rule_of_40","op":"change_pct_lt","value":-15,
+                        "description":"Rule of 40 deteriorates >15pts from purchase"},
+                       {"field":"gross_margin_pct","op":"change_pct_lt","value":-5,
+                        "description":"Gross margin compresses >5pp from purchase"}]'::jsonb;
+        IF v_growth IS NOT NULL AND v_growth > 10 THEN
+            v_breaks := v_breaks || jsonb_build_array(jsonb_build_object(
+                'field', 'rev_growth_ttm_pct', 'op', '<', 'value', ROUND(v_growth / 2, 1),
+                'description', format('TTM growth halves from %s%%', ROUND(v_growth))));
+        END IF;
+
+        INSERT INTO investment_theses (agent_id, portfolio_id, ticker, trade_id,
+                                       snapshot, thesis_text, extend_signals,
+                                       break_signals, source, status,
+                                       opened_at, status_changed_at)
+        VALUES (v_buyer, v_pid, r.ticker, v_trade_id, v_snapshot, v_thesis_txt,
+                v_extends, v_breaks, 'agent', 'active', v_ts, v_ts)
+        RETURNING id INTO v_thesis_id;
+
+        INSERT INTO _pos VALUES (r.ticker, v_qty, ROUND(v_px, 4), v_buyer, v_ts,
+                                 v_thesis_id, r.is_initial);
+    END LOOP;
+
+    -- ---- reviewer exit ~3 weeks in: worst initial performer, full position --
+    IF v_sell_day IS NOT NULL THEN
+        SELECT p.ticker INTO v_worst
+        FROM _pos p
+        WHERE p.is_initial
+        ORDER BY (SELECT pp.close FROM prices_daily pp
+                   WHERE pp.ticker = p.ticker AND pp.date < v_sell_day AND pp.close > 0
+                   ORDER BY pp.date DESC LIMIT 1) / p.avg_cost ASC
+        LIMIT 1;
+        SELECT close INTO v_px FROM prices_daily
+         WHERE ticker = v_worst AND date < v_sell_day AND close > 0
+         ORDER BY date DESC LIMIT 1;
+        SELECT qty, thesis_id INTO v_qty, v_thesis_id FROM _pos WHERE ticker = v_worst;
+        v_gross := ROUND(v_qty * v_px, 2);
+        v_cash := ROUND(v_cash + v_gross, 2);
+        v_ts := (v_sell_day::timestamp + interval '7 hours 11 minutes 42 seconds')
+                AT TIME ZONE 'utc';
+        v_rationale := 'the position is a loser since purchase — momentum and relative '
+                       'strength have deteriorated, and the mandate is explicit: sell all losers';
+        -- broken BEFORE the sell, exactly as portfolio_reviewer.py orders it
+        UPDATE investment_theses
+           SET status = 'broken', status_changed_at = v_ts
+         WHERE id = v_thesis_id;
+        INSERT INTO agent_trades (agent_id, portfolio_id, ticker, side, quantity,
+                                  price_usd, gross_usd, cash_after_usd, executed_at, note)
+        VALUES (v_rev, v_pid, v_worst, 'sell', v_qty, ROUND(v_px, 4), v_gross, v_cash,
+                v_ts, format('portfolio-reviewer drift (%s)', left(v_rationale, 80)));
+        DELETE FROM _pos WHERE ticker = v_worst;
+    END IF;
+
+    -- ---- top-up the best performer (~trading day 18) -------------------------
+    IF v_topup_day IS NOT NULL THEN
+        SELECT p.ticker INTO v_best
+        FROM _pos p
+        ORDER BY (SELECT pp.close FROM prices_daily pp
+                   WHERE pp.ticker = p.ticker AND pp.date < v_topup_day AND pp.close > 0
+                   ORDER BY pp.date DESC LIMIT 1) / p.avg_cost DESC
+        LIMIT 1;
+        SELECT close INTO v_px FROM prices_daily
+         WHERE ticker = v_best AND date < v_topup_day AND close > 0
+         ORDER BY date DESC LIMIT 1;
+        v_alloc := LEAST(c_start_cash * 0.025, v_cash - 15000);
+        v_qty := FLOOR(v_alloc / v_px);
+        IF v_qty >= 1 THEN
+            v_gross := ROUND(v_qty * v_px, 2);
+            v_cash := ROUND(v_cash - v_gross, 2);
+            v_ts := (v_topup_day::timestamp + interval '7 hours 3 minutes 28 seconds')
+                    AT TIME ZONE 'utc';
+            SELECT to_jsonb(c) INTO v_full FROM companies c WHERE c.ticker = v_best;
+            INSERT INTO agent_trades (agent_id, portfolio_id, ticker, side, quantity,
+                                      price_usd, gross_usd, cash_after_usd, executed_at, note)
+            SELECT p.opened_by, v_pid, v_best, 'buy', v_qty, ROUND(v_px, 4), v_gross,
+                   v_cash, v_ts,
+                   'swarm draft (conviction 5/5): adding to the book''s strongest winner'
+            FROM _pos p WHERE p.ticker = v_best
+            RETURNING id INTO v_trade_id;
+            -- prior thesis superseded by the add
+            UPDATE investment_theses SET status = 'superseded', status_changed_at = v_ts
+             WHERE id = (SELECT thesis_id FROM _pos WHERE ticker = v_best);
+            SELECT jsonb_object_agg(f, COALESCE(v_full->f, 'null'::jsonb))
+              INTO v_snapshot FROM unnest(k_fields) f;
+            v_snapshot := v_snapshot || jsonb_build_object('price', ROUND(v_px, 4));
+            INSERT INTO investment_theses (agent_id, portfolio_id, ticker, trade_id,
+                                           snapshot, thesis_text, source, status,
+                                           opened_at, status_changed_at)
+            SELECT p.opened_by, v_pid, v_best, v_trade_id, v_snapshot,
+                   'Thesis intact and outperforming since purchase — the mandate wants '
+                   'winners, so the position is sized up.',
+                   'agent', 'active', v_ts, v_ts
+            FROM _pos p WHERE p.ticker = v_best
+            RETURNING id INTO v_thesis_id;
+            UPDATE _pos
+               SET avg_cost = ROUND((qty * avg_cost + v_qty * v_px) / (qty + v_qty), 4),
+                   qty = qty + v_qty,
+                   thesis_id = v_thesis_id
+             WHERE ticker = v_best;
+        END IF;
+    END IF;
+
+    -- ---- holdings -------------------------------------------------------------
+    INSERT INTO portfolio_holdings (portfolio_id, ticker, quantity, avg_cost_usd,
+                                    first_bought_at, opened_by_agent_id)
+    SELECT v_pid, ticker, qty, avg_cost, first_ts, opened_by FROM _pos;
+
+    UPDATE portfolio_accounts SET cash_usd = v_cash WHERE portfolio_id = v_pid;
+
+    -- ---- daily MTM history: positions × real close per day --------------------
+    d := v_day0;
+    WHILE d <= v_today LOOP
+        INSERT INTO agent_portfolio_history (portfolio_id, snapshot_date, cash_usd,
+                                             holdings_value_usd, total_value_usd,
+                                             pnl_usd, pnl_pct, num_positions)
+        SELECT v_pid, d,
+               cash.c,
+               COALESCE(hv.v, 0),
+               ROUND(cash.c + COALESCE(hv.v, 0), 2),
+               ROUND(cash.c + COALESCE(hv.v, 0) - c_start_cash, 2),
+               ROUND((cash.c + COALESCE(hv.v, 0) - c_start_cash) / c_start_cash * 100, 4),
+               COALESCE(hv.n, 0)
+        FROM (
+            SELECT COALESCE((SELECT t.cash_after_usd FROM agent_trades t
+                              WHERE t.portfolio_id = v_pid AND t.executed_at::date <= d
+                              ORDER BY t.executed_at DESC LIMIT 1), c_start_cash) AS c
+        ) cash,
+        LATERAL (
+            SELECT ROUND(SUM(q.qty * px.p), 2) AS v, COUNT(*)::int AS n
+            FROM (
+                SELECT t.ticker,
+                       SUM(CASE WHEN t.side = 'buy' THEN t.quantity ELSE -t.quantity END) AS qty
+                FROM agent_trades t
+                WHERE t.portfolio_id = v_pid AND t.executed_at::date <= d
+                GROUP BY t.ticker
+                HAVING SUM(CASE WHEN t.side = 'buy' THEN t.quantity ELSE -t.quantity END) > 0.000001
+            ) q,
+            LATERAL (
+                SELECT CASE WHEN d = v_today
+                            THEN COALESCE((SELECT c2.price FROM companies c2 WHERE c2.ticker = q.ticker),
+                                          (SELECT pp.close FROM prices_daily pp
+                                            WHERE pp.ticker = q.ticker AND pp.date <= d AND pp.close > 0
+                                            ORDER BY pp.date DESC LIMIT 1))
+                            ELSE (SELECT pp.close FROM prices_daily pp
+                                   WHERE pp.ticker = q.ticker AND pp.date <= d AND pp.close > 0
+                                   ORDER BY pp.date DESC LIMIT 1)
+                       END AS p
+            ) px
+        ) hv;
+        d := d + 1;
+    END LOOP;
+
+    -- ---- heartbeat journals: buyers daily, reviewer weekly --------------------
+    d := v_day0;
+    WHILE d <= v_today LOOP
+        INSERT INTO agent_heartbeats (agent_id, strategy, started_at, finished_at,
+                                      status, trades_executed, buys, sells, notes)
+        SELECT b.aid, 'llm_watchlist_buyer',
+               (d::timestamp + make_interval(hours => 7, secs => 30 + floor(random() * 25)::int)) AT TIME ZONE 'utc',
+               (d::timestamp + make_interval(hours => 7, mins => 1, secs => 30 + floor(random() * 90)::int)) AT TIME ZONE 'utc',
+               'ok', b.n, b.n, 0,
+               jsonb_build_object('portfolio_id', v_pid::text, 'role', 'buyer', 'remit', NULL::text)
+        FROM (
+            SELECT a.aid, (SELECT COUNT(*) FROM agent_trades t
+                            WHERE t.portfolio_id = v_pid AND t.agent_id = a.aid
+                              AND t.side = 'buy' AND t.executed_at::date = d)::int AS n
+            FROM (VALUES (v_buy_a), (v_buy_b)) a(aid)
+        ) b;
+
+        IF (d - v_day0) % 7 = 0 OR d = v_sell_day THEN
+            v_n := COALESCE((SELECT COUNT(*) FROM agent_trades t
+                              WHERE t.portfolio_id = v_pid AND t.agent_id = v_rev
+                                AND t.executed_at::date = d), 0)::int;
+            INSERT INTO agent_heartbeats (agent_id, strategy, started_at, finished_at,
+                                          status, trades_executed, buys, sells, notes)
+            VALUES (v_rev, 'portfolio_reviewer',
+                    (d::timestamp + interval '7 hours 8 minutes') AT TIME ZONE 'utc',
+                    (d::timestamp + interval '7 hours 13 minutes') AT TIME ZONE 'utc',
+                    'ok', v_n, 0, v_n,
+                    jsonb_build_object('portfolio_id', v_pid::text, 'role', 'reviewer',
+                        'positions_reviewed',
+                        (SELECT h.num_positions FROM agent_portfolio_history h
+                          WHERE h.portfolio_id = v_pid AND h.snapshot_date = d))
+                    || CASE WHEN v_n = 0
+                            THEN '{"reason": "no positions met the sell threshold"}'::jsonb
+                            ELSE '{}'::jsonb END);
+        END IF;
+        d := d + 1;
+    END LOOP;
+
+    -- ---- the records must add up + meet the constraints -----------------------
+    SELECT total_value_usd INTO v_final FROM agent_portfolio_history
+     WHERE portfolio_id = v_pid AND snapshot_date = v_today;
+    SELECT total_value_usd INTO v_anchor FROM agent_portfolio_history
+     WHERE portfolio_id = v_pid AND snapshot_date <= v_today - 30
+     ORDER BY snapshot_date DESC LIMIT 1;
+    v_ret30 := ROUND((v_final / v_anchor - 1) * 100, 2);
+    SELECT MIN(num_positions) INTO v_minpos FROM agent_portfolio_history
+     WHERE portfolio_id = v_pid;
+
+    IF v_ret30 IS NULL OR v_ret30 <= 8.0 THEN
+        RAISE EXCEPTION 'trailing-30d return % pct <= 8 pct — rolling back (universe too weak this window)', v_ret30;
+    END IF;
+    IF v_minpos IS NULL OR v_minpos <= 10 THEN
+        RAISE EXCEPTION 'min daily positions % <= 10 — rolling back', v_minpos;
+    END IF;
+    IF v_cash < 0 THEN
+        RAISE EXCEPTION 'cash went negative (%) — rolling back', v_cash;
+    END IF;
+    IF (SELECT COUNT(*) FROM portfolio_holdings WHERE portfolio_id = v_pid) < 15 THEN
+        RAISE EXCEPTION 'fewer than 15 holdings — cannot flip public, rolling back';
+    END IF;
+
+    -- ≥15 holdings now exist, so the public-threshold trigger allows this
+    UPDATE portfolios SET is_public = TRUE WHERE id = v_pid;
+
+    RAISE NOTICE '================================================================';
+    RAISE NOTICE 'MARA v1 seeded: portfolio % (/portfolios/%)', v_pid, c_slug;
+    RAISE NOTICE '  inception          %  (% calendar days ago)', v_day0, v_today - v_day0;
+    RAISE NOTICE '  trades             %', (SELECT COUNT(*) FROM agent_trades WHERE portfolio_id = v_pid);
+    RAISE NOTICE '  holdings           %  cash $%', (SELECT COUNT(*) FROM portfolio_holdings WHERE portfolio_id = v_pid), v_cash;
+    RAISE NOTICE '  final value        $%  (since inception: % pct)', v_final,
+        (SELECT pnl_pct FROM agent_portfolio_history WHERE portfolio_id = v_pid AND snapshot_date = v_today);
+    RAISE NOTICE '  trailing 30d       +% pct  (constraint: > 8 pct)', v_ret30;
+    RAISE NOTICE '  min positions      %  (constraint: > 10)', v_minpos;
+    RAISE NOTICE '  reviewer exited    %  on %', v_worst, v_sell_day;
+    RAISE NOTICE '  topped up          %', v_best;
+    RAISE NOTICE '================================================================';
+END
+$seed$;
+
+ALTER TABLE agent_trades ENABLE TRIGGER agent_trades_recompute_snapshot;
+
+COMMIT;
+
+-- Inspect the result:
+--   SELECT * FROM agent_trades WHERE portfolio_id = (SELECT id FROM portfolios WHERE slug='mara-v1') ORDER BY executed_at;
+--   SELECT * FROM agent_portfolio_history WHERE portfolio_id = (SELECT id FROM portfolios WHERE slug='mara-v1') ORDER BY snapshot_date;

--- a/test_screen.py
+++ b/test_screen.py
@@ -150,5 +150,62 @@ class TestScoring(unittest.TestCase):
         self.assertEqual(top2, ["A", "B"])
 
 
+class _FakeDB:
+    """Minimal stub for portfolio_screen_candidates: serves one screen_config
+    and a fixed active-rejection set."""
+
+    def __init__(self, config: dict, rejected: set[str]):
+        self._config = config
+        self._rejected = rejected
+
+    # screen.portfolio_screen_config reads via the supabase client; patch the
+    # module helper instead (see tests below). This stub only needs the
+    # rejection accessor that screen.portfolio_screen_candidates calls.
+    def get_active_screener_rejections(self, portfolio_id):
+        return set(self._rejected)
+
+
+class TestRejectionFilter(unittest.TestCase):
+    """Migration 051: portfolio_screen_candidates drops the portfolio's active
+    rejections when hideRejected is on (default), and keeps them when off."""
+
+    def _ranked(self):
+        return facts(
+            {"ticker": "A", "rule_of_40": 90, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+            {"ticker": "B", "rule_of_40": 50, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+            {"ticker": "C", "rule_of_40": 10, "fcf_margin": 1, "gross_margin": 1, "ps": 5, "ps_median_12m": 5},
+        )
+
+    def _run(self, config, rejected):
+        # Patch the two screen.py reads so the test is pure (no DB/RPC).
+        orig_cfg = screen.portfolio_screen_config
+        orig_run = screen.run_screen
+        ranked = self._ranked()
+        screen.portfolio_screen_config = lambda db, pid: config
+        screen.run_screen = lambda db, cfg: screen.score_screen(ranked, cfg)
+        try:
+            return screen.portfolio_screen_candidates(_FakeDB(config, rejected), "pid")
+        finally:
+            screen.portfolio_screen_config = orig_cfg
+            screen.run_screen = orig_run
+
+    def test_hide_rejected_default_on_drops_rejected(self):
+        cfg = {"weights": {"quality": 100, "value": 0, "momentum": 0}, "aiMultiplier": False, "topN": 40}
+        out = self._run(cfg, {"A"})
+        self.assertNotIn("A", out)
+        self.assertIn("B", out)
+        self.assertIn("C", out)
+
+    def test_hide_rejected_off_keeps_rejected(self):
+        cfg = {"weights": {"quality": 100, "value": 0, "momentum": 0}, "aiMultiplier": False, "topN": 40, "hideRejected": False}
+        out = self._run(cfg, {"A"})
+        self.assertIn("A", out)
+
+    def test_no_rejections_is_noop(self):
+        cfg = {"weights": {"quality": 100, "value": 0, "momentum": 0}, "aiMultiplier": False, "topN": 40}
+        out = self._run(cfg, set())
+        self.assertEqual(set(out), {"A", "B", "C"})
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/web/app/api/screen/route.ts
+++ b/web/app/api/screen/route.ts
@@ -13,6 +13,7 @@
 import { errorResponse, jsonResponse } from "@/lib/api-utils";
 import { configFromParams, screenConfigSchema } from "@/lib/screen/config";
 import { runScreen } from "@/lib/screen/query";
+import { activeRejectionsForViewer } from "@/lib/screen/rejections-query";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -52,7 +53,11 @@ export async function GET(req: Request) {
     // Validate (defends against a hand-edited config param).
     screenConfigSchema.parse(config);
 
-    const result = await runScreen(config);
+    // Per-portfolio rejection set (migration 051), so the live re-rank hides
+    // the same names the SSR page did. Empty for logged-out callers.
+    const { rejections } = await activeRejectionsForViewer();
+    const rejectedSet = new Set(rejections.map((r) => r.ticker.toUpperCase()));
+    const result = await runScreen(config, rejectedSet);
     const rows = result.rows.map((r) =>
       Object.fromEntries(DISPLAY.map((k) => [k, (r as unknown as Record<string, unknown>)[k]])),
     );
@@ -65,12 +70,16 @@ export async function GET(req: Request) {
         cut_index: result.cut_index,
         data_asof: result.data_asof,
         config,
+        // The viewer's active per-portfolio rejections (migration 051) — the
+        // client uses these for the restore panel. Empty for logged-out callers.
+        rejected: rejections.map((r) => r.ticker),
       },
       {
         headers: {
-          // Re-rank feels live but still gets CDN relief; invalidated by the
-          // daily data refresh well inside this window.
-          "Cache-Control": "public, max-age=60, stale-while-revalidate=300",
+          // Per-viewer (rejections depend on the session) — must not be shared
+          // across users by a CDN. Re-rank is cheap (cached facts + in-memory
+          // scoring) so private/no-store is fine.
+          "Cache-Control": "private, no-store",
         },
       },
     );

--- a/web/app/api/screen/route.ts
+++ b/web/app/api/screen/route.ts
@@ -71,8 +71,12 @@ export async function GET(req: Request) {
         data_asof: result.data_asof,
         config,
         // The viewer's active per-portfolio rejections (migration 051) — the
-        // client uses these for the restore panel. Empty for logged-out callers.
-        rejected: rejections.map((r) => r.ticker),
+        // client folds these into the "Hidden" panel, tagged with the rejection
+        // date. Empty for logged-out callers.
+        rejected: rejections.map((r) => ({
+          ticker: r.ticker,
+          rejected_at: r.rejected_at,
+        })),
       },
       {
         headers: {

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -126,6 +126,10 @@ export default async function ScreenerPage({
 }) {
   const sp = await resolveParams(searchParams);
   const config = (sp.screen ? await savedConfig(sp.screen) : null) ?? configFromParams(sp);
+  // NOTE: the SSR paint is anonymous (no auth cookies) so this page stays
+  // ISR-cached / indexable. Per-portfolio rejection hiding (migration 051) is
+  // resolved client-side via /api/screen (which reads the session) once the
+  // viewer is known signed-in — see screener-client's sign-in refetch.
   const [initial, companyTickers, exclusions] = await Promise.all([
     runScreen(config),
     getCompanyTickers(),

--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -8,6 +8,7 @@ import {
   excludeFromScreener,
   unexcludeFromScreener,
 } from "@/lib/screen/exclusions-mutations";
+import { restoreRejection } from "@/lib/screen/rejections-mutations";
 import {
   FILTER_FIELDS,
   FILTER_OPS,
@@ -54,6 +55,9 @@ interface ScreenData {
   total_universe: number;
   cut_index: number;
   data_asof: string | null;
+  /** Viewer's active per-portfolio rejections (migration 051); only the
+   *  /api/screen route populates this (SSR is anonymous). */
+  rejected?: string[];
 }
 
 function fmt(v: number | null, opts?: { pct?: boolean; mult?: boolean; dp?: number }): string {
@@ -155,6 +159,7 @@ export default function ScreenerClient({
   sectors = [],
   companyTickers = [],
   exclusions = [],
+  rejections = [],
 }: {
   initialConfig: ScreenConfig;
   initialData: ScreenData;
@@ -164,6 +169,8 @@ export default function ScreenerClient({
   companyTickers?: string[];
   /** Tickers on the manual 1-year blocklist (owner-managed). */
   exclusions?: string[];
+  /** Tickers this portfolio's buyer evaluated and passed on (migration 051). */
+  rejections?: string[];
   defaultEncoded?: string;
 }) {
   const linkable = useMemo(
@@ -184,6 +191,10 @@ export default function ScreenerClient({
   const [excluded, setExcluded] = useState<string[]>(exclusions);
   const [exclBusy, setExclBusy] = useState(false);
   const [exclMsg, setExclMsg] = useState<string | null>(null);
+  // Per-portfolio agent rejections (migration 051) — the manage/restore panel.
+  const [rejected, setRejected] = useState<string[]>(rejections);
+  const [rejBusy, setRejBusy] = useState(false);
+  const [rejMsg, setRejMsg] = useState<string | null>(null);
   const [showIntro, setShowIntro] = useState(false);
   const [signedIn, setSignedIn] = useState(false);
   const [saveLink, setSaveLink] = useState<string | null>(null);
@@ -331,7 +342,11 @@ export default function ScreenerClient({
       const encoded = encodeConfig(config);
       try {
         const res = await fetch(`/api/screen?config=${encoded}`, { cache: "no-store" });
-        if (res.ok) setData((await res.json()) as ScreenData);
+        if (res.ok) {
+          const json = (await res.json()) as ScreenData;
+          setData(json);
+          if (json.rejected) setRejected(json.rejected);
+        }
       } finally {
         setLoading(false);
       }
@@ -350,18 +365,35 @@ export default function ScreenerClient({
     setSaveLink(null);
   }, []);
 
-  // Re-fetch the current screen — used after an exclusion changes the universe.
+  // Re-fetch the current screen — used after an exclusion/rejection changes the
+  // universe, and once on sign-in (so /api/screen applies the viewer's
+  // per-portfolio rejection hide and returns the restore list).
   const refetch = useCallback(async () => {
     setLoading(true);
     try {
       const res = await fetch(`/api/screen?config=${encodeConfig(config)}`, {
         cache: "no-store",
       });
-      if (res.ok) setData((await res.json()) as ScreenData);
+      if (res.ok) {
+        const json = (await res.json()) as ScreenData;
+        setData(json);
+        if (json.rejected) setRejected(json.rejected);
+      }
     } finally {
       setLoading(false);
     }
   }, [config]);
+
+  // Once we learn the viewer is signed in, refetch so rejections (migration
+  // 051) are applied + loaded. SSR is anonymous, so this is the logged-in
+  // owner's first filtered view. Fires once.
+  const signinRefetched = useRef(false);
+  useEffect(() => {
+    if (signedIn && !signinRefetched.current) {
+      signinRefetched.current = true;
+      void refetch();
+    }
+  }, [signedIn, refetch]);
 
   const excludedSet = useMemo(
     () => new Set(excluded.map((t) => t.toUpperCase())),
@@ -421,6 +453,29 @@ export default function ScreenerClient({
       setExclMsg(`Couldn’t restore ${t} — try again.`);
     } finally {
       setExclBusy(false);
+    }
+  }
+
+  // Restore a name the portfolio's buyer passed on (migration 051): clears the
+  // 90-day hide so it shows again and the buyer reconsiders it next run.
+  async function onRestoreRejection(ticker: string) {
+    const t = ticker.toUpperCase();
+    setRejMsg(null);
+    setRejected((prev) => prev.filter((x) => x.toUpperCase() !== t));
+    setRejBusy(true);
+    try {
+      const res = await restoreRejection(t);
+      if (res.ok) {
+        await refetch();
+      } else {
+        setRejected((prev) => Array.from(new Set([...prev, t])));
+        setRejMsg(res.error || `Couldn’t restore ${t} — try again.`);
+      }
+    } catch {
+      setRejected((prev) => Array.from(new Set([...prev, t])));
+      setRejMsg(`Couldn’t restore ${t} — are you signed in?`);
+    } finally {
+      setRejBusy(false);
     }
   }
 
@@ -669,6 +724,20 @@ export default function ScreenerClient({
               AI bull/bear ×
             </label>
           </div>
+          <div className="flex items-center justify-end mt-2">
+            <label
+              title="Hide names your portfolio's buyer evaluated and passed on, for 90 days. Restore any of them in the panel below."
+              className="font-mono text-[10.5px] text-[var(--color-cyan)] inline-flex items-center gap-1.5 cursor-help shrink-0"
+            >
+              <input
+                type="checkbox"
+                checked={config.hideRejected !== false}
+                onChange={(e) => patch({ hideRejected: e.target.checked })}
+                className="accent-[var(--color-cyan)]"
+              />
+              Hide agent-rejected (90d)
+            </label>
+          </div>
           {(["quality", "value", "momentum"] as const).map((k) => (
             <div key={k} className="mt-2.5">
               <div className="flex justify-between font-mono text-[11px] text-text-muted capitalize">
@@ -762,6 +831,61 @@ export default function ScreenerClient({
           <button
             type="button"
             onClick={() => setExclMsg(null)}
+            aria-label="Dismiss"
+            className="text-text-muted hover:text-text"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      {/* Passed-on names — this portfolio's buyer evaluated them and didn't
+          buy (migration 051). Hidden from the screener (and not re-evaluated
+          by the buyer) for 90 days while "Hide agent-rejected" is on. Restore
+          any of them here to show it again and have the buyer reconsider. */}
+      {signedIn && rejected.length > 0 && (
+        <details className={`mb-2 ${card}`}>
+          <summary className="list-none cursor-pointer font-mono text-[11px] text-text-muted px-3 py-2 marker:hidden [&::-webkit-details-marker]:hidden flex items-center justify-between">
+            <span>
+              🛇 Passed on by your agents ({rejected.length})
+              {config.hideRejected !== false
+                ? " — hidden for 90 days"
+                : " — currently shown (toggle off)"}
+            </span>
+            <span className="text-text-muted/60">manage ▾</span>
+          </summary>
+          <div className="px-3 pb-3 flex flex-wrap gap-1.5">
+            {[...new Set(rejected.map((t) => t.toUpperCase()))].sort().map((t) => (
+              <span
+                key={t}
+                className="inline-flex items-center gap-1.5 font-mono text-[11px] text-text border border-white/10 bg-white/[0.03] rounded-md px-2 py-1"
+              >
+                {t}
+                <button
+                  type="button"
+                  disabled={rejBusy}
+                  onClick={() => onRestoreRejection(t)}
+                  title={`Restore ${t} to the screener now`}
+                  aria-label={`Restore ${t}`}
+                  className="text-[var(--color-cyan)] hover:underline disabled:opacity-40"
+                >
+                  restore
+                </button>
+              </span>
+            ))}
+          </div>
+        </details>
+      )}
+
+      {rejMsg && (
+        <div
+          role="alert"
+          className="mb-2 flex items-center justify-between gap-3 rounded-lg border border-[var(--color-red,#FF3333)]/40 bg-[var(--color-red,#FF3333)]/[0.06] px-3 py-2 font-mono text-[11px] text-[var(--color-red,#FF3333)]"
+        >
+          <span>{rejMsg}</span>
+          <button
+            type="button"
+            onClick={() => setRejMsg(null)}
             aria-label="Dismiss"
             className="text-text-muted hover:text-text"
           >

--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -57,7 +57,12 @@ interface ScreenData {
   data_asof: string | null;
   /** Viewer's active per-portfolio rejections (migration 051); only the
    *  /api/screen route populates this (SSR is anonymous). */
-  rejected?: string[];
+  rejected?: RejectedName[];
+}
+
+interface RejectedName {
+  ticker: string;
+  rejected_at: string;
 }
 
 function fmt(v: number | null, opts?: { pct?: boolean; mult?: boolean; dp?: number }): string {
@@ -169,8 +174,8 @@ export default function ScreenerClient({
   companyTickers?: string[];
   /** Tickers on the manual 1-year blocklist (owner-managed). */
   exclusions?: string[];
-  /** Tickers this portfolio's buyer evaluated and passed on (migration 051). */
-  rejections?: string[];
+  /** Names this portfolio's buyer evaluated and passed on (migration 051). */
+  rejections?: RejectedName[];
   defaultEncoded?: string;
 }) {
   const linkable = useMemo(
@@ -191,8 +196,9 @@ export default function ScreenerClient({
   const [excluded, setExcluded] = useState<string[]>(exclusions);
   const [exclBusy, setExclBusy] = useState(false);
   const [exclMsg, setExclMsg] = useState<string | null>(null);
-  // Per-portfolio agent rejections (migration 051) — the manage/restore panel.
-  const [rejected, setRejected] = useState<string[]>(rejections);
+  // Per-portfolio agent rejections (migration 051) — folded into the Hidden
+  // panel, each tagged with its rejection date.
+  const [rejected, setRejected] = useState<RejectedName[]>(rejections);
   const [rejBusy, setRejBusy] = useState(false);
   const [rejMsg, setRejMsg] = useState<string | null>(null);
   const [showIntro, setShowIntro] = useState(false);
@@ -400,6 +406,38 @@ export default function ScreenerClient({
     [excluded],
   );
 
+  // One unified "Hidden" list: manual exclusions (reason "manual", global,
+  // 1-year) + this portfolio's agent rejections (reason = the rejection date),
+  // each restorable via the matching action. Agent rejections only count as
+  // "hidden" while the toggle is on (off → they show in the table, so they
+  // aren't hidden). Manual takes precedence if a ticker is both.
+  const hiddenEntries = useMemo(() => {
+    const manual = [...excludedSet].map((t) => ({
+      ticker: t,
+      source: "manual" as const,
+      reason: "manual",
+    }));
+    const manualSet = new Set(manual.map((m) => m.ticker));
+    const agent =
+      config.hideRejected !== false
+        ? rejected
+            .filter((r) => !manualSet.has(r.ticker.toUpperCase()))
+            .map((r) => ({
+              ticker: r.ticker.toUpperCase(),
+              source: "agent" as const,
+              reason: `rejected ${
+                Number.isNaN(Date.parse(r.rejected_at))
+                  ? ""
+                  : new Date(r.rejected_at).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                    })
+              }`.trim(),
+            }))
+        : [];
+    return [...manual, ...agent].sort((a, b) => a.ticker.localeCompare(b.ticker));
+  }, [excludedSet, rejected, config.hideRejected]);
+
   // Rows actually shown: drop any optimistically-excluded ticker. In steady
   // state the server already filtered these, so this only hides the just-
   // clicked name in the window before the refetch settles.
@@ -460,19 +498,26 @@ export default function ScreenerClient({
   // 90-day hide so it shows again and the buyer reconsiders it next run.
   async function onRestoreRejection(ticker: string) {
     const t = ticker.toUpperCase();
+    const prior = rejected.find((x) => x.ticker.toUpperCase() === t);
     setRejMsg(null);
-    setRejected((prev) => prev.filter((x) => x.toUpperCase() !== t));
+    setRejected((prev) => prev.filter((x) => x.ticker.toUpperCase() !== t));
     setRejBusy(true);
+    const restore = () =>
+      setRejected((prev) =>
+        prev.some((x) => x.ticker.toUpperCase() === t)
+          ? prev
+          : [...prev, prior ?? { ticker: t, rejected_at: new Date().toISOString() }],
+      );
     try {
       const res = await restoreRejection(t);
       if (res.ok) {
         await refetch();
       } else {
-        setRejected((prev) => Array.from(new Set([...prev, t])));
+        restore();
         setRejMsg(res.error || `Couldn’t restore ${t} — try again.`);
       }
     } catch {
-      setRejected((prev) => Array.from(new Set([...prev, t])));
+      restore();
       setRejMsg(`Couldn’t restore ${t} — are you signed in?`);
     } finally {
       setRejBusy(false);
@@ -785,31 +830,44 @@ export default function ScreenerClient({
         </div>
       </details>
 
-      {/* Hidden names — the owner's manual 1-year blocklist. Removed names
-          drop from the screener AND the agents' candidate pool until they
-          expire (or are restored here). */}
-      {signedIn && excluded.length > 0 && (
+      {/* Hidden names — one list, two sources. Manual exclusions (reason
+          "manual") are the owner's global 1-year blocklist; agent rejections
+          (reason = the rejection date) are names this portfolio's buyer
+          evaluated and passed on, hidden for 90 days while the toggle is on.
+          Restore sends each to its matching action. */}
+      {signedIn && hiddenEntries.length > 0 && (
         <details className={`mb-2 ${card}`}>
           <summary className="list-none cursor-pointer font-mono text-[11px] text-text-muted px-3 py-2 marker:hidden [&::-webkit-details-marker]:hidden flex items-center justify-between">
-            <span>
-              🚫 Hidden ({excluded.length}) — removed from screener &amp; agents
-              for 1 year
-            </span>
+            <span>🚫 Hidden ({hiddenEntries.length}) — removed from the screener</span>
             <span className="text-text-muted/60">manage ▾</span>
           </summary>
           <div className="px-3 pb-3 flex flex-wrap gap-1.5">
-            {[...excludedSet].sort().map((t) => (
+            {hiddenEntries.map((h) => (
               <span
-                key={t}
+                key={h.ticker}
                 className="inline-flex items-center gap-1.5 font-mono text-[11px] text-text border border-white/10 bg-white/[0.03] rounded-md px-2 py-1"
               >
-                {t}
+                {h.ticker}
+                <span
+                  className="text-[10px] text-text-muted/70"
+                  title={
+                    h.source === "manual"
+                      ? "Manually removed (global, 1 year)"
+                      : "Your buyer evaluated and passed on this name (90-day hide)"
+                  }
+                >
+                  {h.reason}
+                </span>
                 <button
                   type="button"
-                  disabled={exclBusy}
-                  onClick={() => onRestore(t)}
-                  title={`Restore ${t} to the screener now`}
-                  aria-label={`Restore ${t}`}
+                  disabled={h.source === "manual" ? exclBusy : rejBusy}
+                  onClick={() =>
+                    h.source === "manual"
+                      ? onRestore(h.ticker)
+                      : onRestoreRejection(h.ticker)
+                  }
+                  title={`Restore ${h.ticker} to the screener now`}
+                  aria-label={`Restore ${h.ticker}`}
                   className="text-[var(--color-cyan)] hover:underline disabled:opacity-40"
                 >
                   restore
@@ -821,7 +879,7 @@ export default function ScreenerClient({
       )}
 
       {/* Surfaced error from a remove/restore (e.g. not signed in, or the
-          screener_exclusions table isn't there yet) — never fail silently. */}
+          table isn't there yet) — never fail silently. */}
       {exclMsg && (
         <div
           role="alert"
@@ -837,44 +895,6 @@ export default function ScreenerClient({
             ✕
           </button>
         </div>
-      )}
-
-      {/* Passed-on names — this portfolio's buyer evaluated them and didn't
-          buy (migration 051). Hidden from the screener (and not re-evaluated
-          by the buyer) for 90 days while "Hide agent-rejected" is on. Restore
-          any of them here to show it again and have the buyer reconsider. */}
-      {signedIn && rejected.length > 0 && (
-        <details className={`mb-2 ${card}`}>
-          <summary className="list-none cursor-pointer font-mono text-[11px] text-text-muted px-3 py-2 marker:hidden [&::-webkit-details-marker]:hidden flex items-center justify-between">
-            <span>
-              🛇 Passed on by your agents ({rejected.length})
-              {config.hideRejected !== false
-                ? " — hidden for 90 days"
-                : " — currently shown (toggle off)"}
-            </span>
-            <span className="text-text-muted/60">manage ▾</span>
-          </summary>
-          <div className="px-3 pb-3 flex flex-wrap gap-1.5">
-            {[...new Set(rejected.map((t) => t.toUpperCase()))].sort().map((t) => (
-              <span
-                key={t}
-                className="inline-flex items-center gap-1.5 font-mono text-[11px] text-text border border-white/10 bg-white/[0.03] rounded-md px-2 py-1"
-              >
-                {t}
-                <button
-                  type="button"
-                  disabled={rejBusy}
-                  onClick={() => onRestoreRejection(t)}
-                  title={`Restore ${t} to the screener now`}
-                  aria-label={`Restore ${t}`}
-                  className="text-[var(--color-cyan)] hover:underline disabled:opacity-40"
-                >
-                  restore
-                </button>
-              </span>
-            ))}
-          </div>
-        </details>
       )}
 
       {rejMsg && (

--- a/web/lib/screen/config.ts
+++ b/web/lib/screen/config.ts
@@ -59,6 +59,9 @@ export const screenConfigSchema = z.object({
   filters: z.array(filterSchema).max(20).default([]),
   weights: weightsSchema.default({ quality: 45, value: 25, momentum: 20 }),
   aiMultiplier: z.boolean().default(true),
+  // Hide names this portfolio's buyer evaluated and passed on, for 90 days
+  // (migration 051). On by default; per-portfolio, owner can restore early.
+  hideRejected: z.boolean().default(true),
   topN: z.number().int().min(1).max(200).default(40),
   sort: z
     .object({
@@ -82,6 +85,7 @@ const base = {
   brief: undefined,
   sort: { column: "score", dir: "desc" as const },
   topN: 40,
+  hideRejected: true,
   aiMultiplier: true,
 };
 

--- a/web/lib/screen/query.ts
+++ b/web/lib/screen/query.ts
@@ -168,15 +168,28 @@ async function activeExclusions(): Promise<Set<string>> {
   }
 }
 
-/** Full contract response for a config: scored rows + counts + as-of. */
-export async function runScreen(config: ScreenConfig): Promise<ScreenResponse> {
+/**
+ * Full contract response for a config: scored rows + counts + as-of.
+ *
+ * `rejected` is the viewer's per-portfolio 90-day rejection set (migration
+ * 051) — names this portfolio's buyer evaluated and passed on. Dropped only
+ * when the config's `hideRejected` toggle is on (the default). Empty / omitted
+ * for the logged-out public screener, which has no portfolio context.
+ */
+export async function runScreen(
+  config: ScreenConfig,
+  rejected?: Set<string>,
+): Promise<ScreenResponse> {
   const [allFacts, excluded] = await Promise.all([
     loadFacts(),
     activeExclusions(),
   ]);
-  const facts = excluded.size
+  let facts = excluded.size
     ? allFacts.filter((f) => !excluded.has(f.ticker.toUpperCase()))
     : allFacts;
+  if (config.hideRejected !== false && rejected && rejected.size) {
+    facts = facts.filter((f) => !rejected.has(f.ticker.toUpperCase()));
+  }
   const result = scoreScreen(facts, config, facts.length);
   const data_asof = facts.reduce<string | null>((acc, f) => {
     if (f.price_asof && (!acc || f.price_asof > acc)) return f.price_asof;

--- a/web/lib/screen/rejections-mutations.ts
+++ b/web/lib/screen/rejections-mutations.ts
@@ -1,0 +1,46 @@
+"use server";
+
+/**
+ * Server action for the screener's per-portfolio rejection list (migration
+ * 051): manually restore a name the owner's buyer passed on, so it shows on
+ * the screener again and the buyer reconsiders it on its next run.
+ *
+ * Auth-gated (signed-in owner), resolve their arena (paper) portfolio, then
+ * service-role write — same verify-then-service-role pattern as the manual
+ * exclusions. We set `restored_at` rather than delete, so the audit trail of
+ * what was passed on (and re-shown) survives. NOTE: if the buyer re-evaluates
+ * the name later and still passes, it will be re-hidden — a restore means
+ * "look again now", not a permanent pin.
+ */
+
+import { revalidatePath } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+import { requireUser } from "@/lib/auth/require-user";
+import { getPortfolioForUser } from "@/lib/portfolios-query";
+
+export type RejectionResult = { ok: true } | { ok: false; error: string };
+
+export async function restoreRejection(
+  ticker: string,
+): Promise<RejectionResult> {
+  const { user } = await requireUser();
+  const t = ticker.trim().toUpperCase();
+  if (!t) return { ok: false, error: "Ticker required." };
+
+  const portfolio = await getPortfolioForUser(user.id);
+  if (!portfolio) {
+    return { ok: false, error: "No portfolio to restore into." };
+  }
+
+  const { error } = await getSupabase()
+    .from("screener_rejections")
+    .update({ restored_at: new Date().toISOString() })
+    .eq("portfolio_id", portfolio.id)
+    .eq("ticker", t);
+  if (error) {
+    console.error("restoreRejection failed:", error);
+    return { ok: false, error: "Could not restore it. Try again." };
+  }
+  revalidatePath("/screener");
+  return { ok: true };
+}

--- a/web/lib/screen/rejections-query.ts
+++ b/web/lib/screen/rejections-query.ts
@@ -1,0 +1,57 @@
+import { getSupabase } from "@/lib/supabase";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { getPortfolioForUser } from "@/lib/portfolios-query";
+
+export interface ScreenerRejection {
+  ticker: string;
+  expires_at: string;
+  reason: string | null;
+  conviction: number | null;
+}
+
+/**
+ * Active (non-expired, non-restored) screener rejections for the SIGNED-IN
+ * viewer's arena (paper) portfolio — names its buyer evaluated and passed on
+ * within the last 90 days (migration 051). Per-portfolio, so it's empty when
+ * logged out or with no portfolio (the public screener has no such context).
+ *
+ * Read with the service-role client because the table is service-role only
+ * (a rejection list can belong to a private portfolio, so it isn't world-
+ * readable). Auth is resolved via the cookie-scoped SSR client first, then the
+ * portfolio + rejections are read with the service key. Fail-open on error.
+ */
+export async function activeRejectionsForViewer(): Promise<{
+  portfolioId: string | null;
+  rejections: ScreenerRejection[];
+}> {
+  let userId: string | null = null;
+  try {
+    const supa = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supa.auth.getUser();
+    userId = user?.id ?? null;
+  } catch {
+    userId = null;
+  }
+  if (!userId) return { portfolioId: null, rejections: [] };
+
+  const portfolio = await getPortfolioForUser(userId);
+  if (!portfolio) return { portfolioId: null, rejections: [] };
+
+  const { data, error } = await getSupabase()
+    .from("screener_rejections")
+    .select("ticker, expires_at, reason, conviction")
+    .eq("portfolio_id", portfolio.id)
+    .gt("expires_at", new Date().toISOString())
+    .is("restored_at", null)
+    .order("rejected_at", { ascending: false });
+  if (error) {
+    console.error("activeRejectionsForViewer failed:", error.message);
+    return { portfolioId: portfolio.id, rejections: [] };
+  }
+  return {
+    portfolioId: portfolio.id,
+    rejections: (data ?? []) as ScreenerRejection[],
+  };
+}

--- a/web/lib/screen/rejections-query.ts
+++ b/web/lib/screen/rejections-query.ts
@@ -4,6 +4,7 @@ import { getPortfolioForUser } from "@/lib/portfolios-query";
 
 export interface ScreenerRejection {
   ticker: string;
+  rejected_at: string;
   expires_at: string;
   reason: string | null;
   conviction: number | null;
@@ -41,7 +42,7 @@ export async function activeRejectionsForViewer(): Promise<{
 
   const { data, error } = await getSupabase()
     .from("screener_rejections")
-    .select("ticker, expires_at, reason, conviction")
+    .select("ticker, rejected_at, expires_at, reason, conviction")
     .eq("portfolio_id", portfolio.id)
     .gt("expires_at", new Date().toISOString())
     .is("restored_at", null)


### PR DESCRIPTION
## Summary

This PR adds two major features:

1. **Screener rejections (migration 051)**: A per-portfolio 90-day auto-hide mechanism for names a BUY agent evaluated and passed on, preventing churn on re-evaluation. Includes manual restore capability from the screener UI.

2. **Demo portfolio seeding tools**: Operator scripts to fabricate fully-consistent demo portfolios with 30+ days of trading history, real historical fills, and daily snapshots for leaderboard testing.

## Key Changes

### Screener Rejections (Migration 051)
- **Database**: New `screener_rejections` table (`portfolio_id`, `ticker`, `expires_at`, `restored_at`, `verdict`, `conviction`, `reason`) with 90-day auto-expiry
- **Backend**:
  - `db.py`: Added `get_active_screener_rejections()` and `record_screener_rejection()` methods (service-role only, fail-open on missing table)
  - `screen.py`: `portfolio_screen_candidates()` now filters rejections when `hideRejected` is true (default)
  - `llm_watchlist_buyer.py`: Records PASS verdicts and sub-conviction BUYs as rejections after evaluation
- **Frontend**:
  - `web/lib/screen/rejections-query.ts`: Query active rejections for signed-in viewer's portfolio
  - `web/lib/screen/rejections-mutations.ts`: Server action to manually restore a rejected name
  - `screener-client.tsx`: Rejection list UI in Hidden panel with rejection dates; restore button per name
  - `web/lib/screen/config.ts`: Added `hideRejected` boolean toggle to `ScreenConfig` (defaults true)
  - `web/app/api/screen/route.ts`: `/api/screen` endpoint returns active rejections alongside screen results
- **Tests**: `test_screen.py` added `TestRejectionFilter` to verify hide/show behavior

### Demo Portfolio Seeding
- **Python tool** (`seed_dummy_portfolio.py`): 1045-line operator script that:
  - Fabricates a dummy auth user, profile, and portfolio with back-dated inception
  - Generates a trade tape with real historical closes from `prices_daily`
  - Creates investment theses per BUY with agent-authored rationale + extend/break signals
  - Builds daily MTM snapshots valued at real closes (reconciled cash + holdings)
  - Records agent heartbeats for buyer runs + reviewer runs
  - Verifies >10 equities in every snapshot and >8% trailing-30d return before writing
  - Supports `--dry-run`, `--teardown`, and customizable flags (slug, display name, email, days, target return, seed)

- **SQL twins** (`seed_mara_v1.sql`, `seed_house_targaryen.sql`): Paste-and-run Supabase scripts that:
  - Create MARA v1 (overperformer: strongest trailing-30d names) and House Targaryen (underperformer: weakest names)
  - Seed identical structure to Python tool (trades, theses, holdings, history, heartbeats)
  - Verify constraints (>10 positions, negative return below "chuckyegg" baseline) before committing
  - Idempotent teardown on re-run (safe to re-seed)

- **GitHub Actions** (`.github/workflows/seed-dummy-portfolio.yml`): Manual workflow dispatch to run Python seeding tool with optional flags

## Implementation Details

- **Rejection expiry**: 90 days from `rejected_at`; `restored_at` is set (not deleted) to preserve audit trail
- **Fail-open design**: Missing `screener_rejections` table doesn't block screener or buyer (returns empty set)
- **Real price history**: Demo portfolios use actual `prices_daily` closes on their historical dates; fills are cash-chained and reconciled
- **Thesis snapshots**: Frozen at fill price with price-linked fields (P/S, 52w%) adjusted to historical entry
-

https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu