### PR TITLE
Screener: remove the legacy "Top N highlighted" treatment

### DIFF
--- a/web/app/screener/screener-client.tsx
+++ b/web/app/screener/screener-client.tsx
@@ -1028,14 +1028,10 @@ export default function ScreenerClient({
       </div>
 
       <div className="flex flex-col gap-1.5 mt-1.5">
-        {rows.slice(0, visible).map((r, i) => (
+        {rows.slice(0, visible).map((r) => (
           <RowView
             key={r.ticker}
             r={r}
-            cut={i === data.cut_index && data.cut_index < rows.length}
-            dim={i >= data.cut_index}
-            topN={config.topN}
-            runHref={runHref}
             hasPage={linkable.has(r.ticker.toUpperCase())}
             canExclude={signedIn}
             exclBusy={exclBusy}
@@ -1661,10 +1657,6 @@ function HoldingPill({ h }: { h: ScreenHolding | null }) {
 
 function RowView({
   r,
-  cut,
-  dim,
-  topN,
-  runHref,
   hasPage,
   canExclude,
   exclBusy,
@@ -1674,10 +1666,6 @@ function RowView({
   onExpand,
 }: {
   r: Row;
-  cut: boolean;
-  dim: boolean;
-  topN: number;
-  runHref: string;
   hasPage: boolean;
   /** Owner-only: show the ✕ "remove from screener for a year" control. */
   canExclude: boolean;
@@ -1721,21 +1709,9 @@ function RowView({
 
   return (
     <>
-      {cut && (
-        <div className="flex justify-between items-center gap-2 flex-wrap bg-green/[0.07] border border-green/45 rounded-lg px-2.5 py-1.5 mt-1">
-          <span className="font-mono text-[10px] text-green tracking-[0.05em]">
-            ▲ TOP {topN} — what flows to a portfolio
-          </span>
-          <Link href={runHref} className="font-mono text-[10px] text-green hover:underline">
-            Run as a portfolio →
-          </Link>
-        </div>
-      )}
       <div
         style={tintStyle}
-        className={`relative rounded-lg border border-white/10 hover:border-white/20 overflow-hidden ${
-          dim ? "opacity-50" : ""
-        }`}
+        className="relative rounded-lg border border-white/10 hover:border-white/20 overflow-hidden"
       >
         <span className={`absolute left-0 top-0 bottom-0 w-1 ${edgeCls}`} aria-hidden />
         {/* Collapsed row head — click toggles the expand. */}


### PR DESCRIPTION
## Summary

Removes the legacy "Top N highlighted" treatment from the screener results, since we're moving to different ways of evaluating which names feed a portfolio.

Gone:
- The green **`▲ TOP {topN} — what flows to a portfolio`** banner that split the list at the cut.
- The **dimming** (`opacity-50`) of rows past the cut.
- `RowView`'s now-unused `cut` / `dim` / `topN` / `runHref` props.

All rows now render uniformly.

## Scope

UI-only (`web/app/screener/screener-client.tsx`). Deliberately **not** touched:
- the backend `topN` / candidate-pool logic (`screen.py`, the buyer) — still selects the top N for trading;
- the **"Configure scoring" Top-N slider** and the "How this works" intro's portfolio framing;
- `cut_index` stays in the `/api/screen` response (just no longer rendered).

If you also want the Top-N slider / intro portfolio framing removed as part of rethinking evaluation, say so and I'll follow up.

`tsc --noEmit` clean. Needs a redeploy to show on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGgXZGFGyUZTnjFsWTiZcu)_