### PR TITLE
Daily data-freshness report (emailed)

### DIFF
--- a/.github/workflows/data-freshness-report.yml
+++ b/.github/workflows/data-freshness-report.yml
@@ -1,0 +1,54 @@
+name: Data Freshness Report
+
+# Daily survey of Level 0 data freshness, emailed (and optionally Slacked).
+# For each fact type: coverage, freshest/stalest stamp, rows refreshed in 24h,
+# and a RAG status — so a single morning email tells you whether every pipeline
+# is still keeping its data fresh.
+
+on:
+  schedule:
+    # 12:30 UTC — after the morning data jobs (prices, valuation, fundamentals,
+    # AI rotations) have settled.
+    - cron: "30 12 * * *"
+  workflow_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Send data-freshness report
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          REPORT_EMAIL_FROM: ${{ secrets.REPORT_EMAIL_FROM }}
+          REPORT_EMAIL_TO: ${{ secrets.REPORT_EMAIL_TO }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: python data_freshness_report.py --email
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: data-freshness-report-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 14

--- a/data_freshness_report.py
+++ b/data_freshness_report.py
@@ -1,0 +1,309 @@
+"""
+data_freshness_report.py — daily survey of Level 0 data freshness, emailed.
+
+Answers one question every morning: "is every Level 0 fact still being kept
+fresh?" For each data type it reports coverage, the freshest + stalest stamp,
+how many rows were refreshed in the last 24h (the pipeline-alive signal), and a
+RAG status, then emails the digest (reusing user_report.py's Resend→SMTP
+delivery) and/or posts it to Slack.
+
+Status rules (per data type):
+  - 🔴 STALE   — no data, OR a daily-cadence feed wrote nothing in 24h, OR the
+                 stalest name is well past its expected refresh window.
+  - 🟡 WATCH   — stalest name past window, or coverage below the floor.
+  - 🟢 OK      — actively refreshing and within window.
+
+Usage:
+    python data_freshness_report.py                 # print to stdout
+    python data_freshness_report.py --email          # email REPORT_EMAIL_TO
+    python data_freshness_report.py --email me@x.com # email an override addr
+    python data_freshness_report.py --slack          # post to SLACK_WEBHOOK_URL
+"""
+
+import argparse
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from db import SupabaseDB
+from user_report import deliver_slack, _deliver_resend, _deliver_smtp
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger("data_freshness")
+
+OK, WATCH, STALE, INFO = "OK", "WATCH", "STALE", "INFO"
+_EMOJI = {OK: "🟢", WATCH: "🟡", STALE: "🔴", INFO: "⚪"}
+
+
+# ---------------------------------------------------------------------------
+# Pure classification (unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def classify(
+    *,
+    have: int,
+    total: int | None,
+    stalest_age_days: float | None,
+    refreshed_24h: int | None,
+    expected_daily: bool,
+    max_stale_days: float,
+    min_coverage: float,
+) -> str:
+    """RAG status for one data type. Pure → unit-tested."""
+    if have == 0:
+        return STALE
+    if expected_daily and refreshed_24h is not None and refreshed_24h == 0:
+        return STALE
+    if stalest_age_days is not None and stalest_age_days > max_stale_days * 1.5:
+        return STALE
+    if stalest_age_days is not None and stalest_age_days > max_stale_days:
+        return WATCH
+    if total and (have / total) < min_coverage:
+        return WATCH
+    return OK
+
+
+# ---------------------------------------------------------------------------
+# Gathering
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Row:
+    name: str
+    coverage: str
+    freshest: str
+    stalest: str
+    refreshed_24h: str
+    status: str
+    note: str = ""
+
+
+def _parse(ts) -> datetime | None:
+    """Tolerant ISO/date parser → tz-aware UTC datetime, or None."""
+    if not ts:
+        return None
+    s = str(ts).strip().replace("Z", "+00:00")
+    if len(s) == 10:  # date only
+        s += "T00:00:00+00:00"
+    for cand in (s, s + ":00"):  # tolerate a "+00" offset
+        try:
+            d = datetime.fromisoformat(cand)
+            return d if d.tzinfo else d.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+def _age_days(ts, now: datetime) -> float | None:
+    d = _parse(ts)
+    return None if d is None else (now - d).total_seconds() / 86_400
+
+
+def _fmt_age(ts, now: datetime) -> str:
+    age = _age_days(ts, now)
+    if age is None:
+        return "—"
+    d = _parse(ts)
+    datestr = d.strftime("%b %d")
+    days = int(age)
+    return f"{datestr} ({days}d)" if days > 0 else f"{datestr} (today)"
+
+
+def _summarize_map(stamps: list[str], now: datetime):
+    """(newest_ts, oldest_ts, refreshed_24h) over a list of ISO stamps."""
+    parsed = [(s, _parse(s)) for s in stamps if _parse(s) is not None]
+    if not parsed:
+        return None, None, 0
+    parsed.sort(key=lambda p: p[1])
+    oldest, newest = parsed[0][0], parsed[-1][0]
+    cutoff = now.timestamp() - 86_400
+    refreshed = sum(1 for _, d in parsed if d.timestamp() >= cutoff)
+    return newest, oldest, refreshed
+
+
+def gather(db: SupabaseDB) -> list[Row]:
+    now = datetime.now(timezone.utc)
+
+    secs = db.get_all_securities(
+        columns="ticker,is_tier1,price,price_asof", status="active")
+    tier1 = [s for s in secs if s.get("is_tier1")]
+    total = len(tier1)
+    rows: list[Row] = []
+
+    # 1. Current price (securities.price) — the headline canary, intraday cadence.
+    priced = [s for s in tier1 if db.safe_float(s.get("price"))]
+    newest, oldest, r24 = _summarize_map([s.get("price_asof") for s in priced], now)
+    rows.append(_row(
+        "Current price", have=len(priced), total=total,
+        newest=newest, oldest=oldest, refreshed_24h=r24, now=now,
+        expected_daily=True, max_stale_days=4, min_coverage=0.5,
+    ))
+
+    # 2. Daily prices (prices_daily) — EOD layer. Newest date + recent coverage.
+    newest_pd = None
+    try:
+        resp = (db.client.table("prices_daily").select("date")
+                .order("date", desc=True).limit(1).execute())
+        newest_pd = (resp.data or [{}])[0].get("date")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("prices_daily newest read failed: %s", exc)
+    recent_since = (now.date().fromordinal(now.date().toordinal() - 5)).isoformat()
+    try:
+        recent = db.get_tickers_with_recent_prices(recent_since)
+    except Exception:  # noqa: BLE001
+        recent = set()
+    age = _age_days(newest_pd, now)
+    status = STALE if newest_pd is None else (WATCH if (age or 0) > 4 else OK)
+    rows.append(Row(
+        "Daily prices", coverage=f"{len(recent)} (last 5d)",
+        freshest=_fmt_age(newest_pd, now), stalest="—",
+        refreshed_24h="—", status=status,
+        note="EOD; today's bar lands after the close",
+    ))
+
+    # 3. Valuation / P-S (valuation) — daily full-universe via price_sales_updater.
+    val = db.get_all_valuation_latest()
+    newest, oldest, r24 = _summarize_map(
+        [v.get("fetched_at") for v in val.values()], now)
+    rows.append(_row(
+        "Valuation / P-S", have=len(val), total=total,
+        newest=newest, oldest=oldest, refreshed_24h=r24, now=now,
+        expected_daily=True, max_stale_days=4, min_coverage=0.5,
+    ))
+
+    # 4. Fundamentals (fundamentals) — daily ROTATION (~universe/batch days).
+    fund = db.get_fundamentals_freshness()
+    newest, oldest, r24 = _summarize_map(list(fund.values()), now)
+    rows.append(_row(
+        "Fundamentals", have=len(fund), total=total,
+        newest=newest, oldest=oldest, refreshed_24h=r24, now=now,
+        expected_daily=True, max_stale_days=30, min_coverage=0.5,
+        note="rotation: stalest nears the cycle length by design",
+    ))
+
+    # 5. AI analysis (ai_analysis) — rotation (bull/bear/narrative clocks).
+    ai = db.get_ai_analysis_freshness()
+    newest, oldest, r24 = _summarize_map(list(ai.values()), now)
+    rows.append(_row(
+        "AI analysis", have=len(ai), total=total,
+        newest=newest, oldest=oldest, refreshed_24h=r24, now=now,
+        expected_daily=True, max_stale_days=30, min_coverage=0.3,
+        note="rotation",
+    ))
+
+    # 6. Estimates / Events — not ingested yet (informational).
+    for label, table in (("Estimates", "estimates"), ("Events", "events")):
+        try:
+            resp = db.client.table(table).select("ticker", count="exact", head=True).execute()
+            n = resp.count or 0
+        except Exception:  # noqa: BLE001
+            n = 0
+        rows.append(Row(label, coverage=f"{n} rows", freshest="—", stalest="—",
+                        refreshed_24h="—", status=INFO,
+                        note="no ingest job yet"))
+
+    return rows
+
+
+def _row(name, *, have, total, newest, oldest, refreshed_24h, now,
+         expected_daily, max_stale_days, min_coverage, note="") -> Row:
+    status = classify(
+        have=have, total=total,
+        stalest_age_days=_age_days(oldest, now),
+        refreshed_24h=refreshed_24h, expected_daily=expected_daily,
+        max_stale_days=max_stale_days, min_coverage=min_coverage,
+    )
+    return Row(
+        name=name,
+        coverage=f"{have} / {total}" if total else str(have),
+        freshest=_fmt_age(newest, now),
+        stalest=_fmt_age(oldest, now),
+        refreshed_24h=str(refreshed_24h),
+        status=status,
+        note=note,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render(rows: list[Row]) -> tuple[str, int]:
+    """Return (plain-text report, issue_count)."""
+    now = datetime.now(timezone.utc)
+    issues = sum(1 for r in rows if r.status in (WATCH, STALE))
+    headline = "✅ all data fresh" if issues == 0 else f"⚠️ {issues} item(s) need attention"
+
+    w_name = max(len("Data"), *(len(r.name) for r in rows))
+    w_cov = max(len("Coverage"), *(len(r.coverage) for r in rows))
+    w_fresh = max(len("Freshest"), *(len(r.freshest) for r in rows))
+    w_stale = max(len("Stalest"), *(len(r.stalest) for r in rows))
+    w_24 = max(len("24h"), *(len(r.refreshed_24h) for r in rows))
+
+    lines = [
+        f"AlphaMolt — Level 0 data freshness · {now:%Y-%m-%d %H:%M UTC}",
+        headline,
+        "",
+        f"  {'Data':<{w_name}}  {'Coverage':<{w_cov}}  {'Freshest':<{w_fresh}}  "
+        f"{'Stalest':<{w_stale}}  {'24h':>{w_24}}  Status",
+        f"  {'-'*w_name}  {'-'*w_cov}  {'-'*w_fresh}  {'-'*w_stale}  {'-'*w_24}  ------",
+    ]
+    for r in rows:
+        lines.append(
+            f"  {r.name:<{w_name}}  {r.coverage:<{w_cov}}  {r.freshest:<{w_fresh}}  "
+            f"{r.stalest:<{w_stale}}  {r.refreshed_24h:>{w_24}}  {_EMOJI[r.status]} {r.status}"
+        )
+    # Notes for any flagged or annotated row.
+    notes = [f"  · {r.name}: {r.note}" for r in rows if r.note and r.status != OK]
+    if notes:
+        lines += ["", "Notes:"] + notes
+    lines += [
+        "",
+        "Legend: Coverage = names with this fact / Tier-1 universe. "
+        "24h = rows refreshed in the last day (pipeline-alive signal).",
+    ]
+    return "\n".join(lines), issues
+
+
+# ---------------------------------------------------------------------------
+# Delivery
+# ---------------------------------------------------------------------------
+
+
+def deliver_email(report: str, subject: str, to_override: str | None) -> bool:
+    recipient = (to_override or os.environ.get("REPORT_EMAIL_TO", "")).strip()
+    if os.environ.get("RESEND_API_KEY", "").strip():
+        return _deliver_resend(report, subject, recipient)
+    if os.environ.get("SMTP_HOST", "").strip():
+        return _deliver_smtp(report, subject, recipient)
+    logger.warning("--email skipped; set RESEND_API_KEY (+ REPORT_EMAIL_FROM/_TO) or SMTP_*.")
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Daily Level 0 data-freshness report")
+    ap.add_argument("--email", nargs="?", const="", metavar="ADDR",
+                    help="email the report (optional override recipient)")
+    ap.add_argument("--slack", action="store_true", help="post to SLACK_WEBHOOK_URL")
+    args = ap.parse_args()
+
+    db = SupabaseDB()
+    rows = gather(db)
+    report, issues = render(rows)
+    print(report)
+
+    if args.slack:
+        deliver_slack(report)
+    if args.email is not None:
+        subject = (f"AlphaMolt data freshness · {datetime.now(timezone.utc):%Y-%m-%d}"
+                   f" · {'all green' if issues == 0 else f'{issues} issue(s)'}")
+        deliver_email(report, subject, args.email or None)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/db.py
+++ b/db.py
@@ -538,6 +538,33 @@ class SupabaseDB:
             page += 1
         return latest
 
+    def get_ai_analysis_freshness(self) -> dict[str, str]:
+        """Return the latest `analyzed_at` per ticker from `ai_analysis`.
+
+        Used by the daily data-freshness report. `ai_analysis` is one row per
+        ticker (PK), so this is a straight paginated read of (ticker,
+        analyzed_at).
+        """
+        latest: dict[str, str] = {}
+        page = 0
+        page_size = 1000
+        while True:
+            resp = (
+                self.client.table("ai_analysis")
+                .select("ticker, analyzed_at")
+                .range(page * page_size, (page + 1) * page_size - 1)
+                .execute()
+            )
+            batch = resp.data or []
+            for row in batch:
+                t = row.get("ticker")
+                if t and row.get("analyzed_at"):
+                    latest[t] = row["analyzed_at"]
+            if len(batch) < page_size:
+                break
+            page += 1
+        return latest
+
     # --- valuation ---
 
     def upsert_valuation_batch(self, rows: list[dict]) -> None:

--- a/test_data_freshness_report.py
+++ b/test_data_freshness_report.py
@@ -1,0 +1,45 @@
+"""Unit tests for data_freshness_report.classify (RAG status logic)."""
+
+import unittest
+
+from data_freshness_report import classify, OK, WATCH, STALE
+
+
+def _c(**kw):
+    base = dict(have=100, total=100, stalest_age_days=1.0, refreshed_24h=50,
+                expected_daily=True, max_stale_days=4, min_coverage=0.5)
+    base.update(kw)
+    return classify(**base)
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_healthy_is_ok(self):
+        self.assertEqual(_c(), OK)
+
+    def test_no_data_is_stale(self):
+        self.assertEqual(_c(have=0), STALE)
+
+    def test_daily_feed_not_refreshing_is_stale(self):
+        self.assertEqual(_c(refreshed_24h=0), STALE)
+
+    def test_far_past_window_is_stale(self):
+        self.assertEqual(_c(stalest_age_days=10, max_stale_days=4), STALE)
+
+    def test_just_past_window_is_watch(self):
+        self.assertEqual(_c(stalest_age_days=5, max_stale_days=4), WATCH)
+
+    def test_low_coverage_is_watch(self):
+        self.assertEqual(_c(have=30, total=100, min_coverage=0.5), WATCH)
+
+    def test_rotation_within_window_ok_even_if_old(self):
+        # A rotation feed: stalest near cycle length but still refreshing daily.
+        self.assertEqual(
+            _c(stalest_age_days=20, max_stale_days=30, refreshed_24h=150), OK)
+
+    def test_non_daily_feed_zero_24h_not_auto_stale(self):
+        # expected_daily=False → 0 in 24h is not penalised on that rule alone.
+        self.assertEqual(_c(expected_daily=False, refreshed_24h=0), OK)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A morning email that surveys **all Level 0 data freshness**, so the kind of staleness we just hit (valuation frozen at Jun 4, fundamentals at Jun 5) can never go unnoticed again.

## What it does
`data_freshness_report.py` checks every Level 0 fact type and emails a digest:

| Data | Coverage | Freshest | Stalest | 24h | Status |
|---|---|---|---|---|---|
| Current price | n / Tier-1 | … | … | refreshed-in-24h | 🟢/🟡/🔴 |
| Daily prices | recent tickers | … | — | — | … |
| Valuation / P-S | n / Tier-1 | … | … | … | … |
| Fundamentals | n / Tier-1 | … | … | … | … |
| AI analysis | n / Tier-1 | … | … | … | … |
| Estimates / Events | rows | — | — | — | ⚪ no ingest yet |

- **`24h`** = rows refreshed in the last day — the pipeline-alive signal (this is what would have caught the frozen valuation/fundamentals).
- **Status rules:** 🔴 no data / a daily feed wrote nothing in 24h / stalest far past its window; 🟡 past window or coverage below floor; 🟢 actively refreshing and in window. Rotation feeds (fundamentals, AI) tolerate a stalest age near their cycle length by design.

## Delivery
Reuses `user_report.py`'s Resend→SMTP emailer. `--email` (uses `REPORT_EMAIL_TO`, or an override addr), `--slack`, or plain stdout. Daily workflow runs `--email` at **12:30 UTC** (after the morning data jobs settle) + manual dispatch.

## Pieces
- `data_freshness_report.py` — gather + render + deliver; pure `classify()` RAG logic.
- `db.get_ai_analysis_freshness()` — latest `analyzed_at` per ticker (rounds out the freshness readers).
- `.github/workflows/data-freshness-report.yml` — daily cron.
- `test_data_freshness_report.py` — 8 cases on the classifier, all green.

## Setup
Runs on the existing report secrets (`RESEND_API_KEY`, `REPORT_EMAIL_FROM`, `REPORT_EMAIL_TO`; `SMTP_*`/`SLACK_WEBHOOK_URL` optional). No migration. After merge: dispatch it once (Actions → Data Freshness Report) to get the first email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_