### PR TITLE
Supabase MCP: read-only PAT auth (fix broken OAuth in web sessions)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "supabase": {
       "type": "http",
-      "url": "https://mcp.supabase.com/mcp?project_ref=nojoooddiadyrduikgsk"
+      "url": "https://mcp.supabase.com/mcp?project_ref=nojoooddiadyrduikgsk&read_only=true",
+      "headers": {
+        "Authorization": "Bearer ${SUPABASE_ACCESS_TOKEN}"
+      }
     }
   }
 }


### PR DESCRIPTION
## Why

The Supabase MCP was configured for OAuth against the hosted endpoint. In this remote/web Claude Code session the OAuth `localhost` callback can't complete and Supabase returns `{"message":"Unrecognized client_id"}` — so the agent can't query the DB, and every verification this session has been "run SQL in the editor and paste the output."

## What

Switch the `supabase` MCP server to **Personal Access Token** auth (no OAuth callback) and scope it **read-only**:

```json
"supabase": {
  "type": "http",
  "url": "https://mcp.supabase.com/mcp?project_ref=nojoooddiadyrduikgsk&read_only=true",
  "headers": { "Authorization": "Bearer ${SUPABASE_ACCESS_TOKEN}" }
}
```

- `${SUPABASE_ACCESS_TOKEN}` is resolved from an environment secret at connect time — **no secret is committed**.
- `read_only=true` bounds the server to read tools (verification only).

## Owner action (required)
1. Create a Supabase **Personal Access Token** (dashboard → Account → Access Tokens).
2. Add it as a **`SUPABASE_ACCESS_TOKEN`** secret in the Claude Code web environment.
3. Restart the session so the MCP reconnects.

## Verify
After the secret + restart, the agent runs a read-only `select … from agent_trades …` through the MCP to confirm access (and finally check the CLOV/OMDA/HNY sells directly). Auth error → fall back to the stdio `@supabase/mcp-server-supabase --read-only --project-ref` variant (needs Node/npx).

Only `.mcp.json` changes.

https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu)_