### PR TITLE
Add activity timeline drawer to screener & portfolio pages

### DIFF
--- a/web/app/api/portfolios/[slug]/activity/route.ts
+++ b/web/app/api/portfolios/[slug]/activity/route.ts
@@ -1,0 +1,73 @@
+/**
+ * GET /api/portfolios/<slug>/activity
+ *
+ * The portfolio "Activity" drawer feed: what the portfolio's team actually did
+ * — every agent run (including deliberate no-ops), the fills, and (owner-only)
+ * the names a buyer passed on. Resolves the slug, applies the same visibility
+ * gate as the detail page (public OR the viewer's own), and only includes the
+ * private rejection list for the owner.
+ *
+ * Caching mirrors `/api/screen/holdings`: a non-owner view of a public
+ * portfolio is cacheable; the owner view (which carries the private pass list)
+ * is `private, no-store`.
+ */
+
+import { errorResponse, jsonResponse } from "@/lib/api-utils";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { getPortfolioBySlug } from "@/lib/portfolios-query";
+import { getPortfolioActivity } from "@/lib/activity-query";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  try {
+    const { slug: rawSlug } = await params;
+    const slug = decodeURIComponent(rawSlug).toLowerCase();
+
+    const portfolio = await getPortfolioBySlug(slug);
+    if (!portfolio) return jsonResponse({ events: [] }, noStore());
+
+    // Resolve the viewer once — used for both the private-portfolio gate and
+    // the owner-only rejection list.
+    let userId: string | null = null;
+    try {
+      const supa = await createSupabaseServerClient();
+      const {
+        data: { user },
+      } = await supa.auth.getUser();
+      userId = user?.id ?? null;
+    } catch {
+      userId = null;
+    }
+    const isOwner = !!userId && portfolio.owner_user_id === userId;
+
+    // Visibility gate (migration 024): a private portfolio is owner-only.
+    if (!portfolio.is_public && !isOwner) {
+      return jsonResponse({ events: [] }, noStore());
+    }
+
+    const events = await getPortfolioActivity(
+      portfolio.id,
+      portfolio.owner_agent_id ?? null,
+      { includeRejections: isOwner },
+    );
+
+    // The owner view carries the private pass list, so it must never be cached
+    // at the edge; a public, non-owner view is safe to cache.
+    const cache = isOwner
+      ? noStore()
+      : { headers: { "Cache-Control": "public, s-maxage=120, stale-while-revalidate=300" } };
+    return jsonResponse({ events }, cache);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 400);
+  }
+}
+
+function noStore() {
+  return { headers: { "Cache-Control": "private, no-store" } };
+}

--- a/web/app/api/screen/activity/route.ts
+++ b/web/app/api/screen/activity/route.ts
@@ -1,0 +1,27 @@
+/**
+ * GET /api/screen/activity
+ *
+ * The screener's "Activity" drawer feed: a timeline of the background data
+ * refreshes that shape the ranked table (prices, P/S, research cards, AI
+ * signals, universe membership). Universe-wide and identical for every viewer,
+ * so it's publicly cacheable. Fetched client-side after the ISR page paints.
+ */
+
+import { errorResponse, jsonResponse } from "@/lib/api-utils";
+import { getScreenerActivity } from "@/lib/activity-query";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  try {
+    const events = await getScreenerActivity();
+    return jsonResponse(
+      { events },
+      { headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=600" } },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return errorResponse(message, 400);
+  }
+}

--- a/web/app/portfolios/[slug]/page.tsx
+++ b/web/app/portfolios/[slug]/page.tsx
@@ -10,6 +10,7 @@ import SyncLiveButton from "@/components/portfolio/sync-live-button";
 import TeamBuilder from "@/components/portfolio/team-builder";
 import TeamScheduleNote from "@/components/portfolio/team-schedule-note";
 import BetaDisclaimer from "@/components/beta-disclaimer";
+import ActivityDrawer from "@/components/activity-drawer";
 import {
   getPortfolio,
   getPortfolioByPortfolioId,
@@ -250,6 +251,16 @@ export default async function PortfolioPage({ params }: PageParams) {
               </span>
             </div>
             <div className="mt-3 flex flex-wrap items-center gap-3">
+              {/* Activity log (clickthrough drawer) — visible to anyone viewing
+                  the portfolio, so the work the team does in the background is
+                  legible even on the quiet days when nothing changed. */}
+              <ActivityDrawer
+                label="Activity"
+                title="Portfolio activity"
+                subtitle="What your team did and when — including the runs where it decided to hold."
+                endpoint={`/api/portfolios/${portfolio.slug}/activity`}
+                storageKey={`alphamolt:activity:portfolio:${portfolio.id}`}
+              />
               {/* A live portfolio is a private follower of the paper book — it
                   is always private (never publishable) and has no team of its
                   own, so it shows neither the public toggle nor team controls. */}

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -12,6 +12,7 @@ import { listActiveExclusions } from "@/lib/screen/exclusions-query";
 import { getSupabase } from "@/lib/supabase";
 import { screenConfigSchema, type ScreenConfig } from "@/lib/screen/config";
 import ScreenerClient from "@/app/screener/screener-client";
+import ActivityDrawer from "@/components/activity-drawer";
 
 // Re-rank is live client-side; the SSR paint is cached for crawlers + first
 // load. 300s matches the intraday price cadence.
@@ -152,11 +153,23 @@ export default async function ScreenerPage({
               All US-listed equities (incl. ADRs), ranked by a composite you
               control · a research tool, not a recommendation.
             </p>
-            {initial.data_asof && (
-              <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.12em] text-text-muted">
-                Last refreshed {formatAsOf(initial.data_asof)}
-              </p>
-            )}
+            <div className="mt-1.5 flex flex-wrap items-center gap-3">
+              {initial.data_asof && (
+                <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-text-muted">
+                  Last refreshed {formatAsOf(initial.data_asof)}
+                </p>
+              )}
+              {/* Activity log (clickthrough drawer) — the background data
+                  refreshes that shape these rankings, so the screen's freshness
+                  is legible, not just asserted. */}
+              <ActivityDrawer
+                label="Activity log"
+                title="Screener activity"
+                subtitle="Background data refreshes that shape these rankings."
+                endpoint="/api/screen/activity"
+                storageKey="alphamolt:activity:screener"
+              />
+            </div>
           </header>
 
           <ScreenerClient

--- a/web/components/activity-drawer.tsx
+++ b/web/components/activity-drawer.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ActivityEvent } from "@/lib/activity-query";
+
+/**
+ * The "Activity" slide-over (faith-in-the-system brief). A trigger button +
+ * a right-hand drawer that lists what happened when — reused by both the
+ * screener (pipeline refreshes) and the portfolio (team decisions + fills).
+ *
+ * It fetches its feed from `endpoint` once on mount (cheap, after paint, so
+ * the ISR-cached SSR page is untouched) and tracks a "new since you last
+ * looked" count in localStorage keyed by `storageKey`: the newest event's
+ * timestamp the viewer has already seen. Opening the drawer marks everything
+ * as seen.
+ */
+export default function ActivityDrawer({
+  label,
+  title,
+  subtitle,
+  endpoint,
+  storageKey,
+}: {
+  /** Trigger button text. */
+  label: string;
+  /** Drawer heading. */
+  title: string;
+  /** Optional one-line explainer under the heading. */
+  subtitle?: string;
+  /** API route returning `{ events: ActivityEvent[] }`. */
+  endpoint: string;
+  /** localStorage key holding the newest-seen ISO timestamp. */
+  storageKey: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [events, setEvents] = useState<ActivityEvent[] | null>(null);
+  const [error, setError] = useState(false);
+  const [newCount, setNewCount] = useState(0);
+  const fetched = useRef(false);
+
+  // Fetch once on mount and compute the "new" badge against the last-seen mark.
+  useEffect(() => {
+    if (fetched.current) return;
+    fetched.current = true;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(endpoint, { cache: "no-store" });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const json = (await res.json()) as { events?: ActivityEvent[] };
+        if (cancelled) return;
+        const list = json.events ?? [];
+        setEvents(list);
+        const newest = list[0]?.at ?? null;
+        const seen = readSeen(storageKey);
+        if (seen == null) {
+          // First ever visit: establish a silent baseline so we don't flag the
+          // entire backlog as "new".
+          if (newest) writeSeen(storageKey, newest);
+          setNewCount(0);
+        } else {
+          setNewCount(
+            list.filter((e) => Date.parse(e.at) > Date.parse(seen)).length,
+          );
+        }
+      } catch {
+        if (!cancelled) setError(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [endpoint, storageKey]);
+
+  const markSeen = useCallback(() => {
+    const newest = events?.[0]?.at;
+    if (newest) writeSeen(storageKey, newest);
+    setNewCount(0);
+  }, [events, storageKey]);
+
+  const openDrawer = useCallback(() => {
+    setOpen(true);
+    markSeen();
+  }, [markSeen]);
+
+  // Esc to close + lock body scroll while the drawer is open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openDrawer}
+        className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.03] px-2.5 py-1 text-[11px] font-mono uppercase tracking-[0.12em] text-text-muted hover:text-text hover:border-white/20 transition-colors"
+        title="See what's happened in the background"
+      >
+        <ClockGlyph />
+        {label}
+        {newCount > 0 && (
+          <span
+            className="ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--color-cyan)] px-1 text-[10px] font-bold text-black"
+            aria-label={`${newCount} new`}
+          >
+            {newCount > 99 ? "99+" : newCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50" role="dialog" aria-modal="true" aria-label={title}>
+          {/* Backdrop */}
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-[2px] animate-[fadeIn_120ms_ease-out]"
+            onClick={() => setOpen(false)}
+          />
+          {/* Panel */}
+          <div className="absolute right-0 top-0 h-full w-full max-w-md bg-[#0b0d10] border-l border-white/10 shadow-2xl flex flex-col animate-[slideIn_160ms_ease-out]">
+            <header className="flex items-start justify-between gap-3 px-5 py-4 border-b border-white/10">
+              <div>
+                <h2 className="text-[13px] font-mono font-bold uppercase tracking-[0.14em] text-text">
+                  {title}
+                </h2>
+                {subtitle && (
+                  <p className="mt-1 text-[11px] font-mono text-text-muted leading-relaxed">
+                    {subtitle}
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close"
+                className="shrink-0 rounded-md p-1 text-text-muted hover:text-text hover:bg-white/10 transition-colors"
+              >
+                <CloseGlyph />
+              </button>
+            </header>
+
+            <div className="flex-1 overflow-y-auto">
+              {error ? (
+                <p className="px-5 py-6 text-sm text-text-muted">
+                  Couldn&apos;t load activity right now.
+                </p>
+              ) : events == null ? (
+                <p className="px-5 py-6 text-sm text-text-muted">Loading…</p>
+              ) : events.length === 0 ? (
+                <p className="px-5 py-6 text-sm text-text-muted">
+                  No activity recorded yet — background jobs run on a daily and
+                  weekly cadence, so check back soon.
+                </p>
+              ) : (
+                <ul className="divide-y divide-white/[0.06]">
+                  {events.map((e) => (
+                    <EventRow key={e.id} event={e} />
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <style>{keyframes}</style>
+    </>
+  );
+}
+
+function EventRow({ event }: { event: ActivityEvent }) {
+  const stripe = toneColor(event.tone);
+  return (
+    <li className="pl-4 pr-5 py-3 flex flex-col gap-1" style={{ borderLeft: `3px solid ${stripe}` }}>
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span
+          className="rounded px-1.5 py-0.5 text-[9px] font-mono font-bold uppercase tracking-[0.1em]"
+          style={{ color: stripe, backgroundColor: `${stripe}1a` }}
+        >
+          {event.tag}
+        </span>
+        <span className="text-sm font-semibold text-text">{event.title}</span>
+        <span className="ml-auto text-[11px] font-mono text-text-muted whitespace-nowrap">
+          {formatRelative(event.at)}
+        </span>
+      </div>
+      {event.detail && (
+        <p className="text-xs text-text-muted leading-relaxed">{event.detail}</p>
+      )}
+    </li>
+  );
+}
+
+function toneColor(tone: ActivityEvent["tone"]): string {
+  switch (tone) {
+    case "positive":
+      return "var(--color-green)";
+    case "negative":
+      return "var(--color-red)";
+    case "info":
+      return "var(--color-cyan)";
+    default:
+      return "rgba(255,255,255,0.28)";
+  }
+}
+
+function readSeen(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeSeen(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    /* ignore */
+  }
+}
+
+function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return "—";
+  const diffMs = Date.now() - t;
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (days >= 1) return `${days}d ago`;
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  if (hours >= 1) return `${hours}h ago`;
+  const mins = Math.max(0, Math.floor(diffMs / (1000 * 60)));
+  return `${mins}m ago`;
+}
+
+const keyframes = `
+@keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
+@keyframes slideIn { from { transform: translateX(100%) } to { transform: translateX(0) } }
+`;
+
+function ClockGlyph() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2" />
+      <path d="M12 7v5l3 2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function CloseGlyph() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/web/lib/activity-query.ts
+++ b/web/lib/activity-query.ts
@@ -1,0 +1,334 @@
+/**
+ * Activity log — a read-only, unified timeline over the records the pipeline
+ * already writes, surfaced behind the "Activity" drawer on the screener and
+ * portfolio pages (faith-in-the-system brief). Nothing here writes; it merely
+ * re-shapes existing rows into a single `ActivityEvent[]` the client renders.
+ *
+ * Two sources, two questions:
+ *  - Portfolio: "what did my team do?" — `agent_heartbeats` (every real run,
+ *    including the deliberate no-ops — cadence skips are never journaled, so
+ *    each row is a genuine decision), `agent_trades` (the fills), and the
+ *    owner-only `screener_rejections` (names a buyer passed on).
+ *  - Screener: "what background data refreshes happened?" — `run_logs` for the
+ *    jobs that feed the screen (prices, P/S, research cards, AI signals,
+ *    universe membership).
+ *
+ * All reads use the service-role client; callers (API routes) are responsible
+ * for access-gating before returning portfolio events to a viewer.
+ */
+
+import { getSupabase } from "@/lib/supabase";
+
+/** One row in the activity timeline. The client renders this verbatim. */
+export interface ActivityEvent {
+  /** Stable key (table-prefixed row id) for React. */
+  id: string;
+  /** ISO timestamp the event happened at. */
+  at: string;
+  /** Short uppercase chip, e.g. "RAN" / "BUY" / "PASS" / "PRICES". */
+  tag: string;
+  /** Drives the left-stripe colour. */
+  tone: "positive" | "negative" | "neutral" | "info";
+  /** One-line summary. */
+  title: string;
+  /** Optional secondary line (the "roundup of what was decided"). */
+  detail?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Portfolio activity
+// ---------------------------------------------------------------------------
+
+interface HeartbeatRow {
+  id: number | string;
+  agent_id: string;
+  strategy: string;
+  status: string;
+  started_at: string;
+  trades_executed: number | null;
+  buys: number | null;
+  sells: number | null;
+  notes: Record<string, unknown> | null;
+  error_message: string | null;
+}
+
+interface TradeRow {
+  id: number | string;
+  agent_id: string;
+  ticker: string;
+  side: string;
+  quantity: number | string;
+  price_usd: number | string;
+  executed_at: string;
+  note: string | null;
+}
+
+interface RejectionRow {
+  ticker: string;
+  rejected_at: string;
+  rejected_by_agent_id: string | null;
+  verdict: string | null;
+  conviction: number | null;
+  reason: string | null;
+}
+
+/**
+ * Build the portfolio activity timeline. `ownerAgentId` is set for legacy 1:1
+ * agent portfolios (heartbeats keyed by agent_id); human portfolios filter
+ * heartbeats by the `notes.portfolio_id` stamp the heartbeat writes. Rejections
+ * are owner-only (a private portfolio's pass list), so the caller gates
+ * `includeRejections`.
+ */
+export async function getPortfolioActivity(
+  portfolioId: string,
+  ownerAgentId: string | null,
+  { includeRejections }: { includeRejections: boolean },
+  limit = 60,
+): Promise<ActivityEvent[]> {
+  const supabase = getSupabase();
+
+  let heartbeatQuery = supabase
+    .from("agent_heartbeats")
+    .select(
+      "id, agent_id, strategy, status, started_at, trades_executed, buys, sells, notes, error_message",
+    )
+    // Drop operator dry-run rows — they're not real decisions.
+    .neq("status", "dry-run")
+    .order("started_at", { ascending: false })
+    .limit(limit);
+  heartbeatQuery = ownerAgentId
+    ? heartbeatQuery.eq("agent_id", ownerAgentId)
+    : heartbeatQuery.filter("notes->>portfolio_id", "eq", portfolioId);
+
+  const [heartbeatsResp, tradesResp, rejectionsResp] = await Promise.all([
+    heartbeatQuery,
+    supabase
+      .from("agent_trades")
+      .select("id, agent_id, ticker, side, quantity, price_usd, executed_at, note")
+      .eq("portfolio_id", portfolioId)
+      .order("executed_at", { ascending: false })
+      .limit(limit),
+    includeRejections
+      ? supabase
+          .from("screener_rejections")
+          .select("ticker, rejected_at, rejected_by_agent_id, verdict, conviction, reason")
+          .eq("portfolio_id", portfolioId)
+          .eq("verdict", "PASS")
+          .order("rejected_at", { ascending: false })
+          .limit(limit)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  const heartbeats = (heartbeatsResp.data as HeartbeatRow[] | null) ?? [];
+  const trades = (tradesResp.data as TradeRow[] | null) ?? [];
+  const rejections = (rejectionsResp.data as RejectionRow[] | null) ?? [];
+
+  const agentNames = await loadAgentNames(
+    new Set<string>([
+      ...heartbeats.map((h) => h.agent_id),
+      ...trades.map((t) => t.agent_id),
+      ...rejections.map((r) => r.rejected_by_agent_id ?? "").filter(Boolean),
+    ]),
+  );
+
+  const events: ActivityEvent[] = [
+    ...heartbeats.map((h) => heartbeatEvent(h, agentNames)),
+    ...trades.map((t) => tradeEvent(t, agentNames)),
+    ...rejections.map((r) => rejectionEvent(r, agentNames)),
+  ];
+
+  return events
+    .sort((a, b) => Date.parse(b.at) - Date.parse(a.at))
+    .slice(0, limit);
+}
+
+async function loadAgentNames(ids: Set<string>): Promise<Map<string, string>> {
+  const list = [...ids].filter(Boolean);
+  if (list.length === 0) return new Map();
+  const { data } = await getSupabase()
+    .from("agents")
+    .select("id, display_name")
+    .in("id", list);
+  return new Map(
+    ((data as { id: string; display_name: string }[] | null) ?? []).map((a) => [
+      a.id,
+      a.display_name,
+    ]),
+  );
+}
+
+function heartbeatEvent(
+  h: HeartbeatRow,
+  names: Map<string, string>,
+): ActivityEvent {
+  const agent = names.get(h.agent_id) ?? "An agent";
+  const notes = h.notes ?? {};
+  const buys = h.buys ?? 0;
+  const sells = h.sells ?? 0;
+
+  if (h.status === "error") {
+    return {
+      id: `hb-${h.id}`,
+      at: h.started_at,
+      tag: "ERROR",
+      tone: "negative",
+      title: `${agent} hit an error`,
+      detail: truncate(h.error_message ?? noteString(notes, "reason") ?? "see logs", 220),
+    };
+  }
+
+  const parts: string[] = [];
+  const evaluated = numNote(notes, "phase1_evaluations");
+  if (evaluated != null) parts.push(`evaluated ${evaluated} candidate${evaluated === 1 ? "" : "s"}`);
+  const reviewed = numNote(notes, "positions_reviewed");
+  if (reviewed != null) parts.push(`reviewed ${reviewed} position${reviewed === 1 ? "" : "s"}`);
+  if (buys > 0) parts.push(`bought ${buys}`);
+  if (sells > 0) parts.push(`sold ${sells}`);
+  const rejected = numNote(notes, "screener_rejections_recorded");
+  if (rejected != null && rejected > 0) parts.push(`passed on ${rejected}`);
+  if (buys === 0 && sells === 0) {
+    const reason = noteString(notes, "reason");
+    parts.push(reason ? reason : "no changes — held the book");
+  }
+
+  return {
+    id: `hb-${h.id}`,
+    at: h.started_at,
+    tag: "RAN",
+    tone: buys > 0 ? "positive" : "neutral",
+    title: agent,
+    detail: parts.join(" · "),
+  };
+}
+
+function tradeEvent(t: TradeRow, names: Map<string, string>): ActivityEvent {
+  const isBuy = t.side !== "sell";
+  const agent = names.get(t.agent_id) ?? "An agent";
+  const qty = fmtQty(Number(t.quantity));
+  const price = Number(t.price_usd).toFixed(2);
+  const detailBits = [`${qty} @ $${price}`, agent];
+  if (t.note) detailBits.push(t.note);
+  return {
+    id: `tr-${t.id}`,
+    at: t.executed_at,
+    tag: isBuy ? "BUY" : "SELL",
+    tone: isBuy ? "positive" : "negative",
+    title: `${isBuy ? "Bought" : "Sold"} ${t.ticker}`,
+    detail: detailBits.join(" · "),
+  };
+}
+
+function rejectionEvent(
+  r: RejectionRow,
+  names: Map<string, string>,
+): ActivityEvent {
+  const agent = r.rejected_by_agent_id
+    ? names.get(r.rejected_by_agent_id) ?? "A buyer"
+    : "A buyer";
+  const conv = r.conviction != null ? `conviction ${r.conviction}/5` : null;
+  const detailBits = [agent];
+  if (conv) detailBits.push(conv);
+  if (r.reason) detailBits.push(truncate(r.reason, 180));
+  return {
+    id: `rj-${r.ticker}-${r.rejected_at}`,
+    at: r.rejected_at,
+    tag: "PASS",
+    tone: "info",
+    title: `Passed on ${r.ticker}`,
+    detail: detailBits.join(" · "),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Screener / pipeline activity
+// ---------------------------------------------------------------------------
+
+interface RunLogRow {
+  id: number | string;
+  script_name: string;
+  backfilled: number | null;
+  updated: number | null;
+  skipped: number | null;
+  errors: number | null;
+  duration_secs: number | null;
+  created_at: string;
+}
+
+/**
+ * The background jobs that shape what the screener shows, mapped to a
+ * human-readable label + chip. Scripts not in this map are omitted from the
+ * screener log (they don't affect the ranked table). `score_ai_analysis`,
+ * `eodhd_updater` and `nightly_screen` don't yet write `run_logs`, so they
+ * won't appear until they do — a deliberate "surface what's recorded" stance.
+ */
+const SCREENER_JOBS: Record<string, { tag: string; label: string }> = {
+  research_evaluation: { tag: "RESEARCH", label: "Research cards refreshed" },
+  bull_evaluation: { tag: "AI", label: "AI bull/bear signals refreshed" },
+  prices_daily: { tag: "PRICES", label: "Daily prices updated" },
+  price_sales_updater: { tag: "VALUE", label: "P/S valuation series updated" },
+  universe_sync: { tag: "UNIVERSE", label: "Universe membership re-synced" },
+  build_universe_snapshot: { tag: "DATA", label: "Universe snapshot built" },
+  benchmarks_updater: { tag: "DATA", label: "Benchmarks (SPY/URTH) updated" },
+  backfill_tier1_fundamentals: { tag: "DATA", label: "Fundamentals backfilled" },
+  backfill_tier1_valuation: { tag: "DATA", label: "Valuation backfilled" },
+};
+
+export async function getScreenerActivity(limit = 60): Promise<ActivityEvent[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from("run_logs")
+    .select("id, script_name, backfilled, updated, skipped, errors, duration_secs, created_at")
+    .in("script_name", Object.keys(SCREENER_JOBS))
+    .order("created_at", { ascending: false })
+    .limit(limit);
+  if (error) {
+    console.error("getScreenerActivity failed:", error);
+    return [];
+  }
+
+  return ((data as RunLogRow[] | null) ?? []).map((r) => {
+    const job = SCREENER_JOBS[r.script_name];
+    return {
+      id: `rl-${r.id}`,
+      at: r.created_at,
+      tag: job.tag,
+      tone: (r.errors ?? 0) > 0 ? "negative" : "info",
+      title: job.label,
+      detail: runLogDetail(r),
+    } satisfies ActivityEvent;
+  });
+}
+
+function runLogDetail(r: RunLogRow): string {
+  const bits: string[] = [];
+  const changed = (r.updated ?? 0) + (r.backfilled ?? 0);
+  if (changed > 0) bits.push(`${changed.toLocaleString("en-US")} updated`);
+  if ((r.skipped ?? 0) > 0) bits.push(`${(r.skipped ?? 0).toLocaleString("en-US")} unchanged`);
+  if ((r.errors ?? 0) > 0) bits.push(`${r.errors} error${r.errors === 1 ? "" : "s"}`);
+  if (bits.length === 0) bits.push("ran — no changes");
+  if (r.duration_secs != null) bits.push(`${Math.round(Number(r.duration_secs))}s`);
+  return bits.join(" · ");
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+function numNote(notes: Record<string, unknown>, key: string): number | null {
+  const v = notes[key];
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function noteString(notes: Record<string, unknown>, key: string): string | null {
+  const v = notes[key];
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+function fmtQty(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  return Number.isInteger(n) ? n.toLocaleString("en-US") : n.toFixed(2);
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}


### PR DESCRIPTION
## Summary

Introduces an "Activity" drawer component that surfaces a unified timeline of background events across the platform. On the screener, it shows data refresh jobs (prices, P/S, research cards, AI signals, universe membership). On portfolio pages, it displays team decisions (agent runs, fills, and owner-only pass list).

## Key Changes

- **`web/lib/activity-query.ts`** (new)
  - `getPortfolioActivity()` — queries `agent_heartbeats`, `agent_trades`, and `screener_rejections` to build a portfolio's activity timeline
  - `getScreenerActivity()` — queries `run_logs` for background data refresh jobs that feed the screener
  - Unified `ActivityEvent` interface with tone-based coloring (positive/negative/neutral/info) and human-readable tags (RAN, BUY, SELL, PASS, PRICES, etc.)
  - Helper functions to format quantities, truncate strings, and extract metadata from notes

- **`web/components/activity-drawer.tsx`** (new)
  - Client-side drawer component with slide-in animation and backdrop
  - Fetches activity feed from an endpoint on mount (no-store cache)
  - Tracks "new since last viewed" count in localStorage, keyed by `storageKey`
  - Marks all events as seen when drawer opens
  - Responsive event row rendering with relative timestamps (e.g., "3h ago")
  - Keyboard support (Esc to close) and body scroll lock while open

- **`web/app/api/portfolios/[slug]/activity/route.ts`** (new)
  - GET endpoint returning portfolio activity feed
  - Resolves portfolio by slug and applies visibility gate (public OR owner-only)
  - Owner-only rejection list gated by `includeRejections` flag
  - Cache strategy: public portfolios cacheable (120s + SWR), owner views `private, no-store`

- **`web/app/api/screen/activity/route.ts`** (new)
  - GET endpoint returning screener activity feed (background job timeline)
  - Universe-wide and identical for all viewers, so publicly cacheable (300s + SWR)

- **`web/app/screener/page.tsx`** (modified)
  - Integrated `ActivityDrawer` component below the subtitle
  - Displays background data refresh timeline to show screener freshness

- **`web/app/portfolios/[slug]/page.tsx`** (modified)
  - Integrated `ActivityDrawer` component in the portfolio header
  - Shows team decisions and fills to build confidence in the system

## Implementation Details

- Activity events are sorted by timestamp (newest first) and limited to 60 rows per query
- Portfolio heartbeats distinguish between error states, successful runs with trade counts, and deliberate no-ops (held the book)
- Trade events include quantity, price, and agent name; rejections include conviction score and reason
- Screener jobs map script names to human-readable labels and track updated/backfilled/skipped/error counts
- All reads use the service-role Supabase client; API routes handle access control before returning data
- localStorage fallback for "new count" badge gracefully handles private browsing / quota errors

https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r