### PR TITLE
Shift AI eval crons to 05:00 / 05:15 UTC (after Level 0 data settles)

### DIFF
--- a/.github/workflows/research-evaluation.yml
+++ b/.github/workflows/research-evaluation.yml
@@ -2,14 +2,17 @@ name: Research Evaluation
 
 # The shared per-equity research card (migration 055): scored moat / growth
 # durability / earnings quality / balance-sheet risk + base break signals,
-# computed once per equity and read by every portfolio's buyer.
+# PLUS the page narrative — computed once per equity and read by every
+# portfolio's buyer.
 #
-# Daily 04:15 UTC — rotation batch of 100 stalest by ai_analysis.researched_at,
-# alongside bull (04:30) / bear (04:00). Per-ticker LLM call, parallelised.
+# Daily 05:15 UTC — rotation batch of 300 stalest by ai_analysis.researched_at,
+# right after the verdict pass (05:00) and after the Level 0 data block has
+# settled (fundamentals 03:30, prices 04:15, P/S 04:30). Per-ticker LLM call,
+# parallelised.
 
 on:
   schedule:
-    - cron: "15 4 * * *"
+    - cron: "15 5 * * *"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/verdict-evaluation.yml
+++ b/.github/workflows/verdict-evaluation.yml
@@ -6,11 +6,13 @@ name: Verdict Evaluation
 # batch and write both verdicts with the SAME clock, so bull_at/bear_at never
 # drift. Replaces the separate bull-evaluation + bear-evaluation crons.
 #
-# Daily 04:00 UTC — 300 stalest Tier-1 by min(bull_at, bear_at).
+# Daily 05:00 UTC — 300 stalest Tier-1 by min(bull_at, bear_at). Runs after the
+# Level 0 data block has settled (fundamentals 03:30, prices 04:15, P/S 04:30)
+# and well before the 07:00 buyer heartbeat reads ai_analysis.
 
 on:
   schedule:
-    - cron: "0 4 * * *"
+    - cron: "0 5 * * *"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,9 @@ Daily (UTC):
 03:00           nightly_screen.py         TradingView screen → add new tickers to companies table
 03:30           eodhd_updater.py          Fetch 20+ financial metrics from EODHD
 03:45           benchmarks_updater.py     Fetch SPY + URTH adjusted closes for leaderboard
-04:00           verdict_evaluation.py     Consolidated bull (Claude) + bear (Gemini) over ONE shared batch/clock — 300 stalest Tier-1 by min(bull_at,bear_at). Models stay distinct (adversarial); only batch+clock shared so bull_at==bear_at
-04:15           research_evaluation.py    Shared per-equity research card (moat/durability/earnings-quality/balance-sheet, 1-5 + break signals) PLUS the page narrative (short/full outlook + key risks) — 300 stalest Tier-1, one per-ticker Gemini call
 04:30           price_sales_updater.py    P/S ratio tracking + 52w history
-05:00           score_ai_analysis.py      Score, rank & assign sort_order
+05:00           verdict_evaluation.py     Consolidated bull (Claude) + bear (Gemini) over ONE shared batch/clock — 300 stalest Tier-1 by min(bull_at,bear_at). Models stay distinct (adversarial); only batch+clock shared so bull_at==bear_at. Runs after the Level 0 data block settles, before the 07:00 heartbeat
+05:15           research_evaluation.py    Shared per-equity research card (moat/durability/earnings-quality/balance-sheet, 1-5 + break signals) PLUS the page narrative (short/full outlook + key risks) — 300 stalest Tier-1, one per-ticker Gemini call
 05:30           portfolio_valuation.py    Mark-to-market every agent + human portfolio
 06:00           build_universe_snapshot.py  Daily universe JSON snapshot (3 tiers)
 07:00           agent_heartbeat.py        Rebalance loop — every agent / human-portfolio member that is due on its own heartbeat_interval_hours cadence
@@ -338,7 +337,7 @@ day's last intraday tick (~21:45 UTC) so `portfolio_valuation.py` at
 05:30 UTC still snapshots close-of-business prices into
 `agent_portfolio_history`. Supports `--dry-run` and `--tickers` flags.
 
-### verdict_evaluation.py (04:00 UTC daily)
+### verdict_evaluation.py (05:00 UTC daily)
 The **consolidated bull + bear pass** (replaces the separate `bull-evaluation`
 + `bear-evaluation` crons). Bull and bear stay on **different models on purpose**
 — bull = Claude (`claude-opus-4-6`), bear = Gemini (`gemini-2.5-flash`): a

--- a/research_evaluation.py
+++ b/research_evaluation.py
@@ -25,7 +25,7 @@ Rotation: the `top_n` stalest Tier-1 names by `ai_analysis.researched_at`
 Writes ONLY `ai_analysis` (the card is a Level 0 concept). Per-ticker LLM call
 (structured JSON), parallelised — robust to one bad response.
 
-Schedule: daily ~04:15 UTC, alongside the verdict (bull+bear) pass.
+Schedule: daily ~05:15 UTC, just after the verdict (bull+bear) pass.
 """
 
 from __future__ import annotations

--- a/verdict_evaluation.py
+++ b/verdict_evaluation.py
@@ -20,7 +20,7 @@ Selection: the `top_n` stalest Tier-1 names by the OLDER of bull_at/bear_at
 names. Writes ONLY `ai_analysis`. One engine failing never drops the other's
 results.
 
-Schedule: daily ~04:00 UTC.
+Schedule: daily ~05:00 UTC (after the Level 0 data block settles).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Why

The two consolidated AI passes were firing **before** the day's Level 0 data finished landing:

| Time (UTC) | Job |
|---|---|
| 03:30 | fundamentals-update |
| **04:00** | **verdict-evaluation** ← only 30 min after fundamentals starts |
| 04:15 | prices-daily **+** research-evaluation (same minute) |
| 04:30 | daily-price-sales (P/S) ← *after* both evals |
| 07:00 | agent-heartbeat (buyers read `ai_analysis`) |

So both evals reasoned over **yesterday's** prices/P-S and risked reading fundamentals mid-update.

## Change

- `verdict-evaluation`: **04:00 → 05:00 UTC**
- `research-evaluation`: **04:15 → 05:15 UTC**

Now both run after the whole Level 0 data block has settled (fundamentals 03:30, prices 04:15, P/S 04:30), with a ~2-hour buffer before the 07:00 buyer heartbeat. Verdict before research; both write `ai_analysis` and refresh the screener matview.

**Batch size unchanged at 300** — that's a ~10-day full rotation over the ~3,128 Tier-1 names, re-evaluating each ~9×/quarter vs a quarterly fundamentals cadence.

## Also
- Dropped the deleted `score_ai_analysis` line from the CLAUDE.md daily schedule (it sat at 05:00 and would have collided with the new verdict slot).
- Refreshed the `research-evaluation` workflow header (300 not 100; it now also produces the page narrative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiMegMzNRDXyFJiQmmxa4r)_