### PR TITLE
Screener/portfolio UI density: P/S sparkline x-axis labels + tighter summary cards

### DIFF
--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -289,7 +289,7 @@ export default async function PortfolioPage({ params }: PageParams) {
           {/* SUMMARY — paper value, unrealized P&L, holdings, team (brief §5).
               Honest: no invented alpha. */}
           {snapshot && (
-            <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-10 sm:mb-12">
+            <section className="grid grid-cols-2 lg:grid-cols-4 gap-2.5 mb-6 sm:mb-8">
               <PaperValueCard
                 total={totalValue}
                 equity={equityValue}
@@ -431,11 +431,11 @@ function SummaryCard({
         ? "text-[var(--color-red)]"
         : "text-text";
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.02] px-4 py-3.5">
+    <div className="rounded-xl border border-white/10 bg-white/[0.02] px-3.5 py-2.5">
       <p className="text-[10px] font-mono uppercase tracking-[0.14em] text-text-muted">
         {label}
       </p>
-      <p className={`font-mono text-xl sm:text-2xl font-bold tabular-nums ${color} mt-1`}>
+      <p className={`font-mono text-lg sm:text-xl font-bold tabular-nums ${color} mt-0.5`}>
         {value}
       </p>
       {sub && (
@@ -462,15 +462,15 @@ function PaperValueCard({
 }) {
   const pct = Math.max(0, Math.min(100, equityPct));
   return (
-    <div className="rounded-2xl border border-white/10 bg-white/[0.02] px-4 py-3.5">
+    <div className="rounded-xl border border-white/10 bg-white/[0.02] px-3.5 py-2.5">
       <p className="text-[10px] font-mono uppercase tracking-[0.14em] text-text-muted">
         Paper value
       </p>
-      <p className="font-mono text-xl sm:text-2xl font-bold tabular-nums text-text mt-1">
+      <p className="font-mono text-lg sm:text-xl font-bold tabular-nums text-text mt-0.5">
         {formatUsd(total)}
       </p>
       <div
-        className="mt-2.5 h-1.5 w-full rounded-full bg-white/10 overflow-hidden"
+        className="mt-2 h-1.5 w-full rounded-full bg-white/10 overflow-hidden"
         role="img"
         aria-label={`${pct.toFixed(0)}% invested in equities, the rest in cash`}
       >

--- a/web/components/screen-sparkline.tsx
+++ b/web/components/screen-sparkline.tsx
@@ -55,6 +55,12 @@ export default function ScreenSparkline({
 
   const last = points[n - 1];
   const current = last.ps;
+  const fmtDate = (d: string) => {
+    const dt = new Date(d);
+    return Number.isNaN(dt.getTime())
+      ? d
+      : dt.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+  };
   const pctVs = (median: number | null) =>
     median != null && median > 0 ? (current / median - 1) * 100 : null;
   const ownPct = pctVs(ownMedian);
@@ -98,6 +104,11 @@ export default function ScreenSparkline({
         <polyline points={poly} fill="none" stroke="var(--color-cyan)" strokeWidth="1.6" />
         <circle cx={x(n - 1)} cy={y(current)} r="2.6" fill="var(--color-cyan)" />
       </svg>
+
+      <div className="flex justify-between mt-0.5 font-mono text-[9px] text-text-muted">
+        <span>{fmtDate(points[0].date)}</span>
+        <span>{fmtDate(last.date)}</span>
+      </div>
 
       <div className="flex gap-3.5 mt-1.5 font-mono text-[10px] text-text-muted">
         <span className="inline-flex items-center gap-1.5">


### PR DESCRIPTION
## Summary

Two small, display-only UI improvements on top of the now-merged buyer web-search work (#1686). Both are additive/CSS-level — no data, query, or behavior changes.

## Changes

- **P/S sparkline x-axis labels** (`web/components/screen-sparkline.tsx`) — the screener row-expand P/S sparkline drew its line with no x-axis at all, so the time span was unreadable (points are spaced by sample index, oldest→newest, and the series isn't trimmed to a fixed window). Added a small endpoint-date row under the chart showing the first and last **actual sample dates** (month + year), so the viewer can read the window directly. Honest by construction: a name with little history shows two close-together dates rather than a hard-coded "12 mo". No change to point spacing, windowing, data fetching, or the median reference lines.

- **Tighter portfolio summary cards** (`web/app/portfolios/[slug]/page.tsx`) — the summary strip (Paper value / Unrealized P&L / Holdings / Team) used a 3-column desktop grid, so the four cards wrapped to two rows (3 + a lonely Team card) with a large bottom margin. Now fits all four on one row at `lg` (`grid-cols-4`), drops mobile to 2-up, and trims card padding, value font size, and the section margin for a denser header. Live portfolios (3 cards, no Team) still render a single compact row.

## Verification

- `npx tsc --noEmit` passes clean (0 errors) across the web project.
- No visual/dev-server check was run in CI here; both changes are CSS/markup-level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9VKKoduXHPKuh2ih8R4vR

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9VKKoduXHPKuh2ih8R4vR)_