### PR TITLE
Freshness report: fix two false-positive STALE flags (valuation + AI rotation)

### DIFF
--- a/data_freshness_report.py
+++ b/data_freshness_report.py
@@ -68,13 +68,24 @@ def classify(
     expected_daily: bool,
     max_stale_days: float,
     min_coverage: float,
+    rotation: bool = False,
 ) -> str:
-    """RAG status for one data type. Pure → unit-tested."""
+    """RAG status for one data type. Pure → unit-tested.
+
+    `rotation` feeds (fundamentals, AI) refresh a slice of the universe each day,
+    so their STALEST row legitimately lags by ~a cycle and for names that have
+    left the universe. Judge those by "is it still refreshing?" (24h) — a stale
+    tail is at most WATCH, never STALE.
+    """
     if have == 0:
         return STALE
     if expected_daily and refreshed_24h is not None and refreshed_24h == 0:
         return STALE
-    if stalest_age_days is not None and stalest_age_days > max_stale_days * 1.5:
+    if (
+        not rotation
+        and stalest_age_days is not None
+        and stalest_age_days > max_stale_days * 1.5
+    ):
         return STALE
     if stalest_age_days is not None and stalest_age_days > max_stale_days:
         return WATCH
@@ -199,7 +210,7 @@ def gather(db: SupabaseDB) -> list[Row]:
     rows.append(_row(
         "Fundamentals", have=len(fund), total=total,
         newest=newest, oldest=oldest, refreshed_24h=r24, now=now,
-        expected_daily=True, max_stale_days=30, min_coverage=0.5,
+        expected_daily=True, max_stale_days=30, min_coverage=0.5, rotation=True,
         note="rotation: stalest nears the cycle length by design",
     ))
 
@@ -209,8 +220,8 @@ def gather(db: SupabaseDB) -> list[Row]:
     rows.append(_row(
         "AI analysis", have=len(ai), total=total,
         newest=newest, oldest=oldest, refreshed_24h=r24, now=now,
-        expected_daily=True, max_stale_days=30, min_coverage=0.3,
-        note="rotation",
+        expected_daily=True, max_stale_days=30, min_coverage=0.3, rotation=True,
+        note="rotation: refreshing daily; stalest tail is dropped-from-universe names",
     ))
 
     # 6. Estimates / Events — not ingested yet (informational).
@@ -230,12 +241,13 @@ def gather(db: SupabaseDB) -> list[Row]:
 
 
 def _row(name, *, have, total, newest, oldest, refreshed_24h, now,
-         expected_daily, max_stale_days, min_coverage, note="") -> Row:
+         expected_daily, max_stale_days, min_coverage, rotation=False, note="") -> Row:
     status = classify(
         have=have, total=total,
         stalest_age_days=_age_days(oldest, now),
         refreshed_24h=refreshed_24h, expected_daily=expected_daily,
         max_stale_days=max_stale_days, min_coverage=min_coverage,
+        rotation=rotation,
     )
     return Row(
         name=name,

--- a/db.py
+++ b/db.py
@@ -606,7 +606,7 @@ class SupabaseDB:
         while True:
             resp = (
                 self.client.table("valuation")
-                .select("ticker, date, ps, ps_ath, history_json")
+                .select("ticker, date, ps, ps_ath, history_json, fetched_at")
                 .order("date", desc=True)
                 .range(page * page_size, (page + 1) * page_size - 1)
                 .execute()

--- a/test_data_freshness_report.py
+++ b/test_data_freshness_report.py
@@ -36,6 +36,20 @@ class ClassifyTests(unittest.TestCase):
         self.assertEqual(
             _c(stalest_age_days=20, max_stale_days=30, refreshed_24h=150), OK)
 
+    def test_rotation_stale_tail_is_watch_not_stale(self):
+        # Rotation feed actively refreshing but with a far-past-window tail
+        # (dropped-from-universe names) → WATCH, never STALE.
+        self.assertEqual(
+            _c(rotation=True, stalest_age_days=100, max_stale_days=30,
+               refreshed_24h=200), WATCH)
+
+    def test_non_rotation_far_past_window_still_stale(self):
+        # Same numbers without rotation → STALE (a full-universe daily feed
+        # really should have refreshed every name).
+        self.assertEqual(
+            _c(rotation=False, stalest_age_days=100, max_stale_days=30,
+               refreshed_24h=200), STALE)
+
     def test_non_daily_feed_zero_24h_not_auto_stale(self):
         # expected_daily=False → 0 in 24h is not penalised on that rule alone.
         self.assertEqual(_c(expected_daily=False, refreshed_24h=0), OK)


### PR DESCRIPTION
The first real freshness email flagged 3 STALE items; 2 were the report mis-flagging healthy feeds. Verified against the live DB and fixed.

## False positive 1 — Valuation / P-S
Showed STALE (`freshest "—"`, `24h=0`) but the DB has **2,946 valuation rows refreshed today** (newest `fetched_at` 12:54 today). Cause: `db.get_all_valuation_latest()` didn't `SELECT fetched_at`, so the report read `None` for every row → "—" → STALE. **Fix:** add `fetched_at` to the select.

## False positive 2 — AI analysis
Showed STALE but had **249 rows refreshed today**, newest today. It only tripped because its *stalest* row is 73d — a rotation's expected tail (~68 Tier-1 names not yet re-reached + 31 leftover rows for names that left Tier-1). **Fix:** make `classify()` rotation-aware — rotation feeds (fundamentals, AI) go STALE only when they stop refreshing (`24h==0`); a stale tail is at most WATCH. Marked the fundamentals + AI rows `rotation=True`.

## Net effect
Next report reflects reality: **Valuation → OK**, **AI analysis → WATCH**, and the one genuine issue — **Current price** coverage 943/3,128 — correctly stays STALE.

## Verification
Classifier suite 10 pass (added rotation-tail cases). `db.py` + `data_freshness_report.py` only; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_