### PR TITLE
Hotfix: AI evals crash — tier1_eval_candidates read the renamed companies table

### DIFF
--- a/level0_eval.py
+++ b/level0_eval.py
@@ -212,15 +212,16 @@ def tier1_eval_candidates(db, kind: str, top_n: int) -> list[dict]:
     secs = {(s.get("ticker") or "").upper(): s
             for s in _bulk(db, "securities",
                            "ticker,name,country,gics_sector", tickers)}
-    companies = {(c.get("ticker") or "").upper(): c
-                 for c in _bulk(db, "companies", "*", tickers)}
     funds = _latest_by_ticker(
         _bulk(db, "fundamentals", "*", tickers), "period_end")
     vals = _latest_by_ticker(
         _bulk(db, "valuation", "ticker,date,ps,ps_median_12m", tickers), "date")
     ai = db.get_ai_analysis(tickers)
+    # The legacy `companies` overlay is retired — prompt rows are assembled from
+    # Level 0 (securities + fundamentals + valuation) and the ai_analysis
+    # narrative/verdict fallback (handled in _assemble when company is None).
     return [
         _assemble(t, secs.get(t), funds.get(t), vals.get(t),
-                  companies.get(t), ai.get(t))
+                  None, ai.get(t))
         for t in tickers
     ]

--- a/moltbook_heartbeat.py
+++ b/moltbook_heartbeat.py
@@ -917,7 +917,7 @@ def _angle_consensus_conviction(db: Any) -> dict[str, Any] | None:
         log.info("angle consensus_conviction: pct=%.0f swarm_pnl=%.1f, not notable",
                  pct, swarm_pnl)
         return None
-    company = (top.get("companies") or {}).get("company_name") or top["ticker"]
+    company = top.get("company_name") or top["ticker"]
     return {
         "angle": "consensus_conviction",
         "narrative_hint": (

--- a/research_evaluation.py
+++ b/research_evaluation.py
@@ -289,15 +289,14 @@ def main(argv=None) -> int:
         tickers = [t.upper() for t in args.tickers]
         secs = {(s.get("ticker") or "").upper(): s for s in
                 level0_eval._bulk(db, "securities", "ticker,name,country,gics_sector", tickers)}
-        companies = {(c.get("ticker") or "").upper(): c for c in
-                     level0_eval._bulk(db, "companies", "*", tickers)}
         funds = level0_eval._latest_by_ticker(
             level0_eval._bulk(db, "fundamentals", "*", tickers), "period_end")
         vals = level0_eval._latest_by_ticker(
             level0_eval._bulk(db, "valuation", "ticker,date,ps,ps_median_12m", tickers), "date")
         ai = db.get_ai_analysis(tickers)
+        # companies overlay retired — assemble from Level 0 + ai_analysis only.
         batch = [level0_eval._assemble(t, secs.get(t), funds.get(t), vals.get(t),
-                                       companies.get(t), ai.get(t)) for t in tickers]
+                                       None, ai.get(t)) for t in tickers]
     else:
         batch = level0_eval.tier1_eval_candidates(db, "research", args.limit)
 


### PR DESCRIPTION
## The failure
`bull_evaluation` (and bear / narratives / research — they all call it) crashed:
```
level0_eval.tier1_eval_candidates → _bulk(db, "companies", ...) 
PGRST205: Could not find the table 'public.companies'  (hint: 'public.companies_legacy')
```
`tier1_eval_candidates` fetched the legacy `companies` table to *overlay* prompt richness on the Level 0 facts. The Level 0 migration renamed `companies`→`companies_legacy`, so it 404s — and since this is the **hot path of every AI eval rotation**, all four were down (no new bull/bear/research/narrative).

Another missed `companies` read from the migration sweep — apologies; this module wasn't on my radar because it reads via a generic `_bulk(db, "companies", ...)` helper.

## Fix
- **`level0_eval.tier1_eval_candidates`** — drop the `companies` overlay; assemble prompt rows from Level 0 (securities + fundamentals + valuation) with the `ai_analysis` narrative/verdict fallback (`_assemble` already handles `company=None`).
- **`research_evaluation --tickers`** — same fix for its direct `_assemble` call.
- **`moltbook_heartbeat`** — read `company_name` from the already-repointed `get_latest_consensus_top_tickers` result instead of the dead nested `companies` embed key (cosmetic; it was silently falling back to the ticker).

## Exhaustive re-sweep
Checked every remaining `companies` reference: all others are in **retired** workflows (`nightly_screen`, `build_universe_snapshot`, `score_ai_analysis`, `eodhd_updater` — schedules disabled) or the manual `seed_dummy_portfolio` operator tool. No other live-scheduled path reads `companies`.

## Verification
`pytest` 162 pass (2 pre-existing unrelated `_FakeQ` failures in `test_level0_eval`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_