### PR TITLE
Universe hygiene: drop preferred/warrant/unit/rights from Tier 1; honest P/S skip count

### DIFF
--- a/price_sales_updater.py
+++ b/price_sales_updater.py
@@ -551,7 +551,11 @@ def main():
             continue
 
         if result is None:
-            errors += 1
+            # Uncomputable, not a failure: no fundamentals, no/zero revenue
+            # (pre-revenue biotech), or no market cap. Count as skipped so the
+            # activity log reads honestly — genuine fetch exceptions above are
+            # the only thing that counts as an error.
+            skipped += 1
             continue
 
         # Write to the Level 0 `valuation` table — this script is now the daily

--- a/universe_sync.py
+++ b/universe_sync.py
@@ -68,6 +68,42 @@ EXCLUDE_NAME_KEYWORDS = (
 ADR_KEYWORDS = ("ADR", "ADS", "AMERICAN DEPOSITARY")
 REIT_KEYWORDS = ("REIT",)
 
+# --- non-common ticker-suffix gate (preferreds / warrants / units / rights) ---
+# EODHD sometimes mistypes preferred series, warrants and units as
+# "Common Stock" (the Name keywords above then miss them), so they leak into
+# Tier 1 as suffixed tickers: e.g. ALB-PA / BA-PA / BA-P-A (preferred series),
+# ACHR-WS / XYZ-WT (warrants), ABC-U / ABC-UN (units), DEF-R / DEF-RT (rights).
+# We drop these by the *suffix* (everything after the first hyphen). Legitimate
+# dual-class common shares use a single trailing letter (BRK-A / BRK-B /
+# HEI-A / LEN-B / GEF-B) and must be KEPT — so the gate fires only on the
+# known non-common suffix shapes, never on a bare single class letter.
+_PREFERRED_SUFFIX_PREFIX = "P"          # P, PA, PB, P-A … (preferred series)
+_NONCOMMON_SUFFIXES = {
+    "WS", "WT", "W",       # warrants
+    "U", "UN",             # units
+    "R", "RT", "RTS",      # rights
+}
+
+
+def _is_non_common_suffix(code: str) -> bool:
+    """True when a hyphenated ticker's suffix marks a preferred / warrant /
+    unit / rights line rather than a dual-class common share.
+
+    Conservative: a single trailing class letter (A/B/C/K/…) is always kept;
+    only the preferred-series shape (`P…`) and the explicit warrant/unit/rights
+    suffixes are dropped.
+    """
+    if "-" not in code:
+        return False
+    suffix = code.split("-", 1)[1].strip().upper()
+    if not suffix:
+        return False
+    # Preferred series: suffix begins with "P" and is not a lone class letter.
+    # (No common dual-class line uses a "P" class; "P…" is preferred-series.)
+    if suffix.startswith(_PREFERRED_SUFFIX_PREFIX):
+        return True
+    return suffix in _NONCOMMON_SUFFIXES
+
 # --- US-exchange listing gate (Tier 1 = US-exchange-listed only) ---
 # EODHD's "US" symbol list spans every US-market venue: the real exchanges
 # (NYSE / NASDAQ / NYSE MKT (=AMEX) / NYSE ARCA / BATS) PLUS the OTC tiers
@@ -110,6 +146,11 @@ def classify_security(row: dict) -> tuple[str, str | None] | None:
         return None
 
     code = (row.get("Code") or "").strip().upper()
+    # Drop preferred-series / warrant / unit / rights lines that EODHD mistyped
+    # as "Common Stock" — recognised by their ticker suffix (ALB-PA, ACHR-WS,
+    # …). Dual-class common shares (BRK-A / BRK-B) are kept.
+    if _is_non_common_suffix(code):
+        return None
     # Dual-class tickers use a hyphen (BRK-A / BRK-B); the part after the
     # hyphen is the share class. (Preferreds arrive as Type "Preferred Stock"
     # and are already excluded above, so a hyphen here means dual-class.)


### PR DESCRIPTION
## Why

The Screener activity log was reporting **182 P/S "errors"** each run. Diagnosis: two unrelated things both reading as failures.

1. **Preferreds / warrants leaking into Tier 1.** EODHD sometimes mistypes preferred series, warrants and units as `Type: "Common Stock"`, so the Name-keyword gate in `universe_sync.classify_security` misses them and they pass into Tier 1 as suffixed tickers (`ALB-PA`, `BA-P-A`, `ACHR-WS`, …). They have no computable P/S, so they showed up as errors.
2. **Pre-revenue names counted as errors.** When `compute_ps_for_ticker` can't compute a ratio (no fundamentals, zero/no revenue for a pre-revenue biotech, no market cap) it returns `None` — which the main loop was counting as an `error` rather than a `skip`.

## What

- **`universe_sync.classify_security`** — new `_is_non_common_suffix()` gate drops hyphenated tickers whose suffix marks a preferred series (`P…`), warrant (`WS`/`WT`/`W`), unit (`U`/`UN`) or rights (`R`/`RT`/`RTS`) line. Conservative by design: a single trailing class letter (`BRK-A`, `BRK-B`, `HEI-A`, `LEN-B`, `GEF-B`) is always **kept** — only the known non-common suffix shapes are dropped.
- **`price_sales_updater`** — an uncomputable P/S (`result is None`) now counts as **skipped**, not **errors**. Genuine fetch exceptions (the `except` branch) remain the only thing counted as an error, so the activity log reads honestly.

## Verification

Suffix heuristic checked against both leaking patterns and legit class shares:

```
DROP: ALB-PA, BA-PA, BA-P-A, ACHR-WS, XYZ-WT, ABC-U, ABC-UN, DEF-R, DEF-RT, GHI-W, PFD-P
KEEP: BRK-A, BRK-B, HEI-A, LEN-B, GEF-B, BF-B, AAPL, NVDA, TSM (ADR)
```

All pass. `classify_security` end-to-end confirms preferreds/warrants → `None`, dual-class → `('Common Stock', '<letter>')`, ADRs unaffected.

> Note: the preferred/warrant names already in Tier 1 are removed on the next weekly `universe_sync.py` run (soft-delisted as they fall out of the kept set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_