### PR TITLE
Swarm buyers: run real per-name LLM evaluation instead of the rank baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,9 +205,16 @@ no longer read.
   each round; a buyer only drafts a name clearing **its own** conviction gate,
   sized by its `maxPerName` against shared cash; a drafted name is taken (no
   double-buying); each opened position is attributed to its buyer. Conviction
-  source is a deterministic screen-rank baseline (`swarm.rank_to_conviction`) —
-  per-brain LLM conviction can replace it by populating the convictions map; the
-  draft mechanics don't change.
+  source is **per buyer**: an `llm_watchlist_buyer` runs a real per-name LLM
+  evaluation against its own mandate — capped at the top `MAX_SWARM_EVAL` (40)
+  screen names, hard conviction gate, PASSes recorded to `screener_rejections`,
+  and the LLM's `thesis_text` + extend/break signals recorded at the buy site
+  (`agent_heartbeat._llm_swarm_convictions`, reusing
+  `llm_watchlist_buyer.evaluate_candidates`); `ma_sniper` uses 200-week
+  proximity; any other buyer falls back to the deterministic screen-rank
+  baseline (`swarm.rank_to_conviction`). The draft mechanics don't change.
+  `snake_draft_plan` also enforces a `min_order_value` dust guard so the tail of
+  the cash never opens a sub-2% sliver position.
 - **Sell — first valid sell** (`swarm.first_valid_sell_plan` semantics):
   reviewers run their existing sell strategy in order on the shared book, so the
   first to close a name wins.

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -323,6 +323,98 @@ def _resolve_member_mandate(member_row: dict, portfolio_mandate: str | None) -> 
     return portfolio_mandate
 
 
+# Cap how many top-ranked screen names a thinking (llm_watchlist_buyer) swarm
+# buyer evaluates per run — bounds LLM cost/latency against the 30-min job
+# timeout and keeps buyers focused on the best names (the screener already
+# ranks the whole universe). Aligns with the default screen_config.topN.
+MAX_SWARM_EVAL = 40
+# Dust guard: the snake draft won't open a position smaller than this fraction
+# of total value, so a buyer spending down the tail of the cash can't open a
+# $9 sliver (mirrors llm_watchlist_buyer's min_position_pct).
+MIN_DRAFT_POSITION_PCT = 0.02
+
+
+def _llm_swarm_convictions(
+    db: SupabaseDB,
+    member_row: dict,
+    cfg: dict,
+    portfolio_mandate: str | None,
+    pid: str,
+    eval_pool: list[str],
+    by_ticker_data: dict[str, dict],
+    cand_map: dict[str, str],
+    book: dict,
+    *,
+    eval_cache: dict,
+    dry_run: bool,
+    logger: logging.Logger,
+) -> tuple[dict[str, int], dict[str, dict], float, int]:
+    """Per-name LLM convictions + theses for one `llm_watchlist_buyer` in the swarm.
+
+    Runs the SAME Phase-1 evaluation the standalone buyer uses
+    (`llm_watchlist_buyer.evaluate_candidates`) over the top-N screen pool, using
+    THIS buyer's own mandate + provider/model. Returns
+    `(convictions{ticker: 1-5 for BUY >= gate}, evals{ticker: eval}, max_per, gate)`.
+
+    Two deliberate safety choices: identical (provider, model, mandate) sweeps are
+    cached so co-briefed buyers don't double-pay; and any eval failure degrades to
+    "this buyer buys nothing this cycle" — never a fallback to the mechanical rank
+    baseline, which is exactly the bug being fixed. Records true PASSes for the
+    screener 30-day hide (never in dry-run).
+    """
+    import llm_watchlist_buyer as _llm_buyer
+
+    aid = member_row["agent"]["id"]
+    label = member_row["agent"].get("handle", aid[:8])
+    bp = {**_llm_buyer.LLM_WATCHLIST_BUYER_DEFAULTS, **cfg}
+    mandate_m = _resolve_member_mandate(member_row, portfolio_mandate)
+    gate = int(cfg.get("convictionGate") or bp["min_conviction"])
+    max_per = float(cfg.get("target_position_pct", bp["target_position_pct"])) / 100.0
+
+    if not eval_pool:
+        return {}, {}, max_per, gate
+
+    key = (bp["provider"], bp["model"], mandate_m or "")
+    evals_list = eval_cache.get(key)
+    if evals_list is None:
+        try:
+            evals_list, _notes = _llm_buyer.evaluate_candidates(
+                provider=bp["provider"],
+                model=bp["model"],
+                candidates=eval_pool,
+                by_ticker_data=by_ticker_data,
+                combined_rationale=cand_map,
+                portfolio=book,
+                portfolio_mandate=mandate_m,
+                params=bp,
+                label=label,
+            )
+        except Exception as exc:  # noqa: BLE001 — a dead provider buys nothing, never mechanically
+            logger.warning("swarm LLM eval failed for %s: %s", label, exc)
+            evals_list = []
+        eval_cache[key] = evals_list
+
+    evals_by_ticker = {e["ticker"]: e for e in evals_list}
+    convictions = {
+        e["ticker"]: int(e["conviction"])
+        for e in evals_list
+        if str(e.get("verdict") or "").upper() == "BUY"
+        and int(e.get("conviction") or 0) >= gate
+    }
+
+    if not dry_run:
+        rej = _llm_buyer._pass_rejection_rows(evals_list, aid)
+        if rej:
+            try:
+                db.record_screener_rejections(
+                    pid, rej, days=int(bp["rejection_window_days"])
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("swarm rejection record failed for %s: %s", label, exc)
+
+    return convictions, evals_by_ticker, max_per, gate
+
+
 def _run_portfolio_swarm(
     db: SupabaseDB,
     pm: PortfolioManager,
@@ -346,9 +438,12 @@ def _run_portfolio_swarm(
     name removes it before the next sees it (first-valid-sell by construction;
     each sell is tagged with the acting reviewer via agent_trades.agent_id).
 
-    Conviction source: a deterministic screen-rank baseline (swarm.rank_to_
-    conviction). Per-brain LLM conviction can replace it by populating the
-    convictions map — the draft mechanics are unchanged.
+    Conviction source per buyer: an `llm_watchlist_buyer` runs a real per-name
+    LLM evaluation (its own mandate, hard conviction gate, rich thesis with
+    extend/break signals — see `_llm_swarm_convictions`); `ma_sniper` uses its
+    200-week proximity; any other buyer falls back to the deterministic
+    screen-rank baseline (swarm.rank_to_conviction). The draft mechanics
+    (order, gates, shared cash, attribution) are identical across all three.
     """
     import screen as _screen
     import swarm as _swarm
@@ -364,10 +459,27 @@ def _run_portfolio_swarm(
     mode, executor = _resolve_live_executor(portfolio, dry_run=dry_run)
 
     # ---- BUY: snake draft over the screen's top-N candidates ----
-    cand_map = _screen.portfolio_screen_candidates(db, pid)  # {ticker: rationale}
+    # Thinking buyers (llm_watchlist_buyer) evaluate each candidate with their
+    # own mandate rather than the rank baseline, so when any are present we pull
+    # the screen FACT ROWS (rank + Level 0 data) and cap the pool to the top
+    # MAX_SWARM_EVAL names to bound LLM cost/latency.
+    llm_buyers = [
+        m for m in buyers_m
+        if m["agent"].get("strategy") == "llm_watchlist_buyer"
+    ]
+    candidate_rows = _screen.portfolio_screen_candidate_rows(db, pid)
+    if llm_buyers:
+        candidate_rows = candidate_rows[:MAX_SWARM_EVAL]
+    cand_map = {
+        str(r["ticker"]).upper(): f"screen rank #{r['rank']} · score {r['score']:.1f}"
+        for r in candidate_rows
+    }  # {ticker: rationale}
+    fact_rows = {str(r.get("ticker") or "").upper(): r for r in candidate_rows}
     book = pm.get_portfolio_book(pid)
-    held = {h.get("ticker") for h in (book.get("holdings") or [])}
-    recently_sold = db.get_recently_sold_tickers(pid, days=90)
+    held = {str(h.get("ticker") or "").upper() for h in (book.get("holdings") or [])}
+    recently_sold = {
+        str(t).upper() for t in db.get_recently_sold_tickers(pid, days=90)
+    }
     prices: dict[str, float] = {}
     for t in cand_map:
         if t in held or t in recently_sold:
@@ -378,6 +490,19 @@ def _run_portfolio_swarm(
             continue
     draftable = [t for t in cand_map if t in prices]
 
+    # Per-name LLM evaluation inputs for thinking buyers (built once, shared
+    # across co-briefed buyers). Active-thesis names are excluded so we never
+    # re-think or clobber a position we already hold a thesis on.
+    by_ticker_data: dict[str, dict] = {}
+    eval_pool: list[str] = []
+    if llm_buyers:
+        import llm_watchlist_buyer as _llm_buyer
+
+        active_thesis = _llm_buyer._active_thesis_tickers(db, pid)
+        eval_pool = [t for t in draftable if t not in active_thesis]
+        by_ticker_data = _llm_buyer.build_candidate_data(db, fact_rows, eval_pool)
+        eval_pool = [t for t in eval_pool if t in by_ticker_data]
+
     total_value = float(book.get("total_value_usd") or 0)
     cash = float(book.get("cash_usd") or 0)
     n = len(draftable)
@@ -386,10 +511,13 @@ def _run_portfolio_swarm(
     sw_buyers: list = []
     convictions: dict[str, dict[str, int]] = {}
     sniper_details: dict[str, dict] = {}
+    buyer_evals: dict[str, dict[str, dict]] = {}  # agent_id -> ticker -> LLM eval
+    eval_cache: dict[tuple, list[dict]] = {}      # dedupe identical eval sweeps
     for m in buyers_m:
         aid = m["agent"]["id"]
         cfg = m.get("config") or {}
         strat = m["agent"].get("strategy")
+        gate = int(cfg.get("convictionGate", 1) or 1)
         if strat == "ma_sniper":
             # The 200-week sniper sources conviction from each candidate's
             # proximity to its long-run trend instead of the screen-rank
@@ -409,15 +537,18 @@ def _run_portfolio_swarm(
             convictions[aid] = _ma_sniper.sniper_convictions(
                 db, draftable, prices, band=band, details=sniper_details,
             )
+        elif strat == "llm_watchlist_buyer":
+            # The thinking buyer: real per-name LLM verdicts (its own mandate),
+            # a hard conviction gate, and a rich thesis recorded at the buy site.
+            convictions[aid], buyer_evals[aid], max_per, gate = _llm_swarm_convictions(
+                db, m, cfg, mandate, pid, eval_pool, by_ticker_data, cand_map, book,
+                eval_cache=eval_cache, dry_run=dry_run, logger=logger,
+            )
         else:
             max_per = float(cfg.get("maxPerName", 0.08) or 0.08)
             convictions[aid] = dict(rank_conv)
         sw_buyers.append(
-            _swarm.Buyer(
-                aid,
-                gate=int(cfg.get("convictionGate", 1) or 1),
-                max_per_name=max_per,
-            )
+            _swarm.Buyer(aid, gate=gate, max_per_name=max_per)
         )
     if sniper_details:
         logger.info(
@@ -426,7 +557,9 @@ def _run_portfolio_swarm(
         )
 
     plan = _swarm.snake_draft_plan(
-        sw_buyers, draftable, prices, total_value, cash, convictions=convictions
+        sw_buyers, draftable, prices, total_value, cash,
+        min_order_value=total_value * MIN_DRAFT_POSITION_PCT,
+        convictions=convictions,
     )
     logger.info(
         "  portfolio %-22s swarm: %d buyer(s), %d candidate(s), %d draft pick(s)%s",
@@ -448,18 +581,33 @@ def _run_portfolio_swarm(
             members=members, mandate=_resolve_member_mandate(m, mandate),
             mode=mode, executor=executor,
         )
-        rationale = cand_map.get(pick.ticker)
-        snipe = sniper_details.get(pick.ticker)
-        if snipe:
-            # A sniper strike — record the discount to the 200-week average so
-            # the thesis captures the fat pitch, not just the screen rank.
-            disc = snipe["discount_pct"]
-            where = f"{abs(disc):.1f}% below" if disc < 0 else f"{disc:.1f}% above"
-            rationale = (
-                f"At 200-week average ({where} trend); {rationale or 'quality screen pick'}"
-            )
-        note = f"swarm draft (conviction {pick.conviction}/5): {rationale or ''}".strip()
-        thesis = {"thesis_text": rationale} if rationale else None
+        ev = buyer_evals.get(pick.agent_id, {}).get(pick.ticker)
+        if ev:
+            # Thinking buyer: record the LLM's narrative + extend/break signals
+            # so the reviewer's thesis-break machinery actually has something to
+            # check (the rank stub left it with nothing).
+            note = (
+                f"swarm draft (LLM {pick.conviction}/5): "
+                f"{(ev.get('rationale') or '')[:80]}"
+            ).strip()
+            thesis = {
+                "thesis_text": ev.get("thesis_text") or None,
+                "extend_signals": ev.get("extend_signals") or None,
+                "break_signals": ev.get("break_signals") or None,
+            }
+        else:
+            rationale = cand_map.get(pick.ticker)
+            snipe = sniper_details.get(pick.ticker)
+            if snipe:
+                # A sniper strike — record the discount to the 200-week average so
+                # the thesis captures the fat pitch, not just the screen rank.
+                disc = snipe["discount_pct"]
+                where = f"{abs(disc):.1f}% below" if disc < 0 else f"{disc:.1f}% above"
+                rationale = (
+                    f"At 200-week average ({where} trend); {rationale or 'quality screen pick'}"
+                )
+            note = f"swarm draft (conviction {pick.conviction}/5): {rationale or ''}".strip()
+            thesis = {"thesis_text": rationale} if rationale else None
         try:
             ctx.buy(pick.ticker, pick.qty, note=note, thesis=thesis)
             buy_counts[pick.agent_id] += 1

--- a/llm_watchlist_buyer.py
+++ b/llm_watchlist_buyer.py
@@ -510,6 +510,111 @@ def _pass_rejection_rows(evaluations: list[dict], agent_id: str) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Shared evaluation core — used by BOTH this standalone strategy and the
+# portfolio swarm (agent_heartbeat._run_portfolio_swarm), so a swarm buyer
+# "thinks" on exactly the same inputs/logic as the 1:1 buyer.
+# ---------------------------------------------------------------------------
+
+
+def build_candidate_data(
+    db, fact_rows: dict[str, dict], candidates: list[str]
+) -> dict[str, dict]:
+    """Assemble the per-ticker ``equity_data`` map the LLM evaluator consumes.
+
+    One ``ai_analysis`` query for the narrative overlay + the Level 0 fact row
+    per name (`fact_rows` keyed by upper-case ticker). Names without a fact row
+    are dropped (the caller can diff to detect them).
+    """
+    narratives = _load_company_narratives(db, candidates)
+    return {
+        t: _build_equity_data(fact_rows[t], narratives.get(t))
+        for t in candidates
+        if t in fact_rows
+    }
+
+
+def evaluate_candidates(
+    *,
+    provider: str,
+    model: str,
+    candidates: list[str],
+    by_ticker_data: dict[str, dict],
+    combined_rationale: dict[str, str],
+    portfolio: dict,
+    portfolio_mandate: str | None,
+    params: dict,
+    label: str = "buyer",
+) -> tuple[list[dict], dict]:
+    """Phase-1 per-ticker BUY/PASS evaluation, run in parallel.
+
+    The shared "thinking" core: for each candidate it calls the model with the
+    equity data + the buyer's mandate and returns the validated verdict dicts
+    (``{verdict, conviction, rationale, thesis_text, extend_signals,
+    break_signals, ...}``) plus a notes dict (timeouts / parse failures / token
+    totals). Pure w.r.t. the DB — the caller supplies the prepared candidate
+    data — so the standalone strategy and the swarm draft evaluate names
+    identically. Per-ticker errors are captured in notes, never raised.
+    """
+    notes: dict[str, Any] = {}
+    concurrency = max(1, int(params["concurrency"]))
+    timeout_sec = float(params["per_call_timeout_sec"])
+    max_tokens = int(params["max_tokens"])
+    temperature = float(params["temperature"])
+    max_signals = int(params["max_signals_per_kind"])
+
+    evaluations: list[dict] = []
+    parse_failures: dict[str, str] = {}
+    timeouts: list[str] = []
+
+    logger.info(
+        "%s phase 1: %d candidates, concurrency=%d, timeout=%.0fs",
+        label, len(candidates), concurrency, timeout_sec,
+    )
+
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = {
+            pool.submit(
+                _evaluate_ticker,
+                provider=provider,
+                model=model,
+                ticker=ticker,
+                equity_data=by_ticker_data[ticker],
+                curator_rationale=combined_rationale.get(ticker) or None,
+                portfolio=portfolio,
+                portfolio_mandate=portfolio_mandate,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                max_signals=max_signals,
+            ): ticker
+            for ticker in candidates
+            if ticker in by_ticker_data
+        }
+        for fut, ticker in list(futures.items()):
+            try:
+                ev = fut.result(timeout=timeout_sec)
+            except FutureTimeoutError:
+                timeouts.append(ticker)
+                fut.cancel()
+                continue
+            except Exception as exc:  # noqa: BLE001 — defensive
+                parse_failures[ticker] = f"unexpected: {exc}"
+                continue
+            if "error" in ev:
+                parse_failures[ticker] = ev["error"]
+                continue
+            evaluations.append(ev)
+
+    if timeouts:
+        notes["timeouts"] = timeouts
+    if parse_failures:
+        notes["per_ticker_errors"] = parse_failures
+    notes["phase1_evaluations"] = len(evaluations)
+    notes["phase1_input_tokens"] = sum(int(e.get("input_tokens") or 0) for e in evaluations)
+    notes["phase1_output_tokens"] = sum(int(e.get("output_tokens") or 0) for e in evaluations)
+    return evaluations, notes
+
+
+# ---------------------------------------------------------------------------
 # Strategy entrypoint
 # ---------------------------------------------------------------------------
 
@@ -649,12 +754,7 @@ def rebalance_llm_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
     # snapshot only covered names the legacy TradingView screen included, which
     # is why US-listed financials / foreign-domiciled ADRs showed up as
     # "missing" and were never bought). `fact_rows` was fetched once in step 1.
-    narratives = _load_company_narratives(ctx.db, candidates)
-    by_ticker_data: dict[str, dict] = {
-        t: _build_equity_data(fact_rows[t], narratives.get(t))
-        for t in candidates
-        if t in fact_rows
-    }
+    by_ticker_data = build_candidate_data(ctx.db, fact_rows, candidates)
     missing_facts = [t for t in candidates if t not in by_ticker_data]
     if missing_facts:
         # Shouldn't normally happen (candidates ARE the screen top-N), but a
@@ -666,66 +766,18 @@ def rebalance_llm_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
         result.notes["reason"] = "no Level 0 facts for any candidate"
         return result
 
-    concurrency = max(1, int(params["concurrency"]))
-    timeout_sec = float(params["per_call_timeout_sec"])
-    max_tokens = int(params["max_tokens"])
-    temperature = float(params["temperature"])
-    max_signals = int(params["max_signals_per_kind"])
-
-    evaluations: list[dict] = []
-    parse_failures: dict[str, str] = {}
-    timeouts: list[str] = []
-
-    logger.info(
-        "%s phase 1: %d candidates, concurrency=%d, timeout=%.0fs",
-        handle, len(candidates), concurrency, timeout_sec,
+    evaluations, eval_notes = evaluate_candidates(
+        provider=provider,
+        model=model,
+        candidates=candidates,
+        by_ticker_data=by_ticker_data,
+        combined_rationale=combined_rationale,
+        portfolio=portfolio,
+        portfolio_mandate=portfolio_mandate,
+        params=params,
+        label=handle,
     )
-
-    with ThreadPoolExecutor(max_workers=concurrency) as pool:
-        futures = {
-            pool.submit(
-                _evaluate_ticker,
-                provider=provider,
-                model=model,
-                ticker=ticker,
-                equity_data=by_ticker_data[ticker],
-                curator_rationale=combined_rationale.get(ticker) or None,
-                portfolio=portfolio,
-                portfolio_mandate=portfolio_mandate,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                max_signals=max_signals,
-            ): ticker
-            for ticker in candidates
-        }
-        for fut, ticker in list(futures.items()):
-            try:
-                ev = fut.result(timeout=timeout_sec)
-            except FutureTimeoutError:
-                timeouts.append(ticker)
-                fut.cancel()
-                continue
-            except Exception as exc:  # noqa: BLE001 — defensive
-                parse_failures[ticker] = f"unexpected: {exc}"
-                continue
-            if "error" in ev:
-                parse_failures[ticker] = ev["error"]
-                if ev.get("raw_response_truncated"):
-                    parse_failures.setdefault("_raw", {})  # type: ignore[arg-type]
-                continue
-            evaluations.append(ev)
-
-    if timeouts:
-        result.notes["timeouts"] = timeouts
-    if parse_failures:
-        result.notes["per_ticker_errors"] = parse_failures
-
-    # Aggregate token usage for visibility.
-    input_tok = sum(int(e.get("input_tokens") or 0) for e in evaluations)
-    output_tok = sum(int(e.get("output_tokens") or 0) for e in evaluations)
-    result.notes["phase1_evaluations"] = len(evaluations)
-    result.notes["phase1_input_tokens"] = input_tok
-    result.notes["phase1_output_tokens"] = output_tok
+    result.notes.update(eval_notes)
 
     # 3. Filter to BUY @ min_conviction and run Phase 2.
     min_conviction = int(params["min_conviction"])

--- a/swarm.py
+++ b/swarm.py
@@ -67,6 +67,7 @@ def snake_draft_plan(
     cash: float,
     *,
     cash_reserve_pct: float = 0.02,
+    min_order_value: float = 0.0,
     convictions: dict[str, dict[str, int]],
 ) -> DraftResult:
     """Plan a snake-draft buy cycle. Pure — returns the ordered picks.
@@ -75,6 +76,11 @@ def snake_draft_plan(
     name; a missing entry means "no opinion / won't draft". A buyer drafts the
     highest-conviction candidate it can both clear (>= its gate) and afford
     (>= 1 share within its max_per_name and the shared cash, minus reserve).
+
+    `min_order_value` is a dust guard: a candidate whose affordable notional
+    (qty*price) is below this floor is skipped rather than drafted, so a buyer
+    spending down the tail of the cash never opens a $9 sliver position. 0
+    disables it (the default, so existing callers/tests are unaffected).
     """
     result = DraftResult(cash_remaining=cash)
     available = [t for t in candidates if prices.get(t, 0) and prices[t] > 0]
@@ -99,7 +105,7 @@ def snake_draft_plan(
                 target = b.max_per_name * total_value
                 spendable = min(target, result.cash_remaining - min_cash)
                 qty = int(math.floor(spendable / price))
-                if qty >= 1:
+                if qty >= 1 and qty * price >= min_order_value:
                     picked = (t, qty, price)
                     break
             if picked is None:

--- a/test_swarm.py
+++ b/test_swarm.py
@@ -95,6 +95,41 @@ class TestSnakeDraft(unittest.TestCase):
         )
         self.assertEqual(res.picks, [])
 
+    def test_passed_names_omitted_from_convictions_arent_drafted(self):
+        # The LLM-buyer path puts ONLY BUY>=gate names in the convictions map;
+        # PASS / sub-gate names are absent and must never be drafted, even though
+        # they're in the candidate pool.
+        buyers = [Buyer("A", gate=5, max_per_name=0.5)]
+        conv = {"A": {"AAA": 5}}  # BBB was a PASS → omitted entirely
+        res = snake_draft_plan(
+            buyers, ["AAA", "BBB"], PRICES,
+            total_value=1000, cash=1000, cash_reserve_pct=0.0, convictions=conv,
+        )
+        self.assertEqual([p.ticker for p in res.picks], ["AAA"])
+
+    def test_min_order_value_skips_dust_picks(self):
+        # A buyer with only tail cash left should NOT open a sub-floor sliver
+        # (the CLOV $9.62 bug). With a $50 floor and ~$30 spendable, it passes.
+        buyers = [Buyer("A", gate=1, max_per_name=1.0)]
+        conv = {"A": {"AAA": 5}}
+        res = snake_draft_plan(
+            buyers, ["AAA"], PRICES,
+            total_value=1000, cash=30, cash_reserve_pct=0.0,
+            min_order_value=50.0, convictions=conv,
+        )
+        self.assertEqual(res.picks, [])
+
+    def test_min_order_value_allows_above_floor(self):
+        buyers = [Buyer("A", gate=1, max_per_name=1.0)]
+        conv = {"A": {"AAA": 5}}
+        res = snake_draft_plan(
+            buyers, ["AAA"], PRICES,
+            total_value=1000, cash=100, cash_reserve_pct=0.0,
+            min_order_value=50.0, convictions=conv,
+        )
+        self.assertEqual(len(res.picks), 1)
+        self.assertEqual(res.picks[0].qty, 10)  # $100 / $10
+
 
 class TestFirstValidSell(unittest.TestCase):
     def test_first_reviewer_in_order_wins(self):


### PR DESCRIPTION
## The bug

A portfolio with role-tagged buyers runs through the **swarm** (`agent_heartbeat._run_portfolio_swarm`). For a normal buyer the swarm **never called the LLM**: it copied the screener rank into a 1–5 "conviction" (`swarm.rank_to_conviction`) and snake-drafted mechanically down the list, recording a stub thesis `"screen rank #N · score X"` with no narrative and no break signals.

So `buyer-claude` ("Conviction Buyer") did no convicting while in a swarm. That's why on 2026-06-16 it bought **HMY** and **OMDA** at ~$80k each and a **$9.62 dust sliver of CLOV** — a weak #111-ranked name that had bubbled into the visible top-40 because `hideRejected` removed the names above it. The real per-name evaluation already existed in `llm_watchlist_buyer.rebalance_llm_watchlist_buyer`; the swarm just bypassed it.

## The fix

Make swarm buyers whose `strategy == 'llm_watchlist_buyer'` actually evaluate each candidate with the LLM (the behaviour owners expect: read fundamentals + the mandate, decide BUY/PASS, hard 5/5 gate, record a real thesis).

- **`llm_watchlist_buyer.py`** — extract `evaluate_candidates()` (the Phase-1 per-ticker LLM loop) and `build_candidate_data()` so the standalone strategy and the swarm share **one** evaluation path; the strategy is refactored to call them (behaviour unchanged).
- **`agent_heartbeat._run_portfolio_swarm`** — new branch for `llm_watchlist_buyer`: run `evaluate_candidates` with the buyer's own mandate + provider/model over the top **`MAX_SWARM_EVAL` (40)** screen names; `convictions` = BUY verdicts ≥ the hard gate (default 5), so PASS/sub-gate names (CLOV) are **never drafted**; record the LLM `thesis_text` + extend/break signals at the buy site so the reviewer's break-signal machinery works. Identical `(provider, model, mandate)` sweeps are cached; an eval failure buys **nothing** (never a rank fallback — that's the bug). True PASSes go to `screener_rejections` (30-day hide). `ma_sniper` and the rank baseline remain unchanged fallbacks.
- **`swarm.snake_draft_plan`** — `min_order_value` dust guard (default 0 = off, so existing callers/tests are unaffected); the heartbeat passes 2% of total value, killing $9 slivers.
- **`test_swarm.py`** — covers PASS-omitted convictions + the dust guard (13 tests pass).

`topN` was already 40, so **no config change** — the #111 was `hideRejected` bubbling, which the LLM gate now handles by simply PASSing weak names.

## Decisions (confirmed with the owner)
Core fix **+ cleanups** (PASS auto-hide + dust guard); evaluate the **top 40**.

## Risk / cost
- **Live path:** the swarm resolves a live executor; `ctx.buy` places real Alpaca orders when `mode='live'`. This changes *what* gets bought there — validate on the paper `test-portfolio-toby` before any live portfolio.
- **Cost/latency:** bounded by 40 candidates × distinct `(mandate, provider, model)` per run (dedup collapses co-briefed buyers), Gemini 2.5 Pro, concurrency 5 — within the 30-min job timeout for 1–2 distinct mandates.

## Verification
- `py_compile` on all touched modules; `python test_swarm.py` → 13 pass.
- **Not run here:** the full `python agent_heartbeat.py --portfolio test-portfolio-toby --dry-run` needs Supabase + LLM keys (absent in the dev container). After merge, run it and confirm the swarm log shows the LLM Phase-1 eval, far fewer picks (only BUY≥5), no CLOV-style names, and that new `investment_theses` rows have `source='agent'` with narrative + `break_signals`.

https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8)_