### PR TITLE
Add per-name web search at buy time via SerpAPI

### DIFF
--- a/.github/workflows/agent-heartbeat.yml
+++ b/.github/workflows/agent-heartbeat.yml
@@ -72,6 +72,10 @@ jobs:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          # SerpAPI — the LLM buyer enriches each candidate with a per-name
+          # "recent developments" web search at buy time (entry timing /
+          # catalyst / risk). Unset => the buyer simply skips the search.
+          SERPAPI_API_KEY: ${{ secrets.SERPAPI_API_KEY }}
           # Alpaca — a live portfolio mirrors its paper sibling onto a real
           # account right after rebalancing (alpaca_mirror via
           # _mirror_live_sibling). Real orders only fire when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,6 +471,20 @@ Two trade-phase strategies share the buyer slot:
   / foreign-domiciled ADRs ranked by the screener were absent from the
   legacy snapshot and silently dropped (`missing_from_snapshot`), so they
   could never be bought.
+  **Per-name web search at buy time.** Each candidate is also enriched
+  with a compact "recent developments" block fetched live from SerpAPI
+  (`web_search.recent_developments` via `llm_watchlist_buyer.attach_recent_news`)
+  and injected into the per-ticker prompt. The deep, equity-intrinsic
+  business quality stays the shared research card's job (amortised once
+  per equity); the news block is scoped to the part the card can't know —
+  **entry timing + near-term catalyst / risk**. Bounded + parallel (top-N
+  candidates, one query each by default), deduped by a process-level run
+  cache so a name is searched at most once per heartbeat across all
+  portfolios/buyers (the swarm enriches the shared candidate map once).
+  Config knobs (`news_search` / `news_queries` / `news_max_chars`) live in
+  `agents.config`; the whole step auto-no-ops when `SERPAPI_API_KEY` is
+  unset, so it's safe everywhere. The mechanical `watchlist_buyer` is
+  untouched (no LLM, no news).
 
 Both buyers also enforce a **90-day re-buy cooldown** via
 `db.get_recently_sold_tickers` — once a ticker has been sold from a
@@ -1102,7 +1116,11 @@ and `bootstrap_benchmarks.py`.
 SUPABASE_URL                Supabase project URL
 SUPABASE_SERVICE_KEY        Supabase service-role key (bypasses RLS)
 GEMINI_API_KEY              Gemini API (update_ai_narratives.py)
-SERP_API_KEY / SERPAPI_API_KEY  SerpAPI web search
+SERP_API_KEY / SERPAPI_API_KEY  SerpAPI web search — narrative enrichment
+                            (update_ai_narratives.py) AND the LLM buyer's
+                            per-name "recent developments" search at buy time
+                            (agent_heartbeat.py / llm_watchlist_buyer.py). Unset
+                            => both skip the search gracefully.
 EODHD_API_KEY               EODHD financial data
 GITHUB_DISPATCH_TOKEN       Fine-grained PAT / GitHub-App token with
                             `actions: write` on the repo — read by the

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -503,6 +503,23 @@ def _run_portfolio_swarm(
         by_ticker_data = _llm_buyer.build_candidate_data(db, fact_rows, eval_pool)
         eval_pool = [t for t in eval_pool if t in by_ticker_data]
 
+        # Per-name web search at buy time — enrich the shared candidate data ONCE
+        # (every co-briefed buyer reads the same dict; the run cache dedupes across
+        # portfolios). Auto-no-ops when SERPAPI_API_KEY is unset. Uses the buyer
+        # default knobs since the enrichment is shared, not per-buyer.
+        _news_defaults = _llm_buyer.LLM_WATCHLIST_BUYER_DEFAULTS
+        if _news_defaults.get("news_search"):
+            _key = _llm_buyer.serpapi_key()
+            if _key:
+                _llm_buyer.attach_recent_news(
+                    by_ticker_data,
+                    api_key=_key,
+                    concurrency=int(_news_defaults["concurrency"]),
+                    logger=logger,
+                    max_queries=int(_news_defaults.get("news_queries", 1)),
+                    max_chars=int(_news_defaults.get("news_max_chars", 1500)),
+                )
+
     total_value = float(book.get("total_value_usd") or 0)
     cash = float(book.get("cash_usd") or 0)
     n = len(draftable)

--- a/llm_watchlist_buyer.py
+++ b/llm_watchlist_buyer.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import os
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from typing import Any
 
@@ -29,6 +30,7 @@ from llm_picker import (
 )
 from llm_providers import LLMProviderError, call_llm
 from portfolio import PortfolioError
+from web_search import recent_developments
 
 
 # Narrative + AI-overlay fields pulled from the legacy `companies` row to
@@ -122,6 +124,14 @@ LLM_WATCHLIST_BUYER_DEFAULTS: dict[str, Any] = {
     "max_tokens_phase2": 16384,
     "temperature": 0.2,
     "max_signals_per_kind": 5,      # cap LLM-emitted signal arrays
+    # Per-name web search at buy time (SerpAPI). Each candidate is enriched with
+    # a compact "recent developments" block the LLM uses for entry TIMING /
+    # near-term CATALYST / RISK — NOT to re-derive business quality (that's the
+    # shared research card's job). Auto-no-ops when SERPAPI_API_KEY is unset, so
+    # it's safe to leave on everywhere. Deduped per heartbeat run (module cache).
+    "news_search": True,
+    "news_queries": 1,              # SerpAPI queries per candidate (1 = cheapest)
+    "news_max_chars": 1500,         # truncation cap for the injected block
 }
 
 
@@ -164,6 +174,7 @@ Discipline:
 - Conviction 1-5 is only meaningful when verdict="BUY". For PASS, leave conviction=1.
 - Read the curator's rationale, but don't be anchored by it — the curator picks broadly; you decide whether this specific equity is right for THIS portfolio TODAY at THIS price.
 - Read the prior in-house BUY/BEAR verdicts and the research card as data points, not directives.
+- RECENT DEVELOPMENTS (a web-search snippet) may be provided. Use it for entry TIMING and near-term CATALYST / RISK — is now a good moment to add, or is there a fresh red flag? It does NOT override the research card's business-quality read; it's news headlines, so weigh it for what it is and don't over-trade on a single snippet.
 
 Thesis discipline (BUY only):
 - thesis_text: 2-4 sentences. WHAT you expect this equity to do (growth trajectory, margin path, valuation re-rating) and WHY.
@@ -199,6 +210,9 @@ PRIOR IN-HOUSE VERDICTS (from the screening pipeline — treat as data, not dire
 
 SHARED RESEARCH CARD (pre-computed business assessment — your starting point; decide mandate-fit + entry, don't re-derive these):
 {research_card}
+
+RECENT DEVELOPMENTS (web search — use for entry TIMING / near-term CATALYST / RISK, NOT to re-derive business quality):
+{recent_news}
 
 EQUITY DATA (extended-tier snapshot, today's universe):
 {equity_data_json}
@@ -366,6 +380,10 @@ def _evaluate_ticker(
     bull_eval = (equity_data.get("narrative") or {}).get("bull_eval") or "—"
     bear_eval = (equity_data.get("narrative") or {}).get("bear_eval") or "—"
     research = equity_data.get("research")
+    recent_news = equity_data.get("recent_news") or "(no recent web results)"
+    # The news already renders as its own readable block — keep it out of the
+    # equity-data JSON so it isn't injected twice.
+    equity_for_json = {k: v for k, v in equity_data.items() if k != "recent_news"}
 
     pc = _portfolio_context(portfolio)
     cash_pct = (pc["cash_usd"] / pc["total_value_usd"] * 100) if pc["total_value_usd"] else 0.0
@@ -381,7 +399,8 @@ def _evaluate_ticker(
         bull_eval=bull_eval,
         bear_eval=bear_eval,
         research_card=_format_research_card(research),
-        equity_data_json=json.dumps(equity_data, default=str, ensure_ascii=False),
+        recent_news=recent_news,
+        equity_data_json=json.dumps(equity_for_json, default=str, ensure_ascii=False),
     )
 
     try:
@@ -585,6 +604,70 @@ def build_candidate_data(
         for t in candidates
         if t in fact_rows
     }
+
+
+# Process-level cache so a ticker searched for one portfolio/buyer is reused by
+# every other portfolio/buyer in the SAME heartbeat run. Each heartbeat is a
+# fresh process, so the cache lives for exactly one run — no stale-news risk.
+_NEWS_RUN_CACHE: dict[str, str] = {}
+
+
+def serpapi_key() -> str:
+    """SerpAPI key from the environment (matches update_ai_narratives.py)."""
+    return os.environ.get("SERPAPI_API_KEY", "") or os.environ.get("SERP_API_KEY", "")
+
+
+def attach_recent_news(
+    by_ticker_data: dict[str, dict],
+    *,
+    api_key: str,
+    concurrency: int = 5,
+    logger: logging.Logger = logger,
+    cache: dict[str, str] | None = None,
+    max_queries: int = 1,
+    max_chars: int = 1500,
+) -> int:
+    """Enrich each candidate's ``equity_data`` with a ``recent_news`` block, in place.
+
+    Per-name SerpAPI fetch at buy time, run in parallel. Deduped via ``cache``
+    (defaults to the process-level run cache) so a ticker is searched at most
+    once per heartbeat run across all portfolios/buyers. No-op (returns 0) when
+    ``api_key`` is falsy. Best-effort: a failed fetch leaves the ticker without
+    news rather than aborting the run.
+
+    Returns the number of live SerpAPI fetches performed (cache hits excluded).
+    """
+    if not api_key:
+        return 0
+    if cache is None:
+        cache = _NEWS_RUN_CACHE
+
+    to_fetch = [t for t in by_ticker_data if t not in cache]
+
+    def _fetch(t: str) -> tuple[str, str]:
+        try:
+            company = (by_ticker_data[t] or {}).get("company_name")
+            text = recent_developments(
+                company, t, api_key=api_key, logger=logger,
+                max_queries=max_queries, max_chars=max_chars,
+            )
+        except Exception as exc:  # defensive — search is never load-bearing
+            logger.warning("recent_developments failed for %s: %s", t, exc)
+            text = ""
+        return t, text
+
+    fetched = 0
+    if to_fetch:
+        with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+            for t, text in pool.map(_fetch, to_fetch):
+                cache[t] = text
+                fetched += 1
+
+    for t, data in by_ticker_data.items():
+        news = cache.get(t)
+        if news:
+            data["recent_news"] = news
+    return fetched
 
 
 def evaluate_candidates(
@@ -819,6 +902,22 @@ def rebalance_llm_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
     if not candidates:
         result.notes["reason"] = "no Level 0 facts for any candidate"
         return result
+
+    # Per-name web search at buy time — enrich each candidate with a compact
+    # "recent developments" block the LLM weighs for entry timing / catalysts /
+    # near-term risk. Auto-no-ops when SERPAPI_API_KEY is unset.
+    if params.get("news_search"):
+        key = serpapi_key()
+        if key:
+            news_fetched = attach_recent_news(
+                {t: by_ticker_data[t] for t in candidates},
+                api_key=key,
+                concurrency=int(params["concurrency"]),
+                logger=logger,
+                max_queries=int(params.get("news_queries", 1)),
+                max_chars=int(params.get("news_max_chars", 1500)),
+            )
+            result.notes["news_fetched"] = news_fetched
 
     evaluations, eval_notes = evaluate_candidates(
         provider=provider,

--- a/test_web_search.py
+++ b/test_web_search.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Unit tests for the per-name buy-time web search.
+
+Covers the shared `web_search.recent_developments` helper and the buyer's
+`llm_watchlist_buyer.attach_recent_news` enrichment (cache + no-op behaviour).
+SerpAPI is mocked — no network. Run: python test_web_search.py
+"""
+
+from __future__ import annotations
+
+import logging
+import unittest
+from unittest import mock
+
+import web_search
+import llm_watchlist_buyer as buyer
+
+LOG = logging.getLogger("test_web_search")
+
+
+class TestRecentDevelopments(unittest.TestCase):
+    def test_empty_key_is_noop(self):
+        # No API key → no search, returns "" (never raises).
+        with mock.patch.object(web_search, "serpapi_search") as m:
+            out = web_search.recent_developments("Foo Inc", "FOO", api_key="", logger=LOG)
+        self.assertEqual(out, "")
+        m.assert_not_called()
+
+    def test_single_query_by_default(self):
+        with mock.patch.object(web_search, "serpapi_search", return_value="- Headline: body") as m:
+            out = web_search.recent_developments("Foo Inc", "FOO", api_key="k", logger=LOG)
+        self.assertEqual(m.call_count, 1)
+        self.assertIn("Headline", out)
+
+    def test_two_queries_when_requested(self):
+        with mock.patch.object(web_search, "serpapi_search", return_value="- H: b") as m:
+            web_search.recent_developments(
+                "Foo Inc", "FOO", api_key="k", logger=LOG, max_queries=2,
+            )
+        self.assertEqual(m.call_count, 2)
+
+    def test_truncates_to_max_chars(self):
+        long = "x" * 5000
+        with mock.patch.object(web_search, "serpapi_search", return_value=long):
+            out = web_search.recent_developments(
+                "Foo Inc", "FOO", api_key="k", logger=LOG, max_chars=100,
+            )
+        self.assertLessEqual(len(out), 100)
+
+
+class TestAttachRecentNews(unittest.TestCase):
+    def setUp(self):
+        self.data = {
+            "AAA": {"ticker": "AAA", "company_name": "Alpha"},
+            "BBB": {"ticker": "BBB", "company_name": "Beta"},
+        }
+
+    def test_noop_without_key(self):
+        n = buyer.attach_recent_news(self.data, api_key="", cache={})
+        self.assertEqual(n, 0)
+        self.assertNotIn("recent_news", self.data["AAA"])
+
+    def test_populates_recent_news(self):
+        with mock.patch.object(
+            buyer, "recent_developments", return_value="news for it"
+        ):
+            n = buyer.attach_recent_news(
+                self.data, api_key="k", cache={}, concurrency=2,
+            )
+        self.assertEqual(n, 2)
+        self.assertEqual(self.data["AAA"]["recent_news"], "news for it")
+        self.assertEqual(self.data["BBB"]["recent_news"], "news for it")
+
+    def test_cache_dedupes_across_calls(self):
+        cache: dict[str, str] = {}
+        with mock.patch.object(
+            buyer, "recent_developments", return_value="cached"
+        ) as m:
+            buyer.attach_recent_news(self.data, api_key="k", cache=cache)
+            self.assertEqual(m.call_count, 2)
+            # Second call over the same tickers hits the cache — no new fetches.
+            again = {"AAA": {"ticker": "AAA", "company_name": "Alpha"}}
+            fetched = buyer.attach_recent_news(again, api_key="k", cache=cache)
+        self.assertEqual(fetched, 0)
+        self.assertEqual(again["AAA"]["recent_news"], "cached")
+
+    def test_empty_news_not_attached(self):
+        # A name with no results stays without a recent_news key (so the prompt
+        # default "(no recent web results)" shows instead of an empty string).
+        with mock.patch.object(buyer, "recent_developments", return_value=""):
+            buyer.attach_recent_news(self.data, api_key="k", cache={})
+        self.assertNotIn("recent_news", self.data["AAA"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update_ai_narratives.py
+++ b/update_ai_narratives.py
@@ -12,16 +12,15 @@ import json
 import logging
 import os
 import sys
-import re
 import time
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
-import requests
 from dateutil import parser as dateparser
 from dotenv import load_dotenv
 
 from db import SupabaseDB
+from web_search import gather_web_context
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -32,7 +31,6 @@ STALENESS_DAYS = 90
 # names each run so the first pass over the ~3k universe doesn't fire thousands
 # of LLM calls at once — keeps daily cost flat, never-narrated names go first.
 TIER1_NARRATIVE_BATCH = 100
-SERPAPI_ENDPOINT = "https://serpapi.com/search"
 GEMINI_MODEL = "gemini-2.5-flash"
 DELAY_BETWEEN_CALLS = 2  # seconds between tickers
 RETRY_DELAY = 10  # seconds between retries
@@ -91,126 +89,6 @@ def setup_logging() -> logging.Logger:
     logger.addHandler(sh)
 
     return logger
-
-
-# ---------------------------------------------------------------------------
-# SerpAPI web search
-# ---------------------------------------------------------------------------
-
-
-def serpapi_search(query: str, api_key: str, logger: logging.Logger) -> str:
-    """Run a SerpAPI Google search and return concatenated snippets."""
-    try:
-        resp = requests.get(
-            SERPAPI_ENDPOINT,
-            params={"q": query, "api_key": api_key, "num": 5, "engine": "google"},
-            timeout=15,
-        )
-        resp.raise_for_status()
-        data = resp.json()
-    except Exception as exc:
-        logger.warning("SerpAPI search failed for query '%s': %s", query, exc)
-        return ""
-
-    organic = data.get("organic_results", [])
-    snippets = []
-    total_chars = 0
-    for result in organic[:5]:
-        snippet = result.get("snippet", "")
-        title = result.get("title", "")
-        entry = f"- {title}: {snippet}"
-        if total_chars + len(entry) > 2000:
-            break
-        snippets.append(entry)
-        total_chars += len(entry)
-
-    return "\n".join(snippets)
-
-
-# Map terse flag keywords to natural-language search terms
-_EVENT_TYPE_MAP = {
-    "margin swing":   "one-time charge margin impact",
-    "other inc/exp":  "other income expense non-recurring charge",
-    "write-down":     "write-down impairment",
-    "restructuring":  "restructuring charge",
-    "settlement":     "legal settlement",
-    "acquisition":    "acquisition one-time cost",
-    "divestiture":    "divestiture asset sale",
-    "goodwill":       "goodwill impairment write-off",
-    "tax":            "one-time tax benefit charge",
-    "ipo":            "IPO related expenses",
-    "sbc":            "stock-based compensation charge",
-}
-
-# Quarter mapping from month numbers
-_MONTH_TO_QUARTER = {
-    "01": "Q1", "02": "Q1", "03": "Q1",
-    "04": "Q2", "05": "Q2", "06": "Q2",
-    "07": "Q3", "08": "Q3", "09": "Q3",
-    "10": "Q4", "11": "Q4", "12": "Q4",
-}
-
-
-def _build_event_search_query(company: str, ticker: str, event_text: str) -> str:
-    """Turn terse analyst flag text into a useful Google search query.
-
-    Flags look like: '\u2b07 margin swing -22pp vs norm (2025-09)'
-    We want: 'Celsius Holdings CELH one-time charge margin impact Q3 2025'
-    """
-    # Extract date if present -- formats like (2025-09) or (2024-12)
-    date_match = re.search(r"\((\d{4})-(\d{2})\)", event_text)
-    quarter_str = ""
-    if date_match:
-        year = date_match.group(1)
-        month = date_match.group(2)
-        quarter_str = f"{_MONTH_TO_QUARTER.get(month, '')} {year}"
-
-    # Find matching event type from our map
-    event_lower = event_text.lower()
-    search_terms = "one-time non-recurring charge"  # default
-    for key, val in _EVENT_TYPE_MAP.items():
-        if key in event_lower:
-            search_terms = val
-            break
-
-    return f"{company} {ticker} {search_terms} {quarter_str}".strip()
-
-
-def gather_web_context(
-    company: str, ticker: str, api_key: str, logger: logging.Logger,
-    one_time_event: str = "",
-) -> str:
-    """Run SerpAPI searches and merge results.
-
-    When a one_time_event flag is provided, runs an additional targeted search
-    to find context about the specific event (write-down, settlement, etc.).
-    """
-    current_year = date.today().year
-    prev_year = current_year - 1
-
-    q1 = f"{company} {ticker} earnings results {prev_year} {current_year}"
-    q2 = f"{company} {ticker} outlook forecast analyst {current_year}"
-
-    s1 = serpapi_search(q1, api_key, logger)
-    time.sleep(1)
-    s2 = serpapi_search(q2, api_key, logger)
-
-    parts = []
-    if s1:
-        parts.append(f"EARNINGS SEARCH:\n{s1}")
-    if s2:
-        parts.append(f"OUTLOOK SEARCH:\n{s2}")
-
-    # Targeted search for the one-time event to give the model real context
-    if one_time_event:
-        q3 = _build_event_search_query(company, ticker, one_time_event)
-        time.sleep(1)
-        s3 = serpapi_search(q3, api_key, logger)
-        if s3:
-            parts.append(f"ONE-TIME EVENT SEARCH:\n{s3}")
-            logger.info("  Found web context for one-time event on %s", ticker)
-
-    return "\n\n".join(parts)
 
 
 # ---------------------------------------------------------------------------

--- a/web_search.py
+++ b/web_search.py
@@ -1,0 +1,186 @@
+"""Shared SerpAPI web-search helpers.
+
+Single home for the SerpAPI Google-search logic so it isn't duplicated across
+scripts (coding convention: shared logic lives in a module). Two consumers:
+
+- `update_ai_narratives.py` — narrative enrichment (earnings/outlook/one-time
+  event context) via `gather_web_context`.
+- `llm_watchlist_buyer.py` — per-name "recent developments" fed to the buyer's
+  BUY/PASS evaluation at buy time, via `recent_developments`.
+
+Env var: `SERPAPI_API_KEY`. Every helper is best-effort — it returns an empty
+string on any failure or when no API key is supplied, and never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from datetime import date
+
+import requests
+
+SERPAPI_ENDPOINT = "https://serpapi.com/search"
+
+
+def serpapi_search(query: str, api_key: str, logger: logging.Logger) -> str:
+    """Run a SerpAPI Google search and return concatenated snippets."""
+    try:
+        resp = requests.get(
+            SERPAPI_ENDPOINT,
+            params={"q": query, "api_key": api_key, "num": 5, "engine": "google"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        logger.warning("SerpAPI search failed for query '%s': %s", query, exc)
+        return ""
+
+    organic = data.get("organic_results", [])
+    snippets = []
+    total_chars = 0
+    for result in organic[:5]:
+        snippet = result.get("snippet", "")
+        title = result.get("title", "")
+        entry = f"- {title}: {snippet}"
+        if total_chars + len(entry) > 2000:
+            break
+        snippets.append(entry)
+        total_chars += len(entry)
+
+    return "\n".join(snippets)
+
+
+# Map terse flag keywords to natural-language search terms
+_EVENT_TYPE_MAP = {
+    "margin swing":   "one-time charge margin impact",
+    "other inc/exp":  "other income expense non-recurring charge",
+    "write-down":     "write-down impairment",
+    "restructuring":  "restructuring charge",
+    "settlement":     "legal settlement",
+    "acquisition":    "acquisition one-time cost",
+    "divestiture":    "divestiture asset sale",
+    "goodwill":       "goodwill impairment write-off",
+    "tax":            "one-time tax benefit charge",
+    "ipo":            "IPO related expenses",
+    "sbc":            "stock-based compensation charge",
+}
+
+# Quarter mapping from month numbers
+_MONTH_TO_QUARTER = {
+    "01": "Q1", "02": "Q1", "03": "Q1",
+    "04": "Q2", "05": "Q2", "06": "Q2",
+    "07": "Q3", "08": "Q3", "09": "Q3",
+    "10": "Q4", "11": "Q4", "12": "Q4",
+}
+
+
+def _build_event_search_query(company: str, ticker: str, event_text: str) -> str:
+    """Turn terse analyst flag text into a useful Google search query.
+
+    Flags look like: '⬇ margin swing -22pp vs norm (2025-09)'
+    We want: 'Celsius Holdings CELH one-time charge margin impact Q3 2025'
+    """
+    # Extract date if present -- formats like (2025-09) or (2024-12)
+    date_match = re.search(r"\((\d{4})-(\d{2})\)", event_text)
+    quarter_str = ""
+    if date_match:
+        year = date_match.group(1)
+        month = date_match.group(2)
+        quarter_str = f"{_MONTH_TO_QUARTER.get(month, '')} {year}"
+
+    # Find matching event type from our map
+    event_lower = event_text.lower()
+    search_terms = "one-time non-recurring charge"  # default
+    for key, val in _EVENT_TYPE_MAP.items():
+        if key in event_lower:
+            search_terms = val
+            break
+
+    return f"{company} {ticker} {search_terms} {quarter_str}".strip()
+
+
+def gather_web_context(
+    company: str, ticker: str, api_key: str, logger: logging.Logger,
+    one_time_event: str = "",
+) -> str:
+    """Run SerpAPI searches and merge results (narrative enrichment).
+
+    When a one_time_event flag is provided, runs an additional targeted search
+    to find context about the specific event (write-down, settlement, etc.).
+    """
+    current_year = date.today().year
+    prev_year = current_year - 1
+
+    q1 = f"{company} {ticker} earnings results {prev_year} {current_year}"
+    q2 = f"{company} {ticker} outlook forecast analyst {current_year}"
+
+    s1 = serpapi_search(q1, api_key, logger)
+    time.sleep(1)
+    s2 = serpapi_search(q2, api_key, logger)
+
+    parts = []
+    if s1:
+        parts.append(f"EARNINGS SEARCH:\n{s1}")
+    if s2:
+        parts.append(f"OUTLOOK SEARCH:\n{s2}")
+
+    # Targeted search for the one-time event to give the model real context
+    if one_time_event:
+        q3 = _build_event_search_query(company, ticker, one_time_event)
+        time.sleep(1)
+        s3 = serpapi_search(q3, api_key, logger)
+        if s3:
+            parts.append(f"ONE-TIME EVENT SEARCH:\n{s3}")
+            logger.info("  Found web context for one-time event on %s", ticker)
+
+    return "\n\n".join(parts)
+
+
+def recent_developments(
+    company_name: str | None,
+    ticker: str,
+    *,
+    api_key: str,
+    logger: logging.Logger,
+    max_queries: int = 1,
+    max_chars: int = 1500,
+) -> str:
+    """Fetch a compact block of recent news / catalysts for one equity.
+
+    Buyer-focused counterpart to `gather_web_context`: it surfaces TIMING /
+    near-term CATALYST / RISK material for the per-name BUY evaluation, not a
+    full narrative. One query by default (cheapest); a second "earnings
+    guidance" query runs only when ``max_queries >= 2``.
+
+    Best-effort: returns "" when ``api_key`` is falsy or every search fails.
+    """
+    if not api_key:
+        return ""
+
+    name = (company_name or ticker).strip()
+    current_year = date.today().year
+
+    queries = [f"{name} {ticker} stock news catalyst {current_year}"]
+    if max_queries >= 2:
+        queries.append(f"{name} {ticker} earnings guidance outlook {current_year}")
+
+    parts: list[str] = []
+    total = 0
+    for i, q in enumerate(queries):
+        if i:
+            time.sleep(1)
+        snippet = serpapi_search(q, api_key, logger)
+        if not snippet:
+            continue
+        if total + len(snippet) > max_chars:
+            snippet = snippet[: max(0, max_chars - total)]
+        if snippet:
+            parts.append(snippet)
+            total += len(snippet)
+        if total >= max_chars:
+            break
+
+    return "\n".join(parts).strip()


### PR DESCRIPTION
## Summary

Extracts SerpAPI web-search logic into a shared `web_search.py` module and integrates live per-name "recent developments" fetches into the LLM buyer's candidate evaluation. Each candidate is enriched with a compact news block scoped to entry timing and near-term catalysts/risks—not business-quality re-derivation (that remains the research card's job). The feature is bounded, parallel, deduped via process-level cache, and auto-no-ops when `SERPAPI_API_KEY` is unset.

## Key Changes

- **New `web_search.py` module**: Consolidates SerpAPI helpers (`serpapi_search`, `gather_web_context`, `recent_developments`) and event-type mapping logic. Single home for web-search code shared by `update_ai_narratives.py` and `llm_watchlist_buyer.py`.

- **`llm_watchlist_buyer.py` enrichment**: 
  - New `attach_recent_news()` function enriches candidate data in-place with a `recent_news` field via parallel SerpAPI calls.
  - Process-level run cache (`_NEWS_RUN_CACHE`) dedupes across portfolios/buyers within a single heartbeat.
  - New `serpapi_key()` helper reads `SERPAPI_API_KEY` or `SERP_API_KEY` env vars (matches `update_ai_narratives.py`).
  - Config knobs in `LLM_WATCHLIST_BUYER_DEFAULTS`: `news_search` (enable/disable), `news_queries` (1 by default, cheapest), `news_max_chars` (1500 char cap).
  - Per-ticker prompt updated to include recent developments block with guidance that it's for timing/catalyst/risk, not business-quality re-derivation.

- **`agent_heartbeat.py` integration**: Calls `attach_recent_news()` once on the shared candidate map before buyer evaluation, so all co-briefed buyers read the same enriched data.

- **`update_ai_narratives.py` refactor**: Removes duplicate SerpAPI code; imports `gather_web_context` from `web_search.py`.

- **Test coverage**: New `test_web_search.py` with unit tests for `recent_developments` (no-op on empty key, query count, truncation) and `attach_recent_news` (cache deduping, parallel fetch, empty-news handling).

- **Documentation**: Updated `CLAUDE.md` to describe the per-name web search feature, config knobs, and auto-no-op behavior.

## Implementation Details

- **Best-effort design**: All web-search helpers return empty strings on failure and never raise, so a failed SerpAPI call doesn't abort the run.
- **Deduping**: A ticker searched for one portfolio is cached and reused by every other portfolio in the same heartbeat run. Each heartbeat is a fresh process, so no stale-news risk.
- **Parallel fetch**: Uses `ThreadPoolExecutor` with configurable concurrency (defaults to buyer's `concurrency` setting).
- **Prompt integration**: Recent news is injected as a separate block in the per-ticker prompt, with explicit guidance to use it for entry timing and near-term risk, not to re-derive business quality.
- **Mechanical buyer untouched**: The `watchlist_buyer` (non-LLM) is unaffected; only the LLM buyer gets news enrichment.

https://claude.ai/code/session_01J9VKKoduXHPKuh2ih8R4vR