### PR TITLE
research-evaluation: one-off full backfill via workflow_dispatch

### DIFF
--- a/.github/workflows/research-evaluation.yml
+++ b/.github/workflows/research-evaluation.yml
@@ -17,11 +17,23 @@ on:
         required: false
         type: boolean
         default: false
+      limit:
+        description: "Tickers per round (blank = default 100)"
+        required: false
+        type: string
+        default: ""
+      rounds:
+        description: "Sequential rounds this dispatch (each persists; for a full backfill try limit=200, rounds=15)"
+        required: false
+        type: string
+        default: "1"
 
 jobs:
   research-eval:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Daily run is one batch of 100; a manual full-backfill dispatch loops many
+    # rounds, so allow a multi-hour job (under the 360-min Actions cap).
+    timeout-minutes: 350
 
     steps:
       - name: Checkout repository
@@ -45,11 +57,32 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           RESEARCH_DRY_RUN: ${{ inputs.dry_run }}
+          # Manual-dispatch backfill knobs (empty/1 on the scheduled run).
+          LIMIT: ${{ inputs.limit }}
+          ROUNDS: ${{ inputs.rounds }}
         run: |
           set -u
-          ARGS=()
-          if [ "${RESEARCH_DRY_RUN}" = "true" ]; then ARGS+=(--dry-run); fi
-          python research_evaluation.py ${ARGS[@]+"${ARGS[@]}"}
+          # Each round writes its batch at the end (single end-of-run upsert), and
+          # rotation picks the stalest-by-researched_at names — so consecutive
+          # rounds walk the universe without re-doing names, and a killed job
+          # keeps every completed round.
+          for i in $(seq 1 "${ROUNDS:-1}"); do
+            ARGS=()
+            if [ "${RESEARCH_DRY_RUN}" = "true" ]; then ARGS+=(--dry-run); fi
+            if [ -n "${LIMIT}" ]; then ARGS+=(--limit "${LIMIT}"); fi
+            echo "=== research round ${i} / ${ROUNDS:-1} ==="
+            python research_evaluation.py ${ARGS[@]+"${ARGS[@]}"} || echo "round ${i} failed, continuing"
+          done
+
+      - name: Refresh screener matview
+        # Surface the freshly-written cards on /screener immediately instead of
+        # waiting for the next prices-daily run. Skipped on a dry run.
+        if: ${{ inputs.dry_run != true }}
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: python -c "from db import SupabaseDB; SupabaseDB().refresh_screen_facts()"
+
 
       - name: Upload logs
         if: always()


### PR DESCRIPTION
## Summary

Lets you populate the screener's **AI sections** (the durability badge + the `AI ±X.XXσ` score adjustment) for the whole eligible universe in one manual run, instead of waiting ~4 weeks for the daily cron.

Those sections come from `ai_analysis.research_card`, written by `research_evaluation.py`. Only **376 / 3112** Tier-1 names are carded today — but **2912** already pass the verified-fundamentals gate, so the bottleneck is the **100/day** cron cadence, not the gate.

## Why a chunked loop (not `--limit 3000`)

`research_evaluation.py` runs all per-ticker Gemini calls in a thread pool and then writes **once at the end** (`upsert_ai_analysis_batch`). A single giant `--limit 3000` run (~3–4h) that hit the Actions timeout would lose **everything** and waste the spend. So the dispatch loops the script in bounded chunks — each round persists its batch, and the stalest-by-`researched_at` rotation walks the universe without re-doing names, so a killed job keeps every completed round.

## Changes (`.github/workflows/research-evaluation.yml` only — no script change)

- New `workflow_dispatch` inputs: **`limit`** (per-round batch; blank = default 100) and **`rounds`** (sequential runs this dispatch). The scheduled daily run is unchanged (1 × 100).
- `timeout-minutes` **30 → 350** so a multi-hour backfill fits under the 360-min Actions cap.
- Final step refreshes `screen_facts_mv` (`db.refresh_screen_facts()`) so new cards show on `/screener` immediately rather than waiting for the next `prices-daily`; skipped on dry runs.

## How to run it

Actions → **Research Evaluation** → Run workflow → `limit=200`, `rounds=15` (≈3000 capacity, ~3–4h). Optionally dry-run first (`dry_run=true, rounds=2, limit=20`).

**Caveat:** ~2912 Gemini 2.5 Pro calls of one-time LLM spend. `balance_sheet_risk` stays gated off (no cash/debt/shares yet), so cards remain moat/growth/earnings — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu)_