### PR TITLE
Fix jq escape error in purge-deprecated-workflow-runs

### DIFF
--- a/.github/workflows/purge-deprecated-workflow-runs.yml
+++ b/.github/workflows/purge-deprecated-workflow-runs.yml
@@ -34,10 +34,12 @@ jobs:
           # Match deprecated workflows by their (now-deleted) file path. Querying
           # the workflows endpoint returns deleted ones too (state="deleted"),
           # carrying their numeric id, so we can enumerate their runs precisely.
-          PATTERN='(bull-evaluation|bear-evaluation|update-narratives|nightly-eodhd-update|nightly-screen|score-ai-analysis|universe-snapshot)\.yml$'
-
+          # Filter with grep (not jq's test()) to avoid jq string-escape pitfalls
+          # with the regex's "\.".
           IDS=$(gh api --paginate "repos/$REPO/actions/workflows?per_page=100" \
-                  --jq ".workflows[] | select(.path|test(\"$PATTERN\")) | \"\(.id)\t\(.path)\t\(.state)\"")
+                  --jq '.workflows[] | "\(.id)\t\(.path)\t\(.state)"' \
+                | grep -E '/(bull-evaluation|bear-evaluation|update-narratives|nightly-eodhd-update|nightly-screen|score-ai-analysis|universe-snapshot)\.yml' \
+                || true)
 
           if [ -z "$IDS" ]; then
             echo "No deprecated workflows found (already fully purged)."


### PR DESCRIPTION
## Bug

Running **Purge deprecated workflow runs** failed immediately:
```
failed to parse jq expression ... invalid escape sequence "\." in string literal
```
The step built the jq filter by interpolating a regex containing `\.` into a jq **string literal** (`test("...\.yml$")`). jq rejects `\.` inside a string.

## Fix

Filter the workflow list with `grep -E` instead of jq's `test()`, so the regex (`\.yml`) never passes through jq's string-escaping. Guarded the pipeline with `|| true` so a legitimate no-match under `set -euo pipefail` isn't treated as a failure.

After this merges, re-run the workflow (dry-run first) and it'll enumerate the deprecated workflows' runs correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_