### PR TITLE
Advance per-membership heartbeat clock on portfolio member runs

### DIFF
--- a/agent_heartbeat.py
+++ b/agent_heartbeat.py
@@ -193,6 +193,14 @@ def _journal(
     # be touched here.
     if not dry_run and advance_agent:
         db.update_agent_last_heartbeat(agent_id, _now_utc().isoformat())
+    # For a human-portfolio member run (advance_agent=False + a portfolio), stamp
+    # the per-membership clock (portfolio_agents.last_heartbeat_at, migration 029)
+    # instead — the per-(portfolio, agent) cadence track. Keyed on the pair, so
+    # it's a safe no-op for a legacy 1:1 agent with no membership row.
+    elif not dry_run and portfolio_id:
+        db.update_portfolio_member_heartbeat(
+            portfolio_id, agent_id, _now_utc().isoformat()
+        )
 
 
 def _run_one(


### PR DESCRIPTION
## Problem

Investigating why MARA v1 / House Targaryen looked stale, I found their member agents' "last ran" clocks frozen at **Jun 15** while the portfolio rebalanced on **Jun 22**. Root cause: `portfolio_agents.last_heartbeat_at` — the per-(portfolio, agent) cadence track from migration 029 — **is never advanced**. `db.update_portfolio_member_heartbeat()` has zero callers.

Both heartbeat paths journal member runs with `advance_agent=False` (correct — an agent that belongs to several portfolios must not have its global `agents.last_heartbeat_at` bumped by one portfolio's run), but nothing then stamped the membership clock, so it sat at whatever a one-off backfill last wrote. The result was misleading per-agent "last ran" displays.

## Fix

In `_journal`, the `advance_agent=False` **and** `portfolio_id`-set combination uniquely identifies a human-portfolio member run (swarm buyers/reviewers + the legacy per-member loop). Stamp the membership clock there instead of the agent clock:

```python
if not dry_run and advance_agent:
    db.update_agent_last_heartbeat(agent_id, _now_utc().isoformat())
elif not dry_run and portfolio_id:
    db.update_portfolio_member_heartbeat(portfolio_id, agent_id, _now_utc().isoformat())
```

- Keyed on `(portfolio_id, agent_id)`, so it's a **safe no-op** for a legacy 1:1 agent with no membership row.
- Pass-1 legacy agents (`advance_agent=True`) are untouched.
- All existing member-run journaling sites already pass `advance_agent=False` + `portfolio_id`, so every path (swarm buy, swarm sell incl. error, legacy loop incl. error/unknown-strategy) now advances correctly.

## Scope note

This is the display/observability fix the user asked for. The swarm path still gates only at the **portfolio** level (`_portfolio_is_due`) and runs all enabled members on each due tick — it does not yet gate each member on its own `heartbeat_interval_hours` against this clock (the per-member cadence described in CLAUDE.md). That's a larger behavioural change; out of scope here. With this fix the clock now carries accurate data, which is the prerequisite for adding that gating later if wanted.

## Tests

`test_swarm.py` + `test_portfolios.py` — 30 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_