### PR TITLE
Screener rejections: PASS-only + ~30-day hide (was all-non-buys + 90d)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,16 +155,20 @@ Deterministic scoring-as-a-function (Python mirror of
 candidates(db, portfolio_id)` returns the top N `{ticker: rationale}` that both
 buyers (`watchlist_buyer`, `llm_watchlist_buyer`) now trade from. Pure, no LLM.
 
-### Screener rejections — per-portfolio 90-day auto-hide (migration 051)
+### Screener rejections — per-portfolio ~30-day auto-hide (migration 051)
 When a portfolio's BUY agent (`llm_watchlist_buyer`) evaluates a candidate and
-**doesn't buy it** — a PASS verdict, or a BUY below its conviction gate — the
-name is recorded in `screener_rejections` (`(portfolio_id, ticker)` PK,
-`expires_at` = now + 90d, `rejected_by_agent_id`, `verdict`, `conviction`,
-`reason`, `restored_at`). The screener's **`hideRejected`** toggle (in
-`screen_config`, **on by default**) then drops those names from BOTH the
-screener results and the buyer's candidate pool for 90 days, so the agent
-doesn't churn straight back into re-evaluating a name it just passed on. A
-5/5 BUY that merely ran out of cash is **not** a rejection (still wanted). The
+returns a true **PASS**, the name is recorded in `screener_rejections`
+(`(portfolio_id, ticker)` PK, `expires_at` = now + `rejection_window_days`
+(default **30**), `rejected_by_agent_id`, `verdict`, `conviction`, `reason`,
+`restored_at`). A **sub-gate BUY** (e.g. 4/5 — a name the agent wants, just not
+its top pick today) is deliberately **not** recorded, so it stays eligible and
+is re-evaluated as the screen re-ranks (`_pass_rejection_rows`). The screener's
+**`hideRejected`** toggle (in `screen_config`, **on by default**) then drops
+PASSed names from BOTH the screener results and the buyer's candidate pool for
+~30 days — short, so it tracks the daily re-rank / quarterly-earnings cadence
+rather than outliving the reason for the pass (the 90-day window applies only to
+the post-SELL re-buy cooldown, `get_recently_sold_tickers`). A 5/5 BUY that
+merely ran out of cash is **not** a rejection (still wanted). The
 owner can **restore** a name early (sets `restored_at`); a later re-rejection
 re-arms the hide. An actual buy clears any stale rejection. This is the
 per-portfolio cousin of the manual, global 1-year `screener_exclusions`

--- a/db.py
+++ b/db.py
@@ -925,8 +925,8 @@ class SupabaseDB:
     # ------------------------------------------------------------------
 
     def get_active_screener_rejections(self, portfolio_id: str) -> set[str]:
-        """Tickers this portfolio's buyer evaluated and passed on, still within
-        the 90-day window and not manually restored. Upper-cased.
+        """Tickers this portfolio's buyer passed on, still within their expiry
+        window and not manually restored. Upper-cased.
 
         Fail-open: a read error (e.g. the table not yet migrated) returns an
         empty set rather than blocking the screen / buyer.
@@ -951,7 +951,7 @@ class SupabaseDB:
         }
 
     def record_screener_rejections(
-        self, portfolio_id: str, rows: list[dict], *, days: int = 90,
+        self, portfolio_id: str, rows: list[dict], *, days: int = 30,
     ) -> int:
         """Upsert one rejection per row for a portfolio (migration 051).
 

--- a/llm_watchlist_buyer.py
+++ b/llm_watchlist_buyer.py
@@ -102,6 +102,11 @@ LLM_WATCHLIST_BUYER_DEFAULTS: dict[str, Any] = {
     "target_position_pct": 4.0,     # target weight per BUY
     "min_position_pct": 2.0,        # floor on the last (partial) BUY
     "min_conviction": 5,            # hard gate
+    # Screener rejection hide (migration 051): how long a PASSed-on name is
+    # hidden. Short window so it tracks the daily re-rank / quarterly-earnings
+    # cadence rather than outliving the reason it was passed on. (The separate
+    # post-SELL re-buy cooldown stays 90d — see get_recently_sold_tickers.)
+    "rejection_window_days": 30,
     "concurrency": 5,               # ThreadPoolExecutor max_workers for Phase 1
     "per_call_timeout_sec": 90,     # per-future timeout for Phase 1
     # Per-ticker output is small (~500 tokens) but Gemini 2.5 Pro's thinking
@@ -483,6 +488,27 @@ def _active_thesis_tickers(db, portfolio_id: str) -> set[str]:
     return {str(r.get("ticker") or "").upper() for r in (resp.data or []) if r.get("ticker")}
 
 
+def _pass_rejection_rows(evaluations: list[dict], agent_id: str) -> list[dict]:
+    """Rejection rows for the screener hide (migration 051) — only true PASSes.
+
+    A `verdict == "PASS"` is a real "no" and gets hidden. A sub-gate BUY (e.g.
+    4/5) is deliberately NOT recorded: it's a name the agent wants, just not its
+    top pick today, so it stays eligible and is re-evaluated as the screen
+    re-ranks rather than being quarantined.
+    """
+    return [
+        {
+            "ticker": e["ticker"],
+            "rejected_by_agent_id": agent_id,
+            "verdict": e.get("verdict"),
+            "conviction": e.get("conviction"),
+            "reason": (e.get("rationale") or "")[:240] or None,
+        }
+        for e in evaluations
+        if str(e.get("verdict") or "").upper() == "PASS"
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Strategy entrypoint
 # ---------------------------------------------------------------------------
@@ -709,29 +735,21 @@ def rebalance_llm_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
     ]
     result.notes["phase1_qualifying"] = len(qualifying)
 
-    # Record the names this buyer evaluated and passed on — a PASS verdict, or
-    # a BUY below the conviction gate (i.e. it looked and didn't pull the
-    # trigger). The screener's "hide rejected" toggle drops these for 90 days
-    # (migration 051) so the buyer doesn't churn back into re-evaluating them.
-    # A 5/5 BUY that just ran out of cash is NOT a rejection — it's still
-    # wanted — so we key off the agent's verdict, not whether a fill happened.
-    # Always recorded (the toggle governs display, not capture); never in
-    # dry-run.
+    # Record only the names this buyer truly PASSED on (a real "no"). A
+    # high-but-sub-gate BUY (e.g. 4/5) is NOT recorded — it's a name the agent
+    # *wants*, just not its top pick today — so it stays eligible and gets
+    # re-evaluated as the screen re-ranks, instead of being quarantined. The
+    # hide window is short (rejection_window_days, default 30) so it tracks the
+    # daily re-rank / earnings cadence; the 90d window applies only to the
+    # post-SELL cooldown. Always recorded (the toggle governs display, not
+    # capture); never in dry-run.
     if not ctx.dry_run:
-        qualifying_tickers = {e["ticker"] for e in qualifying}
-        rejected_rows = [
-            {
-                "ticker": e["ticker"],
-                "rejected_by_agent_id": ctx.agent["id"],
-                "verdict": e.get("verdict"),
-                "conviction": e.get("conviction"),
-                "reason": (e.get("rationale") or "")[:240] or None,
-            }
-            for e in evaluations
-            if e["ticker"] not in qualifying_tickers
-        ]
+        rejected_rows = _pass_rejection_rows(evaluations, ctx.agent["id"])
         if rejected_rows:
-            n = ctx.db.record_screener_rejections(ctx.portfolio_id, rejected_rows)
+            n = ctx.db.record_screener_rejections(
+                ctx.portfolio_id, rejected_rows,
+                days=int(params["rejection_window_days"]),
+            )
             result.notes["screener_rejections_recorded"] = n
 
     if not qualifying:

--- a/test_buyer_rejections.py
+++ b/test_buyer_rejections.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Unit tests for the buyer's PASS-only rejection recording (migration 051).
+
+Verifies _pass_rejection_rows only hides true PASSes — a sub-gate BUY (a name
+the agent wants, just not its top pick) and a qualifying BUY are NOT recorded,
+so they stay eligible. Pure logic, no DB/LLM. Run: python test_buyer_rejections.py
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import llm_watchlist_buyer as b
+
+
+class PassRejectionRowsTests(unittest.TestCase):
+    def _evals(self):
+        return [
+            {"ticker": "AAA", "verdict": "PASS", "conviction": 1, "rationale": "weak growth"},
+            {"ticker": "BBB", "verdict": "BUY", "conviction": 4, "rationale": "near miss"},   # sub-gate
+            {"ticker": "CCC", "verdict": "BUY", "conviction": 5, "rationale": "top pick"},     # qualifier
+            {"ticker": "DDD", "verdict": "pass", "conviction": 2, "rationale": ""},            # case-insensitive
+        ]
+
+    def test_only_passes_recorded(self):
+        rows = b._pass_rejection_rows(self._evals(), "agent-x")
+        self.assertEqual({r["ticker"] for r in rows}, {"AAA", "DDD"})
+
+    def test_sub_gate_buy_not_hidden(self):
+        rows = b._pass_rejection_rows(self._evals(), "agent-x")
+        self.assertNotIn("BBB", {r["ticker"] for r in rows})  # 4/5 BUY stays eligible
+
+    def test_qualifying_buy_not_hidden(self):
+        rows = b._pass_rejection_rows(self._evals(), "agent-x")
+        self.assertNotIn("CCC", {r["ticker"] for r in rows})
+
+    def test_row_shape(self):
+        rows = b._pass_rejection_rows(self._evals(), "agent-x")
+        aaa = next(r for r in rows if r["ticker"] == "AAA")
+        self.assertEqual(aaa["rejected_by_agent_id"], "agent-x")
+        self.assertEqual(aaa["verdict"], "PASS")
+        self.assertEqual(aaa["reason"], "weak growth")
+        # empty rationale collapses to None
+        ddd = next(r for r in rows if r["ticker"] == "DDD")
+        self.assertIsNone(ddd["reason"])
+
+    def test_empty(self):
+        self.assertEqual(b._pass_rejection_rows([], "a"), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Why

The screener rejection auto-hide (migration 051) was quarantining too hard. On `test-portfolio-toby` (31 evaluated → 1 bought → ~30 hidden) it would:
- hide **sub-gate BUYs** (e.g. 4/5 — names the agent *wants*) for a full quarter, and
- keep them out for **90 days**, far longer than the half-life of the reasons to pass (which resolve in 2–4 weeks as the screen re-ranks daily / earnings land quarterly).

Net effect: the hidden set grows ~30/run while buys trickle, so the candidate pool drains and the buyer trends toward "no candidates after filters" before the book fills.

## What

Make the hide **proportional to a real "no":**
- **PASS-only** — only a true `PASS` verdict is recorded (`_pass_rejection_rows`). A sub-gate BUY stays eligible and is re-evaluated as the screen re-ranks.
- **~30-day window** — `rejection_window_days` (default 30, config-overridable) replaces the flat 90d; `db.record_screener_rejections` default `days` 90 → 30.
- The **90-day post-SELL re-buy cooldown** (`get_recently_sold_tickers`) is deliberate and **unchanged**.

Code-only — no migration (the window is computed in Python at write time).

## Files
- `llm_watchlist_buyer.py` — `_pass_rejection_rows` helper, `rejection_window_days` default, recording call.
- `db.py` — `record_screener_rejections` default + docstrings.
- `CLAUDE.md` — migration-051 section.
- `test_buyer_rejections.py` — PASS-only selection tests. **98 tests pass.**

## Optional one-time cleanup (owner runs in Supabase, not in this PR)
Existing rows predate the new policy (90d, incl. sub-gate BUYs). To apply it retroactively:
```sql
DELETE FROM screener_rejections WHERE verdict = 'BUY';            -- un-hide near-misses
UPDATE screener_rejections
   SET expires_at = rejected_at + INTERVAL '30 days'
 WHERE restored_at IS NULL AND expires_at > rejected_at + INTERVAL '30 days';
```

## Verify
After merge, re-run the buyer: `screener_rejections_recorded` should ≈ the PASS count (not all non-buys), and new rows' `expires_at` ≈ 30 days out.

https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu)_