### PR TITLE
Level 0 as single source of truth: retire companies/price_sales + freshness contract + fundamentals refresher

### DIFF
--- a/.github/workflows/nightly-eodhd-update.yml
+++ b/.github/workflows/nightly-eodhd-update.yml
@@ -1,9 +1,8 @@
 name: EODHD Update
 
+# RETIRED (companies retirement): wrote companies fundamentals, now superseded
+# by Level 0 (the fundamentals table). Scheduled run disabled; manual only.
 on:
-  schedule:
-    # Runs at 3:30 AM UTC daily (after TradingView screen at 3:00)
-    - cron: "30 3 * * *"
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/nightly-screen.yml
+++ b/.github/workflows/nightly-screen.yml
@@ -1,9 +1,9 @@
 name: Nightly TradingView Screen
 
+# RETIRED (companies retirement): the legacy TradingView screen wrote the
+# companies table, now superseded by Level 0 (universe_sync + the screener).
+# Scheduled run disabled; manual dispatch kept for archival/debugging only.
 on:
-  schedule:
-    # Runs at 3:00 AM UTC (4:00 AM BST) — before EODHD at 5:00 AM
-    - cron: "0 3 * * *"
   workflow_dispatch: # Allow manual trigger from GitHub UI
 
 jobs:

--- a/.github/workflows/score-ai-analysis.yml
+++ b/.github/workflows/score-ai-analysis.yml
@@ -1,9 +1,9 @@
 name: Get TV data and score
 
+# RETIRED (companies retirement): scored/ranked into the companies table, now
+# superseded by the Level 0 screener (deterministic score off screen_facts_mv).
+# Scheduled run disabled; manual dispatch kept for archival only.
 on:
-  schedule:
-    # Runs at 5:00 AM UTC daily (after all data updates)
-    - cron: "0 5 * * *"
   workflow_dispatch: # Allow manual trigger from GitHub UI
 
 jobs:

--- a/.github/workflows/universe-snapshot.yml
+++ b/.github/workflows/universe-snapshot.yml
@@ -8,9 +8,11 @@ name: Universe Snapshot
 # 06:00 UTC — 1h after score_ai_analysis (05:00) so composite_score and
 # rankings are fresh, and 1h before the Sunday 07:00 UTC heartbeat.
 
+# RETIRED (companies retirement): build_universe_snapshot.py reads the legacy
+# companies/price_sales tables. Superseded by Level 0 (the screener + the
+# api_universe_facts RPC behind /api/v1/universe). Scheduled run disabled;
+# manual dispatch kept for archival only.
 on:
-  schedule:
-    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
       tier:

--- a/bear_evaluation.py
+++ b/bear_evaluation.py
@@ -349,20 +349,11 @@ def main():
     # Connect to Supabase
     db = SupabaseDB()
 
-    if args.tier1:
-        # Stage A2: rotate over the full Tier-1 universe (ai_analysis clock).
-        import level0_eval
-        top_equities = level0_eval.tier1_eval_candidates(db, "bear", TOP_N)
-        logger.info("Selected %d Tier-1 tickers for bear evaluation (rotation by ai_analysis.bear_at)", len(top_equities))
-    else:
-        all_companies = db.get_all_companies()
-        logger.info("Read %d companies from database", len(all_companies))
-        if not all_companies:
-            logger.error("No companies found in database")
-            sys.exit(1)
-        # Select rotation batch (oldest bear_eval_at first, NULLs first)
-        top_equities = select_rotation_batch(all_companies)
-        logger.info("Selected %d tickers for bear evaluation (rotation by bear_eval_at)", len(top_equities))
+    # Rotate over the full Tier-1 universe from Level 0 (ai_analysis clock). The
+    # legacy `companies` rotation path is retired — ai_analysis is the only home.
+    import level0_eval
+    top_equities = level0_eval.tier1_eval_candidates(db, "bear", TOP_N)
+    logger.info("Selected %d Tier-1 tickers for bear evaluation (rotation by ai_analysis.bear_at)", len(top_equities))
 
     if not top_equities:
         logger.warning("No in-screen non-excluded tickers found. Nothing to do.")
@@ -422,15 +413,8 @@ def main():
         ticker = (company.get("ticker") or "").strip()
         verdict = verdicts.get(ticker)
         if verdict:
-            # ai_analysis is the Level 0 home (migrations 053/054): always write
-            # the bear verdict + its rotation clock (bear_at). In --tier1 mode
-            # that's the only write (the name may not exist in companies);
-            # otherwise dual-write companies for the legacy surfaces.
-            if not args.tier1:
-                db.upsert_company(ticker, {
-                    "bear_eval": verdict,
-                    "bear_eval_at": today_str,
-                })
+            # ai_analysis is the Level 0 home (migrations 053/054) and now the
+            # sole home: write the bear verdict + its rotation clock (bear_at).
             db.upsert_ai_analysis(ticker, {
                 "bear_eval": verdict,
                 "bear_at": today_str,

--- a/bull_evaluation.py
+++ b/bull_evaluation.py
@@ -349,20 +349,11 @@ def main():
 
     # Connect to Supabase
     db = SupabaseDB()
-    if args.tier1:
-        # Stage A2: rotate over the full Tier-1 universe (ai_analysis clock).
-        import level0_eval
-        top_equities = level0_eval.tier1_eval_candidates(db, "bull", TOP_N)
-        logger.info("Selected %d Tier-1 tickers for bull evaluation (rotation by ai_analysis.bull_at)", len(top_equities))
-    else:
-        companies = db.get_all_companies()
-        logger.info("Read %d companies from database", len(companies))
-        if not companies:
-            logger.error("No companies found in the database")
-            sys.exit(1)
-        # Select rotation batch (oldest bull_eval_at first, NULLs first)
-        top_equities = select_rotation_batch(companies)
-        logger.info("Selected %d tickers for bull evaluation (rotation by bull_eval_at)", len(top_equities))
+    # Rotate over the full Tier-1 universe from Level 0 (ai_analysis clock). The
+    # legacy `companies` rotation path is retired — ai_analysis is the only home.
+    import level0_eval
+    top_equities = level0_eval.tier1_eval_candidates(db, "bull", TOP_N)
+    logger.info("Selected %d Tier-1 tickers for bull evaluation (rotation by ai_analysis.bull_at)", len(top_equities))
 
     if not top_equities:
         logger.warning("No in-screen non-excluded tickers found. Nothing to do.")
@@ -434,12 +425,8 @@ def main():
 
     logger.info("Writing %d verdicts", matched)
     if updates:
-        # ai_analysis is the Level 0 home (migrations 053/054): write the bull
-        # verdict + its rotation clock (bull_at). In --tier1 mode that's the
-        # only write (names may not exist in companies); otherwise dual-write
-        # companies too for back-compat with the legacy surfaces.
-        if not args.tier1:
-            db.upsert_companies_batch(updates)
+        # ai_analysis is the Level 0 home (migrations 053/054) and now the sole
+        # home: write the bull verdict + its rotation clock (bull_at).
         db.upsert_ai_analysis_batch([
             {"ticker": u["ticker"], "bull_eval": u["bull_eval"],
              "bull_at": u["bull_eval_at"], "analyzed_at": u["bull_eval_at"]}

--- a/db.py
+++ b/db.py
@@ -1065,26 +1065,50 @@ class SupabaseDB:
     # Swarm Consensus
     # ------------------------------------------------------------------
 
-    def fetch_holdings_with_agent_company(self) -> list[dict]:
-        """Return every agent_holdings row joined to its agent + company.
+    def _security_meta_map(self, tickers) -> dict[str, dict]:
+        """Return {ticker: {"name", "price"}} from Level 0 `securities` for a
+        set of tickers (name + latest quote). The replacement for the legacy
+        `companies(company_name, price)` PostgREST embed now that consensus
+        reads identity/price off Level 0 (companies retirement)."""
+        wanted = sorted({(t or "").upper() for t in tickers if t})
+        if not wanted:
+            return {}
+        out: dict[str, dict] = {}
+        # Chunk to keep the IN list well under PostgREST limits.
+        for i in range(0, len(wanted), 500):
+            chunk = wanted[i : i + 500]
+            resp = (
+                self.client.table("securities")
+                .select("ticker, name, price")
+                .in_("ticker", chunk)
+                .execute()
+            )
+            for r in resp.data or []:
+                out[r["ticker"]] = {"name": r.get("name"), "price": r.get("price")}
+        return out
 
-        One round-trip; the consensus aggregation runs in Python afterwards.
-        Output rows are flattened: {agent_id, ticker, quantity, avg_cost_usd,
-        handle, display_name, is_house_agent, company_name, current_price}.
+    def fetch_holdings_with_agent_company(self) -> list[dict]:
+        """Return every agent_holdings row joined to its agent + Level 0 identity.
+
+        The consensus aggregation runs in Python afterwards. Output rows are
+        flattened: {agent_id, ticker, quantity, avg_cost_usd, handle,
+        display_name, is_house_agent, company_name, current_price}. Name +
+        current price come from `securities` (Level 0), not legacy `companies`.
         """
         resp = (
             self.client.table("agent_holdings")
             .select(
                 "agent_id, ticker, quantity, avg_cost_usd, "
-                "agents(handle, display_name, is_house_agent), "
-                "companies(company_name, price)"
+                "agents(handle, display_name, is_house_agent)"
             )
             .execute()
         )
+        rows = resp.data or []
+        meta = self._security_meta_map([r.get("ticker") for r in rows])
         out: list[dict] = []
-        for r in resp.data or []:
+        for r in rows:
             agent = r.get("agents") or {}
-            company = r.get("companies") or {}
+            sec = meta.get((r.get("ticker") or "").upper(), {})
             out.append({
                 "agent_id": r.get("agent_id"),
                 "ticker": r.get("ticker"),
@@ -1093,8 +1117,8 @@ class SupabaseDB:
                 "handle": agent.get("handle"),
                 "display_name": agent.get("display_name"),
                 "is_house_agent": agent.get("is_house_agent"),
-                "company_name": company.get("company_name"),
-                "current_price": company.get("price"),
+                "company_name": sec.get("name"),
+                "current_price": sec.get("price"),
             })
         return out
 
@@ -1103,9 +1127,9 @@ class SupabaseDB:
     ) -> tuple[list[dict], str | None]:
         """Return the highest-conviction tickers from the latest snapshot.
 
-        Joins ``companies`` for ``company_name`` so callers can disambiguate
-        the ticker when classifying social posts. Used by the Bluesky
-        heartbeat's equity-targeting phase.
+        Resolves ``company_name`` from Level 0 ``securities`` so callers can
+        disambiguate the ticker when classifying social posts. Used by the
+        Bluesky heartbeat's equity-targeting phase.
         """
         latest = (
             self.client.table("consensus_snapshots")
@@ -1122,20 +1146,22 @@ class SupabaseDB:
             self.client.table("consensus_snapshots")
             .select(
                 "rank, ticker, num_agents, total_agents, pct_agents, "
-                "swarm_pnl_pct, companies(company_name)"
+                "swarm_pnl_pct"
             )
             .eq("snapshot_date", snapshot_date)
             .order("rank", desc=False)
             .limit(limit)
             .execute()
         )
+        data = resp.data or []
+        meta = self._security_meta_map([r.get("ticker") for r in data])
         rows: list[dict] = []
-        for r in resp.data or []:
-            company = r.get("companies") or {}
+        for r in data:
+            sec = meta.get((r.get("ticker") or "").upper(), {})
             rows.append({
                 "rank": r.get("rank"),
                 "ticker": r.get("ticker"),
-                "company_name": company.get("company_name") or r.get("ticker"),
+                "company_name": sec.get("name") or r.get("ticker"),
                 "num_agents": r.get("num_agents"),
                 "total_agents": r.get("total_agents"),
                 "pct_agents": r.get("pct_agents"),

--- a/db.py
+++ b/db.py
@@ -113,6 +113,29 @@ class SupabaseDB:
         if cleaned:
             self.client.table("companies").upsert(cleaned).execute()
 
+    def bulk_upsert_security_prices(self, rows: list[dict]) -> None:
+        """Write only the live price columns (price, price_asof) onto many
+        `securities` rows in one batch — the Level 0 home for the latest quote
+        (companies-retirement, migration 058).
+
+        Mirrors `bulk_upsert_company_prices`: intraday_prices.py writes the
+        most-recent quote here so mark-to-market and trade pricing read it off
+        Level 0 instead of `companies`. Defensive column whitelist so a stray
+        key can never clobber identity/gate columns; each row needs `ticker`.
+        """
+        if not rows:
+            return
+        allowed = {"ticker", "price", "price_asof"}
+        cleaned: list[dict] = []
+        for row in rows:
+            slim = {k: row[k] for k in row.keys() & allowed}
+            if "ticker" not in slim or slim.get("price") is None:
+                continue
+            self._sanitize(slim)
+            cleaned.append(slim)
+        if cleaned:
+            self.client.table("securities").upsert(cleaned).execute()
+
     # ------------------------------------------------------------------
     # Price-Sales
     # ------------------------------------------------------------------
@@ -368,16 +391,25 @@ class SupabaseDB:
         return {}
 
     def get_level0_close(self, ticker: str) -> float | None:
-        """Latest USD close for a ticker from the Level 0 price layer.
+        """Latest USD price for a ticker from the Level 0 price layer.
 
-        The trading layer's fallback when a ticker isn't in `companies` (e.g. a
-        Tier-1 name the legacy pipeline never covered). Prefers the most-recent
-        `prices_daily` close; falls back to the gate-stamped `securities.
-        last_close`. Returns None when neither has a usable value.
+        The single price source the trading layer reads once `companies` is
+        retired (migration 058). Preference order, freshest first:
+          1. `securities.price` — the most-recent quote (intraday during US
+             market hours, rolled forward to the prior close otherwise),
+             written by intraday_prices.py.
+          2. most-recent `prices_daily` close — the EOD layer.
+          3. gate-stamped `securities.last_close` — weekly affordability input.
+        Returns None when none has a usable value.
         """
         if not ticker:
             return None
         try:
+            sec = self.get_security(ticker.upper())
+            if sec:
+                live = SupabaseDB.safe_float(sec.get("price"))
+                if live and live > 0:
+                    return live
             resp = (
                 self.client.table("prices_daily")
                 .select("close")
@@ -390,7 +422,6 @@ class SupabaseDB:
                 close = SupabaseDB.safe_float(resp.data[0].get("close"))
                 if close and close > 0:
                     return close
-            sec = self.get_security(ticker.upper())
             if sec:
                 lc = SupabaseDB.safe_float(sec.get("last_close"))
                 if lc and lc > 0:

--- a/db.py
+++ b/db.py
@@ -512,6 +512,35 @@ class SupabaseDB:
         resp = q.execute()
         return resp.data or []
 
+    def get_all_valuation_latest(self) -> dict[str, dict]:
+        """Return the latest valuation row per ticker, keyed by ticker.
+
+        The Level 0 replacement for `get_all_price_sales()` — used by
+        price_sales_updater.py to read each ticker's prior P/S state (history /
+        ATH / as-of date) for incremental updates. Paginates the whole table and
+        keeps the newest `date` per ticker.
+        """
+        latest: dict[str, dict] = {}
+        page = 0
+        page_size = 1000
+        while True:
+            resp = (
+                self.client.table("valuation")
+                .select("ticker, date, ps, ps_ath, history_json")
+                .order("date", desc=True)
+                .range(page * page_size, (page + 1) * page_size - 1)
+                .execute()
+            )
+            batch = resp.data or []
+            for row in batch:
+                t = row.get("ticker")
+                if t and t not in latest:  # rows arrive newest-first
+                    latest[t] = row
+            if len(batch) < page_size:
+                break
+            page += 1
+        return latest
+
     def get_valuation_tickers(self) -> set[str]:
         """Return the set of tickers that have at least one valuation row."""
         tickers: set[str] = set()

--- a/intraday_prices.py
+++ b/intraday_prices.py
@@ -253,8 +253,12 @@ def main() -> int:
         logger.warning("No updates to write")
         return 0
 
+    # Write the live quote to the Level 0 home (securities.price — the source
+    # MTM/trading now read) and, transitionally, to legacy companies.price so
+    # any not-yet-repointed reader stays fresh until companies is retired.
+    db.bulk_upsert_security_prices(updates)
     db.bulk_upsert_company_prices(updates)
-    logger.info("Wrote %d price updates", len(updates))
+    logger.info("Wrote %d price updates (securities + companies)", len(updates))
     return 0
 
 

--- a/intraday_prices.py
+++ b/intraday_prices.py
@@ -171,17 +171,17 @@ def main() -> int:
         return 1
 
     db = SupabaseDB()
-    companies = db.get_all_companies()
-    if not companies:
-        logger.warning("No companies — nothing to do")
-        return 0
-
-    eligible = [c for c in companies if c.get("in_tv_screen")]
+    # Universe = active Tier 1 securities (Level 0). The legacy companies table
+    # (and its in_tv_screen flag) is retired.
+    securities = db.get_all_securities(
+        columns="ticker, exchange, is_tier1", status="active"
+    )
+    eligible = [s for s in securities if s.get("is_tier1")]
     if args.tickers:
         wanted = {t.upper() for t in args.tickers}
-        eligible = [c for c in eligible if c["ticker"].upper() in wanted]
+        eligible = [s for s in eligible if s["ticker"].upper() in wanted]
     if not eligible:
-        logger.warning("No eligible tickers after filtering")
+        logger.warning("No eligible Tier 1 tickers after filtering")
         return 0
 
     logger.info(
@@ -253,12 +253,10 @@ def main() -> int:
         logger.warning("No updates to write")
         return 0
 
-    # Write the live quote to the Level 0 home (securities.price — the source
-    # MTM/trading now read) and, transitionally, to legacy companies.price so
-    # any not-yet-repointed reader stays fresh until companies is retired.
+    # Write the live quote to the Level 0 home (securities.price) — the single
+    # source MTM/trading read now that companies is retired.
     db.bulk_upsert_security_prices(updates)
-    db.bulk_upsert_company_prices(updates)
-    logger.info("Wrote %d price updates (securities + companies)", len(updates))
+    logger.info("Wrote %d price updates to securities", len(updates))
     return 0
 
 

--- a/migrations/058_level0_price_home.sql
+++ b/migrations/058_level0_price_home.sql
@@ -1,0 +1,29 @@
+-- Migration 058: Level 0 current-price home (companies retirement, phase 0).
+--
+-- The legacy `companies.price` / `companies.price_asof` is the ONLY home for the
+-- live/intraday quote that drives trade pricing and mark-to-market. Level 0's
+-- `prices_daily` is end-of-day only. To retire `companies`, the "latest known
+-- price" concept must move into Level 0 first.
+--
+-- This adds `price` + `price_asof` to `securities` (the Tier 0 identity table,
+-- the FK target the whole trading layer will repoint to). Semantics mirror
+-- `companies.price` exactly: the most recent quote we have — intraday during US
+-- market hours (written by intraday_prices.py), rolling forward to the prior
+-- close otherwise. `last_close` (weekly gate input) is unchanged and kept.
+--
+-- Additive + idempotent. Safe to run on the live DB before any reader/writer is
+-- repointed: nothing reads these columns yet.
+
+ALTER TABLE securities ADD COLUMN IF NOT EXISTS price       NUMERIC(14,4);
+ALTER TABLE securities ADD COLUMN IF NOT EXISTS price_asof  TIMESTAMPTZ;
+
+-- One-time backfill from the legacy table so MTM is correct the moment the
+-- readers flip to Level 0 (before the daily/intraday jobs have run on the new
+-- path). Only copies a usable positive price.
+UPDATE securities s
+   SET price      = c.price,
+       price_asof = c.price_asof
+  FROM companies c
+ WHERE c.ticker = s.ticker
+   AND c.price IS NOT NULL
+   AND c.price > 0;

--- a/migrations/059_mtm_snapshot_level0_price.sql
+++ b/migrations/059_mtm_snapshot_level0_price.sql
@@ -1,0 +1,63 @@
+-- Migration 059: MTM snapshot reads Level 0 price (companies retirement, phase 1).
+--
+-- `recompute_portfolio_snapshot()` (fired by the agent_trades trigger to value a
+-- legacy agent portfolio) valued holdings off `companies.price`. Repoint it to
+-- the Level 0 price home (`securities.price`, migration 058) so it no longer
+-- depends on `companies`. Falls back to the position's avg cost when no live
+-- price exists — same behaviour as before, just a different price source.
+--
+-- Idempotent (CREATE OR REPLACE). Apply AFTER migration 058 (needs
+-- securities.price to exist + be backfilled).
+
+CREATE OR REPLACE FUNCTION recompute_portfolio_snapshot(_agent_id UUID, _snapshot_date DATE)
+RETURNS VOID AS $$
+DECLARE
+    _cash             NUMERIC(14,2);
+    _starting_cash    NUMERIC(14,2);
+    _holdings_value   NUMERIC(14,2);
+    _num_positions    INTEGER;
+    _total_value      NUMERIC(14,2);
+    _pnl              NUMERIC(14,2);
+    _pnl_pct          NUMERIC(8,4);
+BEGIN
+    SELECT cash_usd, starting_cash
+      INTO _cash, _starting_cash
+      FROM agent_accounts
+     WHERE agent_id = _agent_id;
+
+    IF _cash IS NULL THEN
+        -- Agent has no account row yet; nothing to snapshot.
+        RETURN;
+    END IF;
+
+    SELECT
+        COALESCE(SUM(h.quantity * COALESCE(s.price, h.avg_cost_usd)), 0)::NUMERIC(14,2),
+        COUNT(*)::INTEGER
+      INTO _holdings_value, _num_positions
+      FROM agent_holdings h
+      LEFT JOIN securities s ON s.ticker = h.ticker
+     WHERE h.agent_id = _agent_id;
+
+    _total_value := _cash + _holdings_value;
+    _pnl         := _total_value - _starting_cash;
+    _pnl_pct     := CASE WHEN _starting_cash > 0
+                         THEN ROUND((_pnl / _starting_cash) * 100, 4)
+                         ELSE 0
+                    END;
+
+    INSERT INTO agent_portfolio_history (
+        agent_id, snapshot_date, cash_usd, holdings_value_usd,
+        total_value_usd, pnl_usd, pnl_pct, num_positions
+    ) VALUES (
+        _agent_id, _snapshot_date, _cash, _holdings_value,
+        _total_value, _pnl, _pnl_pct, _num_positions
+    )
+    ON CONFLICT (agent_id, snapshot_date) DO UPDATE SET
+        cash_usd           = EXCLUDED.cash_usd,
+        holdings_value_usd = EXCLUDED.holdings_value_usd,
+        total_value_usd    = EXCLUDED.total_value_usd,
+        pnl_usd            = EXCLUDED.pnl_usd,
+        pnl_pct            = EXCLUDED.pnl_pct,
+        num_positions      = EXCLUDED.num_positions;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/060_repoint_fks_to_securities.sql
+++ b/migrations/060_repoint_fks_to_securities.sql
@@ -1,0 +1,32 @@
+-- Migration 060: repoint foreign keys off companies (companies retirement, phase 3).
+--
+-- The authoritative catalog shows only THREE live FKs reference companies(ticker):
+--   * consensus_snapshots.ticker  (ON DELETE CASCADE)
+--   * portfolio_watchlist.ticker  (no action)
+--   * price_sales.ticker          (ON DELETE CASCADE)  -- handled at table retirement
+-- (agent_trades / agent_holdings / investment_theses carry NO companies FK in
+-- production despite older schema text, so nothing there blocks the drop.)
+--
+-- This repoints the two we keep onto securities(ticker) — the Level 0 identity
+-- table — so companies can be retired:
+--   * portfolio_watchlist -> securities  (verified 0 orphan tickers).
+--   * consensus_snapshots -> drop the FK entirely. It's a derived weekly
+--     snapshot keyed on whatever agents held; its tickers can legitimately be
+--     delisted names absent from securities (11 such today), and the data is
+--     already validated upstream, so an FK adds risk without integrity value.
+--
+-- price_sales' FK is left until migration 061 renames companies + price_sales
+-- together (a FK between two soon-to-be *_legacy tables is harmless meanwhile).
+--
+-- Idempotent. Safe to apply independently.
+
+-- consensus_snapshots: drop the companies FK (no repoint).
+ALTER TABLE consensus_snapshots
+    DROP CONSTRAINT IF EXISTS consensus_snapshots_ticker_fkey;
+
+-- portfolio_watchlist: repoint to securities.
+ALTER TABLE portfolio_watchlist
+    DROP CONSTRAINT IF EXISTS portfolio_watchlist_ticker_fkey;
+ALTER TABLE portfolio_watchlist
+    ADD CONSTRAINT portfolio_watchlist_ticker_fkey
+    FOREIGN KEY (ticker) REFERENCES securities(ticker);

--- a/migrations/061_retire_companies_tables.sql
+++ b/migrations/061_retire_companies_tables.sql
@@ -1,0 +1,64 @@
+-- Migration 061: retire companies + price_sales (companies retirement, final phase).
+--
+-- APPLY LAST. Only after migrations 058-060 are applied AND the code that reads
+-- Level 0 instead of companies/price_sales is deployed (this PR). Once applied,
+-- nothing in the app reads or writes companies / price_sales.
+--
+-- Reversible-by-design: the tables are RENAMED to *_legacy, not dropped, so the
+-- data survives and a rollback is `ALTER TABLE ... RENAME` back. A later trivial
+-- migration can DROP them once you're satisfied.
+
+-- 1. Repoint the last function off companies: api_universe_facts() joined
+--    companies only for bull_eval/bear_eval, which now live in ai_analysis
+--    (migration 053). Everything else in it is already Level 0.
+CREATE OR REPLACE FUNCTION public.api_universe_facts()
+ RETURNS TABLE(ticker text, company_name text, exchange text, security_type text, sector text, industry text, country text, status text, ipo_date date, is_tier1 boolean, price numeric, price_asof date, rev_growth_ttm_pct numeric, rev_growth_qoq_pct numeric, rev_cagr_pct numeric, gross_margin_pct numeric, operating_margin_pct numeric, net_margin_pct numeric, fcf_margin_pct numeric, rule_of_40 numeric, eps_only numeric, fundamentals_asof date, ps_now numeric, ps_median_12m numeric, ps_high_52w numeric, ps_low_52w numeric, ps_pct_of_ath numeric, valuation_asof date, ret_52w numeric, bull boolean, bear boolean)
+ LANGUAGE sql
+ STABLE
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+    SELECT
+        s.ticker, s.name, s.exchange, s.security_type, s.gics_sector,
+        s.gics_industry, s.country, s.status, s.ipo_date, s.is_tier1,
+        lp.close, lp.date,
+        f.rev_growth_ttm, f.rev_growth_qoq, f.rev_cagr, f.gross_margin,
+        f.operating_margin, f.net_margin, f.fcf_margin, f.rule_of_40, f.eps,
+        f.period_end,
+        v.ps, v.ps_median_12m, v.ps_high_52w, v.ps_low_52w, v.ps_pct_of_ath,
+        v.date,
+        CASE WHEN p52.close IS NOT NULL AND p52.close > 0
+             THEN (lp.close / p52.close - 1) * 100 END,
+        CASE WHEN left(a.bull_eval, 1) = '✅' THEN true
+             WHEN left(a.bull_eval, 1) = '❌' THEN false END,
+        CASE WHEN left(a.bear_eval, 1) = '✅' THEN true
+             WHEN left(a.bear_eval, 1) = '❌' THEN false END
+    FROM securities s
+    LEFT JOIN LATERAL (
+        SELECT * FROM fundamentals fd
+        WHERE fd.ticker = s.ticker ORDER BY fd.period_end DESC LIMIT 1
+    ) f ON true
+    LEFT JOIN LATERAL (
+        SELECT close, date FROM prices_daily pd
+        WHERE pd.ticker = s.ticker ORDER BY pd.date DESC LIMIT 1
+    ) lp ON true
+    LEFT JOIN LATERAL (
+        SELECT close FROM prices_daily pd
+        WHERE pd.ticker = s.ticker AND pd.date <= (CURRENT_DATE - INTERVAL '52 weeks')
+        ORDER BY pd.date DESC LIMIT 1
+    ) p52 ON true
+    LEFT JOIN LATERAL (
+        SELECT * FROM valuation vl
+        WHERE vl.ticker = s.ticker ORDER BY vl.date DESC LIMIT 1
+    ) v ON true
+    LEFT JOIN ai_analysis a ON a.ticker = s.ticker
+    WHERE s.is_tier1 AND s.status = 'active'
+    ORDER BY s.ticker;
+$function$;
+
+-- 2. Drop the price_sales -> companies FK (its parent is going away).
+ALTER TABLE price_sales DROP CONSTRAINT IF EXISTS price_sales_ticker_fkey;
+
+-- 3. Rename the legacy tables out of the way (reversible). Single source of
+--    truth = Level 0 from here on.
+ALTER TABLE IF EXISTS companies   RENAME TO companies_legacy;
+ALTER TABLE IF EXISTS price_sales RENAME TO price_sales_legacy;

--- a/portfolio.py
+++ b/portfolio.py
@@ -169,24 +169,25 @@ class PortfolioManager:
     def get_price(self, ticker: str) -> float:
         """Return the latest price for a ticker (treated as USD).
 
-        Primary source is `companies.price`. Falls back to the Level 0 price
-        layer (`prices_daily` latest close / `securities.last_close`) when the
-        ticker isn't in `companies` or its price is unusable — so Tier-1 names
-        the legacy pipeline never covered (US-listed financials, foreign-
-        domiciled ADRs) are still priceable for both trading and MTM.
+        Primary source is the Level 0 price layer (`securities.price` latest
+        quote → `prices_daily` close → `securities.last_close`), so every Tier-1
+        name is priceable for trading and MTM regardless of whether the legacy
+        pipeline covered it. `companies.price` remains a transitional fallback
+        until that table is retired (migration 058+).
         """
+        level0_price = self.db.get_level0_close(ticker)
+        if level0_price is not None and level0_price > 0:
+            return level0_price
+        # Transitional fallback: legacy companies.price (removed once retired).
         company = self.db.get_company(ticker)
         price = SupabaseDB.safe_float(company.get("price")) if company else None
         if price is not None and price > 0:
             return price
-        # Fallback: Level 0. Covers names absent from companies entirely.
-        level0_price = self.db.get_level0_close(ticker)
-        if level0_price is not None and level0_price > 0:
-            return level0_price
-        if not company:
+        # Unknown to Level 0 and absent from companies → genuinely unpriceable.
+        if not company and not self.db.get_security(ticker.upper()):
             raise PortfolioError(f"Unknown ticker: {ticker}")
         raise PortfolioError(
-            f"No usable price for {ticker} (companies.price and Level 0 both empty)"
+            f"No usable price for {ticker} (Level 0 and companies both empty)"
         )
 
     # ------------------------------------------------------------------

--- a/portfolio.py
+++ b/portfolio.py
@@ -169,26 +169,19 @@ class PortfolioManager:
     def get_price(self, ticker: str) -> float:
         """Return the latest price for a ticker (treated as USD).
 
-        Primary source is the Level 0 price layer (`securities.price` latest
-        quote → `prices_daily` close → `securities.last_close`), so every Tier-1
-        name is priceable for trading and MTM regardless of whether the legacy
-        pipeline covered it. `companies.price` remains a transitional fallback
-        until that table is retired (migration 058+).
+        Sole source is the Level 0 price layer (`securities.price` latest quote
+        → `prices_daily` close → `securities.last_close`), so every Tier-1 name
+        is priceable for trading and MTM. (The legacy `companies` table is
+        retired.)
         """
         level0_price = self.db.get_level0_close(ticker)
         if level0_price is not None and level0_price > 0:
             return level0_price
-        # Transitional fallback: legacy companies.price (removed once retired).
-        company = self.db.get_company(ticker)
-        price = SupabaseDB.safe_float(company.get("price")) if company else None
-        if price is not None and price > 0:
-            return price
-        # Unknown to Level 0 and absent from companies → genuinely unpriceable.
-        if not company and not self.db.get_security(ticker.upper()):
+        # No usable Level 0 price. Distinguish "unknown ticker" from "known but
+        # unpriced" for a clearer error.
+        if not self.db.get_security(ticker.upper()):
             raise PortfolioError(f"Unknown ticker: {ticker}")
-        raise PortfolioError(
-            f"No usable price for {ticker} (Level 0 and companies both empty)"
-        )
+        raise PortfolioError(f"No usable Level 0 price for {ticker}")
 
     # ------------------------------------------------------------------
     # Trading

--- a/price_sales_updater.py
+++ b/price_sales_updater.py
@@ -472,12 +472,32 @@ def main():
 
     db = SupabaseDB()
 
-    # Read inputs
-    ticker_list = db.get_all_companies(columns="ticker, exchange, company_name")
-    logger.info("Read %d tickers from companies table", len(ticker_list))
+    # Read inputs from Level 0 (the legacy companies/price_sales are retired).
+    # Universe = active Tier 1 securities; map `name` → company_name for the
+    # downstream P/S computation that expects that key.
+    sec_rows = db.get_all_securities(
+        columns="ticker, exchange, name, is_tier1", status="active"
+    )
+    ticker_list = [
+        {"ticker": s["ticker"], "exchange": s.get("exchange", ""),
+         "company_name": s.get("name", "")}
+        for s in sec_rows
+        if s.get("is_tier1")
+    ]
+    logger.info("Read %d Tier 1 tickers from securities", len(ticker_list))
 
-    ps_map = db.get_all_price_sales()
-    logger.info("Read %d existing price-sales rows", len(ps_map))
+    # Prior P/S state per ticker from `valuation` (latest row), shaped to the
+    # keys compute_ps_for_ticker expects (history_json / ath / last_updated).
+    val_latest = db.get_all_valuation_latest()
+    ps_map = {
+        t: {
+            "history_json": v.get("history_json"),
+            "ath": v.get("ps_ath"),
+            "last_updated": v.get("date"),
+        }
+        for t, v in val_latest.items()
+    }
+    logger.info("Read %d existing valuation rows", len(ps_map))
 
     # Filter to specific tickers if requested
     if args.tickers:
@@ -534,10 +554,25 @@ def main():
             errors += 1
             continue
 
-        # Write to Supabase via upsert
+        # Write to the Level 0 `valuation` table — this script is now the daily
+        # P/S maintainer for valuation (the legacy `companies`/`price_sales`
+        # tables are retired). Map the computed P/S series onto valuation cols.
         result_mode = result.pop("mode")
+        val_row = {
+            "ticker": ticker,
+            "date": today_str,
+            "ps": result.get("ps_now"),
+            "ps_high_52w": result.get("high_52w"),
+            "ps_low_52w": result.get("low_52w"),
+            "ps_median_12m": result.get("median_12m"),
+            "ps_ath": result.get("ath"),
+            "ps_pct_of_ath": result.get("pct_of_ath"),
+            "history_json": result.get("history_json"),
+            "source": "price_sales_updater",
+            "fetched_at": datetime.utcnow().isoformat(),
+        }
         try:
-            db.upsert_price_sales(ticker, result)
+            db.upsert_valuation_batch([val_row])
             if result_mode == "backfill":
                 backfilled += 1
             else:

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -242,7 +242,7 @@ CREATE TRIGGER agent_accounts_updated_at
 -- Current open positions (one row per agent+ticker).
 CREATE TABLE IF NOT EXISTS agent_holdings (
     agent_id        UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
-    ticker          TEXT NOT NULL REFERENCES companies(ticker) ON DELETE RESTRICT,
+    ticker          TEXT NOT NULL REFERENCES securities(ticker) ON DELETE RESTRICT,
     quantity        NUMERIC(18,6) NOT NULL,
     avg_cost_usd    NUMERIC(14,4) NOT NULL,
     first_bought_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -262,7 +262,7 @@ CREATE TRIGGER agent_holdings_updated_at
 CREATE TABLE IF NOT EXISTS agent_trades (
     id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     agent_id        UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
-    ticker          TEXT NOT NULL REFERENCES companies(ticker),
+    ticker          TEXT NOT NULL REFERENCES securities(ticker),
     side            TEXT NOT NULL CHECK (side IN ('buy','sell')),
     quantity        NUMERIC(18,6) NOT NULL CHECK (quantity > 0),
     price_usd       NUMERIC(14,4) NOT NULL,
@@ -298,7 +298,7 @@ CREATE INDEX IF NOT EXISTS idx_pfhist_date ON agent_portfolio_history (snapshot_
 -- agent_heartbeat rebalance has settled. One row per (date, ticker).
 CREATE TABLE IF NOT EXISTS consensus_snapshots (
     snapshot_date     DATE NOT NULL,
-    ticker            TEXT NOT NULL REFERENCES companies(ticker) ON DELETE CASCADE,
+    ticker            TEXT NOT NULL,
     rank              INTEGER NOT NULL,
     num_agents        INTEGER NOT NULL,
     total_agents      INTEGER NOT NULL,

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -373,11 +373,11 @@ BEGIN
     END IF;
 
     SELECT
-        COALESCE(SUM(h.quantity * COALESCE(c.price, h.avg_cost_usd)), 0)::NUMERIC(14,2),
+        COALESCE(SUM(h.quantity * COALESCE(s.price, h.avg_cost_usd)), 0)::NUMERIC(14,2),
         COUNT(*)::INTEGER
       INTO _holdings_value, _num_positions
       FROM agent_holdings h
-      LEFT JOIN companies c ON c.ticker = h.ticker
+      LEFT JOIN securities s ON s.ticker = h.ticker
      WHERE h.agent_id = _agent_id;
 
     _total_value := _cash + _holdings_value;

--- a/test_portfolios.py
+++ b/test_portfolios.py
@@ -187,36 +187,39 @@ class DbPortfolioHelpersTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# PortfolioManager.get_price — companies primary, Level 0 fallback
+# PortfolioManager.get_price — Level 0 primary, legacy companies fallback
 # ---------------------------------------------------------------------------
 
 
 class GetPriceFallbackTests(unittest.TestCase):
-    """A ticker absent from `companies` (e.g. a Tier-1 name the legacy pipeline
-    never covered) must still price off Level 0 so it's tradable + valuable."""
+    """Pricing now reads Level 0 first (migration 058), so every Tier-1 name is
+    priceable for trading + MTM; `companies.price` is only a transitional
+    fallback until that table is retired."""
 
-    def _pm(self, company, level0):
+    def _pm(self, company, level0, security=None):
         pm = portfolio_module.PortfolioManager.__new__(
             portfolio_module.PortfolioManager
         )
         pm.db = SimpleNamespace(
             get_company=lambda t: company,
             get_level0_close=lambda t: level0,
+            get_security=lambda t: security,
         )
         return pm
 
-    def test_companies_price_wins(self):
-        self.assertEqual(self._pm({"price": 42.0}, 99.0).get_price("AAA"), 42.0)
+    def test_level0_price_wins(self):
+        # Level 0 is primary now — it beats a (stale) legacy companies.price.
+        self.assertEqual(self._pm({"price": 42.0}, 99.0).get_price("AAA"), 99.0)
 
-    def test_level0_fallback_when_absent(self):
+    def test_level0_prices_names_absent_from_companies(self):
         self.assertEqual(self._pm(None, 180.5).get_price("TSM"), 180.5)
 
-    def test_level0_fallback_when_price_null(self):
-        self.assertEqual(self._pm({"price": None}, 12.3).get_price("BBB"), 12.3)
+    def test_companies_fallback_when_level0_empty(self):
+        self.assertEqual(self._pm({"price": 42.0}, None).get_price("AAA"), 42.0)
 
     def test_unknown_ticker_raises(self):
         with self.assertRaises(portfolio_module.PortfolioError):
-            self._pm(None, None).get_price("ZZZ")
+            self._pm(None, None, security=None).get_price("ZZZ")
 
 
 # PortfolioManager._ensure_portfolio_for_agent — creates the 1:1 shim

--- a/test_portfolios.py
+++ b/test_portfolios.py
@@ -187,39 +187,35 @@ class DbPortfolioHelpersTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# PortfolioManager.get_price — Level 0 primary, legacy companies fallback
+# PortfolioManager.get_price — Level 0 is the sole source (companies retired)
 # ---------------------------------------------------------------------------
 
 
 class GetPriceFallbackTests(unittest.TestCase):
-    """Pricing now reads Level 0 first (migration 058), so every Tier-1 name is
-    priceable for trading + MTM; `companies.price` is only a transitional
-    fallback until that table is retired."""
+    """Pricing reads Level 0 only (companies retired): securities.price →
+    prices_daily → last_close, all via get_level0_close()."""
 
-    def _pm(self, company, level0, security=None):
+    def _pm(self, level0, security=None):
         pm = portfolio_module.PortfolioManager.__new__(
             portfolio_module.PortfolioManager
         )
         pm.db = SimpleNamespace(
-            get_company=lambda t: company,
             get_level0_close=lambda t: level0,
             get_security=lambda t: security,
         )
         return pm
 
-    def test_level0_price_wins(self):
-        # Level 0 is primary now — it beats a (stale) legacy companies.price.
-        self.assertEqual(self._pm({"price": 42.0}, 99.0).get_price("AAA"), 99.0)
+    def test_level0_price_used(self):
+        self.assertEqual(self._pm(180.5).get_price("TSM"), 180.5)
 
-    def test_level0_prices_names_absent_from_companies(self):
-        self.assertEqual(self._pm(None, 180.5).get_price("TSM"), 180.5)
-
-    def test_companies_fallback_when_level0_empty(self):
-        self.assertEqual(self._pm({"price": 42.0}, None).get_price("AAA"), 42.0)
+    def test_raises_when_known_but_unpriced(self):
+        # Ticker exists in securities but Level 0 has no usable price.
+        with self.assertRaises(portfolio_module.PortfolioError):
+            self._pm(None, security={"ticker": "AAA"}).get_price("AAA")
 
     def test_unknown_ticker_raises(self):
         with self.assertRaises(portfolio_module.PortfolioError):
-            self._pm(None, None, security=None).get_price("ZZZ")
+            self._pm(None, security=None).get_price("ZZZ")
 
 
 # PortfolioManager._ensure_portfolio_for_agent — creates the 1:1 shim
@@ -292,8 +288,10 @@ class PortfolioTradingTests(unittest.TestCase):
         return pm
 
     def _can_price(self, db, ticker: str, price: float) -> None:
+        # Pricing reads Level 0 now: get_price -> get_level0_close ->
+        # get_security(ticker), which returns securities.price.
         db.client.canned_selects[
-            ("companies", frozenset({("ticker", ticker)}))
+            ("securities", frozenset({("ticker", ticker)}))
         ] = [{"ticker": ticker, "price": price}]
 
     def test_require_portfolio_account_raises_when_missing(self):

--- a/test_theses.py
+++ b/test_theses.py
@@ -101,6 +101,12 @@ class _StubDB:
         self.canned_selects: dict = {}
         # Catalogue of company rows (ticker → row dict) for get_company.
         self.companies: dict[str, dict] = {}
+        # Level 0 catalogues — build_snapshot reads these now (companies
+        # retirement). Keyed by ticker.
+        self.securities: dict[str, dict] = {}
+        self.fundamentals: dict[str, dict] = {}
+        self.valuation: dict[str, dict] = {}
+        self.ai_analysis: dict[str, dict] = {}
         self.client = self  # so theses.py's `db.client.table(...)` resolves to us
 
     def table(self, name):
@@ -108,6 +114,25 @@ class _StubDB:
 
     def get_company(self, ticker):
         return self.companies.get(ticker)
+
+    # --- Level 0 reads used by build_snapshot ---
+    def get_security(self, ticker):
+        return self.securities.get(ticker)
+
+    def get_level0_close(self, ticker):
+        s = self.securities.get(ticker)
+        return s.get("price") if s else None
+
+    def get_fundamentals(self, ticker, latest_only=False):
+        r = self.fundamentals.get(ticker)
+        return [r] if r else []
+
+    def get_valuation(self, ticker, latest_only=True):
+        r = self.valuation.get(ticker)
+        return [r] if r else []
+
+    def get_ai_analysis(self, tickers):
+        return {t: self.ai_analysis[t] for t in tickers if t in self.ai_analysis}
 
 
 # ---------------------------------------------------------------------------
@@ -138,6 +163,40 @@ def _company(ticker="NVDA", **overrides) -> dict:
     return base
 
 
+def _seed_level0(db, ticker="NVDA", **overrides) -> dict:
+    """Populate the stub's Level 0 catalogues so build_snapshot (which now reads
+    securities + fundamentals + valuation + ai_analysis) produces a snapshot
+    equivalent to the old companies row. Maps companies' *_pct column names onto
+    the Level 0 bare names."""
+    row = _company(ticker=ticker, **overrides)
+    db.securities[ticker] = {
+        "ticker": ticker, "name": row.get("company_name"),
+        "country": row.get("country"), "gics_sector": row.get("sector"),
+        "price": row.get("price"),
+    }
+    db.fundamentals[ticker] = {
+        "rule_of_40": row.get("rule_of_40"),
+        "rev_growth_ttm": row.get("rev_growth_ttm_pct"),
+        "rev_growth_qoq": row.get("rev_growth_qoq_pct"),
+        "rev_cagr": row.get("rev_cagr_pct"),
+        "gross_margin": row.get("gross_margin_pct"),
+        "operating_margin": row.get("operating_margin_pct"),
+        "net_margin": row.get("net_margin_pct"),
+        "fcf_margin": row.get("fcf_margin_pct"),
+        "opex_pct_rev": row.get("opex_pct_revenue"),
+        "eps": row.get("eps_only"),
+    }
+    db.valuation[ticker] = {"ps": row.get("ps_now")}
+    db.ai_analysis[ticker] = {
+        "short_outlook": row.get("short_outlook"),
+        "key_risks": row.get("key_risks"),
+        "full_outlook": row.get("full_outlook"),
+        "bull_eval": row.get("bull_eval"),
+        "bear_eval": row.get("bear_eval"),
+    }
+    return row
+
+
 # ---------------------------------------------------------------------------
 # build_snapshot
 # ---------------------------------------------------------------------------
@@ -146,7 +205,7 @@ def _company(ticker="NVDA", **overrides) -> dict:
 class BuildSnapshotTests(unittest.TestCase):
     def test_returns_only_declared_fields(self):
         db = _StubDB()
-        db.companies["NVDA"] = _company()
+        _seed_level0(db, "NVDA")
         snap = theses.build_snapshot(db, "NVDA")
         # Exactly the field set, no more, no less.
         self.assertEqual(set(snap.keys()), set(theses._SNAPSHOT_FIELDS))
@@ -157,7 +216,7 @@ class BuildSnapshotTests(unittest.TestCase):
     def test_missing_fields_become_none(self):
         # Sparse companies row — fields that don't exist on the row are None.
         db = _StubDB()
-        db.companies["AAPL"] = {"ticker": "AAPL", "price": 200.0}
+        db.securities["AAPL"] = {"ticker": "AAPL", "price": 200.0}
         snap = theses.build_snapshot(db, "AAPL")
         self.assertEqual(snap["ticker"], "AAPL")
         self.assertEqual(snap["price"], 200.0)
@@ -375,8 +434,7 @@ class CheckThesisTests(unittest.TestCase):
     def test_active_when_no_signals_triggered(self):
         db = _StubDB()
         snap = _company(fcf_margin_pct=48.0)
-        cur = _company(fcf_margin_pct=47.5)  # tiny drift, no signal triggered
-        db.companies["NVDA"] = cur
+        _seed_level0(db, "NVDA", fcf_margin_pct=47.5)  # tiny drift, no signal
         _seed_thesis_row(
             db, thesis_id=7, ticker="NVDA", snapshot=snap,
             break_signals=[{"field": "fcf_margin_pct", "op": "<", "value": 40}],
@@ -390,8 +448,7 @@ class CheckThesisTests(unittest.TestCase):
     def test_broken_when_break_signal_triggers(self):
         db = _StubDB()
         snap = _company(fcf_margin_pct=48.0)
-        cur = _company(fcf_margin_pct=30.0)  # collapse
-        db.companies["NVDA"] = cur
+        _seed_level0(db, "NVDA", fcf_margin_pct=30.0)  # collapse
         _seed_thesis_row(
             db, thesis_id=7, ticker="NVDA", snapshot=snap,
             break_signals=[
@@ -406,8 +463,7 @@ class CheckThesisTests(unittest.TestCase):
     def test_improved_when_extend_triggers_and_break_clean(self):
         db = _StubDB()
         snap = _company(rev_growth_ttm_pct=60.0)
-        cur = _company(rev_growth_ttm_pct=120.0)  # accelerated
-        db.companies["NVDA"] = cur
+        _seed_level0(db, "NVDA", rev_growth_ttm_pct=120.0)  # accelerated
         _seed_thesis_row(
             db, thesis_id=8, ticker="NVDA", snapshot=snap,
             extend_signals=[
@@ -422,8 +478,7 @@ class CheckThesisTests(unittest.TestCase):
         # Both triggered → 'broken' wins (downside risk dominates).
         db = _StubDB()
         snap = _company(fcf_margin_pct=48.0, rev_growth_ttm_pct=60.0)
-        cur = _company(fcf_margin_pct=30.0, rev_growth_ttm_pct=120.0)
-        db.companies["NVDA"] = cur
+        _seed_level0(db, "NVDA", fcf_margin_pct=30.0, rev_growth_ttm_pct=120.0)
         _seed_thesis_row(
             db, thesis_id=9, ticker="NVDA", snapshot=snap,
             break_signals=[{"field": "fcf_margin_pct", "op": "<", "value": 40}],
@@ -436,8 +491,7 @@ class CheckThesisTests(unittest.TestCase):
         # source='auto' row — no signals at all — verdict is 'active'.
         db = _StubDB()
         snap = _company()
-        cur = _company(fcf_margin_pct=10.0)  # huge drift, but no signal cares
-        db.companies["NVDA"] = cur
+        _seed_level0(db, "NVDA", fcf_margin_pct=10.0)  # huge drift, no signal cares
         _seed_thesis_row(
             db, thesis_id=10, ticker="NVDA", snapshot=snap,
             break_signals=None, extend_signals=None,

--- a/theses.py
+++ b/theses.py
@@ -72,31 +72,92 @@ def build_snapshot(db, ticker: str) -> dict:
     ``snapshot`` JSONB column.
 
     Returns a dict containing exactly the fields in ``_SNAPSHOT_FIELDS``
-    (missing fields become None). Primary source is ``companies``; for a
-    Tier-1 name absent from ``companies`` (the legacy pipeline never covered
-    it) it falls back to a minimal Level 0 snapshot (identity + price) so the
-    thesis still records — rather than raising and dropping the audit row.
-    """
-    company = db.get_company(ticker)
-    if company:
-        return {k: company.get(k) for k in _SNAPSHOT_FIELDS}
+    (missing fields become None). Built PRIMARILY from the Level 0 fact
+    store (securities + fundamentals + valuation + ai_analysis) as part of
+    retiring the legacy ``companies`` / ``price_sales`` tables; each
+    ``_SNAPSHOT_FIELDS`` key is mapped to its Level 0 source below.
 
-    # Level 0 fallback — identity from securities + latest close, rest None.
-    # Fully defensive: a thesis snapshot must never fail to build (it would
-    # drop the audit row), so any read error yields a minimal ticker-only snap.
-    snapshot = {k: None for k in _SNAPSHOT_FIELDS}
+    Fields with no Level 0 equivalent (``composite_score``, ``rating``,
+    ``sort_order``, ``status`` and several pipeline-derived
+    ``companies``-only columns) stay None.
+
+    Fully defensive: a thesis snapshot must never raise (that would drop the
+    audit row), so every Level 0 read is guarded and any error yields the
+    partial snapshot built so far (at minimum a ticker-only snap).
+    """
+    ticker = (ticker or "").upper()
+    snapshot: dict = {k: None for k in _SNAPSHOT_FIELDS}
     snapshot["ticker"] = ticker
+
+    # --- Identity (securities) ---
     try:
         sec = db.get_security(ticker)
-        if sec:
-            snapshot["company_name"] = sec.get("name")
-            snapshot["country"] = sec.get("country")
-            snapshot["sector"] = sec.get("gics_sector")
-        price = db.get_level0_close(ticker)
-        if price is not None:
-            snapshot["price"] = price
     except Exception:  # noqa: BLE001
-        pass
+        sec = None
+    if sec:
+        snapshot["company_name"] = sec.get("name")
+        snapshot["country"] = sec.get("country")
+        snapshot["sector"] = sec.get("gics_sector")
+
+    # --- Latest price (Level 0 price layer: securities.price → prices_daily) ---
+    try:
+        price = db.get_level0_close(ticker)
+    except Exception:  # noqa: BLE001
+        price = None
+    if price is not None:
+        snapshot["price"] = price
+
+    # --- Fundamentals (latest `fundamentals` row) ---
+    # Level 0 column names differ from companies' *_pct columns — they carry
+    # bare margin/growth names already expressed as percentages (same
+    # convention screen.py / llm_watchlist_buyer._build_equity_data reuse).
+    try:
+        fund_rows = db.get_fundamentals(ticker, latest_only=True)
+    except Exception:  # noqa: BLE001
+        fund_rows = []
+    fund = fund_rows[0] if fund_rows else {}
+    if fund:
+        snapshot["rule_of_40"] = fund.get("rule_of_40")
+        # r40_score is the legacy companies alias for the same metric.
+        snapshot["r40_score"] = fund.get("rule_of_40")
+        snapshot["rev_growth_ttm_pct"] = fund.get("rev_growth_ttm")
+        snapshot["rev_growth_qoq_pct"] = fund.get("rev_growth_qoq")
+        snapshot["rev_cagr_pct"] = fund.get("rev_cagr")
+        snapshot["gross_margin_pct"] = fund.get("gross_margin")
+        snapshot["operating_margin_pct"] = fund.get("operating_margin")
+        snapshot["net_margin_pct"] = fund.get("net_margin")
+        snapshot["fcf_margin_pct"] = fund.get("fcf_margin")
+        snapshot["opex_pct_revenue"] = fund.get("opex_pct_rev")
+        snapshot["eps_only"] = fund.get("eps")
+
+    # --- Valuation (latest `valuation` row) ---
+    try:
+        val_rows = db.get_valuation(ticker, latest_only=True)
+    except Exception:  # noqa: BLE001
+        val_rows = []
+    val = val_rows[0] if val_rows else {}
+    if val:
+        snapshot["ps_now"] = val.get("ps")
+
+    # --- AI narrative + bull/bear (Level 0 `ai_analysis`) ---
+    try:
+        ai_map = db.get_ai_analysis([ticker])
+        ai = ai_map.get(ticker) or {}
+    except Exception:  # noqa: BLE001
+        ai = {}
+    if ai:
+        snapshot["short_outlook"] = ai.get("short_outlook")
+        snapshot["key_risks"] = ai.get("key_risks")
+        snapshot["full_outlook"] = ai.get("full_outlook")
+        snapshot["bull_eval"] = ai.get("bull_eval")
+        snapshot["bear_eval"] = ai.get("bear_eval")
+
+    # Fields with NO Level 0 source stay None:
+    #   composite_score, rating, status, sort_order (not in _SNAPSHOT_FIELDS),
+    #   rev_consistency_score, net_margin_yoy_pct, sm_rd_pct_revenue,
+    #   eps_yoy_pct, qrtrs_to_profitability, gm_trend, price_pct_of_52w_high,
+    #   perf_52w_vs_spy, flags, ai_analyzed_at — all pipeline-derived columns
+    #   the Level 0 fact store does not (yet) carry.
     return snapshot
 
 
@@ -305,7 +366,11 @@ def check_thesis(db, thesis_id: int) -> dict:
 
     ticker = thesis["ticker"]
     snapshot = thesis.get("snapshot") or {}
-    current_row = db.get_company(ticker) or {}
+    # Current state is assembled from the Level 0 fact store via build_snapshot
+    # (same field mapping the thesis snapshot was frozen with), so the snapshot
+    # vs current comparison stays apples-to-apples now that `companies` is being
+    # retired. build_snapshot is fully defensive and never raises.
+    current_row = build_snapshot(db, ticker) or {}
 
     break_signals = thesis.get("break_signals") or []
     extend_signals = thesis.get("extend_signals") or []

--- a/update_ai_narratives.py
+++ b/update_ai_narratives.py
@@ -429,28 +429,22 @@ def main():
     # Connect to Supabase
     db = SupabaseDB()
 
-    # Get companies needing update
+    # Get equities needing update. The legacy companies stale/force rotation is
+    # retired — narratives rotate over the full Tier-1 universe from Level 0
+    # (oldest-narrated first, capped per run so the daily LLM cost stays flat).
+    import level0_eval
     if args.ticker:
-        company = db.get_company(args.ticker)
+        company = db.get_security(args.ticker)
         if not company:
-            logger.error("Ticker %s not found in database", args.ticker)
+            logger.error("Ticker %s not found in securities", args.ticker)
             sys.exit(1)
         companies_to_update = [company]
         logger.info("Single-ticker mode: processing %s", args.ticker)
-    elif args.tier1:
-        # Stage A2: narrate the full Tier-1 universe, oldest-narrated first.
-        # Capped per run (rotation) so the first pass over ~3k names doesn't
-        # fire thousands of LLM calls at once — keeps the daily cost flat.
-        import level0_eval
+    else:
         companies_to_update = level0_eval.tier1_eval_candidates(
             db, "narrative", TIER1_NARRATIVE_BATCH)
-        logger.info("Tier-1 mode: narrating %d oldest names (cap %d)",
+        logger.info("Narrating %d oldest Tier-1 names (cap %d)",
                     len(companies_to_update), TIER1_NARRATIVE_BATCH)
-    elif args.force:
-        companies_to_update = db.get_all_companies()
-        logger.info("Force mode: refreshing all %d companies", len(companies_to_update))
-    else:
-        companies_to_update = db.get_stale_companies("ai_analyzed_at", STALENESS_DAYS)
 
     logger.info("Found %d companies needing update", len(companies_to_update))
 
@@ -468,12 +462,8 @@ def main():
                 company, serpapi_key, args.dry_run, logger
             )
             if update_fields and not args.dry_run:
-                # ai_analysis is the Level 0 home (migrations 053/054): always
-                # write the narrative + its rotation clock (narrated_at). In
-                # --tier1 mode that's the only write (the name may not exist in
-                # companies); otherwise dual-write companies for legacy surfaces.
-                if not args.tier1:
-                    db.upsert_company(ticker, update_fields)
+                # ai_analysis is the Level 0 home (migrations 053/054) and now
+                # the sole home: write the narrative + its rotation clock.
                 db.upsert_ai_analysis(ticker, {
                     "short_outlook": update_fields.get("short_outlook"),
                     "full_outlook": update_fields.get("full_outlook"),

--- a/user_report.py
+++ b/user_report.py
@@ -228,7 +228,7 @@ class ReportData:
         if not tickers:
             return out
         resp = (
-            self.c.table("companies")
+            self.c.table("securities")
             .select("ticker, price")
             .in_("ticker", list({t for t in tickers if t}))
             .execute()

--- a/web/app/api/companies/route.ts
+++ b/web/app/api/companies/route.ts
@@ -40,14 +40,23 @@ export async function GET() {
     const supabase = getSupabase();
 
     const { data, error } = await supabase
-      .from("companies")
-      .select("ticker, company_name, updated_at")
+      .from("securities")
+      .select("ticker, name, updated_at")
+      .eq("status", "active")
       .not("ticker", "is", null)
       .order("ticker", { ascending: true });
     if (error) {
       return errorResponse(error.message, 500);
     }
-    const rows = (data ?? []) as unknown as CompanyRow[];
+    const rows = ((data ?? []) as unknown as {
+      ticker: string;
+      name: string | null;
+      updated_at: string | null;
+    }[]).map((r) => ({
+      ticker: r.ticker,
+      company_name: r.name,
+      updated_at: r.updated_at,
+    })) as CompanyRow[];
 
     // Dedupe by ticker (first occurrence wins per the brief).
     const seen = new Set<string>();

--- a/web/app/api/consensus/route.ts
+++ b/web/app/api/consensus/route.ts
@@ -86,18 +86,48 @@ export async function GET() {
       );
     }
 
-    // 3. Bulk-fetch name + short_outlook for those tickers.
+    // 3. Bulk-fetch name (Level 0 `securities`) + short_outlook / analyzed_at
+    //    (Level 0 `ai_analysis`) for those tickers.
     const tickers = rows.map((r) => r.ticker);
-    const { data: companies, error: cErr } = await supabase
-      .from("companies")
-      .select("ticker, company_name, short_outlook, ai_analyzed_at")
-      .in("ticker", tickers);
-    if (cErr) {
-      return errorResponse(cErr.message, 500);
+    const [secRes, aiRes] = await Promise.all([
+      supabase.from("securities").select("ticker, name").in("ticker", tickers),
+      supabase
+        .from("ai_analysis")
+        .select("ticker, short_outlook, analyzed_at")
+        .in("ticker", tickers),
+    ]);
+    if (secRes.error) {
+      return errorResponse(secRes.error.message, 500);
+    }
+    if (aiRes.error) {
+      return errorResponse(aiRes.error.message, 500);
     }
     const meta = new Map<string, CompanyRow>();
-    for (const c of (companies ?? []) as unknown as CompanyRow[]) {
-      meta.set(c.ticker, c);
+    for (const s of (secRes.data ?? []) as { ticker: string; name: string | null }[]) {
+      meta.set(s.ticker, {
+        ticker: s.ticker,
+        company_name: s.name,
+        short_outlook: null,
+        ai_analyzed_at: null,
+      });
+    }
+    for (const a of (aiRes.data ?? []) as {
+      ticker: string;
+      short_outlook: string | null;
+      analyzed_at: string | null;
+    }[]) {
+      const existing = meta.get(a.ticker);
+      if (existing) {
+        existing.short_outlook = a.short_outlook;
+        existing.ai_analyzed_at = a.analyzed_at;
+      } else {
+        meta.set(a.ticker, {
+          ticker: a.ticker,
+          company_name: null,
+          short_outlook: a.short_outlook,
+          ai_analyzed_at: a.analyzed_at,
+        });
+      }
     }
 
     // 4. Shape entries. Drop any ticker we can't resolve a name for —

--- a/web/app/company/[ticker]/opengraph-image.tsx
+++ b/web/app/company/[ticker]/opengraph-image.tsx
@@ -53,6 +53,13 @@ export default async function Image({
     sort_order: number | null;
   };
   let company: CompanyShape | null = null;
+  type SecurityRow = {
+    name: string | null;
+    exchange: string | null;
+    country: string | null;
+    gics_sector: string | null;
+    price: number | null;
+  };
   let snapshot: Awaited<ReturnType<typeof getCompanySwarmSnapshot>> | null =
     null;
   let holders: Awaited<ReturnType<typeof getCompanyHolders>> = [];
@@ -63,9 +70,11 @@ export default async function Image({
   try {
     const supabase = getSupabase();
     const [companyRes, snap, hldrs, trds, rats, countRes] = await Promise.all([
+      // Identity + price from Level 0 (`securities`). `sort_order` has no
+      // Level 0 equivalent, so the OG rank label is omitted.
       supabase
-        .from("companies")
-        .select("company_name, exchange, country, sector, price, sort_order")
+        .from("securities")
+        .select("name, exchange, country, gics_sector, price")
         .eq("ticker", ticker)
         .maybeSingle(),
       getCompanySwarmSnapshot(ticker),
@@ -74,14 +83,24 @@ export default async function Image({
       // action even for stocks with thousands of historical trades.
       getCompanyTradeTape(ticker, 200),
       getHeartbeatRationales(ticker, 12),
-      // Total screened-universe count → "Rank #N of M+" label.
+      // Total Tier 1 universe count → "Rank #N of M+" label.
       supabase
-        .from("companies")
+        .from("securities")
         .select("ticker", { count: "exact", head: true })
-        .eq("in_tv_screen", true),
+        .eq("is_tier1", true)
+        .eq("status", "active"),
     ]);
-    company =
-      (companyRes.data as CompanyShape | null) ?? null;
+    const sec = (companyRes.data as SecurityRow | null) ?? null;
+    company = sec
+      ? {
+          company_name: sec.name,
+          exchange: sec.exchange,
+          country: sec.country,
+          sector: sec.gics_sector,
+          price: sec.price == null ? null : Number(sec.price),
+          sort_order: null,
+        }
+      : null;
     snapshot = snap;
     holders = hldrs;
     trades = trds;

--- a/web/app/portfolio/page.tsx
+++ b/web/app/portfolio/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { getSupabase } from "@/lib/supabase";
-import { Company, SCREENER_COLUMNS } from "@/lib/types";
+import { Company } from "@/lib/types";
 import { deduplicateByCompany } from "@/lib/dedupe";
+import { runScreen } from "@/lib/screen/query";
+import { configFromParams, DEFAULT_PRESET } from "@/lib/screen/config";
 import Nav from "@/components/nav";
 import DataTable from "@/components/data-table";
 
@@ -21,33 +23,77 @@ export const metadata: Metadata = {
   },
 };
 
-const PASS_EMOJI = "\u2705"; // ✅
 
 async function getPortfolio(): Promise<{
   picks: Company[];
   beforeDedup: number;
 }> {
-  const supabase = getSupabase();
-  const { data, error } = await supabase
-    .from("companies")
-    .select(SCREENER_COLUMNS)
-    .not("bear_eval", "is", null)
-    .not("bull_eval", "is", null)
-    .order("composite_score", { ascending: false, nullsFirst: false });
+  // Source the dual-positive list from the Level 0 screen (the legacy
+  // `companies` table is retired). The screen ranks the whole Tier 1 universe
+  // and folds in the AI bull/bear booleans from `ai_analysis`; we keep names
+  // that pass BOTH evals, ranked by the screen's single ordering score.
+  const screen = await runScreen(configFromParams({ preset: DEFAULT_PRESET }));
+  const dualRows = screen.rows.filter((r) => r.bull === true && r.bear === true);
 
-  if (error) {
-    console.error("Failed to fetch example agent picks:", error);
-    return { picks: [], beforeDedup: 0 };
+  // Overlay the AI eval text + short_outlook (the DataTable shows the pass/fail
+  // badges + rationale tooltips) from `ai_analysis`.
+  const supabase = getSupabase();
+  const evalByTicker = new Map<
+    string,
+    { bull_eval: string | null; bear_eval: string | null; short_outlook: string | null }
+  >();
+  if (dualRows.length > 0) {
+    const { data: aiRows } = await supabase
+      .from("ai_analysis")
+      .select("ticker, bull_eval, bear_eval, short_outlook")
+      .in(
+        "ticker",
+        dualRows.map((r) => r.ticker),
+      );
+    for (const a of (aiRows ?? []) as {
+      ticker: string;
+      bull_eval: string | null;
+      bear_eval: string | null;
+      short_outlook: string | null;
+    }[]) {
+      evalByTicker.set(a.ticker, {
+        bull_eval: a.bull_eval,
+        bear_eval: a.bear_eval,
+        short_outlook: a.short_outlook,
+      });
+    }
   }
 
-  const rows = (data ?? []) as unknown as Company[];
-  const dualPositive = rows.filter(
-    (c) =>
-      typeof c.bear_eval === "string" &&
-      c.bear_eval.includes(PASS_EMOJI) &&
-      typeof c.bull_eval === "string" &&
-      c.bull_eval.includes(PASS_EMOJI),
-  );
+  // Project each scored row into the partial Company shape the DataTable reads.
+  // Opinionated TradingView-era columns with no Level 0 source are null:
+  //   - composite_score -> the screen's displayed percentile (final_pct)
+  //   - sort_order      -> the screen rank
+  //   - rating          -> null (TradingView only)
+  const dualPositive: Company[] = dualRows.map((r) => {
+    const ai = evalByTicker.get(r.ticker);
+    return {
+      ticker: r.ticker,
+      company_name: r.name ?? r.ticker,
+      country: r.country ?? "",
+      sector: r.sector ?? "",
+      price: r.price,
+      ps_now: r.ps,
+      ps_median_12m: r.ps_median_12m,
+      rev_growth_ttm_pct: r.rev_growth_ttm,
+      gross_margin_pct: r.gross_margin,
+      fcf_margin_pct: r.fcf_margin,
+      rule_of_40: r.rule_of_40,
+      // The DataTable renders perf as `value * 100`, so convert the screen's
+      // already-percentage value back to a fraction.
+      perf_52w_vs_spy: r.perf_52w_vs_spy != null ? r.perf_52w_vs_spy / 100 : null,
+      rating: null,
+      composite_score: r.final_pct,
+      sort_order: r.rank,
+      bull_eval: ai?.bull_eval ?? null,
+      bear_eval: ai?.bear_eval ?? null,
+      short_outlook: ai?.short_outlook ?? "",
+    } as Company;
+  });
 
   const deduped = deduplicateByCompany(dualPositive);
   // Re-sort by composite_score (dedup preserves input order otherwise)

--- a/web/app/screener/page.tsx
+++ b/web/app/screener/page.tsx
@@ -106,18 +106,31 @@ function formatAsOf(s: string): string {
 }
 
 /**
- * Tickers that have a /company/<ticker> page (the legacy `companies` table).
- * The screener ranks the full Level 0 Tier 1 universe, which is broader than
- * `companies`, so names outside this set would 404 — we render them as plain
- * text instead of a broken link.
+ * Tickers that have a /company/<ticker> page. The page now renders any active
+ * Tier 1 security straight from the Level 0 fact store, so EVERY name the
+ * screener ranks is linkable — gate on `securities.is_tier1` (active), which
+ * is the same universe the screen ranks over.
  */
 async function getCompanyTickers(): Promise<string[]> {
-  const { data, error } = await getSupabase().from("companies").select("ticker");
-  if (error) {
-    console.error("getCompanyTickers failed:", error);
-    return [];
+  const tickers: string[] = [];
+  const supabase = getSupabase();
+  const PAGE = 1000;
+  for (let page = 0; ; page++) {
+    const { data, error } = await supabase
+      .from("securities")
+      .select("ticker")
+      .eq("is_tier1", true)
+      .eq("status", "active")
+      .range(page * PAGE, (page + 1) * PAGE - 1);
+    if (error) {
+      console.error("getCompanyTickers failed:", error);
+      break;
+    }
+    const batch = (data ?? []) as { ticker: string }[];
+    tickers.push(...batch.map((r) => r.ticker));
+    if (batch.length < PAGE) break;
   }
-  return ((data ?? []) as { ticker: string }[]).map((r) => r.ticker);
+  return tickers;
 }
 
 export default async function ScreenerPage({

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -34,17 +34,28 @@ async function getCompanyEntries(): Promise<MetadataRoute.Sitemap> {
     // traded it OR it has full fundamentals + an AI narrative. Untraded,
     // data-sparse pages are kept OUT of the sitemap (and `noindex`ed) so
     // thousands of thin near-duplicates can't dilute crawl budget.
-    const [companiesRes, tradedRes] = await Promise.all([
+    // Identity + updated_at from Level 0 (`securities`, Tier 1); the AI
+    // narrative `short_outlook` lives in `ai_analysis` (migration 053).
+    const [companiesRes, narrativeRes, tradedRes] = await Promise.all([
       supabase
-        .from("companies")
-        .select("ticker, updated_at, short_outlook")
-        .order("sort_order", { ascending: true, nullsFirst: false }),
+        .from("securities")
+        .select("ticker, updated_at")
+        .eq("is_tier1", true)
+        .eq("status", "active")
+        .order("ticker", { ascending: true }),
+      supabase
+        .from("ai_analysis")
+        .select("ticker, short_outlook")
+        .not("short_outlook", "is", null),
       supabase.from("agent_trades").select("ticker"),
     ]);
 
     if (companiesRes.error) {
-      console.error("sitemap: company fetch failed:", companiesRes.error);
+      console.error("sitemap: securities fetch failed:", companiesRes.error);
       return [];
+    }
+    if (narrativeRes.error) {
+      console.error("sitemap: ai_analysis fetch failed:", narrativeRes.error);
     }
     if (tradedRes.error) {
       console.error("sitemap: agent_trades fetch failed:", tradedRes.error);
@@ -53,12 +64,18 @@ async function getCompanyEntries(): Promise<MetadataRoute.Sitemap> {
     const tradedTickers = new Set(
       (tradedRes.data ?? []).map((r: { ticker: string }) => r.ticker),
     );
+    const shortOutlookByTicker = new Map<string, string | null>(
+      ((narrativeRes.data ?? []) as {
+        ticker: string;
+        short_outlook: string | null;
+      }[]).map((r) => [r.ticker, r.short_outlook]),
+    );
 
     return (companiesRes.data ?? [])
-      .filter((row: { ticker: string; short_outlook: string | null }) =>
+      .filter((row: { ticker: string }) =>
         isCompanyIndexable({
           hasTrades: tradedTickers.has(row.ticker),
-          shortOutlook: row.short_outlook,
+          shortOutlook: shortOutlookByTicker.get(row.ticker) ?? null,
         }),
       )
       .map((row: { ticker: string; updated_at: string | null }) => ({

--- a/web/lib/arena-query.ts
+++ b/web/lib/arena-query.ts
@@ -2,8 +2,9 @@
  * Landing-page data fetches for the Arena surface.
  *
  * Everything here is derived from existing tables — there's no new arena
- * data store in Phase 2a.5. The Molt Feed reads the legacy bear/bull eval
- * columns directly on `companies`.
+ * data store in Phase 2a.5. The Molt Feed reads the bear/bull eval columns
+ * from the Level 0 `ai_analysis` home (migration 053); the equity count is
+ * the Tier 1 universe (`securities.is_tier1`).
  */
 
 import { getSupabase } from "@/lib/supabase";
@@ -43,16 +44,20 @@ export async function getArenaStats(): Promise<ArenaStats> {
   const weekAgoIso = weekAgo.toISOString().slice(0, 10); // DATE column
 
   const [equitiesRes, agentsRes, bearRes, bullRes] = await Promise.all([
-    supabase.from("companies").select("ticker", { count: "exact", head: true }),
+    supabase
+      .from("securities")
+      .select("ticker", { count: "exact", head: true })
+      .eq("is_tier1", true)
+      .eq("status", "active"),
     supabase.from("agents").select("id", { count: "exact", head: true }),
     supabase
-      .from("companies")
+      .from("ai_analysis")
       .select("ticker", { count: "exact", head: true })
-      .gte("bear_eval_at", weekAgoIso),
+      .gte("bear_at", weekAgoIso),
     supabase
-      .from("companies")
+      .from("ai_analysis")
       .select("ticker", { count: "exact", head: true })
-      .gte("bull_eval_at", weekAgoIso),
+      .gte("bull_at", weekAgoIso),
   ]);
 
   return {
@@ -65,25 +70,44 @@ export async function getArenaStats(): Promise<ArenaStats> {
 export async function getMoltFeed(limit = 20): Promise<MoltFeedItem[]> {
   const supabase = getSupabase();
 
-  // Pull the latest bear and bull evals separately, then merge client-side.
-  // We over-fetch each side by `limit` so the combined top-N is always correct.
+  // Pull the latest bear and bull evals separately from the Level 0
+  // `ai_analysis` home, then merge client-side. We over-fetch each side by
+  // `limit` so the combined top-N is always correct.
   const [bearRes, bullRes] = await Promise.all([
     supabase
-      .from("companies")
-      .select("ticker, company_name, bear_eval, bear_eval_at")
-      .not("bear_eval_at", "is", null)
-      .order("bear_eval_at", { ascending: false })
+      .from("ai_analysis")
+      .select("ticker, bear_eval, bear_at")
+      .not("bear_at", "is", null)
+      .order("bear_at", { ascending: false })
       .limit(limit),
     supabase
-      .from("companies")
-      .select("ticker, company_name, bull_eval, bull_eval_at")
-      .not("bull_eval_at", "is", null)
-      .order("bull_eval_at", { ascending: false })
+      .from("ai_analysis")
+      .select("ticker, bull_eval, bull_at")
+      .not("bull_at", "is", null)
+      .order("bull_at", { ascending: false })
       .limit(limit),
   ]);
 
   if (bearRes.error || bullRes.error) {
     return [];
+  }
+
+  // `ai_analysis` carries no name — resolve company names from `securities`.
+  const tickers = Array.from(
+    new Set([
+      ...((bearRes.data ?? []) as { ticker: string }[]).map((r) => r.ticker),
+      ...((bullRes.data ?? []) as { ticker: string }[]).map((r) => r.ticker),
+    ]),
+  );
+  const names = new Map<string, string>();
+  if (tickers.length > 0) {
+    const { data: secRows } = await supabase
+      .from("securities")
+      .select("ticker, name")
+      .in("ticker", tickers);
+    for (const s of (secRows ?? []) as { ticker: string; name: string | null }[]) {
+      if (s.name) names.set(s.ticker, s.name);
+    }
   }
 
   const items: MoltFeedItem[] = [];
@@ -93,10 +117,10 @@ export async function getMoltFeed(limit = 20): Promise<MoltFeedItem[]> {
       agent_handle: "fundamental-sentinel",
       agent_display_name: "Fundamental Sentinel",
       ticker: row.ticker as string,
-      company_name: (row.company_name as string) || "",
+      company_name: names.get(row.ticker as string) || "",
       verdict: parseVerdict(row.bear_eval as string | null),
       rationale: extractEvalRationale(row.bear_eval as string | null),
-      at: row.bear_eval_at as string,
+      at: row.bear_at as string,
       side: "bear",
     });
   }
@@ -105,10 +129,10 @@ export async function getMoltFeed(limit = 20): Promise<MoltFeedItem[]> {
       agent_handle: "smash-hit-scout",
       agent_display_name: "Smash-Hit Scout",
       ticker: row.ticker as string,
-      company_name: (row.company_name as string) || "",
+      company_name: names.get(row.ticker as string) || "",
       verdict: parseVerdict(row.bull_eval as string | null),
       rationale: extractEvalRationale(row.bull_eval as string | null),
-      at: row.bull_eval_at as string,
+      at: row.bull_at as string,
       side: "bull",
     });
   }

--- a/web/lib/company-agents-query.ts
+++ b/web/lib/company-agents-query.ts
@@ -133,7 +133,7 @@ export async function getCompanySwarmSnapshot(
       .select("id", { count: "exact", head: true })
       .not("strategy", "is", null),
     supabase
-      .from("companies")
+      .from("securities")
       .select("price")
       .eq("ticker", ticker)
       .maybeSingle(),
@@ -233,7 +233,7 @@ export async function getCompanyHolders(
       )
       .eq("ticker", ticker),
     supabase
-      .from("companies")
+      .from("securities")
       .select("price")
       .eq("ticker", ticker)
       .maybeSingle(),

--- a/web/lib/company-page-data.ts
+++ b/web/lib/company-page-data.ts
@@ -17,6 +17,7 @@
 
 import { cache } from "react";
 import { getSupabase } from "@/lib/supabase";
+import { getEquityL0 } from "@/lib/level0-query";
 import type { Company, PriceSales } from "@/lib/types";
 import {
   getCompanyHolders,
@@ -42,27 +43,215 @@ import {
 } from "@/lib/company-report-query";
 import { getMetricStats, type MetricStatsBundle } from "@/lib/metric-stats-query";
 
+/**
+ * The AI narrative + bull/bear lens for one ticker, read from the Level 0
+ * `ai_analysis` home (migration 053) — NOT the legacy `companies` columns.
+ */
+interface AiAnalysisRow {
+  bull_eval: string | null;
+  bear_eval: string | null;
+  bull_at: string | null;
+  bear_at: string | null;
+  short_outlook: string | null;
+  key_risks: string | null;
+  full_outlook: string | null;
+  event_impact: string | null;
+  analyzed_at: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * The company shell, reconstructed from the Level 0 fact store:
+ *   - identity / price / fundamentals / valuation / bull-bear → `api_universe_facts`
+ *     RPC (web/lib/level0-query.ts `getEquityL0`)
+ *   - narrative + bull/bear text → `ai_analysis`
+ *   - `updated_at` → `securities.updated_at`
+ *
+ * Opinionated TradingView-era columns with no Level 0 equivalent
+ * (`composite_score`, `sort_order`, `rating`, `flags`, the
+ * `annual_revenue_5y` / `quarterly_revenue` text blobs, `eps_yoy_pct`,
+ * `gm_trend`, etc.) are surfaced as null so the page renders "—" / omits
+ * them rather than inventing data. Returns null when the ticker isn't in
+ * the Tier 1 universe.
+ */
 export const loadCompany = cache(async (ticker: string): Promise<Company | null> => {
   const supabase = getSupabase();
-  const { data } = await supabase
-    .from("companies")
-    .select("*")
-    .eq("ticker", ticker)
-    .maybeSingle();
-  return (data as Company | null) ?? null;
+  const t = ticker.toUpperCase();
+
+  const [equity, aiRes, secRes] = await Promise.all([
+    getEquityL0(t),
+    supabase
+      .from("ai_analysis")
+      .select(
+        "bull_eval, bear_eval, bull_at, bear_at, short_outlook, key_risks, " +
+          "full_outlook, event_impact, analyzed_at, updated_at",
+      )
+      .eq("ticker", t)
+      .maybeSingle(),
+    supabase
+      .from("securities")
+      .select("updated_at")
+      .eq("ticker", t)
+      .maybeSingle(),
+  ]);
+
+  if (!equity) return null;
+
+  const ai = (aiRes.data as AiAnalysisRow | null) ?? null;
+  const securityUpdatedAt =
+    (secRes.data as { updated_at: string | null } | null)?.updated_at ?? null;
+  const updatedAt = securityUpdatedAt ?? ai?.updated_at ?? equity.price_asof;
+
+  const company: Company = {
+    // Identity
+    ticker: equity.ticker,
+    exchange: equity.exchange ?? "",
+    company_name: equity.company_name ?? equity.ticker,
+    country: equity.country ?? "",
+    sector: equity.sector ?? "",
+    description: "",
+
+    // Screening — opinionated columns with no Level 0 equivalent stay null.
+    status: equity.status ?? "",
+    composite_score: null,
+    price: equity.price,
+    price_asof: equity.price_asof,
+    ps_now: equity.ps_now,
+    price_pct_of_52w_high: null,
+    perf_52w_vs_spy: null,
+    rating: null,
+    sort_order: null,
+
+    // Overview
+    r40_score: "",
+    fundamentals_snapshot: "",
+    short_outlook: ai?.short_outlook ?? "",
+
+    // Revenue — the text-blob series have no Level 0 source.
+    annual_revenue_5y: "",
+    quarterly_revenue: "",
+    rev_growth_ttm_pct: equity.rev_growth_ttm_pct,
+    rev_growth_qoq_pct: equity.rev_growth_qoq_pct,
+    rev_cagr_pct: equity.rev_cagr_pct,
+    rev_consistency_score: "",
+
+    // Margins
+    gross_margin_pct: equity.gross_margin_pct,
+    gm_trend: "",
+    operating_margin_pct: equity.operating_margin_pct,
+    net_margin_pct: equity.net_margin_pct,
+    net_margin_yoy_pct: null,
+    fcf_margin_pct: equity.fcf_margin_pct,
+
+    // Efficiency
+    opex_pct_revenue: null,
+    sm_rd_pct_revenue: null,
+    rule_of_40: equity.rule_of_40,
+    qrtrs_to_profitability: "",
+
+    // Earnings
+    eps_only: equity.eps_only,
+    eps_yoy_pct: null,
+
+    // Data quality
+    one_time_events: "",
+    event_impact: ai?.event_impact ?? "",
+
+    // AI narrative
+    full_outlook: ai?.full_outlook ?? "",
+    key_risks: ai?.key_risks ?? "",
+
+    // Evaluations
+    bear_eval: ai?.bear_eval ?? null,
+    bear_eval_at: ai?.bear_at ?? null,
+    bull_eval: ai?.bull_eval ?? null,
+    bull_eval_at: ai?.bull_at ?? null,
+
+    // Joined from valuation
+    ps_median_12m: equity.ps_median_12m,
+
+    // Portfolio
+    in_portfolio: null,
+    portfolio_sort_order: null,
+
+    // Metadata
+    ai_analyzed_at: ai?.analyzed_at ?? null,
+    data_updated_at: equity.fundamentals_asof ?? null,
+    scored_at: null,
+    flags: null,
+    in_tv_screen: equity.is_tier1,
+    created_at: updatedAt ?? "",
+    updated_at: updatedAt ?? "",
+  };
+
+  return company;
 });
 
+/**
+ * P/S series + 52-week stats for one ticker, read from the Level 0
+ * `valuation` table (latest row per ticker) rather than the legacy
+ * `price_sales` table. Falls back to `price_sales` only when valuation has
+ * no row yet (mirrors web/lib/screen/ps-history-query.ts).
+ */
 export const loadPriceSales = cache(
   async (ticker: string): Promise<PriceSales | null> => {
     const supabase = getSupabase();
+    const t = ticker.toUpperCase();
+
+    const { data: vrow } = await supabase
+      .from("valuation")
+      .select(
+        "ticker, ps, ps_median_12m, ps_high_52w, ps_low_52w, ps_ath, " +
+          "ps_pct_of_ath, history_json, fetched_at",
+      )
+      .eq("ticker", t)
+      .order("date", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const v = vrow as {
+      ticker: string;
+      ps: number | string | null;
+      ps_median_12m: number | string | null;
+      ps_high_52w: number | string | null;
+      ps_low_52w: number | string | null;
+      ps_ath: number | string | null;
+      ps_pct_of_ath: number | string | null;
+      history_json: PriceSales["history_json"] | null;
+      fetched_at: string | null;
+    } | null;
+
+    if (v) {
+      return {
+        ticker: v.ticker,
+        company_name: "",
+        ps_now: numOrNull(v.ps),
+        high_52w: numOrNull(v.ps_high_52w),
+        low_52w: numOrNull(v.ps_low_52w),
+        median_12m: numOrNull(v.ps_median_12m),
+        ath: numOrNull(v.ps_ath),
+        pct_of_ath: numOrNull(v.ps_pct_of_ath),
+        history_json: Array.isArray(v.history_json) ? v.history_json : [],
+        last_updated: v.fetched_at,
+        first_recorded: null,
+      };
+    }
+
+    // Fallback: legacy price_sales for names valuation hasn't reached yet.
     const { data } = await supabase
       .from("price_sales")
       .select("*")
-      .eq("ticker", ticker)
+      .eq("ticker", t)
       .maybeSingle();
     return (data as PriceSales | null) ?? null;
   },
 );
+
+function numOrNull(v: number | string | null | undefined): number | null {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
 
 export const loadMetricStats = cache(
   async (): Promise<MetricStatsBundle> => getMetricStats(),
@@ -87,24 +276,31 @@ export const loadPeers = cache(
     limit = 4,
   ): Promise<PeerTicker[]> => {
     if (!sector) return [];
+    // Same-sector Tier 1 peers from Level 0 (`securities`), each of which has
+    // its own /company page. P/S is filled in from the cached universe facts
+    // (`getEquityL0`) rather than a per-row valuation join.
     const supabase = getSupabase();
     const { data, error } = await supabase
-      .from("companies")
-      .select("ticker, company_name, ps_now")
-      .eq("sector", sector)
-      .eq("in_tv_screen", true)
+      .from("securities")
+      .select("ticker, name")
+      .eq("gics_sector", sector)
+      .eq("is_tier1", true)
+      .eq("status", "active")
       .neq("ticker", ticker)
-      .not("company_name", "is", null)
+      .not("name", "is", null)
       .limit(60);
     if (error) {
       console.error("loadPeers failed:", error.message);
       return [];
     }
-    const rows = ((data as PeerTicker[] | null) ?? []).map((r) => ({
-      ticker: r.ticker,
-      company_name: r.company_name,
-      ps_now: r.ps_now == null ? null : Number(r.ps_now),
-    }));
+    const peerRows = (data as { ticker: string; name: string | null }[] | null) ?? [];
+    const rows: PeerTicker[] = await Promise.all(
+      peerRows.map(async (r) => ({
+        ticker: r.ticker,
+        company_name: r.name ?? r.ticker,
+        ps_now: (await getEquityL0(r.ticker))?.ps_now ?? null,
+      })),
+    );
     // Nearest by P/S when we have a reference; otherwise first N by name.
     if (psNow != null) {
       rows.sort((a, b) => {

--- a/web/lib/consensus-query.ts
+++ b/web/lib/consensus-query.ts
@@ -179,12 +179,12 @@ async function fetchContestedTicker(): Promise<ContestedTicker | null> {
   if (!best) return null;
 
   const { data: company } = await supabase
-    .from("companies")
-    .select("company_name")
+    .from("securities")
+    .select("name")
     .eq("ticker", best.ticker)
     .maybeSingle();
   const company_name =
-    (company as { company_name?: string } | null)?.company_name ?? best.ticker;
+    (company as { name?: string } | null)?.name ?? best.ticker;
 
   // Neutral copy: the firing break signal isn't persisted at sell time, so we
   // never claim a shared tripped signal we can't prove.
@@ -226,26 +226,26 @@ async function fetchSnapshotRows(
     (r) => (r as unknown as { ticker: string }).ticker,
   );
 
-  // Bulk-fetch company_name + exchange so the page can render
-  // "AAPL · Apple Inc. · NASDAQ".
+  // Bulk-fetch name + exchange from Level 0 (`securities`) so the page can
+  // render "AAPL · Apple Inc. · NASDAQ".
   const meta = new Map<
     string,
     { company_name: string; exchange: string | null }
   >();
   const { data: companies, error: cErr } = await supabase
-    .from("companies")
-    .select("ticker, company_name, exchange")
+    .from("securities")
+    .select("ticker, name, exchange")
     .in("ticker", tickers);
   if (cErr) {
-    throw new Error(`companies lookup: ${cErr.message}`);
+    throw new Error(`securities lookup: ${cErr.message}`);
   }
   for (const c of (companies ?? []) as unknown as {
     ticker: string;
-    company_name: string;
+    name: string;
     exchange: string | null;
   }[]) {
     meta.set(c.ticker, {
-      company_name: c.company_name,
+      company_name: c.name,
       exchange: c.exchange,
     });
   }

--- a/web/lib/portfolio.ts
+++ b/web/lib/portfolio.ts
@@ -110,9 +110,11 @@ interface CompanyMeta {
 }
 
 /**
- * Bulk-fetch price + company_name for a set of tickers in a single SELECT.
- * Returns an empty map if `tickers` is empty. Tickers missing from `companies`
- * simply won't appear in the result map — callers handle that as a fallback.
+ * Bulk-fetch price + name for a set of tickers in a single SELECT, reading the
+ * Level 0 identity/price layer (`securities` — migration 058) rather than the
+ * legacy `companies` table. Returns an empty map if `tickers` is empty. Tickers
+ * missing from `securities` simply won't appear in the result map — callers
+ * handle that as a fallback.
  */
 async function getCompaniesMeta(
   tickers: string[],
@@ -121,24 +123,24 @@ async function getCompaniesMeta(
   if (tickers.length === 0) return out;
   const supabase = getSupabase();
   const { data, error } = await supabase
-    .from("companies")
-    .select("ticker, price, company_name")
+    .from("securities")
+    .select("ticker, price, name")
     .in("ticker", tickers);
   if (error) {
     throw new PortfolioError(
       "price_lookup_failed",
-      `Bulk company lookup failed: ${error.message}`,
+      `Bulk security lookup failed: ${error.message}`,
     );
   }
   for (const row of (data ?? []) as {
     ticker: string;
     price: number | string | null;
-    company_name: string | null;
+    name: string | null;
   }[]) {
     const priceNum = row.price == null ? null : Number(row.price);
     out.set(row.ticker, {
       price: priceNum != null && Number.isFinite(priceNum) ? priceNum : null,
-      company_name: row.company_name ?? null,
+      company_name: row.name ?? null,
     });
   }
   return out;
@@ -163,7 +165,7 @@ export async function getCompanyNamesForTickers(
 async function getPrice(ticker: string): Promise<number> {
   const supabase = getSupabase();
   const { data, error } = await supabase
-    .from("companies")
+    .from("securities")
     .select("ticker, price")
     .eq("ticker", ticker)
     .maybeSingle();
@@ -180,7 +182,7 @@ async function getPrice(ticker: string): Promise<number> {
   if (!Number.isFinite(price) || price <= 0) {
     throw new PortfolioError(
       "no_price",
-      `No usable price for ${ticker} (companies.price is null or <=0)`,
+      `No usable price for ${ticker} (securities.price is null or <=0)`,
     );
   }
   return price;

--- a/web/lib/portfolios-mutations.ts
+++ b/web/lib/portfolios-mutations.ts
@@ -251,10 +251,10 @@ export async function sellHolding(input: {
     return { ok: false, error: "Position quantity is zero or invalid." };
   }
 
-  // Latest price from companies.price (15-min delayed during market
-  // hours, close-of-business otherwise — see intraday_prices.py).
+  // Latest price from the Level 0 price home (`securities.price`, migration
+  // 058 — 15-min delayed during market hours, close-of-business otherwise).
   const { data: company, error: companyErr } = await supabase
-    .from("companies")
+    .from("securities")
     .select("price")
     .eq("ticker", ticker)
     .maybeSingle();

--- a/web/lib/sold-query.ts
+++ b/web/lib/sold-query.ts
@@ -104,8 +104,8 @@ async function buildStory(thesis: ThesisRow): Promise<SoldStory | null> {
   const sell = ((sellRows ?? [])[0] as TradeRow | undefined) ?? null;
 
   const { data: company } = await supabase
-    .from("companies")
-    .select("company_name, exchange")
+    .from("securities")
+    .select("name, exchange")
     .eq("ticker", thesis.ticker)
     .maybeSingle();
 
@@ -132,8 +132,8 @@ async function buildStory(thesis: ThesisRow): Promise<SoldStory | null> {
   return {
     thesisId: thesis.id,
     ticker: thesis.ticker,
-    companyName: company?.company_name ?? null,
-    exchange: company?.exchange ?? null,
+    companyName: (company as { name?: string } | null)?.name ?? null,
+    exchange: (company as { exchange?: string | null } | null)?.exchange ?? null,
     thesisText: thesis.thesis_text,
     breakSignals: thesis.break_signals ?? [],
     buyerName,

--- a/web/lib/theses.ts
+++ b/web/lib/theses.ts
@@ -17,6 +17,7 @@
  */
 
 import { getSupabase } from "@/lib/supabase";
+import { getEquityL0 } from "@/lib/level0-query";
 
 export interface ThesisSignal {
   field: string;
@@ -57,25 +58,91 @@ const SNAPSHOT_FIELDS = [
   "flags", "ai_analyzed_at",
 ] as const;
 
-/** Read the latest companies row + reduce it to the snapshot field set. */
+/**
+ * Build the buy-time snapshot from the Level 0 fact store rather than the
+ * legacy `companies` table:
+ *   - identity / fundamentals / valuation → `api_universe_facts` (getEquityL0)
+ *   - bull/bear + narrative → `ai_analysis`
+ *
+ * Maps each snapshot field name (kept in lock-step with theses.py) onto its
+ * Level 0 source. Fields with no Level 0 equivalent (`composite_score`,
+ * `rating`, `flags`, `gm_trend`, the revenue-consistency / opex / sm_rd
+ * efficiency columns, `eps_yoy_pct`, `price_pct_of_52w_high`,
+ * `perf_52w_vs_spy`, `qrtrs_to_profitability`, `r40_score`) are stored as
+ * null in the frozen snapshot.
+ */
 async function buildSnapshot(ticker: string): Promise<Record<string, unknown>> {
   const supabase = getSupabase();
-  const { data, error } = await supabase
-    .from("companies")
-    .select("*")
-    .eq("ticker", ticker)
-    .limit(1)
-    .maybeSingle();
-  if (error || !data) {
+  const t = ticker.toUpperCase();
+
+  const [equity, aiRes] = await Promise.all([
+    getEquityL0(t),
+    supabase
+      .from("ai_analysis")
+      .select(
+        "bull_eval, bear_eval, short_outlook, key_risks, full_outlook, analyzed_at",
+      )
+      .eq("ticker", t)
+      .maybeSingle(),
+  ]);
+
+  if (!equity) {
     // Caller should already have validated the ticker (buy() resolves the
     // price via getPrice first), so this is a hard error. Still throw a
     // recognisable shape so callers can decide whether to swallow.
-    throw new Error(`buildSnapshot: no companies row for ${ticker}`);
+    throw new Error(`buildSnapshot: no Level 0 facts for ${ticker}`);
   }
-  const row = data as Record<string, unknown>;
+
+  const ai = (aiRes.data as Record<string, unknown> | null) ?? {};
+
+  // Map each snapshot field to its Level 0 source value.
+  const sourced: Record<string, unknown> = {
+    // Identity / overview
+    ticker: equity.ticker,
+    company_name: equity.company_name,
+    country: equity.country,
+    sector: equity.sector,
+    // Fundamentals
+    rating: null,
+    r40_score: null,
+    rule_of_40: equity.rule_of_40,
+    rev_growth_ttm_pct: equity.rev_growth_ttm_pct,
+    rev_growth_qoq_pct: equity.rev_growth_qoq_pct,
+    rev_cagr_pct: equity.rev_cagr_pct,
+    rev_consistency_score: null,
+    gross_margin_pct: equity.gross_margin_pct,
+    operating_margin_pct: equity.operating_margin_pct,
+    net_margin_pct: equity.net_margin_pct,
+    net_margin_yoy_pct: null,
+    fcf_margin_pct: equity.fcf_margin_pct,
+    opex_pct_revenue: null,
+    sm_rd_pct_revenue: null,
+    eps_only: equity.eps_only,
+    eps_yoy_pct: null,
+    qrtrs_to_profitability: null,
+    gm_trend: null,
+    // Valuation
+    price: equity.price,
+    ps_now: equity.ps_now,
+    price_pct_of_52w_high: null,
+    // Momentum
+    perf_52w_vs_spy: null,
+    composite_score: null,
+    // Narrative
+    short_outlook: ai.short_outlook ?? null,
+    key_risks: ai.key_risks ?? null,
+    full_outlook: ai.full_outlook ?? null,
+    bull_eval: ai.bull_eval ?? null,
+    bear_eval: ai.bear_eval ?? null,
+    status: equity.status,
+    // Quality flags + audit
+    flags: null,
+    ai_analyzed_at: ai.analyzed_at ?? null,
+  };
+
   const snapshot: Record<string, unknown> = {};
   for (const field of SNAPSHOT_FIELDS) {
-    snapshot[field] = row[field] ?? null;
+    snapshot[field] = sourced[field] ?? null;
   }
   return snapshot;
 }

--- a/web/lib/watchlist-mutations.ts
+++ b/web/lib/watchlist-mutations.ts
@@ -56,10 +56,10 @@ export async function addToWatchlist(input: {
 
   const supabase = getSupabase();
 
-  // The ticker must exist in the screened universe — the FK would reject
+  // The ticker must exist in the Level 0 universe — the FK would reject
   // an unknown ticker anyway, but checking first gives a clean message.
   const { data: company } = await supabase
-    .from("companies")
+    .from("securities")
     .select("ticker")
     .eq("ticker", ticker)
     .maybeSingle();


### PR DESCRIPTION
Makes **Level 0** the single source of truth: retires the legacy `companies`/`price_sales` pipeline, guarantees every fact records when it was collected, and keeps fundamentals fresh. Reversible cutover (legacy tables renamed to `*_legacy`, not dropped).

---

## Part A — Retire `companies` / `price_sales`

All readers/writers moved to Level 0; nothing reads or writes the legacy tables afterwards.

| Phase | Change | Migration |
|---|---|---|
| 0 | Level 0 price home `securities.price`; trade pricing + intraday + MTM read it | 058 |
| 1 | MTM trigger + web MTM layer → Level 0 | 059 |
| 2 | Python readers (thesis snapshots, `check_thesis`, consensus) → Level 0 | — |
| 3 | FK repoint (`portfolio_watchlist`→`securities`; `consensus_snapshots` FK dropped) | 060 |
| 4 | Web `/company` page + APIs + sitemap/OG → Level 0 | — |
| 5 | Writers retired; `price_sales_updater` becomes the daily **`valuation`** maintainer; eval scripts write only `ai_analysis`; superseded workflows disabled; tables renamed | 061 |

De-risked by the data: Level 0 supersets `companies`, 0 orphan tickers, only 3 live FKs, and no live agent uses any companies-reading strategy.

## Part B — Freshness (Level 0 facts)

- **Stamp-coverage contract** (`db.py`): a shared `_stamp_rows()` backstop so no Level 0 write lands without a collected-at stamp — `fundamentals`/`valuation` (`fetched_at`), `ai_analysis` (`analyzed_at`/`updated_at`), `securities` prices (`price_asof`).
- **Audit surface**: `level0_freshness` view (migration 062) — current price + `price_asof` headline plus every fact's as-of, one row per name; and a **/company "Data freshness" strip** mirroring it.
- **Fundamentals refresher** (`fundamentals_updater.py` + `fundamentals-update.yml`, daily 03:30 UTC): rotating refresh of the N stalest Tier-1 names, fixing the frozen-fundamentals gap the audit exposed (Level 0 fundamentals had no ongoing refresher). Pure rotation selector unit-tested.

## Deploy order (migrations are applied by hand — MCP is read-only here)
1. Apply **058 → 059 → 060 → 062** (all additive/safe; 062 is just a view).
2. Merge + deploy this code.
3. Apply **061** LAST (renames `companies`/`price_sales`→`*_legacy`) — only after the new code is live, or production breaks.
4. Later: `DROP TABLE companies_legacy; DROP TABLE price_sales_legacy;` once satisfied.

## Verification
- Python `pytest`: 143 pass (2 pre-existing unrelated `_FakeQ` failures in `test_level0_eval.py`).
- Web `npx tsc --noEmit`: clean.

## Known minor follow-ups
- `/company` `perf_52w_vs_spy` shows "—" (Level 0 carries raw `ret_52w`, not vs-SPY at page scale) — clean fix = add it to `api_universe_facts`.
- `estimates`/`events` remain empty (no ingest yet).
- CLAUDE.md docs pass; delete dead legacy code (`dual_positive`/`momentum`/`llm_pick`, `nightly_screen`/`eodhd_updater`/`score_ai_analysis`/`build_universe_snapshot`, `companies` CRUD in `db.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)