### PR TITLE
Add one-off job to purge deprecated workflows' leftover run history

### DIFF
--- a/.github/workflows/purge-deprecated-workflow-runs.yml
+++ b/.github/workflows/purge-deprecated-workflow-runs.yml
@@ -1,0 +1,72 @@
+name: Purge deprecated workflow runs (one-off)
+
+# One-off cleanup. The deprecated workflows (bull/bear/narratives evals +
+# the companies-retirement jobs) had their .yml files deleted, but GitHub keeps
+# a deleted workflow visible in the Actions sidebar while it still has run
+# history. This job deletes that leftover run history so the entries disappear.
+#
+# Run it from the Actions tab → "Purge deprecated workflow runs" → Run workflow.
+# After it finishes (and the sidebar entries are gone) this workflow file can be
+# deleted too. dry_run=true (default) only lists what it WOULD delete.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List runs that would be deleted, but delete nothing"
+        type: boolean
+        default: true
+
+permissions:
+  actions: write   # required to delete workflow runs
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      DRY_RUN: ${{ inputs.dry_run }}
+    steps:
+      - name: Delete runs of deprecated workflows
+        run: |
+          set -euo pipefail
+          # Match deprecated workflows by their (now-deleted) file path. Querying
+          # the workflows endpoint returns deleted ones too (state="deleted"),
+          # carrying their numeric id, so we can enumerate their runs precisely.
+          PATTERN='(bull-evaluation|bear-evaluation|update-narratives|nightly-eodhd-update|nightly-screen|score-ai-analysis|universe-snapshot)\.yml$'
+
+          IDS=$(gh api --paginate "repos/$REPO/actions/workflows?per_page=100" \
+                  --jq ".workflows[] | select(.path|test(\"$PATTERN\")) | \"\(.id)\t\(.path)\t\(.state)\"")
+
+          if [ -z "$IDS" ]; then
+            echo "No deprecated workflows found (already fully purged)."
+            exit 0
+          fi
+          echo "Deprecated workflows found:"
+          echo "$IDS"
+          echo
+
+          total=0
+          while IFS=$'\t' read -r wid wpath wstate; do
+            [ -z "$wid" ] && continue
+            echo "=== $wpath (id=$wid, state=$wstate) ==="
+            RUN_IDS=$(gh api --paginate "repos/$REPO/actions/workflows/$wid/runs?per_page=100" \
+                        --jq '.workflow_runs[].id' || true)
+            for rid in $RUN_IDS; do
+              total=$((total+1))
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  [dry-run] would delete run $rid"
+              else
+                echo "  deleting run $rid"
+                gh api -X DELETE "repos/$REPO/actions/runs/$rid" || echo "    failed $rid"
+              fi
+            done
+          done <<< "$IDS"
+
+          echo
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN: $total run(s) would be deleted. Re-run with dry_run=false to purge."
+          else
+            echo "Deleted $total run(s). Deprecated workflows should drop from the sidebar shortly."
+          fi


### PR DESCRIPTION
## Why

The 7 deprecated workflows' `.yml` files are already deleted (#1781 + #1784), so they never run again — confirmed: the API's active-workflow list returns 27, none of them deprecated. But GitHub keeps a deleted workflow **visible in the Actions sidebar** as long as it still has **run history**, and there's no "delete workflow" button or API to remove the workflow object. The entry only disappears once it has **zero runs**. My MCP tools can't delete runs (only clear logs, which keeps the run record).

## What

A one-off `workflow_dispatch` job (`purge-deprecated-workflow-runs.yml`) that uses the built-in `GITHUB_TOKEN` (`permissions: actions: write`) to:
1. Find the deprecated workflows by their now-deleted file path (the `…/actions/workflows` endpoint still returns deleted ones, `state="deleted"`, with their numeric id).
2. Enumerate and delete **all their runs**.

Once each has zero runs, it drops from the sidebar.

- **`dry_run: true` by default** — lists what it *would* delete without touching anything. Re-run with `dry_run=false` to actually purge.
- Targets exactly: `bull-evaluation`, `bear-evaluation`, `update-narratives`, `nightly-eodhd-update`, `nightly-screen`, `score-ai-analysis`, `universe-snapshot`. Nothing else.

## How to use
1. Merge this PR.
2. Actions tab → **Purge deprecated workflow runs** → **Run workflow** (leave dry_run on first) → check the list.
3. Run again with **dry_run = false** to delete.
4. Once the sidebar entries are gone, delete this workflow file too (it's a one-off).

If you'd rather not bother, they also age out on their own once their last runs pass the repo's run-retention window (~90 days).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_