### PR TITLE
Alpaca sync_to_db: validate holdings against securities, not companies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1142,8 +1142,10 @@ going live is an `ALPACA_BASE_URL` + key swap.
 `portfolio_holdings` + `portfolio_accounts.cash_usd` to match Alpaca's current
 positions and cash, so the website / MTM snapshot / leaderboard reflect the
 real account. It **refuses** unless the portfolio is `mode='live'` (so it can
-never clobber a paper book), validates each Alpaca symbol against `companies`
-before writing (the holdings FK target; unknown symbols are skipped), and
+never clobber a paper book), validates each Alpaca symbol against `securities`
+(Level 0 Tier 0 — the real `portfolio_holdings.ticker` FK target, so Level-0-only
+names like foreign ADRs are written, not dropped; only symbols absent from
+`securities` are skipped), and
 preserves `first_bought_at`. The MTM snapshot is produced on the next
 `portfolio_valuation.py` run from the mirrored holdings; per-trade journaling
 into `agent_trades` (Alpaca activities, deduped by order id) is the remaining

--- a/alpaca_execution.py
+++ b/alpaca_execution.py
@@ -398,15 +398,18 @@ class AlpacaExecutionBackend:
         print(f"\n{tag}{head}  portfolio={portfolio_slug}  mode=live  "
               f"alpaca={'PAPER' if self.client.is_paper else 'LIVE'}\n")
 
-        # Upsert every Alpaca position. Validate the symbol against `companies`
-        # first — portfolio_holdings.ticker FKs to companies, and the website
-        # joins through it for price/name, so an unknown symbol must be skipped
-        # rather than written. (US symbols map 1:1; exchange-suffix / FX mapping
-        # for non-US listings is a follow-up.)
+        # Upsert every Alpaca position. Validate the symbol against `securities`
+        # (Level 0 Tier 0) — that's the real FK target of
+        # portfolio_holdings.ticker, so a Level-0-only name (e.g. a foreign ADR
+        # like TSM that the legacy `companies` TradingView screen excludes) is a
+        # perfectly valid holding and must be written, not dropped. The paper
+        # book already holds such names; the live mirror must too, or a real
+        # fill silently never reaches the DB/website. Skip only symbols absent
+        # from `securities` entirely (the FK would otherwise reject the write).
         for symbol, (qty, avg) in sorted(alpaca_pos.items()):
-            if not db.get_company(symbol):
+            if not db.get_security(symbol):
                 logger.warning(
-                    "skip %s: not in companies universe (FK target missing)",
+                    "skip %s: not in securities universe (FK target missing)",
                     symbol,
                 )
                 continue


### PR DESCRIPTION
A filled live TSM order never reached the DB/website. sync_to_db skipped TSM with 'not in companies universe' — but portfolio_holdings.ticker actually FKs to securities (Level 0), not companies. TSM is in securities (the paper book already holds it); it's just absent from the legacy companies screen (Taiwan is excluded). So the write-back was dropping a perfectly valid holding.

Validate each Alpaca position against db.get_security() (the true FK target) instead of db.get_company(). Level-0-only names (foreign ADRs, financials) now mirror into the live book; only symbols absent from securities are skipped.

The paper portfolio already holds TSM and renders fine, so writing it into the live book follows the same proven path.

CLAUDE.md updated to match.

https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8