### PR TITLE
Equity income-statement chart + live portfolio "Sync to Alpaca" button

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1117,6 +1117,10 @@ follower row — slug = the PAPER slug), `go-live`, `mirror` (drifted names
 only), `replicate` (full match — `--threshold 0`, buys the entire current
 paper book, not just changes), `sync`. The inline heartbeat mirror stays as a
 best-effort top-up for any rebalance that happens to land during market hours.
+The live portfolio's own (private) detail page also exposes an owner-only
+**Sync to Alpaca** button (`sync-live-button.tsx` → `syncLivePortfolioToAlpaca`
+in `web/lib/live-mirror-mutations.ts`) that `workflow_dispatch`es `live-mirror.yml`
+with `action=mirror` (real orders, `dry_run=false`) for an on-demand convergence.
 
 The per-decision routing below (`ctx.buy/sell` → Alpaca) is the alternative
 mechanism for a live portfolio that runs *its own* agents; a follower has none,

--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -8,6 +8,7 @@ import { absoluteUrl } from "@/lib/site";
 import { isCompanyIndexable } from "@/lib/company-indexable";
 import Nav from "@/components/nav";
 import PsValuationChart from "@/components/ps-valuation-chart";
+import RevenueChart from "@/components/revenue-chart";
 import DistributionStrips from "@/components/distribution-strips";
 import type { CompanyHolder, CompanyTrade } from "@/lib/company-agents-query";
 import type {
@@ -31,13 +32,15 @@ import {
   buildHeroSummary,
   humaniseReason,
   buildCompiledSummary,
-  buildFaq,
   buildMetaDescription,
   formatLongDate,
   COMPILED_NOTE,
   type BadgeTone,
-  type FaqEntry,
 } from "@/lib/company-templates";
+import {
+  parseAnnualRevenue,
+  parseQuarterlyRevenue,
+} from "@/lib/company-financials";
 
 // P0: all agent activity is server-rendered in the synchronous body (no
 // Suspense streaming) so the page is fully meaningful with JS off and the
@@ -139,18 +142,6 @@ function breadcrumbJsonLd(ticker: string, name: string | null, sector: string | 
   };
 }
 
-function faqJsonLd(faq: FaqEntry[]) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: faq.map((f) => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: f.a },
-    })),
-  };
-}
-
 function datasetJsonLd({
   ticker,
   name,
@@ -208,17 +199,10 @@ export default async function CompanyPage({
     activity: a14d,
     totalAgents: activity.totalAgents,
   });
-  const faq = buildFaq({
-    company,
-    priceSales,
-    lifecycle: activity.lifecycle,
-    activity: a14d,
-    totalAgents: activity.totalAgents,
-    dataUpdated,
-  });
+  const annualRevenue = parseAnnualRevenue(company.annual_revenue_5y);
+  const quarterlyRevenue = parseQuarterlyRevenue(company.quarterly_revenue);
 
   const breadcrumb = breadcrumbJsonLd(company.ticker, company.company_name, company.sector);
-  const faqLd = faqJsonLd(faq);
   const dataset = datasetJsonLd({
     ticker: company.ticker,
     name: company.company_name,
@@ -230,7 +214,6 @@ export default async function CompanyPage({
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(dataset) }} />
       <Nav />
       <main className="flex-1 w-full">
@@ -316,8 +299,18 @@ export default async function CompanyPage({
               />
             )}
 
-            {/* FAQ (P3) — mirrors the FAQPage JSON-LD */}
-            <Faq ticker={company.ticker} faq={faq} />
+            {/* Income statement — revenue bars (annual / quarterly toggle).
+                Replaces the FAQ section. Net income is omitted until a real
+                per-period series is stored (see RevenueChart). */}
+            {(annualRevenue.length > 0 || quarterlyRevenue.length > 0) && (
+              <Block heading="Income statement">
+                <RevenueChart
+                  ticker={company.ticker}
+                  annual={annualRevenue}
+                  quarterly={quarterlyRevenue}
+                />
+              </Block>
+            )}
 
             {/* Related — peer entity links + category links (P5) */}
             <RelatedLinks ticker={company.ticker} sector={company.sector} peers={peers} />
@@ -1002,26 +995,6 @@ function LedgerRow({
       </div>
       <span className="font-mono text-[11px] text-text-muted text-right whitespace-nowrap">{right}</span>
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// FAQ (P3)
-// ---------------------------------------------------------------------------
-
-function Faq({ ticker, faq }: { ticker: string; faq: FaqEntry[] }) {
-  if (faq.length === 0) return null;
-  return (
-    <Block heading={`${ticker} · frequently asked`}>
-      <dl>
-        {faq.map((f, i) => (
-          <div key={i}>
-            <dt className={`text-[15px] font-semibold ${i === 0 ? "" : "mt-5"}`}>{f.q}</dt>
-            <dd className="mt-1.5 text-[14px] text-text-muted leading-[1.65]">{f.a}</dd>
-          </div>
-        ))}
-      </dl>
-    </Block>
   );
 }
 

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -6,6 +6,7 @@ import HoldingsList from "@/components/holdings-list";
 import { TradeTape, type Trade } from "@/components/trade-tape";
 import VisibilityToggle from "@/components/portfolio/visibility-toggle";
 import RebalanceCadenceToggle from "@/components/portfolio/rebalance-cadence-toggle";
+import SyncLiveButton from "@/components/portfolio/sync-live-button";
 import TeamBuilder from "@/components/portfolio/team-builder";
 import TeamScheduleNote from "@/components/portfolio/team-schedule-note";
 import BetaDisclaimer from "@/components/beta-disclaimer";
@@ -330,7 +331,7 @@ export default async function PortfolioPage({ params }: PageParams) {
               (visitor). A live follower has no team of its own: it mirrors the
               paper portfolio's positions, so it shows an explainer instead. */}
           {mode === "live" ? (
-            <LiveFollowerNote />
+            <LiveFollowerNote portfolioId={portfolio.id} isOwner={isOwner} />
           ) : isOwner ? (
             <section id="team" className="mb-12 sm:mb-14 scroll-mt-20">
               <TeamBuilder
@@ -498,7 +499,13 @@ function PaperValueCard({
 // A live portfolio is a private follower of the owner's paper portfolio: it
 // runs no agents of its own and is never public, so instead of the team
 // builder it shows a short explainer of how it's driven.
-function LiveFollowerNote() {
+function LiveFollowerNote({
+  portfolioId,
+  isOwner,
+}: {
+  portfolioId: string;
+  isOwner: boolean;
+}) {
   return (
     <section id="team" className="mb-12 sm:mb-14 scroll-mt-20">
       <h2 className="text-[11px] font-mono font-bold uppercase tracking-[0.14em] text-[var(--color-green)] mb-3">
@@ -518,6 +525,10 @@ function LiveFollowerNote() {
           portfolio&apos;s agents do the deciding, and this account follows
           automatically after each rebalance.
         </p>
+        {/* Manual trigger: converge the Alpaca account onto the paper book now,
+            rather than waiting for the scheduled mirror. Owner-only; the action
+            re-verifies ownership + live mode server-side. */}
+        {isOwner && <SyncLiveButton portfolioId={portfolioId} />}
       </div>
     </section>
   );

--- a/web/components/portfolio/sync-live-button.tsx
+++ b/web/components/portfolio/sync-live-button.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { syncLivePortfolioToAlpaca } from "@/lib/live-mirror-mutations";
+
+/**
+ * Owner control on a live portfolio: trigger a real-money mirror of the paper
+ * book onto the Alpaca account (buys/sells the drifted names). Because this
+ * places REAL orders, it's two-step — the first click arms a confirm, the
+ * second dispatches. After dispatch it shows a "started" note (the workflow
+ * runs async on GitHub Actions; fills land on the next sync/refresh).
+ */
+export default function SyncLiveButton({ portfolioId }: { portfolioId: string }) {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function dispatch() {
+    setError(null);
+    startTransition(async () => {
+      const result = await syncLivePortfolioToAlpaca({ portfolioId });
+      if (!result.ok) {
+        setError(result.error);
+        setConfirming(false);
+        return;
+      }
+      setDone(true);
+      setConfirming(false);
+      router.refresh();
+    });
+  }
+
+  if (done) {
+    return (
+      <p className="mt-3 text-[13px] text-[var(--color-green)] leading-relaxed">
+        Sync started — Alpaca orders are being placed to match your paper book.
+        Fills appear here after the next reconcile (give it a minute, then
+        refresh).
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-3">
+      {!confirming ? (
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          className="inline-flex items-center rounded-lg bg-[var(--color-green)] px-4 py-2 text-sm font-bold text-black hover:brightness-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-green)]/40 transition-[filter]"
+        >
+          Sync to Alpaca →
+        </button>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <p className="text-[13px] text-text-dim leading-relaxed">
+            This places <span className="text-text font-semibold">real buy &amp; sell
+            orders</span> on your Alpaca account to match your paper portfolio.
+            Continue?
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={dispatch}
+              disabled={pending}
+              className="inline-flex items-center rounded-lg bg-[var(--color-green)] px-4 py-2 text-sm font-bold text-black hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-green)]/40 transition-[filter]"
+            >
+              {pending ? "Starting…" : "Yes, place real orders"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              disabled={pending}
+              className="inline-flex items-center rounded-lg border border-white/[0.12] px-4 py-2 text-sm font-medium text-text-dim hover:text-text hover:border-white/20 disabled:opacity-50 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+      {error && (
+        <p className="mt-2 text-xs text-[var(--color-red)] font-mono">{error}</p>
+      )}
+      <p className="mt-2 text-[11px] text-text-muted leading-relaxed">
+        Mirrors only the names that have drifted. Runs in the background; orders
+        fill during US market hours.
+      </p>
+    </div>
+  );
+}

--- a/web/components/revenue-chart.tsx
+++ b/web/components/revenue-chart.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+/**
+ * Income-statement chart for the equity overview page — a Revenue bar chart
+ * with an Annual / Quarterly toggle (modelled on the reference mockup). Only
+ * the Revenue series exists in the data store today; net income is intentionally
+ * omitted rather than approximated from a single current margin (which would
+ * misrepresent history). The legend leaves room for net income to slot in once
+ * a real per-period series is stored.
+ *
+ * Client component for the toggle, but its initial (Annual) view is server-
+ * rendered to HTML, so the revenue figures ship in the SSR markup for crawlers
+ * and there's no layout shift (space reserved via an aspect-ratio box).
+ */
+
+import { useState } from "react";
+import type { RevenuePoint } from "@/lib/company-financials";
+import { formatCompactUsd } from "@/lib/company-financials";
+
+const W = 620;
+const H = 240;
+const PAD = { left: 8, right: 8, top: 28, bottom: 26 };
+const REVENUE = "#00F2FF";
+
+export default function RevenueChart({
+  ticker,
+  annual,
+  quarterly,
+}: {
+  ticker: string;
+  annual: RevenuePoint[];
+  quarterly: RevenuePoint[];
+}) {
+  // Default to whichever has data, preferring Annual (matches the mockup).
+  const [view, setView] = useState<"annual" | "quarterly">(
+    annual.length > 0 ? "annual" : "quarterly",
+  );
+  const points = view === "annual" ? annual : quarterly;
+
+  const hasAnnual = annual.length > 0;
+  const hasQuarterly = quarterly.length > 0;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
+        <div className="inline-flex items-center gap-1 font-mono text-[11px]">
+          <Tab
+            active={view === "annual"}
+            disabled={!hasAnnual}
+            onClick={() => setView("annual")}
+          >
+            Annual
+          </Tab>
+          <Tab
+            active={view === "quarterly"}
+            disabled={!hasQuarterly}
+            onClick={() => setView("quarterly")}
+          >
+            Quarterly
+          </Tab>
+        </div>
+        <div className="inline-flex items-center gap-1.5 font-mono text-[10.5px] text-text-muted">
+          <span
+            aria-hidden
+            className="inline-block h-2 w-2 rounded-[2px]"
+            style={{ background: REVENUE }}
+          />
+          Revenue
+        </div>
+      </div>
+      <Bars ticker={ticker} points={points} view={view} />
+    </div>
+  );
+}
+
+function Tab({
+  active,
+  disabled,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active}
+      className={`px-2.5 py-1 rounded-[6px] border tracking-[0.04em] uppercase transition-colors disabled:opacity-30 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan/40 ${
+        active
+          ? "border-cyan/40 text-cyan bg-cyan/[0.08]"
+          : "border-white/[0.12] text-text-muted hover:text-text-dim"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Bars({
+  ticker,
+  points,
+  view,
+}: {
+  ticker: string;
+  points: RevenuePoint[];
+  view: "annual" | "quarterly";
+}) {
+  if (points.length === 0) {
+    return (
+      <p className="text-sm text-text-muted">
+        No {view} revenue data to chart yet.
+      </p>
+    );
+  }
+
+  const yMax = Math.max(...points.map((p) => p.value), 0) || 1;
+  const plotW = W - PAD.left - PAD.right;
+  const plotH = H - PAD.top - PAD.bottom;
+  const baseY = PAD.top + plotH;
+  const slot = plotW / points.length;
+  // Cap bar width so a 5-bar annual view doesn't render chunky blocks.
+  const barW = Math.min(slot * 0.5, 56);
+
+  const ariaLabel =
+    `${ticker} ${view} revenue: ` +
+    points.map((p) => `${p.label} ${formatCompactUsd(p.value)}`).join(", ") +
+    ".";
+
+  return (
+    <div style={{ aspectRatio: `${W} / ${H}` }} className="w-full">
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        width="100%"
+        height="100%"
+        role="img"
+        aria-label={ariaLabel}
+        preserveAspectRatio="xMidYMid meet"
+      >
+        {/* baseline */}
+        <line
+          x1={PAD.left}
+          y1={baseY}
+          x2={W - PAD.right}
+          y2={baseY}
+          stroke="#5e696f"
+          strokeWidth={1}
+        />
+        {points.map((p, i) => {
+          const cx = PAD.left + slot * (i + 0.5);
+          const h = (p.value / yMax) * plotH;
+          const barX = cx - barW / 2;
+          const barY = baseY - h;
+          return (
+            <g key={`${p.label}-${i}`}>
+              <rect
+                x={barX}
+                y={barY}
+                width={barW}
+                height={Math.max(h, 1)}
+                rx={3}
+                fill={REVENUE}
+                opacity={0.85}
+              />
+              {/* value label above the bar */}
+              <text
+                x={cx}
+                y={barY - 7}
+                fontSize={11}
+                fill="#A1A1AA"
+                fontFamily="monospace"
+                textAnchor="middle"
+              >
+                {p.raw}
+              </text>
+              {/* period label below the baseline */}
+              <text
+                x={cx}
+                y={H - 9}
+                fontSize={10.5}
+                fill="#5e696f"
+                fontFamily="monospace"
+                textAnchor="middle"
+              >
+                {p.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/web/lib/company-financials.ts
+++ b/web/lib/company-financials.ts
@@ -1,0 +1,77 @@
+/**
+ * Parsers for the `companies` revenue strings into chartable numeric series.
+ *
+ * The pipeline stores revenue as pre-formatted human strings, not numbers:
+ *   annual_revenue_5y: "2025: $1.0B | 2024: $748M | ... | 2021: $251M"
+ *   quarterly_revenue: "$292M (2026-03-31) | $283M (2025-12-31) | ..."
+ * Both are newest-first. These helpers parse them to oldest-first
+ * {label, value, raw} points so a bar chart reads left→right in time order.
+ *
+ * Net income per period is intentionally absent — the store has only a single
+ * current net_margin_pct, so a faithful net-income series can't be derived
+ * here (see the income-statement chart). Revenue is the only real series today.
+ */
+
+export interface RevenuePoint {
+  /** Axis label, e.g. "2025" (annual) or "Q1 '26" (quarterly). */
+  label: string;
+  /** Numeric USD value for bar heights. */
+  value: number;
+  /** The source's own formatted string, e.g. "$1.0B" — used as the bar label
+   *  so the chart matches the pipeline's rounding exactly. */
+  raw: string;
+}
+
+const UNIT: Record<string, number> = { K: 1e3, M: 1e6, B: 1e9, T: 1e12 };
+
+/** Parse a single "$1.0B" / "$748M" / "$251M" token to a number. */
+function parseAmount(s: string): number | null {
+  const m = s.match(/\$?\s*([\d,.]+)\s*([KMBT])?/i);
+  if (!m) return null;
+  const num = parseFloat(m[1].replace(/,/g, ""));
+  if (!Number.isFinite(num)) return null;
+  const unit = m[2] ? (UNIT[m[2].toUpperCase()] ?? 1) : 1;
+  return num * unit;
+}
+
+/** "2025: $1.0B | 2024: $748M | ..." → [{2021…}, …, {2025…}] (oldest first). */
+export function parseAnnualRevenue(raw: string | null | undefined): RevenuePoint[] {
+  if (!raw) return [];
+  const out: RevenuePoint[] = [];
+  for (const piece of raw.split("|")) {
+    const m = piece.match(/(\d{4})\s*:\s*(.+)/);
+    if (!m) continue;
+    const value = parseAmount(m[2]);
+    if (value == null) continue;
+    out.push({ label: m[1], value, raw: m[2].trim() });
+  }
+  return out.reverse();
+}
+
+/** "$292M (2026-03-31) | $283M (2025-12-31) | ..." → oldest-first quarters. */
+export function parseQuarterlyRevenue(raw: string | null | undefined): RevenuePoint[] {
+  if (!raw) return [];
+  const out: RevenuePoint[] = [];
+  for (const piece of raw.split("|")) {
+    const m = piece.match(/(.+?)\((\d{4})-(\d{2})-\d{2}\)/);
+    if (!m) continue;
+    const value = parseAmount(m[1]);
+    if (value == null) continue;
+    const year = m[2];
+    const month = parseInt(m[3], 10);
+    const q = month <= 3 ? 1 : month <= 6 ? 2 : month <= 9 ? 3 : 4;
+    out.push({ label: `Q${q} '${year.slice(2)}`, value, raw: m[1].trim() });
+  }
+  return out.reverse();
+}
+
+/** Compact USD for axis ticks / aria, e.g. "$1.2B", "$748M". */
+export function formatCompactUsd(n: number): string {
+  const sign = n < 0 ? "-" : "";
+  const abs = Math.abs(n);
+  if (abs >= 1e12) return `${sign}$${(abs / 1e12).toFixed(abs / 1e12 >= 10 ? 0 : 1)}T`;
+  if (abs >= 1e9) return `${sign}$${(abs / 1e9).toFixed(abs / 1e9 >= 10 ? 0 : 1)}B`;
+  if (abs >= 1e6) return `${sign}$${(abs / 1e6).toFixed(0)}M`;
+  if (abs >= 1e3) return `${sign}$${(abs / 1e3).toFixed(0)}K`;
+  return `${sign}$${abs.toFixed(0)}`;
+}

--- a/web/lib/live-mirror-mutations.ts
+++ b/web/lib/live-mirror-mutations.ts
@@ -1,0 +1,125 @@
+"use server";
+
+/**
+ * Server Action for the "Sync to Alpaca" button on a live portfolio.
+ *
+ * Dispatches the `live-mirror.yml` workflow with `action=mirror` for the
+ * caller's LIVE follower portfolio — placing real buy/sell orders on their
+ * Alpaca account to converge it onto the paper sibling's target weights (only
+ * names that have drifted past the mirror's threshold). The routine path runs
+ * this automatically (market-hours cron + the heartbeat's inline mirror); this
+ * is the manual "do it now" trigger.
+ *
+ * Defense in depth: real orders only fire when the portfolio is mode='live'
+ * AND ALPACA_LIVE_EXECUTION_ENABLED is set in the workflow env — so dispatching
+ * against a portfolio that isn't truly live is a no-op on the real account.
+ * We still gate the dispatch on owner + mode='live' here so the button never
+ * fires for the wrong portfolio.
+ */
+
+import { revalidatePath } from "next/cache";
+import { getSupabase } from "@/lib/supabase";
+import { requireUser } from "@/lib/auth/require-user";
+
+export type ActionResult = { ok: true } | { ok: false; error: string };
+
+/** Confirm the portfolio is the caller's own LIVE follower, returning its slug.
+ *  Scoped to owner_user_id + mode='live' so it can't resolve a paper book or
+ *  someone else's portfolio. Service-role read on an owner-authenticated path. */
+async function resolveOwnedLivePortfolio(
+  portfolioId: string,
+  userId: string,
+): Promise<{ slug: string } | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("portfolios")
+    .select("slug")
+    .eq("id", portfolioId)
+    .eq("owner_user_id", userId)
+    .eq("mode", "live")
+    .maybeSingle();
+  if (error) {
+    console.error("resolveOwnedLivePortfolio failed:", error);
+    return null;
+  }
+  return (data as { slug: string } | null) ?? null;
+}
+
+/** POST to GitHub's `workflow_dispatch` for `live-mirror.yml`. 204 = success. */
+async function dispatchLiveMirror(inputs: {
+  action: string;
+  slug: string;
+  dry_run: string;
+}): Promise<ActionResult> {
+  const token = process.env.GITHUB_DISPATCH_TOKEN;
+  if (!token) {
+    console.error("GITHUB_DISPATCH_TOKEN is not set");
+    return { ok: false, error: "Live sync isn't configured on this server." };
+  }
+  const owner = process.env.GITHUB_DISPATCH_OWNER || "tobyrowland";
+  const repo = process.env.GITHUB_DISPATCH_REPO || "update_ai_analysis";
+  const ref = process.env.GITHUB_DISPATCH_REF || "main";
+  const url = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/live-mirror.yml/dispatches`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ ref, inputs }),
+      cache: "no-store",
+    });
+  } catch (err) {
+    console.error("live-mirror dispatch fetch failed:", err);
+    return { ok: false, error: "Could not reach GitHub. Try again." };
+  }
+
+  if (response.status === 204) return { ok: true };
+
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    body = "";
+  }
+  console.error(
+    `live-mirror dispatch returned ${response.status}: ${body || "(empty)"}`,
+  );
+  return {
+    ok: false,
+    error: `GitHub returned ${response.status}: ${body || "no body"}`,
+  };
+}
+
+/**
+ * Trigger a real-money mirror of the caller's live portfolio onto Alpaca.
+ * Eligibility: signed in → owns a portfolio with this id at mode='live'.
+ */
+export async function syncLivePortfolioToAlpaca(input: {
+  portfolioId: string;
+}): Promise<ActionResult> {
+  const { user } = await requireUser();
+
+  const live = await resolveOwnedLivePortfolio(input.portfolioId, user.id);
+  if (!live) {
+    return { ok: false, error: "That isn't your live portfolio." };
+  }
+
+  // action=mirror: buy/sell only the names that have drifted past the mirror's
+  // threshold so the real account converges on the paper book. dry_run=false so
+  // it actually trades (still gated by ALPACA_LIVE_EXECUTION_ENABLED server-side).
+  const result = await dispatchLiveMirror({
+    action: "mirror",
+    slug: live.slug,
+    dry_run: "false",
+  });
+  if (!result.ok) return result;
+
+  revalidatePath(`/portfolios/${live.slug}`);
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary

Two independent features pushed to this branch **after PR #1594 merged** (that PR landed the daily-cron fix + rebalance cadence toggle). This PR is just the newer work:

1. **Equity overview: income-statement revenue chart** (replaces the FAQ section)
2. **Live portfolio: owner "Sync to Alpaca" button**

## 1. Income-statement revenue chart

Adds a Revenue bar chart with an **Annual / Quarterly** toggle to the company overview page (`/company/[ticker]`), in place of the FAQ section, modelled on a standard income-statement widget.

- `web/lib/company-financials.ts` — pure parsers turning the pipeline's pre-formatted revenue strings (`annual_revenue_5y`, `quarterly_revenue`) into oldest-first `{label, value, raw}` series + a compact USD formatter.
- `web/components/revenue-chart.tsx` — SVG bar chart, client component for the toggle; its initial (Annual) view server-renders so the figures ship in the SSR HTML.
- `web/app/company/[ticker]/page.tsx` — renders the chart where the FAQ was; removes the FAQ block **and** its FAQPage JSON-LD (keeping structured data honest now that the visible FAQ is gone).

**Data note:** only Revenue is charted. Per-period **net income isn't in the data store** (`companies` has a single current `net_margin_pct`; Level 0 `fundamentals` holds one recent snapshot with null revenue), so a faithful net-income series can't be derived — the legend leaves room for it once a real per-period series is stored, rather than faking it from one margin. (Confirmed with the user: ship Revenue-only now.)

## 2. Live portfolio "Sync to Alpaca" button

Adds a confirm-gated, owner-only button on the live portfolio's private detail page that places real buy/sell orders to converge the Alpaca account onto the paper book on demand, instead of waiting for the scheduled mirror.

- `web/lib/live-mirror-mutations.ts` — `syncLivePortfolioToAlpaca`: `requireUser`, re-verify the portfolio is the caller's own `mode='live'` book, then `workflow_dispatch` `live-mirror.yml` with `action=mirror`, `dry_run=false` (reuses the `GITHUB_DISPATCH_TOKEN` pattern from `run-agent-mutations.ts`).
- `web/components/portfolio/sync-live-button.tsx` — two-step confirm (real money), with pending + "started" states.
- `web/app/portfolios/[slug]/page.tsx` — rendered inside `LiveFollowerNote` (owner-only; the live detail page is already owner-private).
- `CLAUDE.md` — documents the button.

**Safety:** the action is `mirror` (only drifted names, self-correcting/idempotent). Real orders still only fire when `ALPACA_LIVE_EXECUTION_ENABLED` is set server-side **and** the portfolio is `mode='live'`, so dispatching can never trade a non-live book.

## Not verified

`node_modules` isn't installed in the dev container, so `tsc` / `next build` were **not** run. Parser logic was validated directly with Node; the React/TSX is reviewed by hand. Recommend a typecheck/preview build before merge.

https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8)_