### PR TITLE
Screener: drop break-signal penalty so carded names aren't all demoted

### DIFF
--- a/screen.py
+++ b/screen.py
@@ -47,7 +47,7 @@ MOM_CAP = 40.0     # blow-off-top collar
 # percentile round(Φ(final_z)·100). These MUST match web/lib/screen/score.ts.
 W_MOAT = 0.58       # AI moat weight inside the trajectory adjustment
 W_EARN = 0.42       # AI earnings-quality weight
-K_BREAK = 0.5       # per-break-signal penalty (additive — decision 3)
+# (break-count penalty removed from the screen score — see _adj_z)
 FLOOR = -1.5        # asymmetric floor on adj_z (in σ)
 BUDGET = 0.7        # AI authority ceiling (in σ) — fixed server constant (decision 1)
 LENS_NAMES = ("quality", "value", "momentum")
@@ -213,21 +213,23 @@ def _adj_z(row: dict, budget: float = BUDGET) -> dict:
     if not has_card:
         return {"adj_z": 0.0, "moat_z": 0.0, "earn_z": 0.0, "break_z": 0.0,
                 "capped": False, "floored": False, "has_card": False}
-    nbreak = _f(row.get("break_count")) or 0.0
     u_moat = (moat - 3) / 2
     u_earn = (earn - 3) / 2
     moat_z = budget * W_MOAT * u_moat
     earn_z = budget * W_EARN * u_earn
-    break_z = -budget * K_BREAK * nbreak
+    # Break signals are forward-looking watch-conditions (e.g. "fcf_margin < 5%"),
+    # not faults that are currently true — and every card ships a base set of 3+.
+    # Counting them sank EVERY researched name below the unresearched ones, so the
+    # screen score no longer penalizes them. They stay visible on the card + the
+    # badge flag pip, and still drive the buyer/reviewer.
+    break_z = 0.0
     smooth_unit = W_MOAT * u_moat + W_EARN * u_earn  # natural max = 1.0 ⇒ +budget
-    adj = moat_z + earn_z + break_z
+    adj = moat_z + earn_z
     floored = adj < FLOOR
     if floored:
         adj = FLOOR
-    # Upward bound is structural: the smooth part maxes at +budget (both u=1),
-    # break signals only subtract — so adj never exceeds +budget. `capped` is a
-    # display flag for a name that hit that natural ceiling.
-    capped = (nbreak == 0 and smooth_unit >= 0.999 and budget > 0)
+    # Upward bound is structural: the smooth part maxes at +budget (both u=1).
+    capped = (smooth_unit >= 0.999 and budget > 0)
     return {"adj_z": adj, "moat_z": moat_z, "earn_z": earn_z, "break_z": break_z,
             "capped": capped, "floored": floored, "has_card": True}
 

--- a/test_screen.py
+++ b/test_screen.py
@@ -152,19 +152,35 @@ class TestSingleScore(unittest.TestCase):
         self.assertTrue(out[0]["capped"])
         self.assertFalse(out[0]["floored"])
 
-    def test_weak_moat_with_breaks_demotes_and_floors(self):
-        # moat=1, earn=1, 3 break signals → adj_z below FLOOR → clamped to FLOOR.
+    def test_weak_moat_demotes_without_floor(self):
+        # moat=1, earn=1 → both u=−1 → adj_z = budget·(W_MOAT·−1 + W_EARN·−1) = −budget.
+        # Break signals no longer subtract, so it demotes but does NOT hit the floor.
         rows = facts({"ticker": "WEAK", **carded(moat_score=1, earnings_score=1, break_count=3)})
         out = screen.score_screen(rows, {"weights": {"quality": 60, "value": 25, "momentum": 15}}, UNIT_STATS)
-        self.assertEqual(out[0]["adj_z"], screen.FLOOR)
-        self.assertTrue(out[0]["floored"])
+        self.assertAlmostEqual(out[0]["adj_z"], -screen.BUDGET, places=9)
+        self.assertFalse(out[0]["floored"])
 
-    def test_break_signal_additive_penalty(self):
-        # One break signal subtracts budget·K_BREAK from adj_z (additive — not a
-        # hard cap; decision 3). Neutral 3/3 card → adj_z = −budget·K_BREAK.
-        rows = facts({"ticker": "BRK", **carded(moat_score=3, earnings_score=3, break_count=1)})
+    def test_break_signals_do_not_affect_score(self):
+        # Break signals are watch-only — the screen score ignores their count.
+        # A 3/3 card with 3 breaks and one with 0 breaks score identically (≈0).
+        rows = facts(
+            {"ticker": "BRK", **carded(moat_score=3, earnings_score=3, break_count=3)},
+            {"ticker": "NOBRK", **carded(moat_score=3, earnings_score=3, break_count=0)},
+        )
         out = screen.score_screen(rows, {"weights": {"quality": 100, "value": 0, "momentum": 0}}, UNIT_STATS)
-        self.assertAlmostEqual(out[0]["adj_z"], -screen.BUDGET * 0.5, places=9)
+        brk = next(r for r in out if r["ticker"] == "BRK")
+        nob = next(r for r in out if r["ticker"] == "NOBRK")
+        self.assertAlmostEqual(brk["adj_z"], 0.0, places=9)
+        self.assertAlmostEqual(brk["adj_z"], nob["adj_z"], places=12)
+        self.assertEqual(brk["break_z"], 0.0)
+
+    def test_strong_card_with_breaks_still_caps(self):
+        # A perfect 5/5 card lifts to +budget even WITH break signals (breaks no
+        # longer demote) — the fix that keeps researched names from sinking.
+        rows = facts({"ticker": "STRONGBRK", **carded(moat_score=5, earnings_score=5, break_count=4)})
+        out = screen.score_screen(rows, {"weights": {"quality": 60, "value": 25, "momentum": 15}}, UNIT_STATS)
+        self.assertAlmostEqual(out[0]["adj_z"], screen.BUDGET, places=9)
+        self.assertTrue(out[0]["capped"])
 
     def test_carded_lift_beats_uncarded_same_base(self):
         # A low-base strong-card name lifts above a same-base uncarded name.

--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -1481,8 +1481,8 @@ function ScoreLedger({ r }: { r: Row }) {
           {(r.break_count ?? 0) > 0 && (
             <Line
               label={`Break signals ×${r.break_count}`}
-              v={`${sgn(r.break_z)}σ`}
-              tone="text-[var(--color-red,#FF3333)]"
+              v="watch-only"
+              tone="text-text-muted"
             />
           )}
           {r.capped && <Line label="at +budget ceiling" v={`+${BUDGET}σ`} tone="text-text-muted" />}

--- a/web/lib/screen/score.ts
+++ b/web/lib/screen/score.ts
@@ -114,7 +114,7 @@ const MOM_CAP = 40;
 // Single-score constants (migration 057) — MUST match screen.py.
 const W_MOAT = 0.58;
 const W_EARN = 0.42;
-const K_BREAK = 0.5;
+// (break-count penalty removed from the screen score — see adjZ)
 const FLOOR = -1.5;
 export const BUDGET = 0.7; // AI authority ceiling (σ) — fixed server constant
 const LENS_NAMES = ["quality", "value", "momentum"] as const;
@@ -205,17 +205,21 @@ function adjZ(r: ScreenFacts, budget = BUDGET): Adj {
   const hasCard = r.has_card && moat != null && earn != null;
   if (!hasCard)
     return { adj_z: 0, moat_z: 0, earn_z: 0, break_z: 0, capped: false, floored: false };
-  const nbreak = num(r.break_count) ?? 0;
   const uMoat = (moat! - 3) / 2;
   const uEarn = (earn! - 3) / 2;
   const moat_z = budget * W_MOAT * uMoat;
   const earn_z = budget * W_EARN * uEarn;
-  const break_z = -budget * K_BREAK * nbreak;
+  // Break signals are forward-looking watch-conditions (e.g. "fcf_margin < 5%"),
+  // not faults that are currently true — and every card ships a base set of 3+.
+  // Counting them sank EVERY researched name below the unresearched ones, so the
+  // screen score no longer penalizes them. They stay visible on the card + the
+  // badge flag pip, and still drive the buyer/reviewer.
+  const break_z = 0;
   const smoothUnit = W_MOAT * uMoat + W_EARN * uEarn; // natural max 1.0 ⇒ +budget
-  let adj = moat_z + earn_z + break_z;
+  let adj = moat_z + earn_z;
   const floored = adj < FLOOR;
   if (floored) adj = FLOOR;
-  const capped = nbreak === 0 && smoothUnit >= 0.999 && budget > 0;
+  const capped = smoothUnit >= 0.999 && budget > 0;
   return { adj_z: adj, moat_z, earn_z, break_z, capped, floored };
 }
 


### PR DESCRIPTION
## Summary

Fixes "**no stock on the screener has an AI score**." The AI cards exist and are served (85 of 268 names in the default view are carded), but the `adj_z` **break-signal penalty drove every carded name negative**, sinking all of them to ranks **183–268** — so the top of the page (all you see) was 100% uncarded.

**Root cause:** `adj_z = budget·(W_MOAT·u_moat + W_EARN·u_earn − K_BREAK·n_break)`. Every research card ships a base set of **≥3 break signals** (median 3, 100% have ≥3), so the penalty `0.7·0.5·3 = −1.05` exceeded the *maximum possible* lift `0.7·1.0 = +0.70` (perfect 5/5 moat + 5/5 earnings). No card could ever be net-positive — even HALO (5/5, 5/5) netted −0.35σ at rank 183. Those `break_signals` are forward-looking *watch-conditions* ("fcf_margin < 5%"), not faults that are currently true, so counting them punished every researched name equally.

## Change (both scorers, in lockstep — no DB/migration)

`adj_z = budget·(W_MOAT·u_moat + W_EARN·u_earn)` — drop the break-count term.
- `web/lib/screen/score.ts` `adjZ()` + `screen.py` `_adj_z()`: `break_z = 0`, `capped` no longer gates on `n_break`, floor retained as a safety bound (no longer binds). `K_BREAK` removed.
- `screener-client.tsx` `ScoreLedger`: the break line is now **`watch-only`** (no σ). Break signals stay visible in the expand's "Break signals" section + the badge flag pip, and still drive the buyer/reviewer.

Now `adj_z ∈ [−0.7, +0.7]`: strong cards lift toward the top, weak ones sink — carded names spread through the ranking. HALO goes from −0.35σ/rank-183 to **+0.70σ near the top**.

## Verification
- `python -m pytest test_screen.py -q` → 26 pass (break tests rewritten: breaks no longer affect score; strong card with breaks still caps at +budget).
- Cross-language parity `score.ts == screen.py` re-verified via the harness.
- `tsc --noEmit` clean.
- **Needs a redeploy** — no migration; the screener's ISR/5-min facts cache surfaces it within ~5 min of deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu)_