### PR TITLE
Fix NameError: define temperature in the standalone buyer (Phase 2)

### DIFF
--- a/llm_watchlist_buyer.py
+++ b/llm_watchlist_buyer.py
@@ -831,6 +831,7 @@ def rebalance_llm_watchlist_buyer(ctx: RebalanceContext) -> RebalanceResult:
 
     provider = params["provider"]
     model = params["model"]
+    temperature = float(params["temperature"])
     if not provider or not model:
         result.errors.append("agents.config must set provider + model")
         return result


### PR DESCRIPTION
## Summary

Follow-up to #1758. Fixes a **pre-existing latent crash** on the standalone buyer path:

> `Buyer · Claude hit an error — name 'temperature' is not defined`
> (`agent_heartbeat.py … result = strategy(ctx)` → `rebalance_llm_watchlist_buyer`)

## Root cause

`rebalance_llm_watchlist_buyer` (`llm_watchlist_buyer.py`) calls
`_prioritise(..., temperature=temperature)`, but `temperature` was never defined in that
function's scope — only `evaluate_candidates` defined it locally. That line is reached
**only when ≥1 candidate clears the conviction gate** (past the early `if not qualifying:
return`). Every prior run had 0 qualifiers, so it returned early and the bug stayed
latent; the standalone path is also rarer than the swarm path (which defines
`temperature` locally). The moment a buyer config let a name qualify, Phase 2 ran and
threw.

Not introduced by the value-band work in #1758 — just unmasked by it (the band
reconfiguration let a candidate through for the first time).

## Fix

One line: define `temperature = float(params["temperature"])` alongside the other param
reads (`provider`/`model`), mirroring `evaluate_candidates`. No behaviour change beyond
making the Phase-2 prioritise call resolve.

## Verification
- `python -m py_compile llm_watchlist_buyer.py agent_heartbeat.py` — clean.
- `test_buyer_value_gate.py` (7), `test_buyer_rejections.py` (5), `test_swarm.py` (13) — all green.
- Grep confirmed line 1041 was the only `temperature` reference in the function; the trade-execution block uses only earlier-defined locals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mGKDX7zn1dKEaYq8GYv9o)_