### PR TITLE
Trading: let the buyer transact the full Tier-1 universe (Level 0 pricing + FK repoint)

### DIFF
--- a/db.py
+++ b/db.py
@@ -312,6 +312,38 @@ class SupabaseDB:
         )
         return resp.data[0]["date"] if resp.data else None
 
+    def get_level0_close(self, ticker: str) -> float | None:
+        """Latest USD close for a ticker from the Level 0 price layer.
+
+        The trading layer's fallback when a ticker isn't in `companies` (e.g. a
+        Tier-1 name the legacy pipeline never covered). Prefers the most-recent
+        `prices_daily` close; falls back to the gate-stamped `securities.
+        last_close`. Returns None when neither has a usable value.
+        """
+        if not ticker:
+            return None
+        try:
+            resp = (
+                self.client.table("prices_daily")
+                .select("close")
+                .eq("ticker", ticker.upper())
+                .order("date", desc=True)
+                .limit(1)
+                .execute()
+            )
+            if resp.data:
+                close = SupabaseDB.safe_float(resp.data[0].get("close"))
+                if close and close > 0:
+                    return close
+            sec = self.get_security(ticker.upper())
+            if sec:
+                lc = SupabaseDB.safe_float(sec.get("last_close"))
+                if lc and lc > 0:
+                    return lc
+        except Exception:  # noqa: BLE001 — never block a trade on the fallback read
+            return None
+        return None
+
     # --- fundamentals (history) ---
 
     def upsert_fundamentals_batch(self, rows: list[dict]) -> None:

--- a/llm_providers.py
+++ b/llm_providers.py
@@ -112,6 +112,10 @@ def call_llm(
 # Anthropic
 # ---------------------------------------------------------------------------
 
+# Models discovered (this process) to reject the `temperature` param, so we
+# stop sending it after the first 400 instead of paying the retry tax per call.
+_NO_TEMPERATURE_MODELS: set[str] = set()
+
 
 def _call_anthropic(
     model: str,
@@ -130,9 +134,11 @@ def _call_anthropic(
 
     client = Anthropic(api_key=api_key)
     last_err: Exception | None = None
-    # Some newer Anthropic models (e.g. Opus 4.7) reject `temperature`. We
-    # try with it first, drop it on the second attempt if that's the issue.
-    send_temperature = True
+    # Some newer Anthropic models (e.g. Opus 4.7+) reject `temperature`. We try
+    # with it first, drop it on a temperature error, and REMEMBER that for the
+    # model so every later call this process skips it from the start (a buyer
+    # run is ~40 calls — without the cache each one pays a 400-then-retry tax).
+    send_temperature = model not in _NO_TEMPERATURE_MODELS
     for attempt in range(2):
         try:
             kwargs = {
@@ -162,6 +168,7 @@ def _call_anthropic(
             logger.warning("anthropic call attempt %d failed: %s", attempt + 1, exc)
             if "temperature" in str(exc).lower() and send_temperature:
                 send_temperature = False
+                _NO_TEMPERATURE_MODELS.add(model)  # skip it for the rest of the process
                 continue  # retry immediately without the deprecated param
             time.sleep(2 ** attempt)
     raise LLMProviderError(f"anthropic call failed after retries: {last_err}")

--- a/migrations/052_trading_fk_to_securities.sql
+++ b/migrations/052_trading_fk_to_securities.sql
@@ -1,0 +1,71 @@
+-- Migration 052: repoint the trading tables' ticker FK from companies -> securities.
+--
+-- The trading tables (portfolio_holdings, agent_holdings, agent_trades,
+-- investment_theses) constrained `ticker` to companies(ticker) — the legacy
+-- TradingView-screen universe. That blocked the buyer from ever holding /
+-- journaling a Tier-1 name the legacy pipeline never covered (US-listed
+-- financials, foreign-domiciled ADRs like TSM/ING), even though the screener
+-- ranks them and the buyer (post-PR #1596) now evaluates them: the buy RPC
+-- hit a foreign-key violation.
+--
+-- securities (Level 0, migration 039) is the universe of record now and a
+-- superset of companies (every US-exchange-listed name). Repointing the FK
+-- there keeps real referential integrity (no booking a garbage symbol) while
+-- letting the full Tier-1 universe be traded.
+--
+-- SAFE BY DESIGN:
+--   * securities soft-deletes (status='delisted'), never hard-deletes, so the
+--     FK target for a historical trade on a now-delisted name still exists.
+--   * The new constraint is added NOT VALID — existing rows are grandfathered
+--     (never re-checked), so the migration can't fail on legacy data that
+--     predates the securities universe. Only NEW inserts are checked, which is
+--     exactly what we want: a new buy must reference a known security.
+--
+-- Idempotent: drops whatever FK currently points ticker->companies on each
+-- table, then adds the securities FK if not already present. Paste-and-run.
+
+DO $$
+DECLARE
+    t        TEXT;
+    conname  TEXT;
+    tables   TEXT[] := ARRAY[
+        'portfolio_holdings', 'agent_holdings', 'agent_trades', 'investment_theses'
+    ];
+BEGIN
+    FOREACH t IN ARRAY tables LOOP
+        -- 1. Drop the existing ticker->companies FK (whatever it's named).
+        FOR conname IN
+            SELECT c.conname
+            FROM pg_constraint c
+            WHERE c.conrelid = t::regclass
+              AND c.contype = 'f'
+              AND c.confrelid = 'companies'::regclass
+              AND (SELECT a.attname
+                     FROM pg_attribute a
+                    WHERE a.attrelid = c.conrelid
+                      AND a.attnum = c.conkey[1]) = 'ticker'
+        LOOP
+            EXECUTE format('ALTER TABLE %I DROP CONSTRAINT %I', t, conname);
+            RAISE NOTICE 'dropped % on %', conname, t;
+        END LOOP;
+
+        -- 2. Add the securities FK (NOT VALID → grandfathers existing rows).
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint c
+            WHERE c.conrelid = t::regclass
+              AND c.contype = 'f'
+              AND c.confrelid = 'securities'::regclass
+              AND (SELECT a.attname
+                     FROM pg_attribute a
+                    WHERE a.attrelid = c.conrelid
+                      AND a.attnum = c.conkey[1]) = 'ticker'
+        ) THEN
+            EXECUTE format(
+                'ALTER TABLE %I ADD CONSTRAINT %I '
+                'FOREIGN KEY (ticker) REFERENCES securities(ticker) NOT VALID',
+                t, t || '_ticker_securities_fkey'
+            );
+            RAISE NOTICE 'added %_ticker_securities_fkey on %', t, t;
+        END IF;
+    END LOOP;
+END $$;

--- a/portfolio.py
+++ b/portfolio.py
@@ -167,16 +167,27 @@ class PortfolioManager:
     # ------------------------------------------------------------------
 
     def get_price(self, ticker: str) -> float:
-        """Return the latest `companies.price` for a ticker (treated as USD)."""
+        """Return the latest price for a ticker (treated as USD).
+
+        Primary source is `companies.price`. Falls back to the Level 0 price
+        layer (`prices_daily` latest close / `securities.last_close`) when the
+        ticker isn't in `companies` or its price is unusable — so Tier-1 names
+        the legacy pipeline never covered (US-listed financials, foreign-
+        domiciled ADRs) are still priceable for both trading and MTM.
+        """
         company = self.db.get_company(ticker)
+        price = SupabaseDB.safe_float(company.get("price")) if company else None
+        if price is not None and price > 0:
+            return price
+        # Fallback: Level 0. Covers names absent from companies entirely.
+        level0_price = self.db.get_level0_close(ticker)
+        if level0_price is not None and level0_price > 0:
+            return level0_price
         if not company:
             raise PortfolioError(f"Unknown ticker: {ticker}")
-        price = SupabaseDB.safe_float(company.get("price"))
-        if price is None or price <= 0:
-            raise PortfolioError(
-                f"No usable price for {ticker} (companies.price is null or <=0)"
-            )
-        return price
+        raise PortfolioError(
+            f"No usable price for {ticker} (companies.price and Level 0 both empty)"
+        )
 
     # ------------------------------------------------------------------
     # Trading

--- a/test_portfolios.py
+++ b/test_portfolios.py
@@ -187,6 +187,38 @@ class DbPortfolioHelpersTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# PortfolioManager.get_price — companies primary, Level 0 fallback
+# ---------------------------------------------------------------------------
+
+
+class GetPriceFallbackTests(unittest.TestCase):
+    """A ticker absent from `companies` (e.g. a Tier-1 name the legacy pipeline
+    never covered) must still price off Level 0 so it's tradable + valuable."""
+
+    def _pm(self, company, level0):
+        pm = portfolio_module.PortfolioManager.__new__(
+            portfolio_module.PortfolioManager
+        )
+        pm.db = SimpleNamespace(
+            get_company=lambda t: company,
+            get_level0_close=lambda t: level0,
+        )
+        return pm
+
+    def test_companies_price_wins(self):
+        self.assertEqual(self._pm({"price": 42.0}, 99.0).get_price("AAA"), 42.0)
+
+    def test_level0_fallback_when_absent(self):
+        self.assertEqual(self._pm(None, 180.5).get_price("TSM"), 180.5)
+
+    def test_level0_fallback_when_price_null(self):
+        self.assertEqual(self._pm({"price": None}, 12.3).get_price("BBB"), 12.3)
+
+    def test_unknown_ticker_raises(self):
+        with self.assertRaises(portfolio_module.PortfolioError):
+            self._pm(None, None).get_price("ZZZ")
+
+
 # PortfolioManager._ensure_portfolio_for_agent — creates the 1:1 shim
 # ---------------------------------------------------------------------------
 

--- a/test_theses.py
+++ b/test_theses.py
@@ -165,10 +165,16 @@ class BuildSnapshotTests(unittest.TestCase):
         self.assertIn("fcf_margin_pct", snap)
         self.assertIsNone(snap["fcf_margin_pct"])
 
-    def test_unknown_ticker_raises(self):
+    def test_unknown_ticker_falls_back_to_minimal_snapshot(self):
+        # A ticker absent from companies (a Tier-1 name the legacy pipeline
+        # never covered) must NOT raise — it returns a minimal Level 0 snapshot
+        # so the thesis still records. (This stub has no get_security/
+        # get_level0_close, so the fallback degrades to ticker-only.)
         db = _StubDB()
-        with self.assertRaises(ValueError):
-            theses.build_snapshot(db, "GHOST")
+        snap = theses.build_snapshot(db, "GHOST")
+        self.assertEqual(set(snap.keys()), set(theses._SNAPSHOT_FIELDS))
+        self.assertEqual(snap["ticker"], "GHOST")
+        self.assertIsNone(snap["fcf_margin_pct"])
 
 
 # ---------------------------------------------------------------------------
@@ -272,7 +278,9 @@ class CloseThesesTests(unittest.TestCase):
         self.assertEqual(n, 2)
         self.assertEqual(db.log[0]["op"], "update")
         self.assertEqual(db.log[0]["filters"], {"agent_id": "A", "ticker": "NVDA"})
-        self.assertEqual(db.log[0]["neq"], {"status": "closed"})
+        # close_theses_for_position only closes ACTIVE theses (preserves
+        # terminal statuses like 'broken'), so it filters eq status=active.
+        self.assertEqual(db.log[0]["eq"], {"status": "active"})
         payload = db.log[0]["payload"]
         self.assertEqual(payload["status"], "closed")
         self.assertIn("status_changed_at", payload)

--- a/theses.py
+++ b/theses.py
@@ -72,13 +72,32 @@ def build_snapshot(db, ticker: str) -> dict:
     ``snapshot`` JSONB column.
 
     Returns a dict containing exactly the fields in ``_SNAPSHOT_FIELDS``
-    (missing fields become None). Raises ``ValueError`` if the ticker
-    isn't in ``companies``.
+    (missing fields become None). Primary source is ``companies``; for a
+    Tier-1 name absent from ``companies`` (the legacy pipeline never covered
+    it) it falls back to a minimal Level 0 snapshot (identity + price) so the
+    thesis still records — rather than raising and dropping the audit row.
     """
     company = db.get_company(ticker)
-    if not company:
-        raise ValueError(f"no companies row for {ticker}")
-    return {k: company.get(k) for k in _SNAPSHOT_FIELDS}
+    if company:
+        return {k: company.get(k) for k in _SNAPSHOT_FIELDS}
+
+    # Level 0 fallback — identity from securities + latest close, rest None.
+    # Fully defensive: a thesis snapshot must never fail to build (it would
+    # drop the audit row), so any read error yields a minimal ticker-only snap.
+    snapshot = {k: None for k in _SNAPSHOT_FIELDS}
+    snapshot["ticker"] = ticker
+    try:
+        sec = db.get_security(ticker)
+        if sec:
+            snapshot["company_name"] = sec.get("name")
+            snapshot["country"] = sec.get("country")
+            snapshot["sector"] = sec.get("gics_sector")
+        price = db.get_level0_close(ticker)
+        if price is not None:
+            snapshot["price"] = price
+    except Exception:  # noqa: BLE001
+        pass
+    return snapshot
 
 
 def record_thesis(


### PR DESCRIPTION
## Context

After #1596 a `buyer-claude` heartbeat went **4 → 33** candidates and TSM qualified **5/5 BUY** — but couldn't be bought (`Unknown ticker: TSM`) because the trading layer was still coupled to `companies`.

## Changes

- **`get_price` Level 0 fallback** — price off `prices_daily`/`securities.last_close` when a ticker isn't in `companies` (`db.get_level0_close`).
- **Migration 052 — FK repoint** `companies → securities` on `portfolio_holdings` / `agent_holdings` / `agent_trades` / `investment_theses` (`NOT VALID`, so existing rows grandfathered; only new trades checked).
- **Thesis snapshot fallback** — `theses.build_snapshot` records a minimal Level 0 snapshot for non-`companies` names instead of raising.
- **Anthropic no-temperature cache** — removes the per-call 400-then-retry tax on Claude buyers.

## Deploy
Run **migration 052** after merge.

_(AI-analysis-on-Level-0 / Stage A1 was split into its own PR, #1598.)_

https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu