### PR TITLE
Buyer: settable conviction + optional signed P/S-vs-median band; rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,17 +455,20 @@ Two trade-phase strategies share the buyer slot:
   them. Buys in ranked order at 4% target (2% floor on the last
   position); stops when cash drops below 2% of portfolio. Skips
   tickers with an existing active `investment_theses` row to avoid
-  re-buy thrashing. **Synchronous value gate** (`min_ps_discount_pct`,
-  migration 064, default 0 = off): when set, drops any candidate not at
-  least N% below its own 12-mo P/S median *before* the LLM eval
-  (`passes_value_gate`) — entry-price discipline at buy time with no
-  standing orders. A value-filtered name is NOT recorded as a rejection,
-  so it stays eligible and auto-buys on a later heartbeat once it drifts
-  cheap enough; names with no usable P/S median are excluded while the
-  gate is engaged. AND'd with the conviction gate, the two knobs let one
-  Buyer "pay up" for top-fit names and another demand a discount for
-  lower-conviction ones (the conviction↔price trade-off, composed across
-  the swarm). Reads the portfolio mandate
+  re-buy thrashing. **Optional P/S-vs-median band** (`ps_vs_median_mode`
+  ∈ off|at_most|at_least + signed `ps_vs_median_pct`, migration 064,
+  default off): a synchronous, two-directional valuation gate applied
+  *before* the LLM eval (`passes_ps_band`) — entry-price discipline at
+  buy time with no standing orders. `at_most` buys only when
+  `ps ≤ median·(1+pct/100)` (ceiling / don't-overpay; pct<0 demands a
+  discount, pct>0 tolerates a premium); `at_least` buys only when
+  `ps ≥ median·(1+pct/100)` (floor / "double-positive" premium). A
+  band-filtered name is NOT recorded as a rejection, so it stays eligible
+  and auto-buys on a later heartbeat once it moves into the band; names
+  with no usable P/S median are excluded while the band is engaged. AND'd
+  with the conviction gate, the knobs let one Buyer "pay up" for top-fit
+  names and another demand value (the conviction↔price trade-off,
+  composed across the swarm). Reads the portfolio mandate
   (`portfolios.description`) — the single owner-written brief that
   covers both *what* to own and *how* to evaluate adds.
   **Evaluation data is sourced from Level 0** — the same Tier-1 screen
@@ -861,8 +864,8 @@ managed, no heartbeat). `heartbeat_interval_hours` defaults to 168 (weekly).
 `config` is a JSONB bag for per-agent strategy parameters — the
 `watchlist_curator` strategy uses `{provider, model, watchlist_size}`, the
 `llm_watchlist_buyer` strategy uses `{provider, model, target_position_pct,
-min_conviction, min_ps_discount_pct}` (the last two are the team-builder
-conviction + value-gate knobs, migration 064); the mechanical
+min_conviction, ps_vs_median_mode, ps_vs_median_pct}` (the last three are the
+team-builder conviction + P/S-band knobs, migration 064); the mechanical
 `watchlist_buyer` ignores
 it. House agents `alphamolt-shortlist` (`watchlist_curator`, `watchlist_size=40`)
 and four `llm_watchlist_buyer` flavors — `buyer-gemini` (`gemini-2.5-pro`),

--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -369,7 +369,10 @@ def _llm_swarm_convictions(
     bp = {**_llm_buyer.LLM_WATCHLIST_BUYER_DEFAULTS, **cfg}
     mandate_m = _resolve_member_mandate(member_row, portfolio_mandate)
     gate = int(cfg.get("convictionGate") or bp["min_conviction"])
-    min_ps_discount_pct = float(cfg.get("min_ps_discount_pct") or bp["min_ps_discount_pct"])
+    ps_mode = str(cfg.get("ps_vs_median_mode") or bp["ps_vs_median_mode"]).strip().lower()
+    ps_pct = cfg.get("ps_vs_median_pct")
+    if ps_pct is None:
+        ps_pct = bp["ps_vs_median_pct"]
     max_per = float(cfg.get("target_position_pct", bp["target_position_pct"])) / 100.0
 
     if not eval_pool:
@@ -397,14 +400,14 @@ def _llm_swarm_convictions(
 
     evals_by_ticker = {e["ticker"]: e for e in evals_list}
 
-    # Per-buyer value gate (synchronous entry-price discipline). The shared eval
-    # pool is cached across co-briefed buyers, so this can't pre-filter the pool —
-    # it's applied here, after eval, on THIS buyer's conviction map (its discount
-    # may differ from a co-briefed buyer's). No-op when the gate is OFF (default 0).
+    # Per-buyer P/S-vs-median band (synchronous entry-price discipline). The shared
+    # eval pool is cached across co-briefed buyers, so this can't pre-filter the
+    # pool — it's applied here, after eval, on THIS buyer's conviction map (its band
+    # may differ from a co-briefed buyer's). No-op when mode is OFF (default).
     def _value_ok(ticker: str) -> bool:
         val = (by_ticker_data.get(ticker) or {}).get("valuation") or {}
-        return _llm_buyer.passes_value_gate(
-            val.get("ps"), val.get("ps_median_12m"), min_ps_discount_pct
+        return _llm_buyer.passes_ps_band(
+            val.get("ps"), val.get("ps_median_12m"), ps_mode, ps_pct
         )
 
     convictions = {

--- a/llm_watchlist_buyer.py
+++ b/llm_watchlist_buyer.py
@@ -115,13 +115,15 @@ LLM_WATCHLIST_BUYER_DEFAULTS: dict[str, Any] = {
     "target_position_pct": 4.0,     # target weight per BUY
     "min_position_pct": 2.0,        # floor on the last (partial) BUY
     "min_conviction": 5,            # hard gate
-    # Value gate: minimum discount to the name's own TTM P/S median required
-    # before a BUY. 0 = OFF (current behaviour — buy regardless of valuation).
-    # When > 0, a name must trade at/below median*(1 - pct/100) to be eligible,
-    # and a name with no usable P/S median is EXCLUDED (no valuation read).
-    # Applied as a candidate filter BEFORE the LLM eval (standalone) and as a
-    # per-buyer filter on the conviction map (swarm) — see passes_value_gate.
-    "min_ps_discount_pct": 0.0,
+    # Optional, two-directional P/S-vs-median band (entry-price discipline at buy
+    # time; synchronous, no standing orders). mode ∈ {off, at_most, at_least}:
+    #   off       — no valuation constraint (default; exact current behaviour).
+    #   at_most   — buy only if ps <= median*(1 + pct/100)  (ceiling / don't overpay;
+    #               pct<0 demands a discount, pct>0 tolerates a premium).
+    #   at_least  — buy only if ps >= median*(1 + pct/100)  (floor / "double-positive").
+    # When engaged, a name with no usable P/S median is EXCLUDED. See passes_ps_band.
+    "ps_vs_median_mode": "off",
+    "ps_vs_median_pct": 0.0,
     # Screener rejection hide (migration 051): how long a PASSed-on name is
     # hidden. Short window so it tracks the daily re-rank / quarterly-earnings
     # cadence rather than outliving the reason it was passed on. (The separate
@@ -322,32 +324,35 @@ def _truncate(text: str, limit: int = 2000) -> str:
     return text if len(text) <= limit else text[: limit - 1] + "…"
 
 
-def passes_value_gate(ps: Any, median: Any, min_discount_pct: float) -> bool:
-    """Is this name cheap enough vs its own 12-mo P/S median to be buyable?
+def passes_ps_band(ps: Any, median: Any, mode: Any, pct: Any) -> bool:
+    """Optional, two-directional P/S-vs-median band — is this name buyable?
 
-    The synchronous value gate (no standing orders): a name is eligible only
-    when its current P/S is at least ``min_discount_pct`` below its trailing
-    12-month median P/S — i.e. ``ps <= median * (1 - pct/100)``.
+    The synchronous value gate (no standing orders). ``mode``:
 
-    - ``min_discount_pct <= 0`` → gate OFF: always True (exact current
-      behaviour, nobody excluded).
-    - gate ON + no usable ``ps``/``median`` → False: a name with no valuation
-      read is EXCLUDED for a value-disciplined buyer (decided in design).
+    - ``off`` (or anything unrecognised) → no constraint: always True (exact
+      current behaviour, nobody excluded).
+    - ``at_most``  → True iff ``ps <= median * (1 + pct/100)`` (ceiling /
+      don't-overpay; ``pct`` signed — negative demands a discount, positive
+      tolerates a premium).
+    - ``at_least`` → True iff ``ps >= median * (1 + pct/100)`` (floor /
+      "double-positive" — only buy at a premium to its own median).
 
-    Shared by the standalone strategy (pre-LLM filter) and the swarm
-    (per-buyer filter on the conviction map).
+    When the band is engaged, a name with no usable ``ps``/``median`` is
+    EXCLUDED (no valuation read — decided in design). Shared by the standalone
+    strategy (pre-LLM filter) and the swarm (per-buyer conviction-map filter).
     """
-    try:
-        pct = float(min_discount_pct)
-    except (TypeError, ValueError):
-        return True
-    if pct <= 0:
+    mode = str(mode or "off").strip().lower()
+    if mode not in ("at_most", "at_least"):
         return True
     ps_f = SupabaseDB.safe_float(ps)
     med_f = SupabaseDB.safe_float(median)
     if not ps_f or not med_f or ps_f <= 0 or med_f <= 0:
         return False
-    return ps_f <= med_f * (1.0 - pct / 100.0)
+    try:
+        threshold = med_f * (1.0 + float(pct) / 100.0)
+    except (TypeError, ValueError):
+        return True
+    return ps_f <= threshold if mode == "at_most" else ps_f >= threshold
 
 
 _RESEARCH_CARD_LABELS = {
@@ -921,25 +926,26 @@ def rebalance_llm_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
         result.notes["skipped_recent_sell_cooldown"] = skipped_cooldown
     candidates = [t for t in candidates if t not in recently_sold]
 
-    # Filter: value gate. Drop names not at least `min_ps_discount_pct` below
-    # their own 12-mo P/S median — entry-price discipline at buy time (synchronous,
-    # no standing orders). No-op when the gate is OFF (default 0). Applied BEFORE
-    # the LLM eval so we don't pay for evaluations on names that fail the value
-    # bar. A filtered name is NOT recorded as a rejection, so it stays eligible and
-    # auto-buys on a later heartbeat once it drifts cheap enough.
-    min_ps_discount_pct = float(params["min_ps_discount_pct"])
-    if min_ps_discount_pct > 0:
+    # Filter: optional P/S-vs-median band — entry-price discipline at buy time
+    # (synchronous, no standing orders). No-op when mode is OFF (default). Applied
+    # BEFORE the LLM eval so we don't pay for evaluations on names outside the band.
+    # A filtered name is NOT recorded as a rejection, so it stays eligible and
+    # auto-buys on a later heartbeat once it moves into the band.
+    ps_mode = str(params.get("ps_vs_median_mode") or "off").strip().lower()
+    ps_pct = params.get("ps_vs_median_pct") or 0.0
+    if ps_mode in ("at_most", "at_least"):
         skipped_value: list[str] = []
         kept: list[str] = []
         for t in candidates:
             fr = fact_rows.get(t) or {}
-            if passes_value_gate(fr.get("ps"), fr.get("ps_median_12m"), min_ps_discount_pct):
+            if passes_ps_band(fr.get("ps"), fr.get("ps_median_12m"), ps_mode, ps_pct):
                 kept.append(t)
             else:
                 skipped_value.append(t)
         if skipped_value:
-            result.notes["skipped_value_gate"] = skipped_value
-            result.notes["min_ps_discount_pct"] = min_ps_discount_pct
+            result.notes["skipped_ps_band"] = skipped_value
+            result.notes["ps_vs_median_mode"] = ps_mode
+            result.notes["ps_vs_median_pct"] = ps_pct
         candidates = kept
 
     if not candidates:

--- a/migrations/064_buyer_value_gate.sql
+++ b/migrations/064_buyer_value_gate.sql
@@ -1,48 +1,60 @@
--- Migration 064: Buyer — settable conviction + P/S-discount value gate; rename.
+-- Migration 064: Buyer — settable conviction + optional P/S-vs-median band; rename.
 --
 -- The "Conviction Buyer" family (four brains on one strategy, llm_watchlist_buyer)
--- becomes simply "Buyer", with two newly-exposed team-builder controls beside the
+-- becomes simply "Buyer", with newly-exposed team-builder controls beside the
 -- existing position-size slider:
 --
---   * min_conviction        — the conviction gate (1-5). The engine ALREADY reads
---                             this (cfg.convictionGate || min_conviction); migration
---                             047 just never surfaced it. Default stays 5.
---   * min_ps_discount_pct   — synchronous value gate: only buy a name trading at
---                             least N% below its own 12-month P/S median. 0 = OFF
---                             (exact current behaviour). When > 0, names with no
---                             usable P/S median are EXCLUDED. See passes_value_gate
---                             in llm_watchlist_buyer.py.
+--   * min_conviction       — the conviction gate (1-5). The engine ALREADY reads
+--                            this (cfg.convictionGate || min_conviction); migration
+--                            047 just never surfaced it. Default stays 5.
+--   * ps_vs_median_mode    — optional, two-directional P/S-vs-median band:
+--       + ps_vs_median_pct    off       no valuation constraint (default).
+--                             at_most   buy only if ps <= median*(1 + pct/100)
+--                                       (ceiling / don't-overpay; pct signed —
+--                                       negative demands a discount, positive
+--                                       tolerates a premium).
+--                             at_least  buy only if ps >= median*(1 + pct/100)
+--                                       (floor / "double-positive" premium).
+--                            When engaged, names with no usable P/S median are
+--                            EXCLUDED. See passes_ps_band in llm_watchlist_buyer.py.
 --
--- AND'd together, the two knobs let one Buyer "pay up" for top-fit names and another
--- demand a discount for lower-conviction ones — the conviction<->price trade-off,
--- composed across the swarm. Conviction is now a dial, so "Conviction Buyer" is
--- renamed "Buyer".
+-- AND'd with the conviction gate, the knobs let one Buyer "pay up" for top-fit names
+-- and another demand value — the conviction<->price trade-off, composed across the
+-- swarm. Conviction is now a dial, so "Conviction Buyer" is renamed "Buyer". The
+-- valuation rule is deliberately kept OUT of sentence_template (static interpolation
+-- can't drop a clause when off) — the labelled controls express it instead.
 --
 -- Only the library-presentation columns change; UUIDs / portfolios / track records
 -- are untouched. Idempotent per-handle UPDATEs (mirror of migration 047).
 -- Paste-and-run in the Supabase SQL editor.
 
--- ---- The four LLM buyers: rename + expose the two knobs ---------------------
+-- The shared schema/sentence (same for all four brains).
+--   param_schema:
+--     [ target_position_pct (number 2-10),
+--       min_conviction (number 1-5),
+--       ps_vs_median_mode (select off|at_most|at_least),
+--       ps_vs_median_pct (number -40..+40, signed) ]
+
 UPDATE agents SET
     display_name      = 'Buyer · Gemini',
-    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4},{"key":"min_conviction","label":"Minimum conviction to buy","type":"number","min":1,"max":5,"step":1,"default":5},{"key":"min_ps_discount_pct","label":"Min discount to TTM P/S median","type":"number","min":0,"max":40,"step":1,"unit":"%","default":0}]'::jsonb,
-    sentence_template = 'Weighs every candidate against your brief and buys only names at conviction {min_conviction}/5 or higher, up to {target_position_pct}% per position — and only at a discount of {min_ps_discount_pct}% or more to its 12-month P/S median.'
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4},{"key":"min_conviction","label":"Minimum conviction to buy","type":"number","min":1,"max":5,"step":1,"default":5},{"key":"ps_vs_median_mode","label":"P/S vs 12-mo median","type":"select","default":"off","options":[{"value":"off","label":"No P/S limit"},{"value":"at_most","label":"Buy only at/below threshold"},{"value":"at_least","label":"Buy only at/above threshold"}]},{"key":"ps_vs_median_pct","label":"Threshold (% vs median)","type":"number","min":-40,"max":40,"step":1,"unit":"%","default":0}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only names at conviction {min_conviction}/5 or higher, up to {target_position_pct}% per position.'
     WHERE handle = 'buyer-gemini';
 
 UPDATE agents SET
     display_name      = 'Buyer · Claude',
-    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4},{"key":"min_conviction","label":"Minimum conviction to buy","type":"number","min":1,"max":5,"step":1,"default":5},{"key":"min_ps_discount_pct","label":"Min discount to TTM P/S median","type":"number","min":0,"max":40,"step":1,"unit":"%","default":0}]'::jsonb,
-    sentence_template = 'Weighs every candidate against your brief and buys only names at conviction {min_conviction}/5 or higher, up to {target_position_pct}% per position — and only at a discount of {min_ps_discount_pct}% or more to its 12-month P/S median.'
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4},{"key":"min_conviction","label":"Minimum conviction to buy","type":"number","min":1,"max":5,"step":1,"default":5},{"key":"ps_vs_median_mode","label":"P/S vs 12-mo median","type":"select","default":"off","options":[{"value":"off","label":"No P/S limit"},{"value":"at_most","label":"Buy only at/below threshold"},{"value":"at_least","label":"Buy only at/above threshold"}]},{"key":"ps_vs_median_pct","label":"Threshold (% vs median)","type":"number","min":-40,"max":40,"step":1,"unit":"%","default":0}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only names at conviction {min_conviction}/5 or higher, up to {target_position_pct}% per position.'
     WHERE handle = 'buyer-claude';
 
 UPDATE agents SET
     display_name      = 'Buyer · GPT-5',
-    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4},{"key":"min_conviction","label":"Minimum conviction to buy","type":"number","min":1,"max":5,"step":1,"default":5},{"key":"min_ps_discount_pct","label":"Min discount to TTM P/S median","type":"number","min":0,"max":40,"step":1,"unit":"%","default":0}]'::jsonb,
-    sentence_template = 'Weighs every candidate against your brief and buys only names at conviction {min_conviction}/5 or higher, up to {target_position_pct}% per position — and only at a discount of {min_ps_discount_pct}% or more to its 12-month P/S median.'
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4},{"key":"min_conviction","label":"Minimum conviction to buy","type":"number","min":1,"max":5,"step":1,"default":5},{"key":"ps_vs_median_mode","label":"P/S vs 12-mo median","type":"select","default":"off","options":[{"value":"off","label":"No P/S limit"},{"value":"at_most","label":"Buy only at/below threshold"},{"value":"at_least","label":"Buy only at/above threshold"}]},{"key":"ps_vs_median_pct","label":"Threshold (% vs median)","type":"number","min":-40,"max":40,"step":1,"unit":"%","default":0}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only names at conviction {min_conviction}/5 or higher, up to {target_position_pct}% per position.'
     WHERE handle = 'buyer-chatgpt';
 
 UPDATE agents SET
     display_name      = 'Buyer · Grok',
-    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4},{"key":"min_conviction","label":"Minimum conviction to buy","type":"number","min":1,"max":5,"step":1,"default":5},{"key":"min_ps_discount_pct","label":"Min discount to TTM P/S median","type":"number","min":0,"max":40,"step":1,"unit":"%","default":0}]'::jsonb,
-    sentence_template = 'Weighs every candidate against your brief and buys only names at conviction {min_conviction}/5 or higher, up to {target_position_pct}% per position — and only at a discount of {min_ps_discount_pct}% or more to its 12-month P/S median.'
+    param_schema      = '[{"key":"target_position_pct","label":"Target per position","type":"number","min":2,"max":10,"step":0.5,"unit":"%","default":4},{"key":"min_conviction","label":"Minimum conviction to buy","type":"number","min":1,"max":5,"step":1,"default":5},{"key":"ps_vs_median_mode","label":"P/S vs 12-mo median","type":"select","default":"off","options":[{"value":"off","label":"No P/S limit"},{"value":"at_most","label":"Buy only at/below threshold"},{"value":"at_least","label":"Buy only at/above threshold"}]},{"key":"ps_vs_median_pct","label":"Threshold (% vs median)","type":"number","min":-40,"max":40,"step":1,"unit":"%","default":0}]'::jsonb,
+    sentence_template = 'Weighs every candidate against your brief and buys only names at conviction {min_conviction}/5 or higher, up to {target_position_pct}% per position.'
     WHERE handle = 'buyer-grok';

--- a/test_buyer_value_gate.py
+++ b/test_buyer_value_gate.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Unit tests for the Buyer's synchronous P/S-discount value gate (migration 058).
+"""Unit tests for the Buyer's optional P/S-vs-median band (migration 064).
 
-Verifies passes_value_gate: OFF (default 0) includes everyone incl. names with no
-P/S median; ON excludes missing/zero median (no valuation read) and names not at
-least N% below their own 12-mo median; boundary is inclusive. Pure logic, no
+passes_ps_band(ps, median, mode, pct):
+  off       -> no constraint (default; nobody excluded, incl. missing median).
+  at_most   -> ps <= median*(1 + pct/100)  (ceiling; pct signed).
+  at_least  -> ps >= median*(1 + pct/100)  (floor / premium).
+When engaged, names with no usable ps/median are EXCLUDED. Pure logic, no
 DB/LLM. Run: python test_buyer_value_gate.py
 """
 
@@ -14,45 +16,54 @@ import unittest
 import llm_watchlist_buyer as b
 
 
-class ValueGateTests(unittest.TestCase):
-    # ---- gate OFF (default) -> never excludes -----------------------------
+class PsBandTests(unittest.TestCase):
+    # ---- OFF / unknown -> never excludes ----------------------------------
     def test_off_includes_everyone(self):
-        self.assertTrue(b.passes_value_gate(100.0, 10.0, 0))      # richly valued
-        self.assertTrue(b.passes_value_gate(5.0, 10.0, 0))        # cheap
-        self.assertTrue(b.passes_value_gate(None, None, 0))       # no valuation read
-        self.assertTrue(b.passes_value_gate(10.0, None, 0))
+        self.assertTrue(b.passes_ps_band(100.0, 10.0, "off", 0))    # richly valued
+        self.assertTrue(b.passes_ps_band(5.0, 10.0, "off", -20))    # cheap
+        self.assertTrue(b.passes_ps_band(None, None, "off", 0))     # no valuation read
+        self.assertTrue(b.passes_ps_band(10.0, None, "off", 0))
 
-    def test_negative_pct_treated_as_off(self):
-        self.assertTrue(b.passes_value_gate(100.0, 10.0, -5))
+    def test_unknown_mode_treated_as_off(self):
+        self.assertTrue(b.passes_ps_band(100.0, 10.0, "", 0))
+        self.assertTrue(b.passes_ps_band(100.0, 10.0, None, 0))
+        self.assertTrue(b.passes_ps_band(100.0, 10.0, "bogus", 0))
 
-    # ---- gate ON -> excludes names with no usable valuation ---------------
-    def test_on_excludes_missing_or_zero_median(self):
-        self.assertFalse(b.passes_value_gate(10.0, None, 15))
-        self.assertFalse(b.passes_value_gate(10.0, 0, 15))
-        self.assertFalse(b.passes_value_gate(None, 10.0, 15))
-        self.assertFalse(b.passes_value_gate(0, 10.0, 15))
+    # ---- engaged -> excludes names with no usable valuation ---------------
+    def test_engaged_excludes_missing_or_zero_median(self):
+        for mode in ("at_most", "at_least"):
+            self.assertFalse(b.passes_ps_band(10.0, None, mode, 0))
+            self.assertFalse(b.passes_ps_band(10.0, 0, mode, 0))
+            self.assertFalse(b.passes_ps_band(None, 10.0, mode, 0))
+            self.assertFalse(b.passes_ps_band(0, 10.0, mode, 0))
 
-    # ---- gate ON -> discount maths ---------------------------------------
-    def test_on_richer_than_median_fails(self):
-        # ps == median -> 0% discount, needs 15% -> fail
-        self.assertFalse(b.passes_value_gate(10.0, 10.0, 15))
-        # ps above median -> fail
-        self.assertFalse(b.passes_value_gate(12.0, 10.0, 15))
+    # ---- at_most (ceiling), pct negative = discount required --------------
+    def test_at_most_negative_pct_requires_discount(self):
+        # need ps <= 10 * 0.85 = 8.5
+        self.assertTrue(b.passes_ps_band(8.0, 10.0, "at_most", -15))   # 20% below -> ok
+        self.assertTrue(b.passes_ps_band(8.5, 10.0, "at_most", -15))   # exactly -> inclusive
+        self.assertFalse(b.passes_ps_band(8.51, 10.0, "at_most", -15)) # just over -> fail
+        self.assertFalse(b.passes_ps_band(10.0, 10.0, "at_most", -15)) # at median -> fail
 
-    def test_on_cheaper_passes(self):
-        # 20% below median, needs 15% -> pass
-        self.assertTrue(b.passes_value_gate(8.0, 10.0, 15))
+    # ---- at_most (ceiling), pct positive = tolerate premium --------------
+    def test_at_most_positive_pct_tolerates_premium(self):
+        # need ps <= 10 * 1.10 = 11.0  (don't pay > 10% over median)
+        self.assertTrue(b.passes_ps_band(11.0, 10.0, "at_most", 10))   # inclusive
+        self.assertTrue(b.passes_ps_band(9.0, 10.0, "at_most", 10))    # cheap -> ok
+        self.assertFalse(b.passes_ps_band(12.0, 10.0, "at_most", 10))  # too rich -> fail
 
-    def test_on_boundary_is_inclusive(self):
-        # exactly 15% below median (8.5 == 10 * 0.85) -> pass
-        self.assertTrue(b.passes_value_gate(8.5, 10.0, 15))
-        # a hair above the threshold -> fail
-        self.assertFalse(b.passes_value_gate(8.51, 10.0, 15))
+    # ---- at_least (floor / "double-positive") ----------------------------
+    def test_at_least_requires_premium(self):
+        # need ps >= 10 * 1.20 = 12.0
+        self.assertTrue(b.passes_ps_band(12.0, 10.0, "at_least", 20))  # inclusive
+        self.assertTrue(b.passes_ps_band(15.0, 10.0, "at_least", 20))  # well above -> ok
+        self.assertFalse(b.passes_ps_band(11.0, 10.0, "at_least", 20)) # not enough premium
+        self.assertFalse(b.passes_ps_band(8.0, 10.0, "at_least", 20))  # cheap -> fail
 
-    def test_string_inputs_coerced(self):
-        # safe_float handles strings; gate still works
-        self.assertTrue(b.passes_value_gate("8.0", "10.0", 15))
-        self.assertFalse(b.passes_value_gate("9.9", "10.0", 15))
+    # ---- coercion / casing ------------------------------------------------
+    def test_string_inputs_and_casing(self):
+        self.assertTrue(b.passes_ps_band("8.0", "10.0", "AT_MOST", -15))
+        self.assertFalse(b.passes_ps_band("9.9", "10.0", " at_most ", -15))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Makes the buyer family more flexible and powerful, and renames **"Conviction Buyer" → "Buyer"** (conviction is now a dial, not a hidden binary).

Two previously-hidden/absent levers are now owner-settable in the team builder:

1. **Minimum conviction** — the gate was already a config value the engine reads (`convictionGate || min_conviction`), just hard-defaulted to 5 and never surfaced. Now exposed as a slider (1–5, default 5).
2. **Optional, two-directional P/S-vs-median band** — valuation discipline applied *at buy time* (synchronous, no standing orders / nothing on Alpaca to administer):

| `ps_vs_median_mode` | `ps_vs_median_pct` (signed) | behaviour |
|---|---|---|
| **off** (default) | — | no valuation constraint — exact current behaviour |
| **at_most** | `-15` | only buy ≥15% **below** median (deep value) |
| **at_most** | `+10` | don't overpay — only if ≤10% **above** median |
| **at_least** | `+20` | "double-positive" — only buy at a ≥20% **premium** to its own median |

AND'd with the conviction gate, the knobs let one Buyer "pay up" for top-fit names while another demands value — the conviction↔price trade-off, composed across the swarm (which is how the team builder is meant to work).

## Design decisions
- **Synchronous filter, not standing orders.** A band-filtered name is *not* recorded as a rejection, so it stays eligible and auto-buys on a later heartbeat once it moves into the band (a poor-man's, daily-granularity limit order with no new table).
- **No-median names** (financials / recent listings / some foreign ADRs) are excluded **only when the band is engaged**; with the band off, nobody is excluded.
- **Valuation rule kept out of `sentence_template`** — interpolation is static and can't drop a clause when off, so a Buyer with no P/S limit no longer reads "…at a discount of 0% or more." The labelled dropdown + slider express it instead.

## Changes
- `llm_watchlist_buyer.py` — new `passes_ps_band(ps, median, mode, pct)` helper + `ps_vs_median_mode`/`ps_vs_median_pct` defaults; standalone pre-LLM filter.
- `agent_heartbeat.py` — swarm path (`_llm_swarm_convictions`) applies the band per-buyer on the conviction map (shared eval pool is cached, so it can't pre-filter).
- `migrations/064_buyer_value_gate.sql` — renames the four buyers to `Buyer · <model>` and exposes the conviction slider + P/S mode dropdown + signed threshold slider (idempotent per-handle UPDATEs).
- `web/lib/home-roster-query.ts` / `home-roster.tsx` — title + family filter rename (the `startsWith` filter was a functional must-fix).
- `CLAUDE.md` — updated buyer description + config keys.
- `test_buyer_value_gate.py` — unit tests for `passes_ps_band` (off / at_most ± / at_least / missing-median exclusion / boundaries / coercion).

## Verification
- `python test_buyer_value_gate.py` (7), `test_buyer_rejections.py` (5), `test_swarm.py` (13) all green; both engine modules byte-compile.
- ⚠️ **Migration 064 must be applied** in Supabase, and a live `--dry-run` heartbeat against a configured Buyer wasn't runnable here (no Supabase/LLM creds in the sandbox). Defaults preserve current behaviour exactly (mode `off`, conviction 5).

## Known follow-up
The team builder renders every param unconditionally, so the threshold slider shows (inert) even when mode = `off`. Conditional show/hide is a larger team-builder change, left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mGKDX7zn1dKEaYq8GYv9o)_