### PR TITLE
Shared per-equity research card + card-driven buyer

### DIFF
--- a/.github/workflows/research-evaluation.yml
+++ b/.github/workflows/research-evaluation.yml
@@ -1,0 +1,61 @@
+name: Research Evaluation
+
+# The shared per-equity research card (migration 055): scored moat / growth
+# durability / earnings quality / balance-sheet risk + base break signals,
+# computed once per equity and read by every portfolio's buyer.
+#
+# Daily 04:15 UTC — rotation batch of 100 stalest by ai_analysis.researched_at,
+# alongside bull (04:30) / bear (04:00). Per-ticker LLM call, parallelised.
+
+on:
+  schedule:
+    - cron: "15 4 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Evaluate but write nothing"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  research-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run Research Evaluation
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          # The card's model is configurable (--model); pipe the common LLM keys
+          # so google (default) or anthropic both work.
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RESEARCH_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -u
+          ARGS=()
+          if [ "${RESEARCH_DRY_RUN}" = "true" ]; then ARGS+=(--dry-run); fi
+          python research_evaluation.py ${ARGS[@]+"${ARGS[@]}"}
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: research-eval-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Daily (UTC):
 03:45           benchmarks_updater.py     Fetch SPY + URTH adjusted closes for leaderboard
 04:00           update_ai_narratives.py   Gemini refresh of stale narratives (90+ days)
 04:00           bear_evaluation.py        Refresh 100 oldest bear_eval rows (rotation, ~5d full cycle)
+04:15           research_evaluation.py    Shared per-equity research card — 100 stalest Tier-1 (moat/durability/earnings-quality/balance-sheet, scored 1-5 + break signals)
 04:30           bull_evaluation.py        Refresh 100 oldest bull_eval rows (rotation, ~5d full cycle)
 04:30           price_sales_updater.py    P/S ratio tracking + 52w history
 05:00           score_ai_analysis.py      Score, rank & assign sort_order
@@ -755,6 +756,19 @@ where present) and write **only** `ai_analysis`, so financials / foreign ADRs
 finally get bull/bear + narratives. Default (no flag) keeps the legacy
 `companies` path untouched; same per-run batch size, so flipping the crons to
 `--tier1` doesn't change daily LLM cost (never-evaluated names sort first).
+**Stage A3** (migration 055) broadens the shared card with a `research_card`
+JSONB column (+ `researched_at` rotation clock): the deep, equity-intrinsic
+business analysis — **moat, growth durability, earnings quality, balance-sheet
+risk, each scored 1-5 with an anchored rubric + rationale, rolled into a
+`quality_score`**, plus a base set of machine-checkable `break_signals` (same
+vocab as `theses.check_thesis`). Written once per equity per rotation by
+`research_evaluation.py` (daily 04:15, 100 stalest Tier-1, per-ticker LLM call),
+read by the buyer (`db.get_ai_analysis` returns it) so the per-portfolio call
+reasons over the pre-digested card instead of re-deriving business quality from
+raw numbers every run — the deep thinking amortized across all portfolios. The
+card's `break_signals` are inherited by every holding's thesis
+(`llm_watchlist_buyer._merge_break_signals`) so the reviewer always has a
+consistent set to watch.
 
 All Level 0 tables: public-read RLS, service-role writes. `metric_stats`
 (distribution percentiles) is reused from migration 038.

--- a/db.py
+++ b/db.py
@@ -344,20 +344,28 @@ class SupabaseDB:
 
         Used by the buyer's narrative enrichment. Best-effort: returns {} on a
         read error (e.g. the table not yet migrated) so the buyer still runs.
+
+        Tries the full select including `research_card` (migration 055) and
+        falls back to the base columns if that column doesn't exist yet — so the
+        buyer keeps its bull/bear + narrative enrichment in the window before the
+        migration is applied, and picks up the card automatically once it is.
         """
         tl = sorted({str(t).upper() for t in tickers if t})
         if not tl:
             return {}
-        try:
-            resp = (
-                self.client.table("ai_analysis")
-                .select("ticker,short_outlook,key_risks,full_outlook,bull_eval,bear_eval")
-                .in_("ticker", tl)
-                .execute()
-            )
-        except Exception:  # noqa: BLE001
-            return {}
-        return {str(r.get("ticker") or "").upper(): r for r in (resp.data or [])}
+        base = "ticker,short_outlook,key_risks,full_outlook,bull_eval,bear_eval"
+        for cols in (base + ",research_card", base):
+            try:
+                resp = (
+                    self.client.table("ai_analysis")
+                    .select(cols)
+                    .in_("ticker", tl)
+                    .execute()
+                )
+            except Exception:  # noqa: BLE001 — fall back without research_card, then give up
+                continue
+            return {str(r.get("ticker") or "").upper(): r for r in (resp.data or [])}
+        return {}
 
     def get_level0_close(self, ticker: str) -> float | None:
         """Latest USD close for a ticker from the Level 0 price layer.

--- a/level0_eval.py
+++ b/level0_eval.py
@@ -23,7 +23,12 @@ from __future__ import annotations
 
 from typing import Any
 
-_CLOCK_COLUMN = {"bull": "bull_at", "bear": "bear_at", "narrative": "narrated_at"}
+_CLOCK_COLUMN = {
+    "bull": "bull_at",
+    "bear": "bear_at",
+    "narrative": "narrated_at",
+    "research": "researched_at",  # the shared research card (migration 055)
+}
 
 # Level 0 fundamentals field -> companies-style key the prompt/build_equity_block
 # expects, so a Tier-1-only name reads like a companies row in the prompt.
@@ -73,7 +78,9 @@ def stale_tier1_tickers(db, kind: str, top_n: int) -> list[str]:
     """
     clock = _CLOCK_COLUMN.get(kind)
     if clock is None:
-        raise ValueError(f"unknown kind {kind!r} (expected bull|bear|narrative)")
+        raise ValueError(
+            f"unknown kind {kind!r} (expected bull|bear|narrative|research)"
+        )
 
     # Active Tier-1 universe.
     tier1: list[str] = []

--- a/llm_watchlist_buyer.py
+++ b/llm_watchlist_buyer.py
@@ -85,6 +85,10 @@ def _build_equity_data(fact_row: dict, company: dict | None) -> dict:
         },
         "ai_overlay": {"bull": fact_row.get("bull"), "bear": fact_row.get("bear")},
         "narrative": narrative,
+        # Shared per-equity research card (migration 055) — pre-computed business
+        # analysis (scored moat / durability / earnings quality / balance-sheet
+        # + base break signals) the buyer reasons over instead of re-deriving.
+        "research": (company or {}).get("research_card"),
         "source": "level0",
     }
 
@@ -155,10 +159,11 @@ You are an equity research analyst making BUY decisions for a $1M paper-money po
 Your job per call: evaluate ONE equity against the portfolio's mandate(s) and current state, and return a strict JSON verdict.
 
 Discipline:
+- A SHARED RESEARCH CARD (pre-computed business analysis: quality_score + scored moat / growth durability / earnings quality / balance-sheet safety, each 1-5) is provided when available. Treat it as the BUSINESS-QUALITY assessment — you don't need to re-derive whether the business is good. Your job is the part the card can't know: does THIS equity fit THIS portfolio's mandate, given its current holdings, at TODAY's price? Spend your judgement there.
 - Only verdict="BUY" with conviction=5 actually triggers a trade. Anything below 5 means "interesting but I'm not pulling the trigger today". Be honest, not over-eager — most names should be 1-4.
 - Conviction 1-5 is only meaningful when verdict="BUY". For PASS, leave conviction=1.
 - Read the curator's rationale, but don't be anchored by it — the curator picks broadly; you decide whether this specific equity is right for THIS portfolio TODAY at THIS price.
-- Read the prior in-house BUY/BEAR verdicts (if present) as data points, not directives.
+- Read the prior in-house BUY/BEAR verdicts and the research card as data points, not directives.
 
 Thesis discipline (BUY only):
 - thesis_text: 2-4 sentences. WHAT you expect this equity to do (growth trajectory, margin path, valuation re-rating) and WHY.
@@ -191,6 +196,9 @@ CURATOR'S RATIONALE (why this is on the watchlist):
 PRIOR IN-HOUSE VERDICTS (from the screening pipeline — treat as data, not directives):
 - Bull eval: {bull_eval}
 - Bear eval: {bear_eval}
+
+SHARED RESEARCH CARD (pre-computed business assessment — your starting point; decide mandate-fit + entry, don't re-derive these):
+{research_card}
 
 EQUITY DATA (extended-tier snapshot, today's universe):
 {equity_data_json}
@@ -285,6 +293,44 @@ def _truncate(text: str, limit: int = 2000) -> str:
     return text if len(text) <= limit else text[: limit - 1] + "…"
 
 
+_RESEARCH_CARD_LABELS = {
+    "moat": "Moat",
+    "growth_durability": "Growth durability",
+    "earnings_quality": "Earnings quality",
+    "balance_sheet_risk": "Balance-sheet safety",
+}
+
+
+def _format_research_card(research: Any) -> str:
+    """Render the shared research card (migration 055) for the buyer prompt."""
+    if not isinstance(research, dict) or not research:
+        return "(not yet researched — judge on the data below)"
+    lines = [f"Quality score: {research.get('quality_score', '?')}/5"]
+    for key, label in _RESEARCH_CARD_LABELS.items():
+        d = research.get(key)
+        if isinstance(d, dict) and d.get("score") is not None:
+            rationale = str(d.get("rationale") or "").strip()
+            lines.append(f"- {label}: {d['score']}/5{' — ' + rationale if rationale else ''}")
+    return "\n".join(lines)
+
+
+def _merge_break_signals(llm_signals: list[dict], card: Any, *, max_count: int) -> list[dict]:
+    """Merge the shared card's base break signals into the buyer's, deduped.
+
+    So EVERY holding — even one whose buyer authored none — carries the
+    company-defined base set for the reviewer (theses.check_thesis) to watch.
+    """
+    out = list(llm_signals or [])
+    seen = {(s.get("field"), s.get("op"), s.get("value")) for s in out}
+    card_signals = card.get("break_signals") if isinstance(card, dict) else None
+    for s in _validate_signals(card_signals, max_count=max_count):
+        key = (s.get("field"), s.get("op"), s.get("value"))
+        if key not in seen:
+            out.append(s)
+            seen.add(key)
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Phase 1 — per-ticker BUY/PASS verdict
 # ---------------------------------------------------------------------------
@@ -319,6 +365,7 @@ def _evaluate_ticker(
     """
     bull_eval = (equity_data.get("narrative") or {}).get("bull_eval") or "—"
     bear_eval = (equity_data.get("narrative") or {}).get("bear_eval") or "—"
+    research = equity_data.get("research")
 
     pc = _portfolio_context(portfolio)
     cash_pct = (pc["cash_usd"] / pc["total_value_usd"] * 100) if pc["total_value_usd"] else 0.0
@@ -333,6 +380,7 @@ def _evaluate_ticker(
         curator_rationale=(curator_rationale or "(no rationale on watchlist row)").strip(),
         bull_eval=bull_eval,
         bear_eval=bear_eval,
+        research_card=_format_research_card(research),
         equity_data_json=json.dumps(equity_data, default=str, ensure_ascii=False),
     )
 
@@ -374,6 +422,12 @@ def _evaluate_ticker(
         conviction = 1
     conviction = max(1, min(5, conviction))
 
+    break_signals = _validate_signals(parsed.get("break_signals"), max_count=max_signals)
+    if verdict == "BUY":
+        # Inherit the shared card's base break signals so every holding carries a
+        # consistent set for the reviewer, even if the buyer authored none.
+        break_signals = _merge_break_signals(break_signals, research, max_count=max_signals + 5)
+
     return {
         "ticker": ticker,
         "verdict": verdict,
@@ -381,7 +435,7 @@ def _evaluate_ticker(
         "rationale": str(parsed.get("rationale") or "").strip(),
         "thesis_text": str(parsed.get("thesis_text") or "").strip(),
         "extend_signals": _validate_signals(parsed.get("extend_signals"), max_count=max_signals),
-        "break_signals": _validate_signals(parsed.get("break_signals"), max_count=max_signals),
+        "break_signals": break_signals,
         "input_tokens": resp.input_tokens,
         "output_tokens": resp.output_tokens,
     }

--- a/migrations/055_research_card.sql
+++ b/migrations/055_research_card.sql
@@ -1,0 +1,35 @@
+-- Migration 055: shared per-equity research card on ai_analysis.
+--
+-- bull/bear are coarse (binary ✅/❌). The research card broadens the shared,
+-- compute-once-per-equity layer with structured, scored business analysis that
+-- every portfolio's buyer reads instead of re-deriving from raw numbers each
+-- run. One JSONB column keeps it extensible (new dimensions need no migration):
+--
+--   research_card = {
+--     "quality_score": 1-5,                          -- rolled-up
+--     "moat":               {"score":1-5,"rationale":"…","evidence":"…"},
+--     "growth_durability":  {"score":1-5,…},
+--     "earnings_quality":   {"score":1-5,…},
+--     "balance_sheet_risk": {"score":1-5,…},         -- 5 = safest
+--     "break_signals": [{"field":"gross_margin_pct","op":"<","value":55,…}, …],
+--     "model": "…", "version": 1
+--   }
+--
+-- `researched_at` is the per-kind rotation clock (mirrors bull_at/bear_at/
+-- narrated_at, migration 054) — research_evaluation.py refreshes the stalest
+-- first. Public-read / service-role-write inherited from migration 053.
+-- Additive & idempotent.
+--
+-- PREREQUISITE: this ALTERs `ai_analysis`, which is created by migration 053 and
+-- extended by 054. Apply 053 → 054 → 055 in order. (As of writing, 053/054 were
+-- NOT yet applied to the live project — verify `ai_analysis` exists first.)
+
+ALTER TABLE ai_analysis ADD COLUMN IF NOT EXISTS research_card JSONB;
+ALTER TABLE ai_analysis ADD COLUMN IF NOT EXISTS researched_at TIMESTAMPTZ;
+
+-- Staleness scan ("oldest N to research") orders by the clock NULLS FIRST.
+CREATE INDEX IF NOT EXISTS idx_ai_analysis_researched_at
+    ON ai_analysis (researched_at NULLS FIRST);
+
+COMMENT ON COLUMN ai_analysis.research_card IS
+    'Shared per-equity scored business analysis (moat/growth durability/earnings quality/balance-sheet risk, 1-5 + rationale) + a base set of break signals. Read by the buyer; written by research_evaluation.py. See migration 055.';

--- a/research_evaluation.py
+++ b/research_evaluation.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+Research Evaluation — the shared per-equity research card.
+
+The deep, equity-intrinsic business analysis, computed ONCE per equity and
+shared by every portfolio (public-read `ai_analysis.research_card`, migration
+055). It broadens the coarse binary bull/bear with four SCORED dimensions —
+moat, growth durability, earnings quality, balance-sheet risk — each 1-5 with
+an anchored rubric + rationale, rolled into a `quality_score`, plus a base set
+of machine-checkable break signals every holding's reviewer can watch.
+
+The per-portfolio buyer reads this card instead of re-deriving business quality
+from raw numbers on every run — so the expensive thinking happens here, once,
+amortized across all users, while the buyer's per-run call shrinks to a
+mandate-fit judgment.
+
+Rotation: the `top_n` stalest Tier-1 names by `ai_analysis.researched_at`
+(NULLs first), via `level0_eval.tier1_eval_candidates(db, "research", N)`.
+Writes ONLY `ai_analysis` (the card is a Level 0 concept). Per-ticker LLM call
+(structured JSON), parallelised — robust to one bad response.
+
+Schedule: daily ~04:15 UTC, alongside bull/bear.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+
+from db import SupabaseDB
+from llm_providers import LLMProviderError, call_llm
+from llm_picker import _parse_with_retry
+# Reuse the buyer's signal validator + vocabulary so the card's break_signals
+# are exactly what theses.check_thesis (the reviewer) can evaluate.
+from llm_watchlist_buyer import _validate_signals, _ALLOWED_SIGNAL_FIELDS
+
+logger = logging.getLogger("research_evaluation")
+
+DEFAULTS = {
+    "provider": "google",
+    "model": "gemini-2.5-pro",
+    "top_n": 100,
+    "concurrency": 5,
+    "per_call_timeout_sec": 90,
+    "max_tokens": 32768,
+    "temperature": 0.2,
+    "max_break_signals": 5,
+}
+
+_DIMENSIONS = ("moat", "growth_durability", "earnings_quality", "balance_sheet_risk")
+
+# Noise keys not worth sending to the model (identity dupes / stale verdicts it
+# shouldn't anchor on / large blobs).
+_BLOCK_EXCLUDE = {
+    "ticker", "company_name", "history_json", "flags", "sort_order",
+    "in_tv_screen", "created_at", "updated_at", "scored_at", "data_updated_at",
+    "ai_analyzed_at", "composite_score", "status", "research_card",
+}
+
+RESEARCH_SYSTEM_PROMPT = """\
+You are a buy-side equity research analyst writing a concise, reusable research
+card on ONE company. The card is shared across many portfolios, so judge the
+BUSINESS on its own merits — not any single mandate, not the entry price.
+
+Score each dimension 1-5 using these anchors (5 is always good/safe so they
+roll up consistently):
+
+MOAT (durability of the franchise):
+  5 = wide, durable moat — pricing power, high switching costs, network effects
+  3 = some differentiation, partial protection
+  1 = commodity / no defensible advantage
+
+GROWTH_DURABILITY (is the growth structural & repeatable):
+  5 = secular, repeatable demand; long runway
+  3 = mixed — real but maturing or partly cyclical
+  1 = cyclical / one-off / demand pulled forward
+
+EARNINGS_QUALITY (do earnings convert to cash, recurring vs one-off):
+  5 = clean — FCF tracks/exceeds net income, recurring revenue
+  3 = acceptable, some accrual or one-time noise
+  1 = poor — earnings don't convert to cash, heavy one-time items
+
+BALANCE_SHEET_RISK (downside guardrail — 5 = SAFEST):
+  5 = net cash, ample runway, no dilution
+  3 = manageable leverage / modest dilution
+  1 = stretched balance sheet, cash burn, heavy dilution risk
+
+Be discriminating — do NOT default everything to 4. Use the full 1-5 range; most
+companies are average on most dimensions.
+
+Also emit break_signals: a SHORT base set (max {max_break_signals}) of
+machine-checkable conditions that, if they later become true, would mean the
+business case has weakened — every portfolio holding this name inherits them.
+Each is {{"field","op","value","description"}}.
+- field MUST be one of: {allowed_fields}
+- op MUST be one of: >, >=, <, <=, ==, !=, change_pct_lt, change_pct_gt
+- value MUST be a number (never a string with "%"/"pp").
+
+Use ONLY the data provided plus your general knowledge of the sector. Do not
+invent company-specific numbers.
+
+Output strict JSON only — no prose, no markdown fences."""
+
+RESEARCH_USER_TEMPLATE = """\
+COMPANY: {ticker} — {company_name}
+SECTOR: {sector}   COUNTRY: {country}
+
+DATA (Level 0 facts + prior in-house notes):
+{equity_data_json}
+
+OUTPUT SCHEMA (strict JSON, no other text):
+{{
+  "quality_score": <integer 1-5 — your overall read of the business>,
+  "moat":               {{"score": <1-5>, "rationale": "<one line>", "evidence": "<one line>"}},
+  "growth_durability":  {{"score": <1-5>, "rationale": "<one line>", "evidence": "<one line>"}},
+  "earnings_quality":   {{"score": <1-5>, "rationale": "<one line>", "evidence": "<one line>"}},
+  "balance_sheet_risk": {{"score": <1-5>, "rationale": "<one line>", "evidence": "<one line>"}},
+  "break_signals": [{{"field": "...", "op": "...", "value": <number>, "description": "..."}}]
+}}
+Output JSON only."""
+
+
+def _setup_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+def _equity_block(equity: dict) -> str:
+    """Compact JSON of the equity's facts for the prompt (drops noise keys)."""
+    clean = {
+        k: v for k, v in equity.items()
+        if k not in _BLOCK_EXCLUDE and not k.startswith("_") and v not in (None, "", "—")
+    }
+    return json.dumps(clean, default=str, ensure_ascii=False)
+
+
+def _clamp_score(v) -> int | None:
+    try:
+        return max(1, min(5, int(round(float(v)))))
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_card(parsed: dict, model: str, max_break_signals: int) -> dict | None:
+    """Validate the LLM JSON into a stored research_card, or None if unusable."""
+    card: dict = {"version": 1, "model": model}
+    dims_ok = 0
+    for dim in _DIMENSIONS:
+        d = parsed.get(dim)
+        if not isinstance(d, dict):
+            continue
+        score = _clamp_score(d.get("score"))
+        if score is None:
+            continue
+        card[dim] = {
+            "score": score,
+            "rationale": str(d.get("rationale") or "").strip()[:240],
+            "evidence": str(d.get("evidence") or "").strip()[:240],
+        }
+        dims_ok += 1
+    if dims_ok == 0:
+        return None  # nothing usable — skip the write rather than store junk
+
+    q = _clamp_score(parsed.get("quality_score"))
+    if q is None:
+        # Fall back to the mean of the scored dimensions.
+        scores = [card[d]["score"] for d in _DIMENSIONS if d in card]
+        q = max(1, min(5, round(sum(scores) / len(scores))))
+    card["quality_score"] = q
+
+    card["break_signals"] = _validate_signals(
+        parsed.get("break_signals"), max_count=max_break_signals
+    )
+    return card
+
+
+def _evaluate_one(equity: dict, cfg: dict) -> dict:
+    """One LLM research call for one equity. Returns {ticker, card} or {ticker, error}."""
+    ticker = equity["ticker"]
+    system = RESEARCH_SYSTEM_PROMPT.format(
+        max_break_signals=cfg["max_break_signals"],
+        allowed_fields=", ".join(sorted(_ALLOWED_SIGNAL_FIELDS)),
+    )
+    user = RESEARCH_USER_TEMPLATE.format(
+        ticker=ticker,
+        company_name=equity.get("company_name") or ticker,
+        sector=equity.get("sector") or "—",
+        country=equity.get("country") or "—",
+        equity_data_json=_equity_block(equity),
+    )
+    try:
+        resp = call_llm(
+            provider=cfg["provider"], model=cfg["model"],
+            system=system, user=user,
+            max_tokens=cfg["max_tokens"], temperature=cfg["temperature"],
+        )
+    except LLMProviderError as exc:
+        return {"ticker": ticker, "error": f"LLM call failed: {exc}"}
+    try:
+        parsed, _retry = _parse_with_retry(cfg["provider"], cfg["model"], resp.text, system=system)
+    except LLMProviderError as exc:
+        return {"ticker": ticker, "error": f"JSON parse failed: {exc}"}
+
+    card = _build_card(parsed, cfg["model"], cfg["max_break_signals"])
+    if card is None:
+        return {"ticker": ticker, "error": "no usable dimension scores"}
+    return {"ticker": ticker, "card": card}
+
+
+def main(argv=None) -> int:
+    load_dotenv()
+    _setup_logging()
+    ap = argparse.ArgumentParser(description="Research Evaluation — shared per-equity card")
+    ap.add_argument("--dry-run", action="store_true", help="evaluate but write nothing")
+    ap.add_argument("--limit", type=int, default=DEFAULTS["top_n"],
+                    help="max equities this run (default 100, the rotation batch)")
+    ap.add_argument("--tickers", nargs="*", help="evaluate these tickers instead of the rotation")
+    ap.add_argument("--model", default=DEFAULTS["model"])
+    ap.add_argument("--provider", default=DEFAULTS["provider"])
+    args = ap.parse_args(argv)
+
+    cfg = {**DEFAULTS, "model": args.model, "provider": args.provider}
+    db = SupabaseDB()
+    import level0_eval
+
+    if args.tickers:
+        # Targeted run: assemble the same prompt rows for explicit tickers.
+        tickers = [t.upper() for t in args.tickers]
+        secs = {(s.get("ticker") or "").upper(): s for s in
+                level0_eval._bulk(db, "securities", "ticker,name,country,gics_sector", tickers)}
+        companies = {(c.get("ticker") or "").upper(): c for c in
+                     level0_eval._bulk(db, "companies", "*", tickers)}
+        funds = level0_eval._latest_by_ticker(
+            level0_eval._bulk(db, "fundamentals", "*", tickers), "period_end")
+        vals = level0_eval._latest_by_ticker(
+            level0_eval._bulk(db, "valuation", "ticker,date,ps,ps_median_12m", tickers), "date")
+        ai = db.get_ai_analysis(tickers)
+        batch = [level0_eval._assemble(t, secs.get(t), funds.get(t), vals.get(t),
+                                       companies.get(t), ai.get(t)) for t in tickers]
+    else:
+        batch = level0_eval.tier1_eval_candidates(db, "research", args.limit)
+
+    logger.info("=== Research Evaluation: %d equities (dry_run=%s, model=%s) ===",
+                len(batch), args.dry_run, cfg["model"])
+    if not batch:
+        logger.warning("nothing to evaluate")
+        return 0
+
+    start = time.time()
+    cards: dict[str, dict] = {}
+    errors: dict[str, str] = {}
+    with ThreadPoolExecutor(max_workers=cfg["concurrency"]) as pool:
+        futures = {pool.submit(_evaluate_one, eq, cfg): eq["ticker"] for eq in batch}
+        for fut, ticker in list(futures.items()):
+            try:
+                res = fut.result(timeout=cfg["per_call_timeout_sec"])
+            except FutureTimeoutError:
+                errors[ticker] = "timeout"
+                fut.cancel()
+                continue
+            except Exception as exc:  # noqa: BLE001
+                errors[ticker] = f"unexpected: {exc}"
+                continue
+            if "error" in res:
+                errors[ticker] = res["error"]
+            else:
+                cards[ticker] = res["card"]
+
+    logger.info("scored %d / %d (%d errors)", len(cards), len(batch), len(errors))
+    for t, c in list(cards.items())[:10]:
+        logger.info("  %s quality=%d  moat=%s dur=%s eq=%s bs=%s  breaks=%d",
+                    t, c["quality_score"],
+                    c.get("moat", {}).get("score"), c.get("growth_durability", {}).get("score"),
+                    c.get("earnings_quality", {}).get("score"), c.get("balance_sheet_risk", {}).get("score"),
+                    len(c.get("break_signals", [])))
+    if errors:
+        logger.info("errors: %s", json.dumps(errors)[:1000])
+
+    if args.dry_run:
+        logger.info("[dry-run] no writes. (%.1fs)", time.time() - start)
+        return 0
+
+    now = datetime.now(timezone.utc).isoformat()
+    rows = [
+        {"ticker": t, "research_card": c, "researched_at": now, "analyzed_at": now}
+        for t, c in cards.items()
+    ]
+    if rows:
+        db.upsert_ai_analysis_batch(rows)
+    db.log_run("research_evaluation", {
+        "updated": len(rows), "skipped": len(batch) - len(rows), "errors": len(errors),
+        "duration_secs": round(time.time() - start, 1),
+        "details": {"batch_size": len(batch), "scored": len(cards)},
+    })
+    logger.info("=== Research Evaluation complete: %d cards written (%.1fs) ===",
+                len(rows), time.time() - start)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this does

Moves the deep, equity-intrinsic business analysis **out of** the per-portfolio buyer (which re-derived it from raw numbers on every run, per portfolio, per mandate, daily) **into a shared layer computed once per equity** and read by all portfolios — and rewires the buyer to reason over that pre-digested card.

### Shared research card (`ai_analysis.research_card`, migration 055)
A JSONB card per equity:
- `quality_score` 1–5, rolled up from four **scored** dimensions (1–5 + rationale + evidence, all "5 = good/safe"): **moat, growth durability, earnings quality, balance-sheet risk** — each with an anchored per-level rubric in the prompt so scores don't inflate to all-4s.
- a base set of machine-checkable `break_signals` (same vocab as `theses.check_thesis`).

`research_evaluation.py` (new) rotates the 100 stalest Tier-1 names by `researched_at`, one per-ticker LLM call (parallelised), writing only `ai_analysis`. Workflow `research-evaluation.yml`, daily 04:15 UTC — one shared pass, amortized across every user. Reuses the bull/bear rotation pattern + `level0_eval` candidate assembly.

### Card-driven buyer (`llm_watchlist_buyer.py`)
- The buyer prompt now presents the card as the **business assessment**, so the per-run LLM does a *mandate-fit* judgment instead of a from-scratch deep dive (cheaper input, sharper decision). Same `evaluate_candidates` output contract — swarm + standalone paths unchanged downstream.
- Every buy **inherits the card's break_signals** (`_merge_break_signals`), so the reviewer always has a consistent base set to watch — even on holdings whose buyer authored none (the gap behind the HMY/CLOV no-signal thesis).

### Plumbing
- `level0_eval.py`: `research` kind + `researched_at` clock.
- `db.get_ai_analysis`: selects `research_card`, with graceful fallback to base columns if the column isn't there yet.
- CLAUDE.md: documents the card (Stage A3) + the daily run.

## Migrations applied to the live DB (during this session)
The project **did not have `ai_analysis` at all** — migrations 053/054 had never been applied. I applied the chain via MCP:
- **053 core** — created `ai_analysis` + seeded from `companies` (**1,037 rows, 1,025 with bull/bear** — zero coverage loss).
- **054** — rotation clocks.
- **055** — `research_card` + `researched_at`.

**Deferred:** 053's materialized-view repoint (`screen_facts_mv`/`screen_ai_overlay` → read bull/bear from `ai_analysis`) kept timing out the gateway on the heavy matview rebuild. It's **not needed for the research card** (the buyer reads `research_card` directly), and is non-regressive either way (the screener keeps reading bull/bear as it does today). Worth finishing later via the SQL editor to complete Stage A1's screener-coverage goal.

## Verification
- `py_compile` on all touched modules; `test_swarm.py` green (13).
- DB: confirmed `ai_analysis` exists, seeded, all 5 new columns present.
- **Not run here** (needs Supabase + LLM keys in the runner): the first `research_evaluation.py` run — cards are empty until the 04:15 cron fires (100/day). Recommend a manual `workflow_dispatch` with `dry_run` first to eyeball scores/rubric calibration.

https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8)_