### PR TITLE
Compact team card meta line: merge powered-by and schedule

### DIFF
--- a/web/components/portfolio/team-builder.tsx
+++ b/web/components/portfolio/team-builder.tsx
@@ -515,7 +515,7 @@ function TeamCard({
   }
 
   return (
-    <li className="px-4 py-4">
+    <li className="px-4 py-2.5">
       <div className="flex items-start gap-3">
         {/* Action dot — static identity colour; pulses only during a run. */}
         <span
@@ -536,12 +536,34 @@ function TeamCard({
               </span>
             )}
           </div>
-          {agent.poweredBy && (
-            <p className="text-[11px] font-mono text-text-muted mt-0.5">
-              powered by {agent.poweredBy}
-            </p>
+          {/* One compact meta line: powered-by · next-run (merges the old
+              "powered by" line and the separate footer schedule line). */}
+          {!editing && (
+            <div className="mt-0.5 flex items-center gap-1.5 flex-wrap text-[11px] font-mono text-text-muted">
+              {running && (
+                <span
+                  aria-hidden
+                  className="h-1.5 w-1.5 rounded-full animate-pulse"
+                  style={{ background: meta.color }}
+                />
+              )}
+              {agent.poweredBy && <span>{agent.poweredBy}</span>}
+              {agent.poweredBy && <span aria-hidden>·</span>}
+              <span>
+                {running
+                  ? "Running now…"
+                  : scheduleText(
+                      agent.lastRunAt,
+                      agent.heartbeatIntervalHours,
+                      now,
+                    )}
+              </span>
+            </div>
           )}
-          <p className="text-sm text-text-dim mt-1.5 leading-relaxed">
+          <p
+            className="text-xs text-text-dim mt-1 leading-snug line-clamp-1"
+            title={fillSentence(agent, agent.params)}
+          >
             {fillSentence(agent, agent.params)}
           </p>
           {agent.action === "sell" && agent.triggers.length > 0 && (
@@ -643,23 +665,7 @@ function TeamCard({
         )}
       </div>
 
-      {/* Schedule line — the agent's resting state, or "Running now…". */}
-      {!editing && (
-        <div className="mt-3 pl-5 flex items-center gap-2">
-          {running && (
-            <span
-              aria-hidden
-              className="h-1.5 w-1.5 rounded-full animate-pulse"
-              style={{ background: meta.color }}
-            />
-          )}
-          <span className="text-[11px] font-mono text-text-muted">
-            {running
-              ? "Running now…"
-              : scheduleText(agent.lastRunAt, agent.heartbeatIntervalHours, now)}
-          </span>
-        </div>
-      )}
+      {/* Schedule now lives inline in the meta line above (compact). */}
       {runError && (
         <p className="mt-2 pl-5 text-[11px] font-mono text-[var(--color-red)]">
           {runError}


### PR DESCRIPTION
## Summary
Refactors the TeamCard component to consolidate the "powered by" attribution and schedule information into a single compact meta line, reducing visual clutter and improving space efficiency.

## Key Changes
- **Reduced vertical padding** on team card list items from `py-4` to `py-2.5` to accommodate the more compact layout
- **Merged meta information** into one inline flex row that combines:
  - Running pulse indicator (when agent is actively running)
  - "Powered by" attribution (if present)
  - Separator dot (when both powered-by and schedule are shown)
  - Schedule text ("Running now…" or next run time based on heartbeat interval)
- **Removed separate footer schedule line** that previously appeared below the description, eliminating redundant spacing
- **Improved description styling**:
  - Reduced font size from `text-sm` to `text-xs`
  - Changed line-height from `leading-relaxed` to `leading-snug`
  - Added `line-clamp-1` to prevent wrapping
  - Added `title` attribute for full text on hover
  - Reduced top margin from `mt-1.5` to `mt-1`
- **Conditional rendering**: Meta line only displays when not in editing mode, keeping the edit interface clean

## Implementation Details
The new meta line uses flexbox with `flex-wrap` to allow graceful wrapping on narrow viewports while maintaining the compact single-line appearance on standard widths. The pulse indicator, powered-by text, and schedule information are now visually grouped together with consistent typography (`text-[11px] font-mono text-text-muted`), creating a unified metadata presentation.

https://claude.ai/code/session_01MMNQ9XrsgmEjvVSoDoJtmj