### PR TITLE
Hotfix: bull_evaluation crash — stale `companies` ref in run_logs details

### DIFF
--- a/bull_evaluation.py
+++ b/bull_evaluation.py
@@ -441,7 +441,7 @@ def main():
         "errors": 0,
         "duration_secs": round(elapsed, 1),
         "details": {
-            "total_companies": len(companies),
+            "total_companies": len(top_equities),
             "batch_size": len(top_equities),
             "verdicts_parsed": len(verdicts),
             "passed": passed,


### PR DESCRIPTION
## Problem

`bull_evaluation.py` crashed at the end of a **successful** run:

```
2026-06-23 09:54:36 [INFO] Writing 298 verdicts
NameError: name 'companies' is not defined   (line 444: "total_companies": len(companies))
```

The evaluation worked fully — 300 Tier-1 candidates selected, Claude called, **298 verdicts parsed and written to `ai_analysis`**. The crash was purely in the `run_logs` journaling step afterwards: a single leftover reference to `companies`, the variable name from before the Level 0 port renamed the candidate list to `top_equities`.

## Fix

One line — `details.total_companies` now uses `len(top_equities)`.

## Scope check

I grepped the three sibling eval scripts (`bear_evaluation`, `update_ai_narratives`, `research_evaluation`) for the same pattern — they all use correctly-scoped variables (`companies_to_update`, function params), so `bull_evaluation` was the only one carrying this straggler.

This is split out from #1777 (universe hygiene) as a standalone hotfix so it can merge fast and unblock the bull eval's run-log write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_