### PR TITLE
Stage A1: move AI bull/bear + narratives to a Level 0 table (ai_analysis)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -727,6 +727,18 @@ ps_ath, ps_pct_of_ath, history_json, source, fetched_at — PK (ticker, date)
 
 **`events`** `ticker (FK), type (earnings|split|dividend), date, value, source, fetched_at — PK (ticker, type, date)`
 
+**`ai_analysis`** (Level 0 home for AI bull/bear + narratives — migration 053,
+Stage A1) `ticker (PK, no FK — a derived lens table), bull_eval, bear_eval,
+short_outlook, key_risks, full_outlook, event_impact, analyzed_at, updated_at`.
+The screener's AI multiplier (`screen_ai_overlay` / `screen_facts_mv`) and the
+buyer's narrative enrichment (`db.get_ai_analysis`) read bull/bear + narratives
+from **here**, not `companies` — the first step of retiring the legacy TV
+`companies` flow. Seeded from `companies` (zero coverage loss) and kept fresh by
+the eval scripts **dual-writing** it (`db.upsert_ai_analysis`) alongside
+`companies`. **Stage A2** (pending) repoints those scripts' *input* universe
+from `companies` to Tier 1, so bull/bear + narratives finally cover the whole
+Tier-1 universe (today they cover only the legacy screen's names).
+
 All Level 0 tables: public-read RLS, service-role writes. `metric_stats`
 (distribution percentiles) is reused from migration 038.
 

--- a/bear_evaluation.py
+++ b/bear_evaluation.py
@@ -419,6 +419,12 @@ def main():
                 "bear_eval": verdict,
                 "bear_eval_at": today_str,
             })
+            # Dual-write Level 0 ai_analysis (migration 053) — the screener
+            # overlay + buyer read bear verdicts off Level 0, not companies.
+            db.upsert_ai_analysis(ticker, {
+                "bear_eval": verdict,
+                "analyzed_at": today_str,
+            })
             matched += 1
         else:
             logger.warning("No verdict found for %s", ticker)

--- a/bull_evaluation.py
+++ b/bull_evaluation.py
@@ -427,6 +427,13 @@ def main():
     logger.info("Writing %d verdicts", matched)
     if updates:
         db.upsert_companies_batch(updates)
+        # Dual-write to the Level 0 ai_analysis table (migration 053) so the
+        # screener overlay + buyer read bull verdicts off Level 0, not companies.
+        db.upsert_ai_analysis_batch([
+            {"ticker": u["ticker"], "bull_eval": u["bull_eval"],
+             "analyzed_at": u["bull_eval_at"]}
+            for u in updates
+        ])
 
     # Log the run
     elapsed = time.time() - start_time

--- a/db.py
+++ b/db.py
@@ -312,6 +312,53 @@ class SupabaseDB:
         )
         return resp.data[0]["date"] if resp.data else None
 
+    def upsert_ai_analysis_batch(self, rows: list[dict]) -> None:
+        """Upsert AI-analysis rows (bull/bear + narratives) into the Level 0
+        `ai_analysis` table (migration 053), conflict on ticker.
+
+        PostgREST upsert merges — only the columns present in each row are
+        updated on conflict, so a bull-only write doesn't clobber an existing
+        bear verdict or narrative. Best-effort: a write error is logged, never
+        raised, so it can't break the eval job it's dual-writing from.
+        """
+        if not rows:
+            return
+        for r in rows:
+            self._sanitize(r)
+        try:
+            self.client.table("ai_analysis").upsert(
+                rows, on_conflict="ticker"
+            ).execute()
+        except Exception as exc:  # noqa: BLE001 — dual-write must never crash the writer
+            import logging
+            logging.getLogger("db").warning("upsert_ai_analysis_batch failed: %s", exc)
+
+    def upsert_ai_analysis(self, ticker: str, fields: dict) -> None:
+        """Single-ticker convenience over ``upsert_ai_analysis_batch``."""
+        if not ticker:
+            return
+        self.upsert_ai_analysis_batch([{"ticker": ticker, **fields}])
+
+    def get_ai_analysis(self, tickers) -> dict[str, dict]:
+        """Map ticker -> ai_analysis row for the given tickers (one query).
+
+        Used by the buyer's narrative enrichment. Best-effort: returns {} on a
+        read error (e.g. the table not yet migrated) so the buyer still runs.
+        """
+        tl = sorted({str(t).upper() for t in tickers if t})
+        if not tl:
+            return {}
+        try:
+            resp = (
+                self.client.table("ai_analysis")
+                .select("ticker,short_outlook,key_risks,full_outlook,bull_eval,bear_eval")
+                .in_("ticker", tl)
+                .execute()
+            )
+        except Exception:  # noqa: BLE001
+            return {}
+        return {str(r.get("ticker") or "").upper(): r for r in (resp.data or [])}
+
     def get_level0_close(self, ticker: str) -> float | None:
         """Latest USD close for a ticker from the Level 0 price layer.
 

--- a/llm_watchlist_buyer.py
+++ b/llm_watchlist_buyer.py
@@ -41,24 +41,13 @@ _COMPANY_NARRATIVE_FIELDS = (
 
 
 def _load_company_narratives(db, tickers) -> dict[str, dict]:
-    """Map ticker -> companies narrative row for the given tickers (one query).
+    """Map ticker -> AI narrative row for the given tickers (one query).
 
-    Best-effort: a read error returns {} so the buyer still evaluates on the
-    Level 0 facts alone.
+    Reads the Level 0 `ai_analysis` table (migration 053), so the enrichment
+    covers any Tier-1 name once evaluated — not just the legacy companies set.
+    Best-effort: returns {} on error so the buyer still evaluates on facts alone.
     """
-    tl = sorted({str(t).upper() for t in tickers if t})
-    if not tl:
-        return {}
-    try:
-        resp = (
-            db.client.table("companies")
-            .select("ticker,company_name," + ",".join(_COMPANY_NARRATIVE_FIELDS))
-            .in_("ticker", tl)
-            .execute()
-        )
-    except Exception:  # noqa: BLE001 — never block the buyer on the enrichment join
-        return {}
-    return {str(r.get("ticker") or "").upper(): r for r in (resp.data or [])}
+    return db.get_ai_analysis(tickers)
 
 
 def _build_equity_data(fact_row: dict, company: dict | None) -> dict:

--- a/migrations/053_ai_analysis_level0.sql
+++ b/migrations/053_ai_analysis_level0.sql
@@ -1,0 +1,118 @@
+-- Migration 053 (Stage A1): a Level 0 home for AI analysis (bull/bear + narratives).
+--
+-- The screener's AI multiplier and the buyer's enrichment read bull/bear +
+-- narratives from `companies` — the legacy TradingView-selected universe. To
+-- let those cover the full Tier-1 universe (and ultimately retire `companies`),
+-- AI analysis moves to its own table, `ai_analysis`, keyed by ticker.
+--
+-- This migration is the SAFE first step (A1): create the table, SEED it from
+-- the existing companies AI columns (zero coverage loss), and repoint the read
+-- paths (screen_ai_overlay + screen_facts_mv) to it. The evaluation scripts
+-- dual-write `ai_analysis` alongside `companies` (accompanying Python change),
+-- so it stays fresh. A2 repoints those scripts' INPUT to the Tier-1 universe so
+-- coverage actually expands beyond the legacy screen.
+--
+-- No FK on ticker (this is a derived opinion/lens table, not a Level 0 fact
+-- table): keeps the dual-write from ever failing a screen ticker that isn't yet
+-- in `securities`, and the screener join (screen_facts_mv WHERE is_tier1) drops
+-- any stray row anyway. Public-read (the overlay is read anon/SSR), service
+-- writes. Additive & idempotent.
+
+CREATE TABLE IF NOT EXISTS ai_analysis (
+    ticker         TEXT PRIMARY KEY,
+    bull_eval      TEXT,
+    bear_eval      TEXT,
+    short_outlook  TEXT,
+    key_risks      TEXT,
+    full_outlook   TEXT,
+    event_impact   TEXT,
+    analyzed_at    TIMESTAMPTZ,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+DROP TRIGGER IF EXISTS ai_analysis_updated_at ON ai_analysis;
+CREATE TRIGGER ai_analysis_updated_at
+    BEFORE UPDATE ON ai_analysis
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE ai_analysis ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "public read ai_analysis" ON ai_analysis;
+CREATE POLICY "public read ai_analysis" ON ai_analysis FOR SELECT USING (true);
+-- No INSERT/UPDATE/DELETE policy → writes are service-role only.
+
+-- ---- Seed from the existing companies AI columns (no coverage loss) -------
+INSERT INTO ai_analysis (
+    ticker, bull_eval, bear_eval, short_outlook, key_risks, full_outlook,
+    event_impact, analyzed_at
+)
+SELECT ticker, bull_eval, bear_eval, short_outlook, key_risks, full_outlook,
+       event_impact, ai_analyzed_at
+FROM companies
+WHERE bull_eval IS NOT NULL OR bear_eval IS NOT NULL
+   OR short_outlook IS NOT NULL OR full_outlook IS NOT NULL
+   OR key_risks IS NOT NULL OR event_impact IS NOT NULL
+ON CONFLICT (ticker) DO NOTHING;
+
+-- ---- Repoint screen_ai_overlay() to ai_analysis --------------------------
+CREATE OR REPLACE FUNCTION screen_ai_overlay()
+RETURNS TABLE (ticker TEXT, bull BOOLEAN, bear BOOLEAN)
+LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public, pg_temp AS $$
+  SELECT ticker,
+    CASE WHEN left(bull_eval,1)='✅' THEN true WHEN left(bull_eval,1)='❌' THEN false END,
+    CASE WHEN left(bear_eval,1)='✅' THEN true WHEN left(bear_eval,1)='❌' THEN false END
+  FROM ai_analysis
+  WHERE bull_eval IS NOT NULL OR bear_eval IS NOT NULL;
+$$;
+
+-- ---- Repoint screen_facts_mv's bull/bear join to ai_analysis -------------
+-- Same definition as migration 044, with the AI join moved companies -> ai_analysis.
+-- (screen_facts() reads this matview and is unchanged.)
+DROP MATERIALIZED VIEW IF EXISTS screen_facts_mv;
+CREATE MATERIALIZED VIEW screen_facts_mv AS
+    SELECT
+        s.ticker,
+        s.name,
+        s.gics_sector       AS sector,
+        s.gics_industry     AS industry,
+        s.country,
+        lp.close            AS price,
+        lp.date             AS price_asof,
+        f.rev_growth_ttm,
+        f.gross_margin,
+        f.fcf_margin,
+        f.net_margin,
+        f.operating_margin,
+        f.rule_of_40,
+        v.ps,
+        v.ps_median_12m,
+        CASE WHEN p52.close IS NOT NULL AND p52.close > 0
+             THEN (lp.close / p52.close - 1) * 100 END AS ret_52w,
+        CASE WHEN left(a.bull_eval, 1) = '✅' THEN true
+             WHEN left(a.bull_eval, 1) = '❌' THEN false END AS bull,
+        CASE WHEN left(a.bear_eval, 1) = '✅' THEN true
+             WHEN left(a.bear_eval, 1) = '❌' THEN false END AS bear
+    FROM securities s
+    JOIN LATERAL (
+        SELECT rev_growth_ttm, gross_margin, fcf_margin, net_margin,
+               operating_margin, rule_of_40
+        FROM fundamentals fd
+        WHERE fd.ticker = s.ticker ORDER BY fd.period_end DESC LIMIT 1
+    ) f ON true
+    LEFT JOIN LATERAL (
+        SELECT close, date FROM prices_daily pd
+        WHERE pd.ticker = s.ticker ORDER BY pd.date DESC LIMIT 1
+    ) lp ON true
+    LEFT JOIN LATERAL (
+        SELECT close FROM prices_daily pd
+        WHERE pd.ticker = s.ticker AND pd.date <= (CURRENT_DATE - INTERVAL '52 weeks')
+        ORDER BY pd.date DESC LIMIT 1
+    ) p52 ON true
+    LEFT JOIN LATERAL (
+        SELECT ps, ps_median_12m FROM valuation vl
+        WHERE vl.ticker = s.ticker ORDER BY vl.date DESC LIMIT 1
+    ) v ON true
+    LEFT JOIN ai_analysis a ON a.ticker = s.ticker
+    WHERE s.is_tier1 AND s.status = 'active';
+
+CREATE UNIQUE INDEX IF NOT EXISTS screen_facts_mv_ticker ON screen_facts_mv (ticker);
+GRANT SELECT ON screen_facts_mv TO anon, authenticated, service_role;

--- a/update_ai_narratives.py
+++ b/update_ai_narratives.py
@@ -575,6 +575,15 @@ def main():
             )
             if update_fields and not args.dry_run:
                 db.upsert_company(ticker, update_fields)
+                # Dual-write narratives to the Level 0 ai_analysis table
+                # (migration 053) so the company narratives live off Level 0.
+                db.upsert_ai_analysis(ticker, {
+                    "short_outlook": update_fields.get("short_outlook"),
+                    "full_outlook": update_fields.get("full_outlook"),
+                    "key_risks": update_fields.get("key_risks"),
+                    "event_impact": update_fields.get("event_impact"),
+                    "analyzed_at": update_fields.get("ai_analyzed_at"),
+                })
                 total_written += 1
                 logger.info("  Wrote update for %s", ticker)
             elif not update_fields and not args.dry_run:


### PR DESCRIPTION
**Stage A1 only** (this PR merged before A2 existed). Moves AI bull/bear + narratives onto Level 0, preserving them.

- New **`ai_analysis`** table (migration 053, Level 0, public-read), **seeded from `companies`** (zero coverage loss). Repoints `screen_ai_overlay()` + `screen_facts_mv` bull/bear join `companies → ai_analysis`.
- Eval scripts **dual-write** `ai_analysis` (fail-soft) so it stays fresh.
- Buyer enrichment reads `ai_analysis` (`db.get_ai_analysis`).

Deploy: run **migration 053** after merge.

➡️ **Stage A2** (migration 054 + `--tier1` full-Tier-1 eval) is in **#1599**, not here.

https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu