### PR TITLE
Alpaca: centre the live-order price band on the live quote (fixes stale-price no-fills)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1178,11 +1178,18 @@ view is the live portfolio's own (private) detail page.
 
 **Price protection.** All live orders (mirror + forward path) are placed as
 marketable **limit** orders one `ALPACA_PRICE_BAND_PCT` band (default 3%) from
-the intended price — a buy never pays more than band% above, a sell never
-accepts more than band% below. If the market gaps past the band (classic
-at-the-open / illiquid risk) the order doesn't fill, and the next mirror run
-re-converges. `execute_and_wait(..., ref_price=)` computes the limit; the
-mirror passes the sizing price, the forward path passes `companies.price`.
+the **live market price** — a buy never pays more than band% above, a sell
+never accepts more than band% below. `execute_and_wait(..., ref_price=)`
+centres the band on Alpaca's latest trade price
+(`AlpacaClient.get_latest_trade_price`, IEX feed, best-effort) and only falls
+back to the passed `ref_price` (the mirror's sizing price / the forward path's
+`companies.price`) when the data API returns nothing. This matters because a
+Level-0-only ticker (e.g. a foreign ADR like `TSM` the legacy pipeline doesn't
+price intraday) is otherwise referenced off a stale daily close — anchoring the
+band there pushes a marketable limit out of reach and it never fills. Centring
+on the live quote keeps the band as genuine slippage protection. If the market
+still gaps past the band (classic at-the-open / illiquid risk) the order
+doesn't fill, and the next mirror run re-converges.
 
 **Scheduling.** The swarm rebalances the paper book at the 07:00 UTC heartbeat,
 which is *before* the US open (13:30 UTC) — so the heartbeat's inline

--- a/alpaca_client.py
+++ b/alpaca_client.py
@@ -37,6 +37,9 @@ logger = logging.getLogger(__name__)
 
 PAPER_BASE_URL = "https://paper-api.alpaca.markets"
 LIVE_BASE_URL = "https://api.alpaca.markets"
+# Market-data API lives on its own host (separate from the trading API). Same
+# auth headers. Used only for best-effort live pricing of the execution band.
+DATA_BASE_URL = "https://data.alpaca.markets"
 
 DEFAULT_TIMEOUT = 15  # seconds
 
@@ -136,6 +139,34 @@ class AlpacaClient:
     def get_asset(self, symbol: str) -> dict:
         """Asset metadata — tradable, fractionable, exchange, status."""
         return self._request("GET", f"/v2/assets/{symbol}")
+
+    def get_latest_trade_price(self, symbol: str) -> float | None:
+        """Latest trade price from Alpaca's market-data API, or None.
+
+        Best-effort and never raises: it exists so the execution band can be
+        centred on the *live* market instead of a possibly-stale DB price (the
+        cause of marketable-limit no-fills on names the legacy pipeline doesn't
+        price intraday — e.g. Level-0-only tickers like foreign ADRs). Any
+        failure (no data entitlement, network, off-hours, unknown symbol)
+        returns None so the caller falls back to its intended price.
+
+        Hits the IEX feed explicitly — it's available on every Alpaca plan,
+        so this works without a paid SIP subscription.
+        """
+        try:
+            resp = self._session.request(
+                "GET",
+                f"{DATA_BASE_URL}/v2/stocks/{symbol}/trades/latest",
+                params={"feed": "iex"},
+                timeout=DEFAULT_TIMEOUT,
+            )
+            if resp.status_code >= 400 or not resp.content:
+                return None
+            px = (resp.json().get("trade") or {}).get("p")
+            px = float(px) if px is not None else None
+            return px if px and px > 0 else None
+        except (requests.exceptions.RequestException, ValueError, TypeError):
+            return None
 
     # ------------------------------------------------------------------
     # Positions

--- a/alpaca_execution.py
+++ b/alpaca_execution.py
@@ -227,14 +227,22 @@ class AlpacaExecutionBackend:
         """
         self._guard_live(allow_live)
         if ref_price and self.price_band > 0:
-            limit_price = self._band_limit_price(side, ref_price)
+            # Centre the band on the LIVE market price when we can get one, so a
+            # stale DB ref (e.g. a Level-0 daily close for a name the intraday
+            # job doesn't cover) can't push a marketable limit out of reach and
+            # leave it unfilled. Falls back to the passed ref_price when the
+            # data API has nothing (off-hours, no entitlement, unknown symbol).
+            live = self.client.get_latest_trade_price(symbol)
+            band_ref = live if (live and live > 0) else ref_price
+            limit_price = self._band_limit_price(side, band_ref)
             order = self.client.submit_order(
                 symbol, side, qty=qty,
                 order_type="limit", limit_price=limit_price,
             )
             logger.info(
-                "%s %s x%s  limit=$%.4f (ref=$%.4f, band=%.1f%%)",
-                side.upper(), symbol, qty, limit_price, ref_price,
+                "%s %s x%s  limit=$%.4f (band_ref=$%.4f [live=%s intended=$%.4f], band=%.1f%%)",
+                side.upper(), symbol, qty, limit_price, band_ref,
+                f"${live:.4f}" if live else "n/a", ref_price,
                 self.price_band * 100,
             )
         else:


### PR DESCRIPTION
## Problem

A live-mirror buy of **TSM** never filled (`orders=1, placed=0`), so the live Alpaca account didn't update. Root cause:

- TSM isn't in the `companies` table — the nightly TradingView screen excludes Taiwan. So `PortfolioManager.get_price` fell back to the Level-0 **daily close** (`prices_daily`, a prior-day close: $423.93 from Fri Jun 12).
- `execute_and_wait` capped the marketable limit at that stale ref + 3% band = **$436.65**. TSM's live market was above that, so Alpaca left the order `new`/unfilled. The 3% band was protecting against the wrong baseline (a stale snapshot, not the live market).

This hits **any Level-0-only ticker** the legacy pipeline doesn't price intraday (foreign ADRs, US financials, etc.), not just TSM.

## Fix

Centre the execution price band on **Alpaca's own live trade price** instead of the DB reference, so a stale/EOD reference can't push a marketable limit out of reach. The band still caps slippage at `ALPACA_PRICE_BAND_PCT` — now measured from the live market, which is the correct semantics for a marketable limit.

- `alpaca_client.get_latest_trade_price(symbol)` — best-effort live price from the Alpaca market-data API (IEX feed, available on every plan). Never raises; returns `None` on any failure.
- `alpaca_execution.execute_and_wait` — `band_ref = live price when available, else the passed ref_price`. **Behaviour is unchanged** when the data API has nothing (off-hours, no entitlement, unknown symbol) — it falls back to the old reference. Logs live vs intended for audit.
- `CLAUDE.md` — documents the live-quote band centring and the Level-0-ticker rationale.

Sizing still uses the DB price (fine for target weights; self-corrects each run); only the execution **band** moved to the live quote.

## Notes / not verified

- `node_modules`/Alpaca creds aren't available here, so this wasn't run end-to-end — both files compile (`py_compile`), and the change is guarded to fall back to prior behaviour on any data-API failure.
- A natural follow-up (not in this PR): TSM being absent from `companies` also affects MTM/valuation on the website for Level-0-only holdings. Separate concern from the fill path.

https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8)_