### PR TITLE
Fix current-price coverage: EOD baseline across all Tier-1 equities

### DIFF
--- a/data_freshness_report.py
+++ b/data_freshness_report.py
@@ -163,13 +163,17 @@ def gather(db: SupabaseDB) -> list[Row]:
     total = len(tier1)
     rows: list[Row] = []
 
-    # 1. Current price (securities.price) — the headline canary, intraday cadence.
+    # 1. Current price (securities.price) — the headline canary. EOD close for
+    # the WHOLE Tier-1 set (prices_daily_updater), overlaid intraday on the
+    # liquid subset. Not "expected_daily": markets close on weekends, so price
+    # freshness is judged by age (weekend-tolerant), not a 24h-refresh count —
+    # a genuinely dead feed still trips once the newest price ages past window.
     priced = [s for s in tier1 if db.safe_float(s.get("price"))]
     newest, oldest, r24 = _summarize_map([s.get("price_asof") for s in priced], now)
     rows.append(_row(
         "Current price", have=len(priced), total=total,
         newest=newest, oldest=oldest, refreshed_24h=r24, now=now,
-        expected_daily=True, max_stale_days=4, min_coverage=0.5,
+        expected_daily=False, max_stale_days=5, min_coverage=0.9,
     ))
 
     # 2. Daily prices (prices_daily) — EOD layer. Newest date + recent coverage.

--- a/migrations/063_backfill_securities_price.sql
+++ b/migrations/063_backfill_securities_price.sql
@@ -1,0 +1,27 @@
+-- Migration 063: backfill securities.price from EOD close (price coverage fix).
+--
+-- The "current price" canary (securities.price) sat at ~30% coverage
+-- (943/3128) because it was only ever seeded from the legacy companies backfill
+-- (migration 058) and the 15-min intraday feed only returns the liquid subset.
+-- Every Tier-1 name DOES have an EOD close in prices_daily, so this one-off
+-- fills the canary from the latest close for names missing it (~2,185).
+--
+-- Going forward prices_daily_updater.daily_increment stamps securities.price
+-- from the EOD close for the whole Tier-1 set daily, and intraday_prices
+-- overlays the liquid subset with fresher quotes — so coverage stays ~100%.
+--
+-- Safe + idempotent: only fills NULLs, so it never clobbers a fresher
+-- intraday/backfilled quote. Re-running is a no-op once filled.
+
+UPDATE securities s
+   SET price      = lp.close,
+       price_asof = (lp.date + TIME '20:00')::timestamptz
+  FROM (
+        SELECT DISTINCT ON (ticker) ticker, close, date
+          FROM prices_daily
+         ORDER BY ticker, date DESC
+       ) lp
+ WHERE lp.ticker = s.ticker
+   AND s.is_tier1
+   AND s.price IS NULL
+   AND lp.close IS NOT NULL;

--- a/prices_daily_updater.py
+++ b/prices_daily_updater.py
@@ -91,6 +91,17 @@ def daily_increment(db: SupabaseDB, client: EODHDClient, tier1: set[str],
                 rows.append(mapped)
     if rows and not dry_run:
         db.upsert_prices_daily_batch(rows)
+        # Stamp the Level 0 "current price" canary (securities.price) from the
+        # EOD close for the WHOLE Tier 1 set — so every name has a price even
+        # when the 15-min intraday feed (which only returns the liquid subset)
+        # doesn't. intraday_prices.py overlays that subset with fresher quotes
+        # during market hours; here we guarantee full coverage at the daily close.
+        sec_rows = [
+            {"ticker": m["ticker"], "price": m["close"],
+             "price_asof": f"{m['date']}T20:00:00+00:00"}
+            for m in rows
+        ]
+        db.bulk_upsert_security_prices(sec_rows)
     logger.info("Daily increment: %d Tier 1 rows for %s",
                 len(rows), bulk[0].get("date") if bulk else "?")
     return len(rows)


### PR DESCRIPTION
Makes **EOD price the baseline across ALL Tier-1 equities** (per your call that full EOD coverage matters more than 15-min freshness right now). Intraday becomes a bonus overlay on the liquid subset.

## Diagnosis
`securities.price` coverage was 943/3,128 (~30%) — just the migration-058 backfill. The 15-min intraday feed only returns the liquid subset, and nothing stamped the canary from the EOD close. But **every** Tier-1 name has an EOD close (0 lack a `prices_daily` row), so EOD can cover everyone.

## Fix
- **`prices_daily_updater.daily_increment`** now stamps `securities.price` + `price_asof` from the EOD close for the **whole** Tier-1 set each day. `intraday_prices` still overlays the liquid subset with fresher quotes during market hours — so EOD = universal floor, intraday = freshness on top.
- **`migration 063`** — one-off backfill from the latest `prices_daily` close for the ~2,185 names missing a price (fills **NULLs only**, never clobbering a fresher quote). Validated against live data: would fill exactly **2,185** → coverage ~100% on apply (rather than waiting for the next daily run).
- **`data_freshness_report`** — the Current-price check is now **weekend-tolerant**: judged by price *age* (markets close on weekends) rather than a 24h-refresh count, with a 90% coverage floor. So once EOD covers all it reads 🟢 OK; a genuinely dead feed still trips once the newest price ages past the window.

## Apply
1. Merge + deploy (then `prices_daily_updater` keeps coverage full daily).
2. Run **migration 063** in the SQL editor for the immediate backfill (→ ~100% now).

## Verification
Report + fundamentals suites 14 pass. Live dry-validate of 063 = 2,185 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_