### PR TITLE
Level 0 freshness: stamp contract, audit surface + daily fundamentals refresher

### DIFF
--- a/.github/workflows/fundamentals-update.yml
+++ b/.github/workflows/fundamentals-update.yml
@@ -1,0 +1,70 @@
+name: Fundamentals Update (Level 0)
+
+# Daily ROTATING refresh of the Level 0 `fundamentals` table — refreshes the N
+# stalest Tier-1 names per run (oldest fundamentals.fetched_at first) so the
+# whole universe cycles and the screener's Quality/Value lenses never go stale.
+# Replaces the retired legacy eodhd_updater (which only fed `companies`).
+
+on:
+  schedule:
+    # 03:30 UTC daily (the slot the retired nightly-eodhd-update used).
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+    inputs:
+      batch:
+        description: "Stalest names to refresh this run"
+        type: string
+        default: "150"
+      tickers:
+        description: "Explicit space-separated tickers (blank = rotation)"
+        type: string
+        default: ""
+      dry_run:
+        description: "Fetch + log, but write nothing"
+        type: boolean
+        default: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run Level 0 fundamentals refresh
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          EODHD_API_KEY: ${{ secrets.EODHD_API_KEY }}
+        run: |
+          ARGS=""
+          if [ -n "${{ github.event.inputs.batch }}" ]; then
+            ARGS="$ARGS --batch ${{ github.event.inputs.batch }}"
+          fi
+          if [ -n "${{ github.event.inputs.tickers }}" ]; then
+            ARGS="$ARGS --tickers ${{ github.event.inputs.tickers }}"
+          fi
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          python fundamentals_updater.py $ARGS
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: fundamentals-update-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 30

--- a/db.py
+++ b/db.py
@@ -509,6 +509,35 @@ class SupabaseDB:
             page += 1
         return tickers
 
+    def get_fundamentals_freshness(self) -> dict[str, str]:
+        """Return the latest `fetched_at` per ticker from `fundamentals`.
+
+        The rotation clock for the daily fundamentals refresher
+        (fundamentals_updater.py): names with the oldest stamp (or none) are
+        refreshed first. Paginates the whole table and keeps the newest
+        fetched_at per ticker.
+        """
+        latest: dict[str, str] = {}
+        page = 0
+        page_size = 1000
+        while True:
+            resp = (
+                self.client.table("fundamentals")
+                .select("ticker, fetched_at")
+                .order("fetched_at", desc=True)
+                .range(page * page_size, (page + 1) * page_size - 1)
+                .execute()
+            )
+            batch = resp.data or []
+            for row in batch:
+                t = row.get("ticker")
+                if t and t not in latest and row.get("fetched_at"):
+                    latest[t] = row["fetched_at"]  # rows arrive newest-first
+            if len(batch) < page_size:
+                break
+            page += 1
+        return latest
+
     # --- valuation ---
 
     def upsert_valuation_batch(self, rows: list[dict]) -> None:

--- a/db.py
+++ b/db.py
@@ -13,7 +13,7 @@ import json
 import math
 import os
 import re
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from dotenv import load_dotenv
 from supabase import create_client, Client
@@ -21,6 +21,23 @@ from supabase import create_client, Client
 load_dotenv()
 
 NULL_VALUE = "\u2014"  # em-dash — consistent placeholder for missing data
+
+
+def _utcnow_iso() -> str:
+    """Current UTC instant as an ISO string — the Level 0 'collected at' stamp."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _stamp_rows(rows: list[dict], *fields: str) -> None:
+    """Level 0 freshness contract: ensure each row carries a collected-at
+    timestamp in every named field. Sets it to now() when the caller omitted it
+    or left it null, so no Level 0 fact is ever written without a freshness
+    stamp. Call AFTER sanitization (which nulls em-dash/NaN placeholders)."""
+    now = _utcnow_iso()
+    for row in rows:
+        for f in fields:
+            if row.get(f) is None:
+                row[f] = now
 
 
 class SupabaseDB:
@@ -133,6 +150,10 @@ class SupabaseDB:
                 continue
             self._sanitize(slim)
             cleaned.append(slim)
+        # Freshness contract: a price must always carry its as-of stamp, so the
+        # current-price canary is auditable. Default to now() if the caller
+        # didn't supply one.
+        _stamp_rows(cleaned, "price_asof")
         if cleaned:
             self.client.table("securities").upsert(cleaned).execute()
 
@@ -348,6 +369,7 @@ class SupabaseDB:
             return
         for r in rows:
             self._sanitize(r)
+        _stamp_rows(rows, "analyzed_at", "updated_at")  # freshness contract
         try:
             self.client.table("ai_analysis").upsert(
                 rows, on_conflict="ticker"
@@ -440,6 +462,7 @@ class SupabaseDB:
         """
         for row in rows:
             self._sanitize(row)
+        _stamp_rows(rows, "fetched_at")  # freshness contract
         if rows:
             (
                 self.client.table("fundamentals")
@@ -492,6 +515,7 @@ class SupabaseDB:
         """Insert or update valuation rows (conflict on ticker,date)."""
         for row in rows:
             self._sanitize(row)
+        _stamp_rows(rows, "fetched_at")  # freshness contract
         if rows:
             (
                 self.client.table("valuation")

--- a/fundamentals_updater.py
+++ b/fundamentals_updater.py
@@ -1,0 +1,176 @@
+"""
+fundamentals_updater.py — daily ROTATING refresher for the Level 0
+`fundamentals` table (closes the "fundamentals frozen, no refresher" gap the
+freshness audit found).
+
+The legacy `eodhd_updater.py` refreshed only the (now-retired) `companies`
+table; Level 0 `fundamentals` was ever only seeded/backfilled once, so its
+metrics — and therefore the screener's Quality/Value lenses — went stale. This
+script keeps them fresh on a rotation, exactly like the bull/bear/research
+evaluators: each daily run refreshes the N **stalest** Tier-1 names (oldest
+`fundamentals.fetched_at` first, never-fetched names ahead of those), so the
+whole universe cycles every `ceil(universe / batch)` days while daily EODHD
+cost stays flat and bounded.
+
+It reuses `eodhd_updater.fetch_eodhd_data` (same revenue-growth / margin / FCF /
+Rule-of-40 / EPS / opex computation as the legacy pipeline) and the
+`backfill_tier1_fundamentals.FUND_FIELDS` mapping, and writes via
+`db.upsert_fundamentals_batch` (which stamps `fetched_at` — the freshness
+contract). `period_end` uses the synthetic fetch-date convention the seed +
+backfill use, so `screen_facts()` (latest period_end) picks up the fresh row.
+
+Usage:
+    python fundamentals_updater.py                 # refresh the 150 stalest
+    python fundamentals_updater.py --batch 300     # refresh more per run
+    python fundamentals_updater.py --tickers NVDA AAPL
+    python fundamentals_updater.py --dry-run
+    python fundamentals_updater.py --delay 0.5
+"""
+
+import argparse
+import logging
+import os
+import time
+from datetime import date
+
+from db import SupabaseDB
+from eodhd_updater import fetch_eodhd_data
+from backfill_tier1_fundamentals import FUND_FIELDS
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("fundamentals_updater")
+
+DEFAULT_BATCH = 150   # stalest names refreshed per run (rotation)
+DEFAULT_DELAY = 1.0   # seconds between EODHD calls
+UPSERT_FLUSH = 200    # rows per upsert flush
+
+
+def select_stale_batch(
+    tier1_tickers: list[str],
+    freshness: dict[str, str],
+    limit: int,
+) -> list[str]:
+    """Rotation selection (pure, unit-tested): the `limit` stalest tickers.
+
+    Names with no fundamentals row at all sort first; the rest by ascending
+    `fetched_at` (oldest refreshed first). ISO timestamps sort lexically, so a
+    plain string compare is correct.
+    """
+    def key(t: str):
+        f = freshness.get(t)
+        return (0, "") if f is None else (1, f)
+
+    return sorted(tier1_tickers, key=key)[: max(0, limit)]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Daily rotating refresher for Level 0 fundamentals",
+    )
+    ap.add_argument("--batch", type=int, default=DEFAULT_BATCH,
+                    help=f"stalest names to refresh this run (default {DEFAULT_BATCH})")
+    ap.add_argument("--tickers", nargs="+",
+                    help="explicit ticker list (still requires Tier 1 active); "
+                         "bypasses the rotation selection")
+    ap.add_argument("--delay", type=float, default=DEFAULT_DELAY,
+                    help=f"seconds between EODHD calls (default {DEFAULT_DELAY})")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="fetch + log, but write nothing")
+    args = ap.parse_args()
+
+    key = os.environ.get("EODHD_API_KEY")
+    if not key:
+        logger.error("EODHD_API_KEY is not set — aborting")
+        raise SystemExit(1)
+
+    started = time.time()
+    db = SupabaseDB()
+
+    secs = db.get_all_securities(
+        columns="ticker,name,exchange,is_tier1,status", status="active")
+    tier1 = {s["ticker"]: s for s in secs if s.get("is_tier1")}
+
+    if args.tickers:
+        want = {t.upper() for t in args.tickers}
+        target_tickers = [t for t in tier1 if t.upper() in want]
+    else:
+        freshness = db.get_fundamentals_freshness()
+        target_tickers = select_stale_batch(list(tier1), freshness, args.batch)
+
+    logger.info("Tier 1 active=%d; refreshing %d stalest this run",
+                len(tier1), len(target_tickers))
+
+    fetch_date = date.today().isoformat()
+    batch: list[dict] = []
+    written = errors = no_data = 0
+
+    for idx, ticker in enumerate(target_tickers):
+        name = (tier1.get(ticker) or {}).get("name") or ""
+        try:
+            data = fetch_eodhd_data(ticker, key, logger, exchange="US", company=name)
+        except Exception as exc:  # noqa: BLE001 — log and keep going
+            logger.error("fetch failed for %s: %s", ticker, exc)
+            errors += 1
+            data = None
+
+        if data:
+            row = {"ticker": ticker, "period_end": fetch_date, "source": "eodhd"}
+            has_metric = False
+            for src, dst in FUND_FIELDS.items():
+                v = db.safe_float(data.get(src))
+                if v is not None:
+                    row[dst] = v
+                    has_metric = True
+            if has_metric:
+                batch.append(row)
+                if args.dry_run:
+                    logger.info("[DRY RUN] %s → %s", ticker,
+                                {k: v for k, v in row.items()
+                                 if k not in ("ticker", "period_end", "source")})
+            else:
+                no_data += 1
+                logger.info("%s: fetched but no usable metrics", ticker)
+        else:
+            no_data += 1
+
+        if not args.dry_run and len(batch) >= UPSERT_FLUSH:
+            db.upsert_fundamentals_batch(batch)
+            written += len(batch)
+            batch = []
+
+        if (idx + 1) % 100 == 0:
+            logger.info("…%d/%d processed (written≈%d, no_data=%d, errors=%d)",
+                        idx + 1, len(target_tickers), written + len(batch),
+                        no_data, errors)
+
+        if idx < len(target_tickers) - 1:
+            time.sleep(args.delay)
+
+    if not args.dry_run and batch:
+        db.upsert_fundamentals_batch(batch)
+        written += len(batch)
+
+    stats = {
+        "updated": written,
+        "skipped": no_data,
+        "errors": errors,
+        "duration_secs": round(time.time() - started, 1),
+        "details": {
+            "tier1_active": len(tier1),
+            "targeted": len(target_tickers),
+            "written": written,
+            "no_data": no_data,
+            "errors": errors,
+            "dry_run": args.dry_run,
+        },
+    }
+    logger.info("Done: %s", stats["details"])
+    if not args.dry_run:
+        db.log_run("fundamentals_updater", stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/migrations/062_level0_freshness_view.sql
+++ b/migrations/062_level0_freshness_view.sql
@@ -1,0 +1,40 @@
+-- Migration 062: Level 0 freshness audit surface.
+--
+-- One row per active security summarising "how fresh is each fact for this
+-- name", with the current share price + its as-of as the headline canary (the
+-- thing that's quick to eyeball). Powers a per-ticker freshness panel on the
+-- website and ad-hoc audits like:
+--   SELECT * FROM level0_freshness WHERE ticker = 'NVDA';
+--   SELECT count(*) FROM level0_freshness WHERE price_asof < now() - interval '2 days';
+--
+-- Read-only view over Level 0 fact tables (all public-read). Idempotent.
+
+CREATE OR REPLACE VIEW level0_freshness AS
+SELECT
+    s.ticker,
+    s.name,
+    s.is_tier1,
+    -- Headline canary: current price + when it was captured.
+    s.price                         AS price,
+    s.price_asof                    AS price_asof,
+    -- Per-fact "collected at" stamps.
+    lp.date                         AS prices_daily_asof,
+    f.fetched_at                    AS fundamentals_asof,
+    f.period_end                    AS fundamentals_period_end,
+    v.fetched_at                    AS valuation_asof,
+    a.analyzed_at                   AS ai_analysis_asof
+FROM securities s
+LEFT JOIN LATERAL (
+    SELECT date FROM prices_daily pd
+    WHERE pd.ticker = s.ticker ORDER BY pd.date DESC LIMIT 1
+) lp ON true
+LEFT JOIN LATERAL (
+    SELECT fetched_at, period_end FROM fundamentals fd
+    WHERE fd.ticker = s.ticker ORDER BY fd.period_end DESC LIMIT 1
+) f ON true
+LEFT JOIN LATERAL (
+    SELECT fetched_at FROM valuation vl
+    WHERE vl.ticker = s.ticker ORDER BY vl.date DESC LIMIT 1
+) v ON true
+LEFT JOIN ai_analysis a ON a.ticker = s.ticker
+WHERE s.status = 'active';

--- a/test_fundamentals_updater.py
+++ b/test_fundamentals_updater.py
@@ -1,0 +1,42 @@
+"""Unit tests for fundamentals_updater.select_stale_batch (rotation selection)."""
+
+import unittest
+
+from fundamentals_updater import select_stale_batch
+
+
+class SelectStaleBatchTests(unittest.TestCase):
+    def test_never_fetched_first_then_oldest(self):
+        tickers = ["AAA", "BBB", "CCC", "DDD"]
+        freshness = {
+            "AAA": "2026-06-20T00:00:00Z",
+            "BBB": "2026-06-01T00:00:00Z",  # oldest stamped
+            "CCC": "2026-06-10T00:00:00Z",
+            # DDD missing entirely → must sort first
+        }
+        out = select_stale_batch(tickers, freshness, limit=10)
+        self.assertEqual(out, ["DDD", "BBB", "CCC", "AAA"])
+
+    def test_limit_caps(self):
+        tickers = ["AAA", "BBB", "CCC"]
+        freshness = {
+            "AAA": "2026-06-03T00:00:00Z",
+            "BBB": "2026-06-02T00:00:00Z",
+            "CCC": "2026-06-01T00:00:00Z",
+        }
+        out = select_stale_batch(tickers, freshness, limit=2)
+        self.assertEqual(out, ["CCC", "BBB"])  # two oldest
+
+    def test_all_missing_keeps_input_order(self):
+        tickers = ["AAA", "BBB", "CCC"]
+        out = select_stale_batch(tickers, {}, limit=10)
+        # All equal-key (0, "") → stable sort preserves input order.
+        self.assertEqual(out, ["AAA", "BBB", "CCC"])
+
+    def test_zero_or_negative_limit(self):
+        self.assertEqual(select_stale_batch(["AAA"], {}, limit=0), [])
+        self.assertEqual(select_stale_batch(["AAA"], {}, limit=-5), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/app/company/[ticker]/page.tsx
+++ b/web/app/company/[ticker]/page.tsx
@@ -231,6 +231,11 @@ export default async function CompanyPage({
               traded={activity.traded}
             />
 
+            <FreshnessStrip
+              company={company}
+              valuationAsOf={priceSales?.last_updated ?? null}
+            />
+
             {compiledClauses.length >= 3 && (
               <CompiledSummary clauses={compiledClauses} />
             )}
@@ -504,6 +509,56 @@ function CompiledSummary({ clauses }: { clauses: string[] }) {
 // ---------------------------------------------------------------------------
 // P/S header line
 // ---------------------------------------------------------------------------
+
+/**
+ * Per-ticker data-freshness strip (Level 0 freshness audit surface). Headlines
+ * the current share price's as-of — the quick-to-eyeball canary — alongside the
+ * collected-at stamp of every other fact, so anyone can audit how fresh this
+ * page's data is. Mirrors the `level0_freshness` DB view (migration 062).
+ */
+function FreshnessStrip({
+  company,
+  valuationAsOf,
+}: {
+  company: Company;
+  valuationAsOf: string | null;
+}) {
+  const items: { label: string; at: string | null }[] = [
+    { label: "Price", at: company.price_asof },
+    { label: "Fundamentals", at: company.data_updated_at },
+    { label: "Valuation", at: valuationAsOf },
+    { label: "AI analysis", at: company.ai_analyzed_at },
+  ];
+  return (
+    <div className="mt-3 rounded-xl border border-white/10 bg-white/[0.02] px-3.5 py-2.5">
+      <p className="text-[10px] font-mono uppercase tracking-[0.14em] text-text-muted">
+        Data freshness
+      </p>
+      <div className="mt-1.5 flex flex-wrap gap-x-5 gap-y-1.5">
+        {items.map((it) => (
+          <span key={it.label} className="text-[11px] font-mono text-text-muted">
+            {it.label}:{" "}
+            <span className="text-text">{fmtFreshness(it.at)}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function fmtFreshness(iso: string | null): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return "—";
+  const datestr = new Date(t).toLocaleDateString("en-US", {
+    timeZone: "UTC",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+  const days = Math.floor((Date.now() - t) / 86_400_000);
+  return days <= 0 ? `${datestr} · today` : `${datestr} · ${days}d ago`;
+}
 
 function PsHeader({ priceSales, psNow }: { priceSales: PriceSales; psNow: number | null }) {
   const ps = psNow ?? priceSales.ps_now;


### PR DESCRIPTION
Follows the now-merged companies retirement (#1739). Ensures every Level 0 fact records when it was collected, makes the current share price an easy-to-audit freshness canary, and fixes the frozen-fundamentals gap the audit exposed. Rebased onto current `main`.

## 1. Stamp-coverage contract (`db.py`)
A shared `_stamp_rows()` backstop so **no Level 0 write lands without a collected-at stamp**:
- `fundamentals` / `valuation` → default `fetched_at`
- `ai_analysis` → default `analyzed_at` + `updated_at`
- `securities` prices → default `price_asof`

Callers that already pass a real stamp are unaffected — this just guarantees the floor.

## 2. Freshness audit surface
- **`migration 062`: `level0_freshness` view** — one row per active security: current `price` + `price_asof` headline plus each fact's as-of (`prices_daily` / `fundamentals` / `valuation` / `ai_analysis`). Quick audit, e.g. `SELECT * FROM level0_freshness WHERE ticker='NVDA'`.
- **`/company` "Data freshness" strip** — headlines the price's as-of + every fact's collected-at, mirroring the view.

## 3. Daily fundamentals refresher
The audit showed Level 0 `fundamentals` were **frozen** (only a one-off backfill, no ongoing refresher), so the screener's Quality/Value lenses read weeks-old data.
- **`fundamentals_updater.py`** — daily **rotation** like the bull/bear/research evaluators: refreshes the N stalest Tier-1 names (oldest `fundamentals.fetched_at` first; never-fetched ahead), so the universe cycles while EODHD cost stays flat. Reuses `eodhd_updater.fetch_eodhd_data` + the field mapping; writes via `upsert_fundamentals_batch` (stamps `fetched_at`). Pure rotation selector `select_stale_batch()` is unit-tested.
- **`db.get_fundamentals_freshness()`** — latest `fetched_at` per ticker (the rotation clock).
- **`.github/workflows/fundamentals-update.yml`** — daily 03:30 UTC + manual dispatch.

## Deploy
- Apply **migration 062** (additive — just a view) anytime.
- `fundamentals_updater` starts on its daily cron once merged; validate now via Actions → Fundamentals Update → Run (`dry_run=true`).

## Verification
- Python `pytest`: 78 pass across the touched suites (full run 143 pass, 2 pre-existing unrelated `_FakeQ` failures in `test_level0_eval.py`).
- Web `npx tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_