### PR TITLE
Stage A2: full Tier-1 AI eval (--tier1) + buyer robustness fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -735,9 +735,15 @@ buyer's narrative enrichment (`db.get_ai_analysis`) read bull/bear + narratives
 from **here**, not `companies` — the first step of retiring the legacy TV
 `companies` flow. Seeded from `companies` (zero coverage loss) and kept fresh by
 the eval scripts **dual-writing** it (`db.upsert_ai_analysis`) alongside
-`companies`. **Stage A2** (pending) repoints those scripts' *input* universe
-from `companies` to Tier 1, so bull/bear + narratives finally cover the whole
-Tier-1 universe (today they cover only the legacy screen's names).
+`companies`. **Stage A2** (migration 054, opt-in) adds per-kind rotation clocks
+(`bull_at`/`bear_at`/`narrated_at`) and an opt-in **`--tier1`** flag on
+`bull_evaluation` / `bear_evaluation` / `update_ai_narratives`: with it they
+rotate over the full Tier-1 universe (`level0_eval.tier1_eval_candidates` —
+prompt rows assembled from Level 0 facts, overlaid with `companies` richness
+where present) and write **only** `ai_analysis`, so financials / foreign ADRs
+finally get bull/bear + narratives. Default (no flag) keeps the legacy
+`companies` path untouched; same per-run batch size, so flipping the crons to
+`--tier1` doesn't change daily LLM cost (never-evaluated names sort first).
 
 All Level 0 tables: public-read RLS, service-role writes. `metric_stats`
 (distribution percentiles) is reused from migration 038.

--- a/bear_evaluation.py
+++ b/bear_evaluation.py
@@ -329,10 +329,14 @@ def main():
     parser = argparse.ArgumentParser(description="Bear Evaluation - Fundamental Sentinel")
     parser.add_argument("--dry-run", action="store_true",
                         help="Print prompt and results without writing to the database")
+    parser.add_argument("--tier1", action="store_true",
+                        help="Evaluate the full Level 0 Tier-1 universe (writes "
+                             "ai_analysis only), not just the legacy companies/in_tv_screen set")
     args = parser.parse_args()
 
     logger = setup_logging()
-    logger.info("=== Bear Evaluation started (dry_run=%s) ===", args.dry_run)
+    logger.info("=== Bear Evaluation started (dry_run=%s, tier1=%s) ===",
+                args.dry_run, args.tier1)
     start_time = time.time()
 
     # Validate Gemini key
@@ -345,17 +349,20 @@ def main():
     # Connect to Supabase
     db = SupabaseDB()
 
-    # Read all companies
-    all_companies = db.get_all_companies()
-    logger.info("Read %d companies from database", len(all_companies))
-
-    if not all_companies:
-        logger.error("No companies found in database")
-        sys.exit(1)
-
-    # Select rotation batch (oldest bear_eval_at first, NULLs first)
-    top_equities = select_rotation_batch(all_companies)
-    logger.info("Selected %d tickers for bear evaluation (rotation by bear_eval_at)", len(top_equities))
+    if args.tier1:
+        # Stage A2: rotate over the full Tier-1 universe (ai_analysis clock).
+        import level0_eval
+        top_equities = level0_eval.tier1_eval_candidates(db, "bear", TOP_N)
+        logger.info("Selected %d Tier-1 tickers for bear evaluation (rotation by ai_analysis.bear_at)", len(top_equities))
+    else:
+        all_companies = db.get_all_companies()
+        logger.info("Read %d companies from database", len(all_companies))
+        if not all_companies:
+            logger.error("No companies found in database")
+            sys.exit(1)
+        # Select rotation batch (oldest bear_eval_at first, NULLs first)
+        top_equities = select_rotation_batch(all_companies)
+        logger.info("Selected %d tickers for bear evaluation (rotation by bear_eval_at)", len(top_equities))
 
     if not top_equities:
         logger.warning("No in-screen non-excluded tickers found. Nothing to do.")
@@ -415,14 +422,18 @@ def main():
         ticker = (company.get("ticker") or "").strip()
         verdict = verdicts.get(ticker)
         if verdict:
-            db.upsert_company(ticker, {
-                "bear_eval": verdict,
-                "bear_eval_at": today_str,
-            })
-            # Dual-write Level 0 ai_analysis (migration 053) — the screener
-            # overlay + buyer read bear verdicts off Level 0, not companies.
+            # ai_analysis is the Level 0 home (migrations 053/054): always write
+            # the bear verdict + its rotation clock (bear_at). In --tier1 mode
+            # that's the only write (the name may not exist in companies);
+            # otherwise dual-write companies for the legacy surfaces.
+            if not args.tier1:
+                db.upsert_company(ticker, {
+                    "bear_eval": verdict,
+                    "bear_eval_at": today_str,
+                })
             db.upsert_ai_analysis(ticker, {
                 "bear_eval": verdict,
+                "bear_at": today_str,
                 "analyzed_at": today_str,
             })
             matched += 1

--- a/bull_evaluation.py
+++ b/bull_evaluation.py
@@ -330,10 +330,14 @@ def main():
     parser = argparse.ArgumentParser(description="Bull Evaluation - Smash-Hit Scout")
     parser.add_argument("--dry-run", action="store_true",
                         help="Print prompt and results without writing to the database")
+    parser.add_argument("--tier1", action="store_true",
+                        help="Evaluate the full Level 0 Tier-1 universe (writes "
+                             "ai_analysis only), not just the legacy companies/in_tv_screen set")
     args = parser.parse_args()
 
     logger = setup_logging()
-    logger.info("=== Bull Evaluation started (dry_run=%s) ===", args.dry_run)
+    logger.info("=== Bull Evaluation started (dry_run=%s, tier1=%s) ===",
+                args.dry_run, args.tier1)
     start_time = time.time()
 
     # Validate Claude API key
@@ -345,16 +349,20 @@ def main():
 
     # Connect to Supabase
     db = SupabaseDB()
-    companies = db.get_all_companies()
-    logger.info("Read %d companies from database", len(companies))
-
-    if not companies:
-        logger.error("No companies found in the database")
-        sys.exit(1)
-
-    # Select rotation batch (oldest bull_eval_at first, NULLs first)
-    top_equities = select_rotation_batch(companies)
-    logger.info("Selected %d tickers for bull evaluation (rotation by bull_eval_at)", len(top_equities))
+    if args.tier1:
+        # Stage A2: rotate over the full Tier-1 universe (ai_analysis clock).
+        import level0_eval
+        top_equities = level0_eval.tier1_eval_candidates(db, "bull", TOP_N)
+        logger.info("Selected %d Tier-1 tickers for bull evaluation (rotation by ai_analysis.bull_at)", len(top_equities))
+    else:
+        companies = db.get_all_companies()
+        logger.info("Read %d companies from database", len(companies))
+        if not companies:
+            logger.error("No companies found in the database")
+            sys.exit(1)
+        # Select rotation batch (oldest bull_eval_at first, NULLs first)
+        top_equities = select_rotation_batch(companies)
+        logger.info("Selected %d tickers for bull evaluation (rotation by bull_eval_at)", len(top_equities))
 
     if not top_equities:
         logger.warning("No in-screen non-excluded tickers found. Nothing to do.")
@@ -426,12 +434,15 @@ def main():
 
     logger.info("Writing %d verdicts", matched)
     if updates:
-        db.upsert_companies_batch(updates)
-        # Dual-write to the Level 0 ai_analysis table (migration 053) so the
-        # screener overlay + buyer read bull verdicts off Level 0, not companies.
+        # ai_analysis is the Level 0 home (migrations 053/054): write the bull
+        # verdict + its rotation clock (bull_at). In --tier1 mode that's the
+        # only write (names may not exist in companies); otherwise dual-write
+        # companies too for back-compat with the legacy surfaces.
+        if not args.tier1:
+            db.upsert_companies_batch(updates)
         db.upsert_ai_analysis_batch([
             {"ticker": u["ticker"], "bull_eval": u["bull_eval"],
-             "analyzed_at": u["bull_eval_at"]}
+             "bull_at": u["bull_eval_at"], "analyzed_at": u["bull_eval_at"]}
             for u in updates
         ])
 

--- a/level0_eval.py
+++ b/level0_eval.py
@@ -1,0 +1,181 @@
+"""Level 0 evaluation candidates (Stage A2).
+
+Lets the bull / bear / narrative eval scripts run over the full **Tier 1**
+universe (`securities.is_tier1`) instead of the legacy `companies`/in_tv_screen
+set — so financials and foreign-domiciled ADRs (TSM, ING, banks) that the
+screener ranks but the legacy TV screen excluded finally get AI bull/bear +
+narratives written to `ai_analysis` (migration 053/054).
+
+`tier1_eval_candidates(db, kind, top_n)` returns prompt-ready equity dicts for
+the `top_n` **stalest** Tier-1 names for that `kind` (`bull` | `bear` |
+`narrative`), ordered least-recently-evaluated first (never-evaluated → NULL →
+first). Each dict is assembled from Level 0 facts (identity + latest
+fundamentals + valuation), overlaid with the richer `companies` row where one
+exists (so names already in companies keep their current prompt depth) and the
+existing `ai_analysis` verdicts/narrative. The dict uses companies-style keys so
+the existing `build_equity_block` in each eval script formats it unchanged.
+
+Pure reads; no LLM. The eval scripts pass these straight into their existing
+prompt → LLM → verdict flow.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_CLOCK_COLUMN = {"bull": "bull_at", "bear": "bear_at", "narrative": "narrated_at"}
+
+# Level 0 fundamentals field -> companies-style key the prompt/build_equity_block
+# expects, so a Tier-1-only name reads like a companies row in the prompt.
+_FUNDAMENTAL_MAP = {
+    "revenue": "revenue",
+    "rev_growth_ttm": "rev_growth_ttm_pct",
+    "rev_growth_qoq": "rev_growth_qoq_pct",
+    "rev_cagr": "rev_cagr_pct",
+    "gross_margin": "gross_margin_pct",
+    "operating_margin": "operating_margin_pct",
+    "net_margin": "net_margin_pct",
+    "fcf_margin": "fcf_margin_pct",
+    "rule_of_40": "rule_of_40",
+    "eps": "eps_only",
+    "opex_pct_rev": "opex_pct_revenue",
+    "cash": "cash",
+    "debt": "debt",
+    "shares_out": "shares_out",
+}
+_NARRATIVE_FIELDS = (
+    "bull_eval", "bear_eval", "short_outlook", "key_risks",
+    "full_outlook", "event_impact",
+)
+
+
+def _chunked(seq, n=200):
+    for i in range(0, len(seq), n):
+        yield seq[i:i + n]
+
+
+def _bulk(db, table: str, select: str, tickers: list[str]) -> list[dict]:
+    """Fetch `table` rows for the given tickers (chunked .in_)."""
+    out: list[dict] = []
+    for chunk in _chunked(tickers):
+        resp = (
+            db.client.table(table).select(select).in_("ticker", chunk).execute()
+        )
+        out.extend(resp.data or [])
+    return out
+
+
+def stale_tier1_tickers(db, kind: str, top_n: int) -> list[str]:
+    """The `top_n` Tier-1 tickers least-recently evaluated for `kind`.
+
+    Never-evaluated names (no ai_analysis row, or a NULL kind-clock) sort first,
+    then oldest first. Pure read over `securities` + `ai_analysis`.
+    """
+    clock = _CLOCK_COLUMN.get(kind)
+    if clock is None:
+        raise ValueError(f"unknown kind {kind!r} (expected bull|bear|narrative)")
+
+    # Active Tier-1 universe.
+    tier1: list[str] = []
+    offset = 0
+    while True:
+        resp = (
+            db.client.table("securities")
+            .select("ticker")
+            .eq("is_tier1", True)
+            .eq("status", "active")
+            .range(offset, offset + 999)
+            .execute()
+        )
+        batch = resp.data or []
+        tier1.extend((r.get("ticker") or "").upper() for r in batch if r.get("ticker"))
+        if len(batch) < 1000:
+            break
+        offset += 1000
+
+    # Per-kind clock from ai_analysis (only evaluated names have a row).
+    clocks: dict[str, str | None] = {}
+    for chunk in _chunked(tier1):
+        resp = (
+            db.client.table("ai_analysis")
+            .select(f"ticker,{clock}")
+            .in_("ticker", chunk)
+            .execute()
+        )
+        for r in (resp.data or []):
+            clocks[(r.get("ticker") or "").upper()] = r.get(clock)
+
+    # NULLs (never evaluated) first, then oldest ISO timestamp first.
+    def _key(t: str):
+        c = clocks.get(t)
+        return (0 if not c else 1, str(c or ""))
+
+    return sorted(tier1, key=_key)[:top_n]
+
+
+def _latest_by_ticker(rows: list[dict], order_field: str) -> dict[str, dict]:
+    """Reduce multi-row-per-ticker results to the latest row per ticker."""
+    best: dict[str, dict] = {}
+    for r in rows:
+        t = (r.get("ticker") or "").upper()
+        if not t:
+            continue
+        cur = best.get(t)
+        if cur is None or str(r.get(order_field) or "") > str(cur.get(order_field) or ""):
+            best[t] = r
+    return best
+
+
+def _assemble(ticker: str, sec: dict | None, fund: dict | None,
+              val: dict | None, company: dict | None, ai: dict | None) -> dict:
+    """Build one prompt-ready equity dict (companies-style keys)."""
+    row: dict[str, Any] = {"ticker": ticker}
+    sec = sec or {}
+    row["company_name"] = (company or {}).get("company_name") or sec.get("name")
+    row["country"] = (company or {}).get("country") or sec.get("country")
+    row["sector"] = (company or {}).get("sector") or sec.get("gics_sector")
+
+    # Level 0 fundamentals → companies-style keys.
+    for src, dst in _FUNDAMENTAL_MAP.items():
+        v = (fund or {}).get(src)
+        if v is not None:
+            row[dst] = v
+    if val:
+        if val.get("ps") is not None:
+            row["ps_now"] = val.get("ps")
+        if val.get("ps_median_12m") is not None:
+            row["ps_median_12m"] = val.get("ps_median_12m")
+
+    # Overlay the richer companies row where it exists (keeps current prompt
+    # depth for legacy-covered names); else fall back to ai_analysis verdicts/
+    # narrative so a bull eval can still see the prior bear, etc.
+    if company:
+        row.update({k: v for k, v in company.items() if v is not None})
+    elif ai:
+        for f in _NARRATIVE_FIELDS:
+            if ai.get(f) is not None:
+                row[f] = ai[f]
+    return row
+
+
+def tier1_eval_candidates(db, kind: str, top_n: int) -> list[dict]:
+    """Prompt-ready equity dicts for the `top_n` stalest Tier-1 names for `kind`,
+    staleness order preserved."""
+    tickers = stale_tier1_tickers(db, kind, top_n)
+    if not tickers:
+        return []
+    secs = {(s.get("ticker") or "").upper(): s
+            for s in _bulk(db, "securities",
+                           "ticker,name,country,gics_sector", tickers)}
+    companies = {(c.get("ticker") or "").upper(): c
+                 for c in _bulk(db, "companies", "*", tickers)}
+    funds = _latest_by_ticker(
+        _bulk(db, "fundamentals", "*", tickers), "period_end")
+    vals = _latest_by_ticker(
+        _bulk(db, "valuation", "ticker,date,ps,ps_median_12m", tickers), "date")
+    ai = db.get_ai_analysis(tickers)
+    return [
+        _assemble(t, secs.get(t), funds.get(t), vals.get(t),
+                  companies.get(t), ai.get(t))
+        for t in tickers
+    ]

--- a/llm_watchlist_buyer.py
+++ b/llm_watchlist_buyer.py
@@ -825,8 +825,14 @@ def rebalance_llm_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
             ctx.db.clear_screener_rejection(ctx.portfolio_id, ticker)
         except PortfolioError as exc:
             result.errors.append(f"buy {ticker} x{item['qty']}: {exc}")
-
-    result.notes["executed_plan"] = plan
+        except Exception as exc:  # noqa: BLE001
+            # A non-PortfolioError (e.g. a Postgres FK/APIError on the insert)
+            # must NOT abort the whole batch — log it, record it, and keep
+            # buying the rest of the ranked plan. Previously this propagated
+            # and crashed the entire heartbeat with zero buys.
+            logger.warning("%s: buy %s x%s failed (skipped): %s",
+                           handle, ticker, item["qty"], exc)
+            result.errors.append(f"buy {ticker} x{item['qty']}: {exc}")
     result.notes["target_pct"] = target_pct
     result.notes["target_usd"] = round(target_usd, 2)
     return result

--- a/migrations/054_ai_analysis_rotation_clocks.sql
+++ b/migrations/054_ai_analysis_rotation_clocks.sql
@@ -1,0 +1,31 @@
+-- Migration 054 (Stage A2): per-kind rotation clocks on ai_analysis.
+--
+-- A2 lets the bull / bear / narrative eval scripts run over the full Tier-1
+-- universe (securities.is_tier1), not just the legacy `companies`/in_tv_screen
+-- set — so financials / foreign-domiciled ADRs (TSM, ING, banks) finally get
+-- AI bull/bear + narratives. Those scripts rotate by "least-recently-evaluated"
+-- (NULLs first). On the legacy path that staleness lived on companies
+-- (bull_eval_at / bear_eval_at / ai_analyzed_at); for Tier-1 names absent from
+-- companies it has to live on ai_analysis. Add one clock per kind.
+--
+-- Backfilled from companies for rows that exist in both, so seeded names aren't
+-- needlessly re-evaluated first; genuinely-new Tier-1 names stay NULL → sorted
+-- first → covered first. Additive & idempotent.
+
+ALTER TABLE ai_analysis ADD COLUMN IF NOT EXISTS bull_at     TIMESTAMPTZ;
+ALTER TABLE ai_analysis ADD COLUMN IF NOT EXISTS bear_at     TIMESTAMPTZ;
+ALTER TABLE ai_analysis ADD COLUMN IF NOT EXISTS narrated_at TIMESTAMPTZ;
+
+-- Backfill the clocks from companies' per-kind timestamps (one-time).
+UPDATE ai_analysis a
+   SET bull_at     = COALESCE(a.bull_at,     c.bull_eval_at),
+       bear_at     = COALESCE(a.bear_at,     c.bear_eval_at),
+       narrated_at = COALESCE(a.narrated_at, c.ai_analyzed_at)
+  FROM companies c
+ WHERE c.ticker = a.ticker;
+
+-- Staleness lookups order by (clock NULLS FIRST); a partial index per kind keeps
+-- the "oldest N" scan cheap as the table grows toward the full Tier-1 set.
+CREATE INDEX IF NOT EXISTS idx_ai_analysis_bull_at     ON ai_analysis (bull_at NULLS FIRST);
+CREATE INDEX IF NOT EXISTS idx_ai_analysis_bear_at     ON ai_analysis (bear_at NULLS FIRST);
+CREATE INDEX IF NOT EXISTS idx_ai_analysis_narrated_at ON ai_analysis (narrated_at NULLS FIRST);

--- a/test_level0_eval.py
+++ b/test_level0_eval.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Unit tests for level0_eval (Stage A2) — the Tier-1 eval candidate loader.
+
+Pure-logic + a tiny fake PostgREST client for the staleness ordering. No DB,
+no LLM. Run: python test_level0_eval.py
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+import level0_eval as L
+
+
+class LatestByTickerTests(unittest.TestCase):
+    def test_keeps_latest(self):
+        rows = [
+            {"ticker": "A", "period_end": "2024-12-31", "gm": 50},
+            {"ticker": "A", "period_end": "2025-03-31", "gm": 52},
+            {"ticker": "B", "period_end": "2025-01-01", "gm": 40},
+        ]
+        out = L._latest_by_ticker(rows, "period_end")
+        self.assertEqual(out["A"]["gm"], 52)
+        self.assertEqual(out["B"]["gm"], 40)
+
+
+class AssembleTests(unittest.TestCase):
+    def test_level0_to_companies_keys_and_ai_fallback(self):
+        row = L._assemble(
+            "TSM",
+            {"name": "Taiwan Semi", "country": "Taiwan", "gics_sector": "Technology"},
+            {"rev_growth_ttm": 30, "gross_margin": 53, "rule_of_40": 55, "eps": 6.1},
+            {"ps": 9.1, "ps_median_12m": 8.0},
+            None,  # not in companies
+            {"bull_eval": "✅ strong", "bear_eval": "❌ none"},
+        )
+        self.assertEqual(row["company_name"], "Taiwan Semi")
+        self.assertEqual(row["sector"], "Technology")
+        self.assertEqual(row["rev_growth_ttm_pct"], 30)
+        self.assertEqual(row["rule_of_40"], 55)
+        self.assertEqual(row["eps_only"], 6.1)
+        self.assertEqual(row["ps_now"], 9.1)
+        self.assertEqual(row["bull_eval"], "✅ strong")  # ai fallback
+
+    def test_companies_overlay_wins(self):
+        row = L._assemble(
+            "AAA", {"name": "X"}, {"gross_margin": 40}, None,
+            {"company_name": "Acme", "annual_revenue_5y": [1, 2, 3], "bull_eval": "✅ co"},
+            {"bull_eval": "✅ ai"},
+        )
+        self.assertEqual(row["company_name"], "Acme")
+        self.assertEqual(row["annual_revenue_5y"], [1, 2, 3])
+        self.assertEqual(row["bull_eval"], "✅ co")  # companies, not ai
+
+
+# --- staleness ordering with a minimal fake PostgREST client ---------------
+
+class _FakeQ:
+    def __init__(self, table, data):
+        self.table_name = table
+        self._data = data
+    def select(self, *_a, **_k): return self
+    def eq(self, *_a, **_k): return self
+    def in_(self, *_a, **_k): return self
+    def range(self, *_a, **_k): return self
+    def execute(self):
+        return SimpleNamespace(data=self._data)
+
+
+class _FakeClient:
+    def __init__(self, securities, ai):
+        self._securities = securities
+        self._ai = ai
+    def table(self, name):
+        return _FakeQ(name, self._securities if name == "securities" else self._ai)
+
+
+class _FakeDB:
+    def __init__(self, securities, ai):
+        self.client = _FakeClient(securities, ai)
+    def get_ai_analysis(self, tickers):
+        return {}
+
+
+class StaleOrderingTests(unittest.TestCase):
+    def test_never_evaluated_first_then_oldest(self):
+        securities = [{"ticker": t} for t in ("AAA", "BBB", "CCC", "DDD")]
+        # AAA has no ai row at all (NULL), BBB NULL clock, CCC old, DDD recent.
+        ai = [
+            {"ticker": "BBB", "bull_at": None},
+            {"ticker": "CCC", "bull_at": "2025-01-01T00:00:00Z"},
+            {"ticker": "DDD", "bull_at": "2026-06-01T00:00:00Z"},
+        ]
+        db = _FakeDB(securities, ai)
+        order = L.stale_tier1_tickers(db, "bull", top_n=4)
+        # NULLs (AAA, BBB) first, then oldest (CCC) before recent (DDD).
+        self.assertEqual(set(order[:2]), {"AAA", "BBB"})
+        self.assertEqual(order[2], "CCC")
+        self.assertEqual(order[3], "DDD")
+
+    def test_top_n_caps(self):
+        securities = [{"ticker": f"T{i}"} for i in range(10)]
+        db = _FakeDB(securities, [])
+        self.assertEqual(len(L.stale_tier1_tickers(db, "bear", top_n=3)), 3)
+
+    def test_unknown_kind_raises(self):
+        db = _FakeDB([], [])
+        with self.assertRaises(ValueError):
+            L.stale_tier1_tickers(db, "sideways", top_n=1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/update_ai_narratives.py
+++ b/update_ai_narratives.py
@@ -28,6 +28,10 @@ from db import SupabaseDB
 # ---------------------------------------------------------------------------
 
 STALENESS_DAYS = 90
+# Per-run cap for --tier1 rotation (Stage A2): narrate the N oldest Tier-1
+# names each run so the first pass over the ~3k universe doesn't fire thousands
+# of LLM calls at once — keeps daily cost flat, never-narrated names go first.
+TIER1_NARRATIVE_BATCH = 100
 SERPAPI_ENDPOINT = "https://serpapi.com/search"
 GEMINI_MODEL = "gemini-2.5-flash"
 DELAY_BETWEEN_CALLS = 2  # seconds between tickers
@@ -525,6 +529,9 @@ def main():
                         help="Process only this specific ticker")
     parser.add_argument("--force", action="store_true",
                         help="Ignore staleness and refresh all tickers")
+    parser.add_argument("--tier1", action="store_true",
+                        help="Narrate the full Level 0 Tier-1 universe (writes "
+                             "ai_analysis only), oldest-narrated first, capped per run")
     args = parser.parse_args()
 
     logger = setup_logging()
@@ -552,6 +559,15 @@ def main():
             sys.exit(1)
         companies_to_update = [company]
         logger.info("Single-ticker mode: processing %s", args.ticker)
+    elif args.tier1:
+        # Stage A2: narrate the full Tier-1 universe, oldest-narrated first.
+        # Capped per run (rotation) so the first pass over ~3k names doesn't
+        # fire thousands of LLM calls at once — keeps the daily cost flat.
+        import level0_eval
+        companies_to_update = level0_eval.tier1_eval_candidates(
+            db, "narrative", TIER1_NARRATIVE_BATCH)
+        logger.info("Tier-1 mode: narrating %d oldest names (cap %d)",
+                    len(companies_to_update), TIER1_NARRATIVE_BATCH)
     elif args.force:
         companies_to_update = db.get_all_companies()
         logger.info("Force mode: refreshing all %d companies", len(companies_to_update))
@@ -574,14 +590,18 @@ def main():
                 company, serpapi_key, args.dry_run, logger
             )
             if update_fields and not args.dry_run:
-                db.upsert_company(ticker, update_fields)
-                # Dual-write narratives to the Level 0 ai_analysis table
-                # (migration 053) so the company narratives live off Level 0.
+                # ai_analysis is the Level 0 home (migrations 053/054): always
+                # write the narrative + its rotation clock (narrated_at). In
+                # --tier1 mode that's the only write (the name may not exist in
+                # companies); otherwise dual-write companies for legacy surfaces.
+                if not args.tier1:
+                    db.upsert_company(ticker, update_fields)
                 db.upsert_ai_analysis(ticker, {
                     "short_outlook": update_fields.get("short_outlook"),
                     "full_outlook": update_fields.get("full_outlook"),
                     "key_risks": update_fields.get("key_risks"),
                     "event_impact": update_fields.get("event_impact"),
+                    "narrated_at": update_fields.get("ai_analyzed_at"),
                     "analyzed_at": update_fields.get("ai_analyzed_at"),
                 })
                 total_written += 1


### PR DESCRIPTION
## Stage A2 — full Tier-1 AI eval (opt-in)

> NOTE: A2 was never actually merged — #1598 merged **only Stage A1** (it merged before A2 was pushed). This PR is Stage A2 (+ a buyer robustness fix).

- **Migration 054** — per-kind rotation clocks on `ai_analysis` (`bull_at`/`bear_at`/`narrated_at`), backfilled from `companies`.
- **`level0_eval.tier1_eval_candidates(db, kind, top_n)`** — the stalest Tier-1 names as prompt-ready rows from Level 0 facts, overlaid with `companies` richness / `ai_analysis` verdicts where present. Unit-tested.
- Opt-in **`--tier1`** flag on `bull_evaluation` / `bear_evaluation` / `update_ai_narratives`: rotate over the full Tier-1 universe, write **only** `ai_analysis`. Default (no flag) leaves the live `companies` crons untouched. Flat per-run cost; never-evaluated names sort first.

## Buyer robustness fix

The buy loop only caught `PortfolioError`, so a raw Postgres `APIError` (e.g. the FK violation seen when migration 052 hadn't been run) propagated and **crashed the whole heartbeat with zero buys** — even for names that would have succeeded. Now broad exceptions are caught per-name: log, record, and continue the ranked plan.

## Deploy
Run **migration 054** after merge. Then add `--tier1` to the eval workflows when you want full-universe coverage.

Tests: 71 pass (screen, level0_eval, portfolios, theses).

https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu)_