### PR TITLE
Verified-data gate for LLM research + quality_score into the screener

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,9 +140,15 @@ filtered candidate set* (so outliers pin to p100 instead of blowing up the
 scale). Composite = weighted blend of Quality (0.60·R40 + 0.25·FCF + 0.15·GM),
 Value (inverse P/S ÷ 12-mo median) and Momentum (collared 52-week return vs
 SPY — `perf_52w_vs_spy`, derived from `benchmark_prices`),
-×optional AI bull/bear multiplier. Implemented once in TS
+×optional AI bull/bear multiplier ×optional research-card quality multiplier
+(migration 056: `quality_score` 1-5 → ×0.8–1.2, gated by the `qualityMultiplier`
+config toggle, **neutral when a name has no card** so the research rollout never
+penalises unresearched names). Implemented once in TS
 (`web/lib/screen/score.ts`) and mirrored in Python (`screen.py`) so the buyer's
-top N is identical to the page's.
+top N is identical to the page's. `quality_score` reaches both scorers from
+`ai_analysis`: Python via `screen_ai_overlay()`, the web via the
+`screen_facts_mv` column (migration 056 also repointed the matview's bull/bear
+join to `ai_analysis`, finishing migration 053's deferred step).
 
 Config lives in the **URL** (shareable/indexable); house presets + sector
 screens are indexed, arbitrary custom permutations `noindex`. **Save** persists
@@ -768,7 +774,12 @@ reasons over the pre-digested card instead of re-deriving business quality from
 raw numbers every run — the deep thinking amortized across all portfolios. The
 card's `break_signals` are inherited by every holding's thesis
 (`llm_watchlist_buyer._merge_break_signals`) so the reviewer always has a
-consistent set to watch.
+consistent set to watch. **Verified-data gate:** no LLM eval is ever sent
+without correct fundamentals — `level0_eval.stale_tier1_tickers` restricts the
+`--tier1` rotation to names with real EODHD financials
+(`level0_eval.verified_fact_tickers`), and `research_evaluation` defensively
+skips any name whose assembled facts lack core financials, so cards are never
+hallucinated from the ticker alone.
 
 All Level 0 tables: public-read RLS, service-role writes. `metric_stats`
 (distribution percentiles) is reused from migration 038.

--- a/level0_eval.py
+++ b/level0_eval.py
@@ -70,11 +70,44 @@ def _bulk(db, table: str, select: str, tickers: list[str]) -> list[dict]:
     return out
 
 
+def verified_fact_tickers(db) -> set[str]:
+    """Tickers we hold VERIFIED financials for — a `fundamentals` row carrying
+    real figures (revenue / margins / rule-of-40) from a trusted source (EODHD).
+
+    The data-quality gate for any LLM research request: we never ask a model to
+    evaluate a name we can't seed with correct fundamentals, or it invents
+    moat/earnings-quality from the ticker alone. Pricing isn't checked here —
+    Tier-1 membership (the affordability gate) already guarantees a live price.
+    """
+    out: set[str] = set()
+    offset = 0
+    while True:
+        resp = (
+            db.client.table("fundamentals")
+            .select("ticker")
+            .or_(
+                "rule_of_40.not.is.null,gross_margin.not.is.null,"
+                "net_margin.not.is.null,rev_growth_ttm.not.is.null,revenue.not.is.null"
+            )
+            .range(offset, offset + 999)
+            .execute()
+        )
+        batch = resp.data or []
+        out.update((r.get("ticker") or "").upper() for r in batch if r.get("ticker"))
+        if len(batch) < 1000:
+            break
+        offset += 1000
+    return out
+
+
 def stale_tier1_tickers(db, kind: str, top_n: int) -> list[str]:
     """The `top_n` Tier-1 tickers least-recently evaluated for `kind`.
 
     Never-evaluated names (no ai_analysis row, or a NULL kind-clock) sort first,
-    then oldest first. Pure read over `securities` + `ai_analysis`.
+    then oldest first. Gated to names with VERIFIED financials
+    (`verified_fact_tickers`) so an LLM eval is never sent without correct data;
+    unverified names re-enter the rotation automatically once their fundamentals
+    backfill. Pure read over `securities` + `fundamentals` + `ai_analysis`.
     """
     clock = _CLOCK_COLUMN.get(kind)
     if clock is None:
@@ -82,7 +115,9 @@ def stale_tier1_tickers(db, kind: str, top_n: int) -> list[str]:
             f"unknown kind {kind!r} (expected bull|bear|narrative|research)"
         )
 
-    # Active Tier-1 universe.
+    verified = verified_fact_tickers(db)
+
+    # Active Tier-1 universe, gated to verified-fact names.
     tier1: list[str] = []
     offset = 0
     while True:
@@ -95,7 +130,10 @@ def stale_tier1_tickers(db, kind: str, top_n: int) -> list[str]:
             .execute()
         )
         batch = resp.data or []
-        tier1.extend((r.get("ticker") or "").upper() for r in batch if r.get("ticker"))
+        tier1.extend(
+            t for r in batch
+            if (t := (r.get("ticker") or "").upper()) and t in verified
+        )
         if len(batch) < 1000:
             break
         offset += 1000

--- a/migrations/056_screener_quality_score.sql
+++ b/migrations/056_screener_quality_score.sql
@@ -1,0 +1,85 @@
+-- Migration 056: feed the research card's quality_score into the screener.
+--
+-- The screener composite currently uses only Q/V/M × a binary bull/bear
+-- multiplier. The research card (migration 055) carries a 1-5 quality_score per
+-- equity (moat/durability/earnings-quality/balance-sheet, computed once + shared
+-- + verified-data-gated). Expose it to the screener so high-quality businesses
+-- rank higher — the scorers apply a gentle ±20% multiplier (screen.py /
+-- web/lib/screen/score.ts), neutral when a name has no card.
+--
+-- Two read paths need it:
+--   * screen_ai_overlay()  — the Python buyer reads this (fast; applied by MCP).
+--   * screen_facts_mv      — the web /screener reads this (heavy rebuild → run in
+--                            the Supabase SQL editor; the MCP gateway times out
+--                            on the ~3k-LATERAL-join rebuild).
+-- The matview rebuild also repoints its bull/bear join companies -> ai_analysis,
+-- finishing migration 053's deferred Stage-A1 step. Non-regressive (ai_analysis
+-- bull/bear were seeded from companies). Additive & idempotent.
+
+-- ---- screen_ai_overlay(): add quality_score, read from ai_analysis ----------
+-- DROP first: the return type changes (new quality_score column), which
+-- CREATE OR REPLACE can't do.
+DROP FUNCTION IF EXISTS screen_ai_overlay();
+CREATE OR REPLACE FUNCTION screen_ai_overlay()
+RETURNS TABLE (ticker TEXT, bull BOOLEAN, bear BOOLEAN, quality_score INT)
+LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public, pg_temp AS $$
+  SELECT ticker,
+    CASE WHEN left(bull_eval,1)='✅' THEN true WHEN left(bull_eval,1)='❌' THEN false END,
+    CASE WHEN left(bear_eval,1)='✅' THEN true WHEN left(bear_eval,1)='❌' THEN false END,
+    (research_card->>'quality_score')::int
+  FROM ai_analysis
+  WHERE bull_eval IS NOT NULL OR bear_eval IS NOT NULL OR research_card IS NOT NULL;
+$$;
+
+-- ---- screen_facts_mv: add quality_score column (+ bull/bear from ai_analysis) -
+-- Same body as migration 053, with the AI join carrying quality_score too.
+DROP MATERIALIZED VIEW IF EXISTS screen_facts_mv;
+CREATE MATERIALIZED VIEW screen_facts_mv AS
+    SELECT
+        s.ticker,
+        s.name,
+        s.gics_sector       AS sector,
+        s.gics_industry     AS industry,
+        s.country,
+        lp.close            AS price,
+        lp.date             AS price_asof,
+        f.rev_growth_ttm,
+        f.gross_margin,
+        f.fcf_margin,
+        f.net_margin,
+        f.operating_margin,
+        f.rule_of_40,
+        v.ps,
+        v.ps_median_12m,
+        CASE WHEN p52.close IS NOT NULL AND p52.close > 0
+             THEN (lp.close / p52.close - 1) * 100 END AS ret_52w,
+        CASE WHEN left(a.bull_eval, 1) = '✅' THEN true
+             WHEN left(a.bull_eval, 1) = '❌' THEN false END AS bull,
+        CASE WHEN left(a.bear_eval, 1) = '✅' THEN true
+             WHEN left(a.bear_eval, 1) = '❌' THEN false END AS bear,
+        (a.research_card->>'quality_score')::int AS quality_score
+    FROM securities s
+    JOIN LATERAL (
+        SELECT rev_growth_ttm, gross_margin, fcf_margin, net_margin,
+               operating_margin, rule_of_40
+        FROM fundamentals fd
+        WHERE fd.ticker = s.ticker ORDER BY fd.period_end DESC LIMIT 1
+    ) f ON true
+    LEFT JOIN LATERAL (
+        SELECT close, date FROM prices_daily pd
+        WHERE pd.ticker = s.ticker ORDER BY pd.date DESC LIMIT 1
+    ) lp ON true
+    LEFT JOIN LATERAL (
+        SELECT close FROM prices_daily pd
+        WHERE pd.ticker = s.ticker AND pd.date <= (CURRENT_DATE - INTERVAL '52 weeks')
+        ORDER BY pd.date DESC LIMIT 1
+    ) p52 ON true
+    LEFT JOIN LATERAL (
+        SELECT ps, ps_median_12m FROM valuation vl
+        WHERE vl.ticker = s.ticker ORDER BY vl.date DESC LIMIT 1
+    ) v ON true
+    LEFT JOIN ai_analysis a ON a.ticker = s.ticker
+    WHERE s.is_tier1 AND s.status = 'active';
+
+CREATE UNIQUE INDEX IF NOT EXISTS screen_facts_mv_ticker ON screen_facts_mv (ticker);
+GRANT SELECT ON screen_facts_mv TO anon, authenticated, service_role;

--- a/research_evaluation.py
+++ b/research_evaluation.py
@@ -56,6 +56,18 @@ DEFAULTS = {
 
 _DIMENSIONS = ("moat", "growth_durability", "earnings_quality", "balance_sheet_risk")
 
+# Verified financials the card reasons over (companies-style keys, as assembled
+# by level0_eval). At least one must be present or we DO NOT call the LLM — a
+# card built without correct fundamentals is a hallucination.
+_CORE_FINANCIAL_KEYS = (
+    "rule_of_40", "gross_margin_pct", "net_margin_pct",
+    "rev_growth_ttm_pct", "fcf_margin_pct", "operating_margin_pct",
+)
+
+
+def _has_verified_financials(equity: dict) -> bool:
+    return any(equity.get(k) is not None for k in _CORE_FINANCIAL_KEYS)
+
 # Noise keys not worth sending to the model (identity dupes / stale verdicts it
 # shouldn't anchor on / large blobs).
 _BLOCK_EXCLUDE = {
@@ -187,6 +199,9 @@ def _build_card(parsed: dict, model: str, max_break_signals: int) -> dict | None
 def _evaluate_one(equity: dict, cfg: dict) -> dict:
     """One LLM research call for one equity. Returns {ticker, card} or {ticker, error}."""
     ticker = equity["ticker"]
+    # Data-quality gate: never research a name without verified financials.
+    if not _has_verified_financials(equity):
+        return {"ticker": ticker, "error": "insufficient verified data — skipped"}
     system = RESEARCH_SYSTEM_PROMPT.format(
         max_break_signals=cfg["max_break_signals"],
         allowed_fields=", ".join(sorted(_ALLOWED_SIGNAL_FIELDS)),

--- a/screen.py
+++ b/screen.py
@@ -106,6 +106,20 @@ def _ai_multiplier(bull: bool | None, bear: bool | None) -> float:
     return 0.4
 
 
+# Research-card business-quality tilt (migration 056). Gentle ±20% so it nudges
+# the rank rather than dominating; neutral (1.0) when a name has no card yet, so
+# the research rollout never penalises unresearched names. Mirror of
+# web/lib/screen/score.ts qualityMultiplier().
+_QUALITY_MULT = {1: 0.8, 2: 0.9, 3: 1.0, 4: 1.1, 5: 1.2}
+
+
+def _quality_multiplier(quality_score: Any) -> float:
+    try:
+        return _QUALITY_MULT.get(int(quality_score), 1.0)
+    except (TypeError, ValueError):
+        return 1.0
+
+
 def _f(v: Any) -> float | None:
     if v is None:
         return None
@@ -149,6 +163,7 @@ def score_screen(facts: list[dict], config: dict) -> list[dict]:
     wm = float(weights.get("momentum", 0))
     wsum = wq + wv + wm or 1.0
     ai_on = bool(config.get("aiMultiplier", True))
+    quality_on = bool(config.get("qualityMultiplier", True))
 
     scored: list[dict] = []
     for i, r in enumerate(subset):
@@ -158,6 +173,8 @@ def score_screen(facts: list[dict], config: dict) -> list[dict]:
         score = ((wq * quality + wv * value + wm * momentum) / wsum) * 100
         if ai_on:
             score *= _ai_multiplier(r.get("bull"), r.get("bear"))
+        if quality_on and r.get("quality_score") is not None:
+            score *= _quality_multiplier(r.get("quality_score"))
         row = dict(r)
         row["score"] = score
         row["quality_pct"] = round(quality * 100)
@@ -248,6 +265,9 @@ def load_facts(db) -> list[dict]:
         v = overlay.get(r["ticker"])
         r["bull"] = (v or {}).get("bull")
         r["bear"] = (v or {}).get("bear")
+        # quality_score from the research card (migration 056) — Python reads it
+        # off the overlay so the buyer gets it without waiting on the matview rebuild.
+        r["quality_score"] = (v or {}).get("quality_score")
         # Derived "vs SPY" — kept in lockstep with query.ts so the buyer ranks
         # the identical filtered set.
         ret = _f(r.get("ret_52w"))

--- a/test_screen.py
+++ b/test_screen.py
@@ -21,7 +21,7 @@ def facts(*rows: dict) -> list[dict]:
         "gross_margin": None, "fcf_margin": None, "net_margin": None,
         "operating_margin": None, "rule_of_40": None, "ps": None,
         "ps_median_12m": None, "ret_52w": None, "perf_52w_vs_spy": None,
-        "bull": None, "bear": None,
+        "bull": None, "bear": None, "quality_score": None,
     }
     return [{**base, **r} for r in rows]
 
@@ -104,6 +104,37 @@ class TestScoring(unittest.TestCase):
         av = next(r for r in out if r["ticker"] == "AV")
         # identical quality percentiles (both p100), so the multiplier decides
         self.assertAlmostEqual(dp["score"] / av["score"], 1.3 / 0.4, places=5)
+
+    def test_quality_multiplier_tilts_by_score(self):
+        # Identical quantitative quality (both p100); the research-card
+        # quality_score (migration 056) tilts the rank: 5 → ×1.2, 1 → ×0.8.
+        rows = facts(
+            {"ticker": "HIQ", "rule_of_40": 50, "fcf_margin": 20, "gross_margin": 60, "ps": 5, "ps_median_12m": 5, "quality_score": 5},
+            {"ticker": "LOQ", "rule_of_40": 50, "fcf_margin": 20, "gross_margin": 60, "ps": 5, "ps_median_12m": 5, "quality_score": 1},
+        )
+        cfg = {"weights": {"quality": 100, "value": 0, "momentum": 0}, "aiMultiplier": False, "qualityMultiplier": True}
+        out = screen.score_screen(rows, cfg)
+        hiq = next(r for r in out if r["ticker"] == "HIQ")
+        loq = next(r for r in out if r["ticker"] == "LOQ")
+        self.assertEqual(out[0]["ticker"], "HIQ")
+        self.assertAlmostEqual(hiq["score"] / loq["score"], 1.2 / 0.8, places=5)
+
+    def test_quality_multiplier_neutral_for_no_card_and_when_off(self):
+        # A name with no card is neutral (×1.0); the toggle off disables entirely.
+        rows = facts(
+            {"ticker": "CARD", "rule_of_40": 50, "fcf_margin": 20, "gross_margin": 60, "ps": 5, "ps_median_12m": 5, "quality_score": 1},
+            {"ticker": "NONE", "rule_of_40": 50, "fcf_margin": 20, "gross_margin": 60, "ps": 5, "ps_median_12m": 5, "quality_score": None},
+        )
+        off = {"weights": {"quality": 100, "value": 0, "momentum": 0}, "aiMultiplier": False, "qualityMultiplier": False}
+        out = screen.score_screen(rows, off)
+        # toggle off → identical scores (multiplier never applied)
+        self.assertAlmostEqual(out[0]["score"], out[1]["score"], places=5)
+        on = {**off, "qualityMultiplier": True}
+        out2 = screen.score_screen(rows, on)
+        none_row = next(r for r in out2 if r["ticker"] == "NONE")
+        card_row = next(r for r in out2 if r["ticker"] == "CARD")
+        # no-card name unchanged vs toggle-off; carded 1/5 name is penalised
+        self.assertGreater(none_row["score"], card_row["score"])
 
     def test_outlier_r40_does_not_blow_up_scale(self):
         # Empirical-percentile scoring: a 26000 R40 just pins to p100.

--- a/web/lib/screen/config.ts
+++ b/web/lib/screen/config.ts
@@ -59,6 +59,9 @@ export const screenConfigSchema = z.object({
   filters: z.array(filterSchema).max(20).default([]),
   weights: weightsSchema.default({ quality: 45, value: 25, momentum: 20 }),
   aiMultiplier: z.boolean().default(true),
+  // Research-card business-quality tilt (migration 056): ±20% by quality_score,
+  // neutral when a name has no card. On by default.
+  qualityMultiplier: z.boolean().default(true),
   // Hide names this portfolio's buyer evaluated and passed on, for 90 days
   // (migration 051). On by default; per-portfolio, owner can restore early.
   hideRejected: z.boolean().default(true),
@@ -87,6 +90,7 @@ const base = {
   topN: 40,
   hideRejected: true,
   aiMultiplier: true,
+  qualityMultiplier: true,
 };
 
 export const PRESETS: Record<string, Preset> = {

--- a/web/lib/screen/query.ts
+++ b/web/lib/screen/query.ts
@@ -80,6 +80,7 @@ async function fetchFacts(): Promise<ScreenFacts[]> {
           : null,
       bull: (r.bull as boolean | null) ?? null,
       bear: (r.bear as boolean | null) ?? null,
+      quality_score: num(r.quality_score),
     } satisfies ScreenFacts;
   });
 }

--- a/web/lib/screen/score.ts
+++ b/web/lib/screen/score.ts
@@ -39,6 +39,8 @@ export interface ScreenFacts {
   // AI verdict overlay (from companies; Level 0 itself is strategy-neutral)
   bull: boolean | null;
   bear: boolean | null;
+  // Research-card business-quality score 1-5 (migration 056); null = no card yet.
+  quality_score: number | null;
 }
 
 export interface ScoredRow extends ScreenFacts {
@@ -122,6 +124,14 @@ function aiMultiplier(bull: boolean | null, bear: boolean | null): number {
   return 0.4; // avoid
 }
 
+// Research-card business-quality tilt (migration 056). Gentle ±20%, neutral
+// when a name has no card yet. Mirror of screen.py _quality_multiplier().
+const QUALITY_MULT: Record<number, number> = { 1: 0.8, 2: 0.9, 3: 1.0, 4: 1.1, 5: 1.2 };
+function qualityMultiplier(score: number | null): number {
+  if (score == null) return 1.0;
+  return QUALITY_MULT[Math.round(score)] ?? 1.0;
+}
+
 export interface ScreenResult {
   rows: ScoredRow[];
   match_count: number;
@@ -169,6 +179,8 @@ export function scoreScreen(
     const momentum = pMom[i] ?? 0;
     let score = ((wq * quality + wv * value + wm * momentum) / wsum) * 100;
     if (config.aiMultiplier) score *= aiMultiplier(r.bull, r.bear);
+    if (config.qualityMultiplier && r.quality_score != null)
+      score *= qualityMultiplier(r.quality_score);
     return {
       ...r,
       rank: 0,


### PR DESCRIPTION
## Part 1 — Verified-data gate (no hallucinated research)

The first research run wrote **6 cards for names with no verified financials** (VSME/AIAI/AIRJ/AIRO/AIV/AKTX) — scored from the ticker/sector alone. Root cause: the `--tier1` eval scripts select straight from `securities` and overlay fundamentals only *if present*, so unverified names reached the LLM.

- **`level0_eval.verified_fact_tickers()`** + a gate in `stale_tier1_tickers` — the rotation (research/bull/bear/narrative) now only selects Tier-1 names with **real EODHD financials** (revenue/margins/R40). The ~273 unverified names are skipped until their fundamentals backfill (they re-enter automatically — `researched_at` stays NULL). Pricing is already guaranteed by Tier-1 membership.
- **`research_evaluation._evaluate_one`** defensively skips any name whose assembled facts lack core financials — **never calls the LLM without verified data**.
- **DB cleanup:** nulled the 4 genuinely-unverified cards (AIRJ/AKTX turned out to have `net_margin`/`rev_growth`, so they're legitimately verified).
- The buyer path was already safe (the `screen_facts_mv` LATERAL join drops names without fundamentals).

## Part 2 — Feed `quality_score` into the screener

The card's 1–5 `quality_score` previously only reached the buyer; the screener that *surfaces* candidates ignored it. Now it tilts the rank:

- **migration 056** (applied to the DB): `screen_ai_overlay()` returns `quality_score` (Python path); `screen_facts_mv` gains a `quality_score` column **and** repoints bull/bear to `ai_analysis` (finishing 053's deferred matview step).
- **`screen.py` + `web/lib/screen/score.ts`:** a gentle **±20% quality multiplier** (1→0.8 … 5→1.2), gated by a new `qualityMultiplier` config toggle (default on), **neutral when a name has no card** so the ~monthly rollout never penalises unresearched names.
- `load_facts` (Python) merges it from the overlay; `query.ts` maps it from the matview; `config.ts` adds the toggle.

## Verification
- `test_screen.py` extended (quality multiplier: 5 beats 1; neutral when null/off) — **20 pass**; `py_compile` clean.
- DB confirmed: 96 cards post-cleanup; `screen_facts_mv` and `screen_ai_overlay()` both expose `quality_score` for those 96.
- **Not run here:** the web build (no `node_modules`) — the TS mirrors the Python exactly and is reviewed by hand.

## Notes
- Migration 056 is **already applied** to the live DB (overlay + matview both succeeded after the Supabase upgrade).
- Quality vs bull/bear both proxy "good business" — started gentle (±20%), tunable; can narrow or make quality supersede bull/bear if it over-tilts once you see a re-ranked top-40.

https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh2YzkkckxnT55m244vby8)_