### PR TITLE
Bump AI eval rotation batch 100 → 300/day

### DIFF
--- a/bear_evaluation.py
+++ b/bear_evaluation.py
@@ -35,7 +35,7 @@ GEMINI_TIMEOUT = 300  # seconds
 MAX_RETRIES = 3
 RETRY_DELAY = 15
 DELAY_BETWEEN_CALLS = 2
-TOP_N = 100
+TOP_N = 300  # stalest Tier-1 names refreshed per run (rotation batch)
 NULL_VALUE = "\u2014"
 
 # Columns to EXCLUDE from the data sent to Gemini

--- a/bull_evaluation.py
+++ b/bull_evaluation.py
@@ -34,7 +34,7 @@ CLAUDE_MODEL = "claude-opus-4-6"
 CLAUDE_TIMEOUT = 300  # seconds
 MAX_RETRIES = 3
 RETRY_DELAY = 15
-TOP_N = 100
+TOP_N = 300  # stalest Tier-1 names refreshed per run (rotation batch)
 
 # Columns to EXCLUDE from the data sent to Claude
 EXCLUDED_COLUMNS = {

--- a/research_evaluation.py
+++ b/research_evaluation.py
@@ -46,7 +46,7 @@ logger = logging.getLogger("research_evaluation")
 DEFAULTS = {
     "provider": "google",
     "model": "gemini-2.5-pro",
-    "top_n": 100,
+    "top_n": 300,
     "concurrency": 5,
     "per_call_timeout_sec": 90,
     "max_tokens": 32768,
@@ -274,7 +274,7 @@ def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description="Research Evaluation — shared per-equity card")
     ap.add_argument("--dry-run", action="store_true", help="evaluate but write nothing")
     ap.add_argument("--limit", type=int, default=DEFAULTS["top_n"],
-                    help="max equities this run (default 100, the rotation batch)")
+                    help="max equities this run (default 300, the rotation batch)")
     ap.add_argument("--tickers", nargs="*", help="evaluate these tickers instead of the rotation")
     ap.add_argument("--model", default=DEFAULTS["model"])
     ap.add_argument("--provider", default=DEFAULTS["provider"])

--- a/update_ai_narratives.py
+++ b/update_ai_narratives.py
@@ -30,7 +30,7 @@ STALENESS_DAYS = 90
 # Per-run cap for --tier1 rotation (Stage A2): narrate the N oldest Tier-1
 # names each run so the first pass over the ~3k universe doesn't fire thousands
 # of LLM calls at once — keeps daily cost flat, never-narrated names go first.
-TIER1_NARRATIVE_BATCH = 100
+TIER1_NARRATIVE_BATCH = 300
 GEMINI_MODEL = "gemini-2.5-flash"
 DELAY_BETWEEN_CALLS = 2  # seconds between tickers
 RETRY_DELAY = 10  # seconds between retries


### PR DESCRIPTION
Triples the daily AI-eval rotation batch so the screener's AI insight fills the full Tier-1 universe in ~10 days instead of ~30.

AI coverage was 22–42% of the 3,128 Tier-1 names because each rotation does 100 stalest/day. Bumped to 300/day:

- `research_evaluation` — `DEFAULTS["top_n"]` 100 → 300 (this drives the screener card / `AI ±σ` re-rank)
- `bull_evaluation` / `bear_evaluation` — `TOP_N` 100 → 300
- `update_ai_narratives` — `TIER1_NARRATIVE_BATCH` 100 → 300

**Tradeoff:** ~3× daily LLM spend on these four evals (you OK'd it). Coverage also keeps widening as the new fundamentals refresher fills eligibility (evals are gated on verified fundamentals). Manual `--limit` override on research is unchanged.

No migration; constant changes only. Syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_