### PR TITLE
Consolidate AI analysis: 4 rotation Actions → 2 (verdict + research), models preserved

### DIFF
--- a/.github/workflows/bear-evaluation.yml
+++ b/.github/workflows/bear-evaluation.yml
@@ -1,10 +1,11 @@
 name: Bear Evaluation
 
 on:
-  schedule:
-    # Daily 04:00 UTC — rotation batch of 100 oldest bear_eval_at.
-    # Full universe cycles every ~5 days at this cadence.
-    - cron: "0 4 * * *"
+  # SCHEDULE RETIRED — the bear side now runs inside verdict-evaluation.yml
+  # (bull + bear over one shared batch / clock). Kept for manual single-side
+  # runs and backfills only.
+  # schedule:
+  #   - cron: "0 4 * * *"
   workflow_dispatch: # Allow manual trigger from GitHub UI
 
 jobs:

--- a/.github/workflows/bull-evaluation.yml
+++ b/.github/workflows/bull-evaluation.yml
@@ -1,10 +1,11 @@
 name: Bull Evaluation
 
 on:
-  schedule:
-    # Daily 04:30 UTC — rotation batch of 100 oldest bull_eval_at, paired
-    # with bear-evaluation at 04:00. Full universe cycles every ~5 days.
-    - cron: "30 4 * * *"
+  # SCHEDULE RETIRED — the bull side now runs inside verdict-evaluation.yml
+  # (bull + bear over one shared batch / clock). Kept for manual single-side
+  # runs and backfills only.
+  # schedule:
+  #   - cron: "30 4 * * *"
   workflow_dispatch: # Allow manual trigger from GitHub UI
 
 jobs:

--- a/.github/workflows/update-narratives.yml
+++ b/.github/workflows/update-narratives.yml
@@ -1,9 +1,12 @@
 name: AI Narratives Update
 
 on:
-  schedule:
-    # Runs at 4:00 AM UTC daily (after EODHD at 3:30)
-    - cron: "0 4 * * *"
+  # SCHEDULE RETIRED — the page narrative (short/full outlook + key risks) is now
+  # produced by research-evaluation.yml in the same per-ticker call that scores
+  # the research card (same Level 0 facts, same Gemini model). Kept for manual
+  # runs / the legacy companies path only.
+  # schedule:
+  #   - cron: "0 4 * * *"
   workflow_dispatch: # Allow manual trigger from GitHub UI
 
 jobs:

--- a/.github/workflows/verdict-evaluation.yml
+++ b/.github/workflows/verdict-evaluation.yml
@@ -1,0 +1,78 @@
+name: Verdict Evaluation
+
+# Consolidated bull + bear pass. Bull (Claude) and bear (Gemini) stay on
+# DIFFERENT models on purpose — adversarial, uncorrelated reads that the
+# screener's bull×bear multiplier depends on — but run over ONE shared rotation
+# batch and write both verdicts with the SAME clock, so bull_at/bear_at never
+# drift. Replaces the separate bull-evaluation + bear-evaluation crons.
+#
+# Daily 04:00 UTC — 300 stalest Tier-1 by min(bull_at, bear_at).
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Evaluate but write nothing"
+        required: false
+        type: boolean
+        default: false
+      only:
+        description: "Run only one side (bull|bear); blank = both"
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  verdict-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run Verdict Evaluation
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}  # bull side
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}        # bear side
+          VERDICT_DRY_RUN: ${{ inputs.dry_run }}
+          VERDICT_ONLY: ${{ inputs.only }}
+        run: |
+          set -u
+          ARGS=()
+          if [ "${VERDICT_DRY_RUN}" = "true" ]; then ARGS+=(--dry-run); fi
+          if [ -n "${VERDICT_ONLY}" ]; then ARGS+=(--only "${VERDICT_ONLY}"); fi
+          python verdict_evaluation.py ${ARGS[@]+"${ARGS[@]}"}
+
+      - name: Refresh screener matview
+        # Surface the fresh bull/bear on /screener (the bull×bear multiplier
+        # reads screen_facts_mv). Best-effort — a matview timeout must not
+        # red-flag a clean verdict run.
+        if: ${{ inputs.dry_run != true }}
+        continue-on-error: true
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: python -c "from db import SupabaseDB; SupabaseDB().refresh_screen_facts()"
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: verdict-eval-logs-${{ github.run_id }}
+          path: logs/
+          retention-days: 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,8 @@ Daily (UTC):
 03:00           nightly_screen.py         TradingView screen → add new tickers to companies table
 03:30           eodhd_updater.py          Fetch 20+ financial metrics from EODHD
 03:45           benchmarks_updater.py     Fetch SPY + URTH adjusted closes for leaderboard
-04:00           update_ai_narratives.py   Gemini refresh of stale narratives (90+ days)
-04:00           bear_evaluation.py        Refresh 100 oldest bear_eval rows (rotation, ~5d full cycle)
-04:15           research_evaluation.py    Shared per-equity research card — 100 stalest Tier-1 (moat/durability/earnings-quality/balance-sheet, scored 1-5 + break signals)
-04:30           bull_evaluation.py        Refresh 100 oldest bull_eval rows (rotation, ~5d full cycle)
+04:00           verdict_evaluation.py     Consolidated bull (Claude) + bear (Gemini) over ONE shared batch/clock — 300 stalest Tier-1 by min(bull_at,bear_at). Models stay distinct (adversarial); only batch+clock shared so bull_at==bear_at
+04:15           research_evaluation.py    Shared per-equity research card (moat/durability/earnings-quality/balance-sheet, 1-5 + break signals) PLUS the page narrative (short/full outlook + key risks) — 300 stalest Tier-1, one per-ticker Gemini call
 04:30           price_sales_updater.py    P/S ratio tracking + 52w history
 05:00           score_ai_analysis.py      Score, rank & assign sort_order
 05:30           portfolio_valuation.py    Mark-to-market every agent + human portfolio
@@ -340,10 +338,27 @@ day's last intraday tick (~21:45 UTC) so `portfolio_valuation.py` at
 05:30 UTC still snapshots close-of-business prices into
 `agent_portfolio_history`. Supports `--dry-run` and `--tickers` flags.
 
-### update_ai_narratives.py (04:00 UTC daily)
-Refreshes stale narratives (90+ days) using Gemini 2.5 Flash.
-Injects full financial context into prompt. Updates `companies` table with
-`description`, `short_outlook`, `full_outlook`, `key_risks`, `event_impact`, `ai_analyzed_at`.
+### verdict_evaluation.py (04:00 UTC daily)
+The **consolidated bull + bear pass** (replaces the separate `bull-evaluation`
++ `bear-evaluation` crons). Bull and bear stay on **different models on purpose**
+— bull = Claude (`claude-opus-4-6`), bear = Gemini (`gemini-2.5-flash`): a
+different brain per side gives **uncorrelated** reads, which is exactly what the
+screener's `bull × bear` multiplier needs. The consolidation is that both run
+over **one shared rotation batch** (`level0_eval.tier1_eval_candidates(db,
+"verdict", 300)` — the 300 stalest Tier-1 by the OLDER of `bull_at`/`bear_at`)
+and write both verdicts with the **same timestamp**, so `bull_at == bear_at`
+going forward and the screener never blends two vintages. Reuses the bull/bear
+engines' prompt + parse code (`bull_evaluation` / `bear_evaluation` stay
+importable; their `main()` still works for a manual single-side run). One engine
+failing never loses the other's verdicts. Writes ONLY `ai_analysis`; logs
+`run_logs`. Flags: `--dry-run`, `--only bull|bear`.
+
+### update_ai_narratives.py (manual / legacy only — schedule retired)
+Legacy Gemini narrative refresher over the `companies` table. **The Tier-1 page
+narrative (short/full outlook + key risks) is now produced by
+`research_evaluation.py`** in the same per-ticker call that scores the research
+card (same Level 0 facts, same Gemini model — no diversity lost). Kept for manual
+runs / the legacy companies path; cron disabled.
 
 ### price_sales_updater.py (04:30 UTC daily)
 Tracks P/S ratios over time. Backfills 52 weeks of history for new tickers.
@@ -813,6 +828,25 @@ mean of the **scored** dimensions (never the model's own rollup). Today
 returns automatically once a balance-sheet backfill lands (a tracked follow-up:
 `backfill_tier1_fundamentals` + `eodhd.py` already have the EODHD fields via
 `price_sales_updater.get_shares_outstanding`).
+
+**Stage A4 — writer consolidation (no schema change).** The four rotation
+writers that all fed `ai_analysis` were collapsed from four Actions to two,
+without touching the model diversity:
+- **`verdict_evaluation.py`** runs bull (Claude) + bear (Gemini) over **one
+  shared batch** and writes both under one clock — distinct models (the
+  adversarial design is the point) but `bull_at == bear_at`, so the screener's
+  `bull × bear` multiplier never blends two vintages. Selection uses the
+  combined `"verdict"` clock = older of `bull_at`/`bear_at`
+  (`level0_eval.tier1_eval_candidates(db, "verdict", N)`).
+- **`research_evaluation.py`** now writes the page **narrative** (short/full
+  outlook + key risks, `narrated_at`) in the same per-ticker call that scores
+  the **research card** — the descriptive `update_ai_narratives` pass merged in
+  (it re-read the same Level 0 facts on the same Gemini model for no diversity
+  benefit). Card + narrative share one vintage.
+
+`bull_evaluation` / `bear_evaluation` / `update_ai_narratives` remain importable
+(engines reused) and dispatch-only (schedules retired). Every reader still reads
+`ai_analysis` unchanged — the consolidation is write-side only.
 
 All Level 0 tables: public-read RLS, service-role writes. `metric_stats`
 (distribution percentiles) is reused from migration 038.
@@ -1349,7 +1383,10 @@ pip install -r requirements.txt
 python nightly_screen.py                   # TradingView screen → add new tickers
 python eodhd_updater.py                    # fetch EODHD financial data
 python eodhd_updater.py --force            # ignore staleness
-python update_ai_narratives.py             # refresh AI narratives
+python verdict_evaluation.py               # consolidated bull (Claude) + bear (Gemini), shared batch/clock
+python verdict_evaluation.py --only bull   # run one side only
+python research_evaluation.py              # research card + page narrative (Gemini, per-ticker)
+python update_ai_narratives.py             # legacy narrative refresh (companies path; schedule retired)
 python score_ai_analysis.py                # score + rank
 python price_sales_updater.py              # P/S update
 python price_sales_updater.py --tickers NVDA AAPL --force

--- a/data_freshness_report.py
+++ b/data_freshness_report.py
@@ -48,7 +48,7 @@ SOURCE = {
     "Daily prices": "prices-daily.yml",
     "Valuation / P-S": "daily-price-sales.yml",
     "Fundamentals": "fundamentals-update.yml",
-    "AI analysis": "bull-evaluation · bear-evaluation · update-narratives · research-evaluation",
+    "AI analysis": "verdict-evaluation (bull+bear) · research-evaluation (card+narrative)",
     "Estimates": "— (no ingest)",
     "Events": "— (no ingest)",
 }

--- a/level0_eval.py
+++ b/level0_eval.py
@@ -109,11 +109,21 @@ def stale_tier1_tickers(db, kind: str, top_n: int) -> list[str]:
     unverified names re-enter the rotation automatically once their fundamentals
     backfill. Pure read over `securities` + `fundamentals` + `ai_analysis`.
     """
-    clock = _CLOCK_COLUMN.get(kind)
-    if clock is None:
-        raise ValueError(
-            f"unknown kind {kind!r} (expected bull|bear|narrative|research)"
-        )
+    if kind == "verdict":
+        # Combined bull+bear staleness: a name is due when EITHER verdict is
+        # stale, and both are refreshed together (shared clock) so the two never
+        # drift apart — the screener's bull×bear multiplier always reads one
+        # vintage. The bull/bear models stay distinct (the adversarial design);
+        # only the rotation batch + clock are shared.
+        clock_cols = ["bull_at", "bear_at"]
+    else:
+        clock = _CLOCK_COLUMN.get(kind)
+        if clock is None:
+            raise ValueError(
+                f"unknown kind {kind!r} "
+                "(expected bull|bear|narrative|research|verdict)"
+            )
+        clock_cols = [clock]
 
     verified = verified_fact_tickers(db)
 
@@ -138,22 +148,27 @@ def stale_tier1_tickers(db, kind: str, top_n: int) -> list[str]:
             break
         offset += 1000
 
-    # Per-kind clock from ai_analysis (only evaluated names have a row).
-    clocks: dict[str, str | None] = {}
+    # Per-kind clock(s) from ai_analysis (only evaluated names have a row).
+    clocks: dict[str, tuple] = {}
+    select = "ticker," + ",".join(clock_cols)
     for chunk in _chunked(tier1):
         resp = (
             db.client.table("ai_analysis")
-            .select(f"ticker,{clock}")
+            .select(select)
             .in_("ticker", chunk)
             .execute()
         )
         for r in (resp.data or []):
-            clocks[(r.get("ticker") or "").upper()] = r.get(clock)
+            t = (r.get("ticker") or "").upper()
+            clocks[t] = tuple(r.get(c) for c in clock_cols)
 
-    # NULLs (never evaluated) first, then oldest ISO timestamp first.
+    # Never-evaluated (no row, or ANY required clock NULL) first, then oldest
+    # first. For "verdict" the staleness is the OLDER of bull_at / bear_at.
     def _key(t: str):
-        c = clocks.get(t)
-        return (0 if not c else 1, str(c or ""))
+        vals = clocks.get(t)
+        if not vals or any(not v for v in vals):
+            return (0, "")
+        return (1, min(str(v) for v in vals))
 
     return sorted(tier1, key=_key)[:top_n]
 

--- a/research_evaluation.py
+++ b/research_evaluation.py
@@ -14,12 +14,18 @@ from raw numbers on every run — so the expensive thinking happens here, once,
 amortized across all users, while the buyer's per-run call shrinks to a
 mandate-fit judgment.
 
+The same per-ticker call also writes the company-page NARRATIVE (short_outlook /
+key_risks / full_outlook) — the descriptive analysis merged in from the retired
+`update_ai_narratives` pass, since it re-read the same Level 0 facts on the same
+model (Gemini) for no diversity benefit. Card + narrative therefore share one
+vintage (`narrated_at` == `researched_at`).
+
 Rotation: the `top_n` stalest Tier-1 names by `ai_analysis.researched_at`
 (NULLs first), via `level0_eval.tier1_eval_candidates(db, "research", N)`.
 Writes ONLY `ai_analysis` (the card is a Level 0 concept). Per-ticker LLM call
 (structured JSON), parallelised — robust to one bad response.
 
-Schedule: daily ~04:15 UTC, alongside bull/bear.
+Schedule: daily ~04:15 UTC, alongside the verdict (bull+bear) pass.
 """
 
 from __future__ import annotations
@@ -150,6 +156,16 @@ Each is {{"field","op","value","description"}}.
 - op MUST be one of: >, >=, <, <=, ==, !=, change_pct_lt, change_pct_gt
 - value MUST be a number (never a string with "%"/"pp").
 
+Finally write a short, plain-language NARRATIVE for the company page (qualitative
+— the page shows live numbers next to it, so do NOT put specific percentages or
+dollar figures in the prose; they would drift out of sync):
+- short_outlook: ONE sentence, max 15 words, starting with 🟢 (positive),
+  🟡 (cautious/mixed) or 🔴 (negative), naming the single most important driver.
+- key_risks: ONE sentence, max 15 words, starting with 🟡 or 🔴, naming the
+  1-2 most specific risks.
+- full_outlook: 3-5 sentences on the fundamental earnings-quality story and the
+  path to (or sustainability of) profitability. No bullet points.
+
 Use ONLY the data provided plus your general knowledge of the sector. Do not
 invent company-specific numbers.
 
@@ -166,7 +182,10 @@ OUTPUT SCHEMA (strict JSON, no other text):
 {{
   "quality_score": <integer 1-5 — your overall read of the business>,
 {dimension_schema}
-  "break_signals": [{{"field": "...", "op": "...", "value": <number>, "description": "..."}}]
+  "break_signals": [{{"field": "...", "op": "...", "value": <number>, "description": "..."}}],
+  "short_outlook": "🟢/🟡/🔴 <max 15 words>",
+  "key_risks": "🟡/🔴 <max 15 words>",
+  "full_outlook": "<3-5 sentences, qualitative, no specific numbers>"
 }}
 Output JSON only."""
 
@@ -229,8 +248,28 @@ def _build_card(parsed: dict, model: str, max_break_signals: int,
     return card
 
 
+def _build_narrative(parsed: dict) -> dict:
+    """Pull the plain-language narrative fields out of the LLM JSON, trimmed.
+
+    Merged in from the retired update_ai_narratives pass — the same deep call
+    that scores the card now also writes the page outlook, so narrative and card
+    share one vintage (narrated_at == researched_at)."""
+    out: dict = {}
+    so = str(parsed.get("short_outlook") or "").strip()
+    kr = str(parsed.get("key_risks") or "").strip()
+    fo = str(parsed.get("full_outlook") or "").strip()
+    if so:
+        out["short_outlook"] = so[:160]
+    if kr:
+        out["key_risks"] = kr[:160]
+    if fo:
+        out["full_outlook"] = fo[:1200]
+    return out
+
+
 def _evaluate_one(equity: dict, cfg: dict) -> dict:
-    """One LLM research call for one equity. Returns {ticker, card} or {ticker, error}."""
+    """One LLM call for one equity → the research card + page narrative.
+    Returns {ticker, card, narrative} or {ticker, error}."""
     ticker = equity["ticker"]
     # Data-quality gate: only score dimensions whose verified inputs are present,
     # and never call the LLM for a name with too little to assess (< 2 dims).
@@ -265,7 +304,7 @@ def _evaluate_one(equity: dict, cfg: dict) -> dict:
     card = _build_card(parsed, cfg["model"], cfg["max_break_signals"], dims)
     if card is None:
         return {"ticker": ticker, "error": "no usable dimension scores"}
-    return {"ticker": ticker, "card": card}
+    return {"ticker": ticker, "card": card, "narrative": _build_narrative(parsed)}
 
 
 def main(argv=None) -> int:
@@ -308,6 +347,7 @@ def main(argv=None) -> int:
 
     start = time.time()
     cards: dict[str, dict] = {}
+    narratives: dict[str, dict] = {}
     errors: dict[str, str] = {}
     with ThreadPoolExecutor(max_workers=cfg["concurrency"]) as pool:
         futures = {pool.submit(_evaluate_one, eq, cfg): eq["ticker"] for eq in batch}
@@ -325,6 +365,7 @@ def main(argv=None) -> int:
                 errors[ticker] = res["error"]
             else:
                 cards[ticker] = res["card"]
+                narratives[ticker] = res.get("narrative") or {}
 
     logger.info("scored %d / %d (%d errors)", len(cards), len(batch), len(errors))
     for t, c in list(cards.items())[:10]:
@@ -341,19 +382,28 @@ def main(argv=None) -> int:
         return 0
 
     now = datetime.now(timezone.utc).isoformat()
-    rows = [
-        {"ticker": t, "research_card": c, "researched_at": now, "analyzed_at": now}
-        for t, c in cards.items()
-    ]
+    rows = []
+    narrated = 0
+    for t, c in cards.items():
+        row = {"ticker": t, "research_card": c,
+               "researched_at": now, "analyzed_at": now}
+        nar = narratives.get(t) or {}
+        if nar:
+            row.update(nar)
+            row["narrated_at"] = now  # narrative shares the card's vintage
+            narrated += 1
+        rows.append(row)
     if rows:
         db.upsert_ai_analysis_batch(rows)
     db.log_run("research_evaluation", {
         "updated": len(rows), "skipped": len(batch) - len(rows), "errors": len(errors),
         "duration_secs": round(time.time() - start, 1),
-        "details": {"batch_size": len(batch), "scored": len(cards)},
+        "details": {"batch_size": len(batch), "scored": len(cards),
+                    "narrated": narrated},
     })
-    logger.info("=== Research Evaluation complete: %d cards written (%.1fs) ===",
-                len(rows), time.time() - start)
+    logger.info(
+        "=== Research Evaluation complete: %d cards (%d w/ narrative) (%.1fs) ===",
+        len(rows), narrated, time.time() - start)
     return 0
 
 

--- a/test_level0_eval.py
+++ b/test_level0_eval.py
@@ -63,22 +63,33 @@ class _FakeQ:
     def select(self, *_a, **_k): return self
     def eq(self, *_a, **_k): return self
     def in_(self, *_a, **_k): return self
+    def or_(self, *_a, **_k): return self
     def range(self, *_a, **_k): return self
     def execute(self):
         return SimpleNamespace(data=self._data)
 
 
 class _FakeClient:
-    def __init__(self, securities, ai):
+    def __init__(self, securities, ai, fundamentals):
         self._securities = securities
         self._ai = ai
+        self._fundamentals = fundamentals
     def table(self, name):
-        return _FakeQ(name, self._securities if name == "securities" else self._ai)
+        data = {
+            "securities": self._securities,
+            "fundamentals": self._fundamentals,
+        }.get(name, self._ai)
+        return _FakeQ(name, data)
 
 
 class _FakeDB:
-    def __init__(self, securities, ai):
-        self.client = _FakeClient(securities, ai)
+    def __init__(self, securities, ai, fundamentals=None):
+        # Default: every security has verified fundamentals (so the verified-fact
+        # gate keeps the whole test universe and only the clock ordering is under
+        # test). Pass an explicit list to test the gate itself.
+        if fundamentals is None:
+            fundamentals = [{"ticker": s["ticker"]} for s in securities]
+        self.client = _FakeClient(securities, ai, fundamentals)
     def get_ai_analysis(self, tickers):
         return {}
 
@@ -108,6 +119,33 @@ class StaleOrderingTests(unittest.TestCase):
         db = _FakeDB([], [])
         with self.assertRaises(ValueError):
             L.stale_tier1_tickers(db, "sideways", top_n=1)
+
+    def test_verdict_uses_older_of_bull_and_bear(self):
+        securities = [{"ticker": t} for t in ("AAA", "BBB", "CCC", "DDD")]
+        ai = [
+            # AAA: bull fresh but bear NULL -> never-evaluated group (most stale).
+            {"ticker": "AAA", "bull_at": "2026-06-01T00:00:00Z", "bear_at": None},
+            # BBB: both old -> stale, key = older (2025-01-01).
+            {"ticker": "BBB", "bull_at": "2025-02-01T00:00:00Z",
+             "bear_at": "2025-01-01T00:00:00Z"},
+            # CCC: both recent -> freshest.
+            {"ticker": "CCC", "bull_at": "2026-06-10T00:00:00Z",
+             "bear_at": "2026-06-09T00:00:00Z"},
+            # DDD: no ai row at all -> never-evaluated group.
+        ]
+        db = _FakeDB(securities, ai)
+        order = L.stale_tier1_tickers(db, "verdict", top_n=4)
+        # Never-evaluated (AAA has a NULL clock, DDD has no row) first…
+        self.assertEqual(set(order[:2]), {"AAA", "DDD"})
+        # …then the older-of-the-two before the fresh pair.
+        self.assertEqual(order[2], "BBB")
+        self.assertEqual(order[3], "CCC")
+
+    def test_verified_fact_gate_filters(self):
+        securities = [{"ticker": t} for t in ("AAA", "BBB", "CCC")]
+        # Only BBB has a fundamentals row -> only BBB is eval-eligible.
+        db = _FakeDB(securities, [], fundamentals=[{"ticker": "BBB"}])
+        self.assertEqual(L.stale_tier1_tickers(db, "bull", top_n=10), ["BBB"])
 
 
 if __name__ == "__main__":

--- a/verdict_evaluation.py
+++ b/verdict_evaluation.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Verdict Evaluation — the consolidated bull + bear pass.
+
+Bull and bear are an ADVERSARIAL pair run on DIFFERENT models on purpose
+(bull = Claude, bear = Gemini): a different brain arguing each side has
+uncorrelated blind spots, so the screener's bull×bear multiplier multiplies two
+genuinely independent reads. This script keeps that — two models, two calls —
+but runs them over ONE shared rotation batch and stamps both verdicts with the
+SAME timestamp. So `bull_at` and `bear_at` never drift apart (they used to be
+two jobs on two clocks, up to ~4 days out of sync), and the screener always
+reads one vintage.
+
+It replaces the separate `bull-evaluation` + `bear-evaluation` crons. The
+underlying engines (`bull_evaluation` / `bear_evaluation`) stay importable
+modules — their `main()` still works for a manual single-side / backfill run.
+
+Selection: the `top_n` stalest Tier-1 names by the OLDER of bull_at/bear_at
+(`level0_eval.tier1_eval_candidates(db, "verdict", N)`), gated to verified-fact
+names. Writes ONLY `ai_analysis`. One engine failing never drops the other's
+results.
+
+Schedule: daily ~04:00 UTC.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from datetime import date
+
+from dotenv import load_dotenv
+
+from db import SupabaseDB
+import level0_eval
+import bull_evaluation as bull
+import bear_evaluation as bear
+
+TOP_N = 300  # stalest Tier-1 names refreshed per run (shared rotation batch)
+
+
+def setup_logging() -> logging.Logger:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    return logging.getLogger("verdict_evaluation")
+
+
+def _run_bull(top_equities: list[dict], api_key: str,
+              logger: logging.Logger) -> dict[str, str]:
+    """Claude bull pass over the shared batch. Returns {ticker: verdict}."""
+    blocks = [bull.build_equity_block(c) for c in top_equities]
+    prompt = bull.build_bull_prompt(blocks)
+    logger.info("Bull (Claude %s): prompt %d chars for %d equities",
+                bull.CLAUDE_MODEL, len(prompt), len(blocks))
+    text = bull.call_claude_bull(prompt, api_key, logger)
+    if text is None:
+        logger.error("Bull: Claude call failed")
+        return {}
+    verdicts = bull.parse_bull_results(text)
+    logger.info("Bull: parsed %d verdicts", len(verdicts))
+    return verdicts
+
+
+def _run_bear(top_equities: list[dict], api_key: str,
+              logger: logging.Logger) -> dict[str, str]:
+    """Gemini bear pass over the shared batch. Returns {ticker: verdict}."""
+    blocks = [bear.build_equity_block(c) for c in top_equities]
+    prompt = bear.build_bear_prompt(blocks)
+    logger.info("Bear (Gemini %s): prompt %d chars for %d equities",
+                bear.GEMINI_MODEL, len(prompt), len(blocks))
+    text = bear.call_gemini_bear(prompt, api_key, logger)
+    if text is None:
+        logger.error("Bear: Gemini call failed")
+        return {}
+    verdicts = bear.parse_bear_results(text)
+    logger.info("Bear: parsed %d verdicts", len(verdicts))
+    return verdicts
+
+
+def main() -> int:
+    load_dotenv()
+    parser = argparse.ArgumentParser(
+        description="Verdict Evaluation — consolidated bull + bear")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Evaluate but write nothing")
+    parser.add_argument("--only", choices=["bull", "bear"],
+                        help="Run only one side (still over the shared batch)")
+    args = parser.parse_args()
+
+    logger = setup_logging()
+    logger.info("=== Verdict Evaluation started (dry_run=%s, only=%s) ===",
+                args.dry_run, args.only or "both")
+    start = time.time()
+
+    claude_key = os.environ.get("ANTHROPIC_API_KEY")
+    gemini_key = os.environ.get("GEMINI_API_KEY")
+    want_bull = args.only in (None, "bull")
+    want_bear = args.only in (None, "bear")
+    if want_bull and not claude_key:
+        logger.error("ANTHROPIC_API_KEY not set (needed for the bull side)")
+        return 1
+    if want_bear and not gemini_key:
+        logger.error("GEMINI_API_KEY not set (needed for the bear side)")
+        return 1
+
+    db = SupabaseDB()
+
+    # ONE shared rotation batch (stalest by the older of bull_at/bear_at).
+    top_equities = level0_eval.tier1_eval_candidates(db, "verdict", TOP_N)
+    logger.info("Selected %d Tier-1 tickers (rotation by min(bull_at, bear_at))",
+                len(top_equities))
+    if not top_equities:
+        logger.warning("Nothing to evaluate.")
+        return 0
+
+    # Each engine runs independently — a failure on one side must not lose the
+    # other's verdicts (the whole point of one resilient job over two crons).
+    bull_verdicts: dict[str, str] = {}
+    bear_verdicts: dict[str, str] = {}
+    if want_bull:
+        try:
+            bull_verdicts = _run_bull(top_equities, claude_key, logger)
+        except Exception:  # noqa: BLE001
+            logger.exception("Bull side crashed — continuing with bear only")
+    if want_bear:
+        try:
+            bear_verdicts = _run_bear(top_equities, gemini_key, logger)
+        except Exception:  # noqa: BLE001
+            logger.exception("Bear side crashed — continuing with bull only")
+
+    bull_pass = sum(1 for v in bull_verdicts.values() if "✅" in v)
+    bear_pass = sum(1 for v in bear_verdicts.values() if "✅" in v)
+    logger.info("Bull: %d verdicts (%d ✅) · Bear: %d verdicts (%d ✅)",
+                len(bull_verdicts), bull_pass, len(bear_verdicts), bear_pass)
+
+    if not bull_verdicts and not bear_verdicts:
+        logger.error("Both sides produced no verdicts. Nothing to write.")
+        return 1
+
+    if args.dry_run:
+        logger.info("[DRY RUN] no writes. (%.1fs)", time.time() - start)
+        return 0
+
+    # Merge into one row per ticker, both verdicts stamped with the SAME clock so
+    # bull_at == bear_at going forward.
+    ts = date.today().isoformat()
+    rows: list[dict] = []
+    for company in top_equities:
+        ticker = (company.get("ticker") or "").strip()
+        if not ticker:
+            continue
+        row: dict = {"ticker": ticker, "analyzed_at": ts}
+        if (bv := bull_verdicts.get(ticker)):
+            row["bull_eval"] = bv
+            row["bull_at"] = ts
+        if (rv := bear_verdicts.get(ticker)):
+            row["bear_eval"] = rv
+            row["bear_at"] = ts
+        # Only write a row that actually carries a verdict.
+        if "bull_eval" in row or "bear_eval" in row:
+            rows.append(row)
+
+    if rows:
+        db.upsert_ai_analysis_batch(rows)
+    logger.info("Wrote %d rows", len(rows))
+
+    elapsed = round(time.time() - start, 1)
+    db.log_run("verdict_evaluation", {
+        "updated": len(rows),
+        "skipped": len(top_equities) - len(rows),
+        "errors": 0,
+        "duration_secs": elapsed,
+        "details": {
+            "batch_size": len(top_equities),
+            "bull_verdicts": len(bull_verdicts),
+            "bear_verdicts": len(bear_verdicts),
+            "bull_pass": bull_pass,
+            "bear_pass": bear_pass,
+        },
+    })
+    logger.info("=== Verdict Evaluation complete: %d rows (%.1fs) ===",
+                len(rows), elapsed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Four per-stock AI Actions all wrote `ai_analysis`, and each one independently re-selected the universe and re-serialized the **same** Level 0 financials into a prompt — up to **4× per rotation cycle**, on **4 drifting clocks**, across **4 workflows**. That produced: contradictory verdicts (a ✅ bull on a name whose card says "weak moat"), vintage skew (the screener's `bull × bear` multiplier blending a fresh bull with a 4-day-old bear), wasted tokens, and 4× the operational surface (this week alone: bull crash, bear with no `run_logs`, research ~28% errors).

This collapses the four to **two**, **without touching the model diversity** you flagged as deliberate.

## What changed

### `verdict_evaluation.py` (new) — bull + bear, one batch, one clock
Bull (**Claude**) and bear (**Gemini**) stay on **different models on purpose** — uncorrelated reads are exactly what the `bull × bear` multiplier needs. The consolidation is that they run over **one shared rotation batch** and write both verdicts with the **same timestamp**, so `bull_at == bear_at` going forward and the screener never blends vintages.
- Reuses the bull/bear engines' prompt + parse code; both stay importable (`--only bull|bear` covers a single-side run).
- One engine failing never loses the other's verdicts.
- Adds `run_logs` journaling that bear never had.
- New combined `"verdict"` clock in `level0_eval` = stalest by the **older** of `bull_at`/`bear_at`.

### `research_evaluation.py` — card + narrative in one call
The page narrative (short/full outlook + key risks, `narrated_at`) is now produced in the **same per-ticker call** that scores the research card. The descriptive `update_ai_narratives` pass merged in — it re-read the same Level 0 facts on the same Gemini model for no diversity benefit. Card + narrative now share one vintage.

### Workflows
- **New:** `verdict-evaluation.yml` (daily 04:00, both model keys, best-effort matview refresh).
- `bull-evaluation` / `bear-evaluation` / `update-narratives` schedules **retired** (`workflow_dispatch` kept). *(Their actual deletion + the other deprecated workflows is the follow-up PR #1782.)*

### Docs / observability
- `data_freshness_report` "Maintained by" map updated to name the two new Actions.
- CLAUDE.md schedule, script descriptions, ai_analysis "Stage A4" note, and Commands updated.

## Net effect

| | Before | After |
|---|---|---|
| AI-analysis workflows | 4 | 2 |
| Bull/bear model diversity | Claude + Gemini | **unchanged** |
| Bull/bear same-vintage | ❌ clocks drift | ✅ shared clock |
| Redundant context loads per stock | up to 4× | 2× |

## Notes
- **No migration** — reuses the existing `ai_analysis` clocks. Every reader is unchanged (everything reads `ai_analysis`).
- Minor coverage nuance: the merged narrative now rides the research gate (≥2 scoreable dimensions) instead of the looser ≥1-verified-financial gate. `event_impact` is not produced by the merged pass; it was already absent from the Tier-1 narrative path, so no regression.

## Tests
`level0_eval` fake gains `.or_` + a `fundamentals` table (fixes 2 pre-existing failures) and now covers the verdict combined clock + the verified-fact gate. **Full suite: 174 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)