### PR TITLE
Hotfix: portfolio_reviewer crash — _us_listed_tickers read the renamed companies table

### DIFF
--- a/llm_picker.py
+++ b/llm_picker.py
@@ -28,7 +28,7 @@ import logging
 import math
 from typing import Any
 
-from agent_strategies import US_EXCHANGES, RebalanceContext, RebalanceResult
+from agent_strategies import RebalanceContext, RebalanceResult
 from db import SupabaseDB
 from llm_providers import (
     ENV_VAR_FOR_PROVIDER,
@@ -91,19 +91,20 @@ def _slice_tickers(snapshot_json: dict, tickers: set[str]) -> dict:
 
 
 def _us_listed_tickers(db: SupabaseDB) -> set[str]:
-    """Tickers in `companies` whose exchange is a US venue.
+    """US-listed (USD-priced) tickers — the universe the picker/reviewer may
+    consider.
 
-    Used to filter snapshots before they're sent to LLM agents — the
-    portfolio layer treats every price as USD, so non-US listings
-    (priced in their native currency) would silently mis-cost trades.
-    Until we add proper FX, agents see US-listed tickers (incl. ADRs,
-    which trade on NYSE/NASDAQ) only.
+    Sourced from Level 0 `securities`, which is US-exchange-listed **by
+    construction** (universe_sync keeps only US-exchange listings; OTC/pink and
+    foreign-primary names are excluded). Every active security therefore trades
+    on a US venue in USD, so it's safe to treat as USD — the same FX guard the
+    old `companies`-exchange filter provided. (Replaces a read of the retired
+    `companies` table — see the Level 0 migration.)
     """
     return {
-        str(c["ticker"]).upper()
-        for c in db.get_all_companies()
-        if c.get("ticker")
-        and str(c.get("exchange") or "").strip().upper() in US_EXCHANGES
+        str(s["ticker"]).upper()
+        for s in db.get_all_securities(columns="ticker", status="active")
+        if s.get("ticker")
     }
 
 


### PR DESCRIPTION
## The failure
The agent heartbeat exited 1 because the **`portfolio_reviewer`** strategy crashed on every portfolio with holdings:

```
portfolio_reviewer.py:379 → _us_listed_tickers(ctx.db)
llm_picker.py:104        → db.get_all_companies()
db.py                    → table("companies")
PGRST205: Could not find the table 'public.companies'
          hint: Perhaps you meant 'public.companies_legacy'
```

The Level 0 migration renamed `companies` → `companies_legacy`, but `llm_picker._us_listed_tickers()` — imported and called by the **live** `portfolio_reviewer` — still read `companies`. So the reviewer 404'd and crashed (4 `reviewer ... crashed` errors → exit 1). Buyers were unaffected (already on Level 0); only sell-side review was down.

Missed in the migration sweep because no agent has `strategy='llm_pick'`, but `portfolio_reviewer` imports a helper from `llm_picker`.

## The fix
Repoint `_us_listed_tickers` to Level 0 `securities`, which is US-exchange-listed **by construction** (universe_sync excludes OTC/pink + foreign-primary), so every active security is USD-priced — same FX guard the old `companies`-exchange filter provided. Drop the now-unused `US_EXCHANGES` import.

## Verification
`pytest` 153 pass (2 pre-existing unrelated `_FakeQ` failures in `test_level0_eval.py`). One-function change; no migration.

## Related follow-up (not in this PR)
`portfolio_reviewer` still loads its per-equity data from the legacy `universe_snapshots` table via `_load_latest_snapshot(...)`, whose builder (`build_universe_snapshot`) was retired in the migration — so that snapshot is now frozen. The reviewer runs (no crash) but on stale/partial company data; it should be ported to read Level 0 facts directly (like the buyer). Flagging for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_